### PR TITLE
Guard managed authz reconciliation by expected set identity

### DIFF
--- a/.github/workflows/reusable-authz-policy-reconcile.yml
+++ b/.github/workflows/reusable-authz-policy-reconcile.yml
@@ -8,6 +8,11 @@ name: Reusable Authz Policy Reconcile
         description: Review or apply the operator-managed desired rule set.
         required: true
         type: string
+      expected_managed_set_id:
+        description: Optional exact managed-set identity required from the protected configuration.
+        required: false
+        default: ""
+        type: string
       reviewed_plan_sha256:
         description: Plan SHA-256 returned by the reviewed dry run; required for apply.
         required: false
@@ -48,6 +53,7 @@ jobs:
         shell: bash
         env:
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          EXPECTED_MANAGED_SET_ID: ${{ inputs.expected_managed_set_id }}
           MODE: ${{ inputs.mode }}
           REASON: ${{ inputs.reason }}
           RELATED_ISSUE: ${{ inputs.related_issue }}
@@ -122,6 +128,11 @@ jobs:
           managed_set_id = str(configuration.get("managed_set_id", "")).strip()
           if re.fullmatch(r"[a-z0-9][a-z0-9._:/-]{0,127}", managed_set_id) is None:
               raise SystemExit("Managed authz configuration requires a stable managed_set_id.")
+          expected_managed_set_id = os.environ.get("EXPECTED_MANAGED_SET_ID", "").strip()
+          if expected_managed_set_id and managed_set_id != expected_managed_set_id:
+              raise SystemExit(
+                  "Managed authz configuration managed_set_id does not match the selected managed set."
+              )
           if configuration.get("schema_migration", "reject") not in {
               "reject",
               "migrate_v1_to_v2",

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -455,6 +455,13 @@ secret instead. The JSON owns desired state only: `schema_version`, `product`,
 Dispatch-time mode, reason, issue reference, and reviewed plan digest are
 deliberately excluded from that secret.
 
+The reusable authz worker accepts an optional exact expected managed-set
+identity from a reviewed wrapper. When provided, the worker rejects protected
+configuration whose `managed_set_id` does not match before rendering or sending
+the reconciliation request. Land this compatibility input before advancing a
+pinned wrapper that depends on it; do not pass a new input to an older immutable
+worker revision.
+
 ### Reusable workflow SHA rollout for readiness-gated actions
 
 Operational-readiness actions require one exact managed rule for the current

--- a/tests/test_authz_operator_workflow.py
+++ b/tests/test_authz_operator_workflow.py
@@ -109,6 +109,9 @@ class AuthzOperatorWorkflowTests(unittest.TestCase):
                 )
                 dispatch_job = self.dispatch_workflow.job(job_name)
                 self.assertEqual(dispatch_job["if"], condition)
+                dispatch_inputs = dispatch_job["with"]
+                assert isinstance(dispatch_inputs, dict)
+                self.assertNotIn("expected_managed_set_id", dispatch_inputs)
                 dispatch_secrets = dispatch_job["secrets"]
                 assert isinstance(dispatch_secrets, dict)
                 self.assertEqual(dispatch_secrets["managed_set_json"], expected_secret)
@@ -163,6 +166,13 @@ class AuthzOperatorWorkflowTests(unittest.TestCase):
         self.assertEqual(set(workflow_call), {"workflow_call"})
         workflow_call_contract = workflow_call["workflow_call"]
         assert isinstance(workflow_call_contract, dict)
+        workflow_call_inputs = workflow_call_contract["inputs"]
+        assert isinstance(workflow_call_inputs, dict)
+        expected_managed_set_id = workflow_call_inputs["expected_managed_set_id"]
+        assert isinstance(expected_managed_set_id, dict)
+        self.assertEqual(expected_managed_set_id["default"], "")
+        self.assertEqual(expected_managed_set_id["required"], False)
+        self.assertEqual(expected_managed_set_id["type"], "string")
         workflow_call_secrets = workflow_call_contract["secrets"]
         assert isinstance(workflow_call_secrets, dict)
         managed_set_secret = workflow_call_secrets["managed_set_json"]
@@ -264,6 +274,7 @@ class AuthzOperatorWorkflowTests(unittest.TestCase):
                     "GITHUB_REF": "refs/heads/main",
                     "GITHUB_RUN_ATTEMPT": "1",
                     "GITHUB_RUN_ID": "1234",
+                    "EXPECTED_MANAGED_SET_ID": "operator.launchplane",
                     "LAUNCHPLANE_AUTHZ_MANAGED_SET_JSON": json.dumps(configuration),
                     "MODE": "dry_run",
                     "REASON": "Review the managed Launchplane authority set.",
@@ -292,6 +303,48 @@ class AuthzOperatorWorkflowTests(unittest.TestCase):
             )
             self.assertEqual(request_summary["managed_set_id"], "operator.launchplane")
             self.assertNotIn("desired_policy", request_summary)
+
+    def test_render_step_rejects_unexpected_managed_set_id(self) -> None:
+        render_step = self.workflow.step_named(
+            "reconcile", "Validate and render managed authz request"
+        )
+        self.assertIsNotNone(render_step)
+        assert render_step is not None
+        configuration = {
+            "schema_version": 2,
+            "product": "launchplane",
+            "managed_set_id": "operator.primary",
+            "desired_policy": {"schema_version": 2},
+        }
+        with TemporaryDirectory() as temporary_directory:
+            result = subprocess.run(
+                ["bash", "-ceu", render_step.run],
+                check=False,
+                capture_output=True,
+                env={
+                    **os.environ,
+                    "DEFAULT_BRANCH": "main",
+                    "EXPECTED_MANAGED_SET_ID": "operator.manager-preview-approval",
+                    "GITHUB_EVENT_NAME": "workflow_dispatch",
+                    "GITHUB_OUTPUT": str(Path(temporary_directory) / "github-output"),
+                    "GITHUB_REF": "refs/heads/main",
+                    "GITHUB_RUN_ATTEMPT": "1",
+                    "GITHUB_RUN_ID": "1234",
+                    "LAUNCHPLANE_AUTHZ_MANAGED_SET_JSON": json.dumps(configuration),
+                    "MODE": "dry_run",
+                    "REASON": "Review the manager preview authorization set.",
+                    "RELATED_ISSUE": "cbusillo/launchplane#1919",
+                    "REVIEWED_PLAN_SHA256": "",
+                    "RUNNER_TEMP": temporary_directory,
+                },
+                text=True,
+            )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(
+            "managed_set_id does not match the selected managed set",
+            result.stderr,
+        )
 
     def test_render_step_rejects_unreviewed_apply(self) -> None:
         render_step = self.workflow.step_named(


### PR DESCRIPTION
## Summary

- add an optional `expected_managed_set_id` contract to the reusable authz worker
- fail before request rendering when protected configuration declares a different managed set
- add positive and negative semantic workflow tests
- document the required two-stage rollout for pinned wrappers

## Rollout

This is stage 1 of `#1919`. It intentionally does **not** update `Manage Launchplane Authorization`, because that wrapper is pinned to an older immutable worker revision that cannot accept the new input. After this PR merges, stage 2 will pin the wrapper to this merge commit and add the generic `manager-preview-approval` selector backed by its own protected secret.

## Validation

- 2,485 unittest targets across 12 shards
- full mypy across 597 source files
- focused authz workflow tests
- actionlint
- config-authority audit: `ok`
- changed-file Ruff and format checks
- JetBrains changed-file inspection: zero findings

Refs #1919
