### PR TITLE
Add protected manager preview authz wrapper

### DIFF
--- a/.github/workflows/authz-policy-reconcile.yml
+++ b/.github/workflows/authz-policy-reconcile.yml
@@ -19,6 +19,7 @@ name: Manage Launchplane Authorization
         type: choice
         options:
           - primary
+          - manager-preview-approval
           - product-health-monitoring
           - odoo-route-binding
           - odoo-external-route-binding
@@ -50,7 +51,7 @@ permissions:
 jobs:
   reconcile-primary:
     if: ${{ inputs.managed_set == 'primary' }}
-    uses: cbusillo/launchplane/.github/workflows/reusable-authz-policy-reconcile.yml@4dbef2945b0a297a6edaa949a42d8c7d4cbc01cd # main
+    uses: cbusillo/launchplane/.github/workflows/reusable-authz-policy-reconcile.yml@39aecc250d6dee91204e24673725bd1ea1ca6bda # main
     with:
       mode: ${{ inputs.mode }}
       reviewed_plan_sha256: ${{ inputs.reviewed_plan_sha256 }}
@@ -59,9 +60,21 @@ jobs:
     secrets:
       managed_set_json: ${{ secrets.LAUNCHPLANE_AUTHZ_MANAGED_SET_JSON }}
 
+  reconcile-manager-preview-approval:
+    if: ${{ inputs.managed_set == 'manager-preview-approval' }}
+    uses: cbusillo/launchplane/.github/workflows/reusable-authz-policy-reconcile.yml@39aecc250d6dee91204e24673725bd1ea1ca6bda # main
+    with:
+      mode: ${{ inputs.mode }}
+      expected_managed_set_id: operator.manager-preview-approval
+      reviewed_plan_sha256: ${{ inputs.reviewed_plan_sha256 }}
+      reason: ${{ inputs.reason }}
+      related_issue: ${{ inputs.related_issue }}
+    secrets:
+      managed_set_json: ${{ secrets.LAUNCHPLANE_AUTHZ_MANAGER_PREVIEW_APPROVAL_MANAGED_SET_JSON }}
+
   reconcile-product-health-monitoring:
     if: ${{ inputs.managed_set == 'product-health-monitoring' }}
-    uses: cbusillo/launchplane/.github/workflows/reusable-authz-policy-reconcile.yml@4dbef2945b0a297a6edaa949a42d8c7d4cbc01cd # main
+    uses: cbusillo/launchplane/.github/workflows/reusable-authz-policy-reconcile.yml@39aecc250d6dee91204e24673725bd1ea1ca6bda # main
     with:
       mode: ${{ inputs.mode }}
       reviewed_plan_sha256: ${{ inputs.reviewed_plan_sha256 }}
@@ -72,7 +85,7 @@ jobs:
 
   reconcile-odoo-route-binding:
     if: ${{ inputs.managed_set == 'odoo-route-binding' }}
-    uses: cbusillo/launchplane/.github/workflows/reusable-authz-policy-reconcile.yml@4dbef2945b0a297a6edaa949a42d8c7d4cbc01cd # main
+    uses: cbusillo/launchplane/.github/workflows/reusable-authz-policy-reconcile.yml@39aecc250d6dee91204e24673725bd1ea1ca6bda # main
     with:
       mode: ${{ inputs.mode }}
       reviewed_plan_sha256: ${{ inputs.reviewed_plan_sha256 }}
@@ -83,7 +96,7 @@ jobs:
 
   reconcile-odoo-external-route-binding:
     if: ${{ inputs.managed_set == 'odoo-external-route-binding' }}
-    uses: cbusillo/launchplane/.github/workflows/reusable-authz-policy-reconcile.yml@4dbef2945b0a297a6edaa949a42d8c7d4cbc01cd # main
+    uses: cbusillo/launchplane/.github/workflows/reusable-authz-policy-reconcile.yml@39aecc250d6dee91204e24673725bd1ea1ca6bda # main
     with:
       mode: ${{ inputs.mode }}
       reviewed_plan_sha256: ${{ inputs.reviewed_plan_sha256 }}
@@ -94,7 +107,7 @@ jobs:
 
   reconcile-odoo-testing-ingress-route:
     if: ${{ inputs.managed_set == 'odoo-testing-ingress-route' }}
-    uses: cbusillo/launchplane/.github/workflows/reusable-authz-policy-reconcile.yml@4dbef2945b0a297a6edaa949a42d8c7d4cbc01cd # main
+    uses: cbusillo/launchplane/.github/workflows/reusable-authz-policy-reconcile.yml@39aecc250d6dee91204e24673725bd1ea1ca6bda # main
     with:
       mode: ${{ inputs.mode }}
       reviewed_plan_sha256: ${{ inputs.reviewed_plan_sha256 }}
@@ -105,7 +118,7 @@ jobs:
 
   reconcile-odoo-testing-route-binding-refresh:
     if: ${{ inputs.managed_set == 'odoo-testing-route-binding-refresh' }}
-    uses: cbusillo/launchplane/.github/workflows/reusable-authz-policy-reconcile.yml@4dbef2945b0a297a6edaa949a42d8c7d4cbc01cd # main
+    uses: cbusillo/launchplane/.github/workflows/reusable-authz-policy-reconcile.yml@39aecc250d6dee91204e24673725bd1ea1ca6bda # main
     with:
       mode: ${{ inputs.mode }}
       reviewed_plan_sha256: ${{ inputs.reviewed_plan_sha256 }}
@@ -116,7 +129,7 @@ jobs:
 
   reconcile-odoo-testing-target-replacement:
     if: ${{ inputs.managed_set == 'odoo-testing-target-replacement' }}
-    uses: cbusillo/launchplane/.github/workflows/reusable-authz-policy-reconcile.yml@4dbef2945b0a297a6edaa949a42d8c7d4cbc01cd # main
+    uses: cbusillo/launchplane/.github/workflows/reusable-authz-policy-reconcile.yml@39aecc250d6dee91204e24673725bd1ea1ca6bda # main
     with:
       mode: ${{ inputs.mode }}
       reviewed_plan_sha256: ${{ inputs.reviewed_plan_sha256 }}
@@ -127,7 +140,7 @@ jobs:
 
   reconcile-odoo-opw-preview-feedback:
     if: ${{ inputs.managed_set == 'odoo-opw-preview-feedback' }}
-    uses: cbusillo/launchplane/.github/workflows/reusable-authz-policy-reconcile.yml@4dbef2945b0a297a6edaa949a42d8c7d4cbc01cd # main
+    uses: cbusillo/launchplane/.github/workflows/reusable-authz-policy-reconcile.yml@39aecc250d6dee91204e24673725bd1ea1ca6bda # main
     with:
       mode: ${{ inputs.mode }}
       reviewed_plan_sha256: ${{ inputs.reviewed_plan_sha256 }}
@@ -138,7 +151,7 @@ jobs:
 
   reconcile-odoo-opw-production-enrollment:
     if: ${{ inputs.managed_set == 'odoo-opw-production-enrollment' }}
-    uses: cbusillo/launchplane/.github/workflows/reusable-authz-policy-reconcile.yml@4dbef2945b0a297a6edaa949a42d8c7d4cbc01cd # main
+    uses: cbusillo/launchplane/.github/workflows/reusable-authz-policy-reconcile.yml@39aecc250d6dee91204e24673725bd1ea1ca6bda # main
     with:
       mode: ${{ inputs.mode }}
       reviewed_plan_sha256: ${{ inputs.reviewed_plan_sha256 }}
@@ -149,7 +162,7 @@ jobs:
 
   reconcile-odoo-production-enrollment:
     if: ${{ inputs.managed_set == 'odoo-production-enrollment' }}
-    uses: cbusillo/launchplane/.github/workflows/reusable-authz-policy-reconcile.yml@4dbef2945b0a297a6edaa949a42d8c7d4cbc01cd # main
+    uses: cbusillo/launchplane/.github/workflows/reusable-authz-policy-reconcile.yml@39aecc250d6dee91204e24673725bd1ea1ca6bda # main
     with:
       mode: ${{ inputs.mode }}
       reviewed_plan_sha256: ${{ inputs.reviewed_plan_sha256 }}
@@ -160,7 +173,7 @@ jobs:
 
   reconcile-odoo-production-operation-read:
     if: ${{ inputs.managed_set == 'odoo-production-operation-read' }}
-    uses: cbusillo/launchplane/.github/workflows/reusable-authz-policy-reconcile.yml@4dbef2945b0a297a6edaa949a42d8c7d4cbc01cd # main
+    uses: cbusillo/launchplane/.github/workflows/reusable-authz-policy-reconcile.yml@39aecc250d6dee91204e24673725bd1ea1ca6bda # main
     with:
       mode: ${{ inputs.mode }}
       reviewed_plan_sha256: ${{ inputs.reviewed_plan_sha256 }}
@@ -171,7 +184,7 @@ jobs:
 
   reconcile-odoo-production-backup-restore:
     if: ${{ inputs.managed_set == 'odoo-production-backup-restore' }}
-    uses: cbusillo/launchplane/.github/workflows/reusable-authz-policy-reconcile.yml@4dbef2945b0a297a6edaa949a42d8c7d4cbc01cd # main
+    uses: cbusillo/launchplane/.github/workflows/reusable-authz-policy-reconcile.yml@39aecc250d6dee91204e24673725bd1ea1ca6bda # main
     with:
       mode: ${{ inputs.mode }}
       reviewed_plan_sha256: ${{ inputs.reviewed_plan_sha256 }}

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -416,6 +416,9 @@ Operators mutate shared or production authz through the deployed service, not
 through direct DB commands or a local CLI from an arbitrary checkout. Store the
 complete desired rules for one `managed_set_id` in a protected repository
 secret. `LAUNCHPLANE_AUTHZ_MANAGED_SET_JSON` owns the primary operator set;
+`LAUNCHPLANE_AUTHZ_MANAGER_PREVIEW_APPROVAL_MANAGED_SET_JSON` owns the generic
+GitHub-human manager preview approval writer set and must declare the exact
+`operator.manager-preview-approval` managed-set identity;
 `LAUNCHPLANE_AUTHZ_PRODUCT_HEALTH_MONITORING_MANAGED_SET_JSON` owns the generic
 Product Health Monitoring wrapper's exact immutable worker grant;
 `LAUNCHPLANE_AUTHZ_ODOO_ROUTE_BINDING_MANAGED_SET_JSON` owns the independent

--- a/tests/test_authz_operator_workflow.py
+++ b/tests/test_authz_operator_workflow.py
@@ -31,6 +31,7 @@ class AuthzOperatorWorkflowTests(unittest.TestCase):
             managed_set_input["options"],
             [
                 "primary",
+                "manager-preview-approval",
                 "product-health-monitoring",
                 "odoo-route-binding",
                 "odoo-external-route-binding",
@@ -48,6 +49,10 @@ class AuthzOperatorWorkflowTests(unittest.TestCase):
             "reconcile-primary": (
                 "${{ inputs.managed_set == 'primary' }}",
                 "${{ secrets.LAUNCHPLANE_AUTHZ_MANAGED_SET_JSON }}",
+            ),
+            "reconcile-manager-preview-approval": (
+                "${{ inputs.managed_set == 'manager-preview-approval' }}",
+                "${{ secrets.LAUNCHPLANE_AUTHZ_MANAGER_PREVIEW_APPROVAL_MANAGED_SET_JSON }}",
             ),
             "reconcile-product-health-monitoring": (
                 "${{ inputs.managed_set == 'product-health-monitoring' }}",
@@ -101,7 +106,7 @@ class AuthzOperatorWorkflowTests(unittest.TestCase):
                     self.dispatch_workflow.job_uses(job_name),
                     "cbusillo/launchplane/.github/workflows/"
                     "reusable-authz-policy-reconcile.yml@"
-                    "4dbef2945b0a297a6edaa949a42d8c7d4cbc01cd",
+                    "39aecc250d6dee91204e24673725bd1ea1ca6bda",
                 )
                 self.assertEqual(
                     self.dispatch_workflow.job_permissions(job_name),
@@ -111,7 +116,13 @@ class AuthzOperatorWorkflowTests(unittest.TestCase):
                 self.assertEqual(dispatch_job["if"], condition)
                 dispatch_inputs = dispatch_job["with"]
                 assert isinstance(dispatch_inputs, dict)
-                self.assertNotIn("expected_managed_set_id", dispatch_inputs)
+                if job_name == "reconcile-manager-preview-approval":
+                    self.assertEqual(
+                        dispatch_inputs["expected_managed_set_id"],
+                        "operator.manager-preview-approval",
+                    )
+                else:
+                    self.assertNotIn("expected_managed_set_id", dispatch_inputs)
                 dispatch_secrets = dispatch_job["secrets"]
                 assert isinstance(dispatch_secrets, dict)
                 self.assertEqual(dispatch_secrets["managed_set_json"], expected_secret)


### PR DESCRIPTION
## Summary
- add a dedicated `manager-preview-approval` managed-set selection
- bind that selection to `operator.manager-preview-approval`
- repin all wrapper jobs to the merged reusable worker revision from #1920
- document and test the protected secret boundary

## Validation
- 2,485 unit tests passed
- `mypy control_plane tests` passed
- targeted Ruff and format checks passed
- `actionlint` passed
- config-authority audit passed
- JetBrains changed-file inspection passed
- independent review found no blocker/high/medium findings

Related to #1919.