### PR TITLE
Establish self-rotating authz reconciler authority

### DIFF
--- a/.github/workflows/authz-policy-reconcile.yml
+++ b/.github/workflows/authz-policy-reconcile.yml
@@ -19,6 +19,7 @@ name: Manage Launchplane Authorization
         type: choice
         options:
           - primary
+          - authz-policy-reconcile
           - manager-preview-approval
           - product-health-monitoring
           - odoo-route-binding
@@ -59,6 +60,18 @@ jobs:
       related_issue: ${{ inputs.related_issue }}
     secrets:
       managed_set_json: ${{ secrets.LAUNCHPLANE_AUTHZ_MANAGED_SET_JSON }}
+
+  reconcile-authz-policy-reconcile:
+    if: ${{ inputs.managed_set == 'authz-policy-reconcile' }}
+    uses: cbusillo/launchplane/.github/workflows/reusable-authz-policy-reconcile.yml@39aecc250d6dee91204e24673725bd1ea1ca6bda # main
+    with:
+      mode: ${{ inputs.mode }}
+      expected_managed_set_id: operator.authz-policy-reconcile
+      reviewed_plan_sha256: ${{ inputs.reviewed_plan_sha256 }}
+      reason: ${{ inputs.reason }}
+      related_issue: ${{ inputs.related_issue }}
+    secrets:
+      managed_set_json: ${{ secrets.LAUNCHPLANE_AUTHZ_POLICY_RECONCILE_MANAGED_SET_JSON }}
 
   reconcile-manager-preview-approval:
     if: ${{ inputs.managed_set == 'manager-preview-approval' }}

--- a/.github/workflows/deploy-launchplane.yml
+++ b/.github/workflows/deploy-launchplane.yml
@@ -21,6 +21,14 @@ on:
           - none
           - dry_run
           - apply
+      authz_managed_set:
+        description: Protected managed set used by the temporary authz bootstrap path.
+        required: false
+        default: primary
+        type: choice
+        options:
+          - primary
+          - authz-policy-reconcile
       authz_managed_reviewed_plan_sha256:
         description: Managed plan SHA-256 returned by the reviewed dry run; required for apply.
         required: false
@@ -1228,7 +1236,8 @@ jobs:
       github.event_name == 'workflow_dispatch' &&
       github.ref_type == 'branch' &&
       github.ref == format('refs/heads/{0}', github.event.repository.default_branch) &&
-      inputs.authz_managed_mode != 'none'
+      inputs.authz_managed_mode != 'none' &&
+      inputs.authz_managed_set == 'primary'
     permissions:
       contents: read
       id-token: write
@@ -1240,6 +1249,26 @@ jobs:
       related_issue: ${{ inputs.authz_managed_related_issue }}
     secrets:
       managed_set_json: ${{ secrets.LAUNCHPLANE_AUTHZ_MANAGED_SET_JSON }}
+
+  operator-authz-policy-reconcile-bootstrap:
+    needs: operator-authz-managed-validate
+    if: >-
+      github.event_name == 'workflow_dispatch' &&
+      github.ref_type == 'branch' &&
+      github.ref == format('refs/heads/{0}', github.event.repository.default_branch) &&
+      inputs.authz_managed_mode != 'none' &&
+      inputs.authz_managed_set == 'authz-policy-reconcile'
+    permissions:
+      contents: read
+      id-token: write
+    uses: cbusillo/launchplane/.github/workflows/reusable-authz-policy-reconcile.yml@4dbef2945b0a297a6edaa949a42d8c7d4cbc01cd # main
+    with:
+      mode: ${{ inputs.authz_managed_mode }}
+      reviewed_plan_sha256: ${{ inputs.authz_managed_reviewed_plan_sha256 }}
+      reason: ${{ inputs.authz_managed_reason }}
+      related_issue: ${{ inputs.authz_managed_related_issue }}
+    secrets:
+      managed_set_json: ${{ secrets.LAUNCHPLANE_AUTHZ_POLICY_RECONCILE_MANAGED_SET_JSON }}
 
   emergency-dokploy-rollback:
     if: >-

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -416,6 +416,9 @@ Operators mutate shared or production authz through the deployed service, not
 through direct DB commands or a local CLI from an arbitrary checkout. Store the
 complete desired rules for one `managed_set_id` in a protected repository
 secret. `LAUNCHPLANE_AUTHZ_MANAGED_SET_JSON` owns the primary operator set;
+`LAUNCHPLANE_AUTHZ_POLICY_RECONCILE_MANAGED_SET_JSON` owns the exact immutable
+policy-admin worker rules for the standalone authz wrapper and must declare the
+`operator.authz-policy-reconcile` managed-set identity;
 `LAUNCHPLANE_AUTHZ_MANAGER_PREVIEW_APPROVAL_MANAGED_SET_JSON` owns the generic
 GitHub-human manager preview approval writer set and must declare the exact
 `operator.manager-preview-approval` managed-set identity;
@@ -457,6 +460,16 @@ secret instead. The JSON owns desired state only: `schema_version`, `product`,
 `managed_set_id`, migration/adoption intent, and `desired_policy`.
 Dispatch-time mode, reason, issue reference, and reviewed plan digest are
 deliberately excluded from that secret.
+
+The policy-admin worker set is self-rotating. Before repinning the standalone
+wrapper, add a distinct exact rule for the next reusable-worker SHA through the
+currently authorized worker, apply the reviewed expansion, then advance the
+wrapper. A first-time recovery may temporarily expose
+`authz_managed_set = authz-policy-reconcile` in the deploy workflow's existing
+authz-only path so the previous immutable worker can add the standalone rule.
+That selector is a bootstrap bridge only: verify the new wrapper, then remove
+the selector in the next change. It must never replace or partially reconstruct
+`LAUNCHPLANE_AUTHZ_MANAGED_SET_JSON`.
 
 The reusable authz worker accepts an optional exact expected managed-set
 identity from a reviewed wrapper. When provided, the worker rejects protected

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -707,6 +707,15 @@ mutable reusable ref may appear only in a reviewed overlap plan when the active
 policy already authorizes that exact ref; narrowing removes it from the same
 stable managed rule after canary evidence.
 
+The standalone policy-admin worker owns its exact immutable grants in the
+separate `operator.authz-policy-reconcile` managed set. Rotate that authority by
+expanding through the currently authorized worker, advancing the wrapper pin,
+verifying the new identity, and then contracting the old rule. When the set is
+first established, the deploy workflow may carry a temporary authz-only
+selector that forwards the dedicated protected secret to the previous worker.
+That bridge does not deploy Launchplane, cannot accept deploy or rollback
+inputs, and is removed after the standalone wrapper succeeds.
+
 Production diagnostic and repair workers do not accept a service URL or OIDC
 audience from their callers. Thin dispatch workflows may forward only the typed
 operation inputs declared by the reusable worker; the worker resolves its

--- a/tests/test_authz_grant_service.py
+++ b/tests/test_authz_grant_service.py
@@ -1482,6 +1482,105 @@ class AuthzManagedPolicyServiceTests(unittest.TestCase):
             (pinned_job_workflow_ref,),
         )
 
+    def test_managed_reconcile_expands_exact_authz_worker_authority(self) -> None:
+        old_job_workflow_ref = (
+            "cbusillo/launchplane/.github/workflows/reusable-authz-policy-reconcile.yml@" + "a" * 40
+        )
+        new_job_workflow_ref = (
+            "cbusillo/launchplane/.github/workflows/reusable-authz-policy-reconcile.yml@" + "b" * 40
+        )
+        deploy_workflow_ref = (
+            "cbusillo/launchplane/.github/workflows/deploy-launchplane.yml@refs/heads/main"
+        )
+        operator_workflow_ref = (
+            "cbusillo/launchplane/.github/workflows/authz-policy-reconcile.yml@refs/heads/main"
+        )
+        current_policy = LaunchplaneAuthzPolicy(
+            schema_version=2,
+            github_actions=(
+                GitHubActionsPolicyRule(
+                    managed_set_id="operator.launchplane",
+                    managed_rule_id="authz.bootstrap",
+                    repository="cbusillo/launchplane",
+                    repository_id="1001",
+                    repository_owner_id="2001",
+                    workflow_refs=(deploy_workflow_ref,),
+                    job_workflow_refs=(old_job_workflow_ref,),
+                    event_names=("workflow_dispatch",),
+                    environments=("launchplane-authz-admin",),
+                    products=("launchplane",),
+                    contexts=("launchplane",),
+                    actions=("authz_policy_grant.write",),
+                ),
+            ),
+        )
+        new_identity = GitHubActionsIdentity(
+            repository="cbusillo/launchplane",
+            repository_owner="cbusillo",
+            repository_id="1001",
+            repository_owner_id="2001",
+            workflow_ref=operator_workflow_ref,
+            job_workflow_ref=new_job_workflow_ref,
+            event_name="workflow_dispatch",
+            ref="refs/heads/main",
+            ref_type="branch",
+            environment="launchplane-authz-admin",
+            subject="repo:cbusillo/launchplane:environment:launchplane-authz-admin",
+            sha="abc123",
+            raw_claims={},
+        )
+        self.assertFalse(
+            current_policy.allows(
+                identity=new_identity,
+                action="authz_policy_grant.write",
+                product="launchplane",
+                context="launchplane",
+            )
+        )
+        request = AuthzManagedPolicyReconcileEnvelope.model_validate(
+            {
+                "schema_version": 2,
+                "product": "launchplane",
+                "managed_set_id": "operator.authz-policy-reconcile",
+                "desired_policy": {
+                    "schema_version": 2,
+                    "github_actions": [
+                        {
+                            "managed_set_id": "operator.authz-policy-reconcile",
+                            "managed_rule_id": "worker.current",
+                            "repository": "cbusillo/launchplane",
+                            "repository_id": "1001",
+                            "repository_owner_id": "2001",
+                            "workflow_refs": [operator_workflow_ref],
+                            "job_workflow_refs": [new_job_workflow_ref],
+                            "event_names": ["workflow_dispatch"],
+                            "environments": ["launchplane-authz-admin"],
+                            "products": ["launchplane"],
+                            "contexts": ["launchplane"],
+                            "actions": ["authz_policy_grant.write"],
+                        }
+                    ],
+                },
+            }
+        )
+
+        _, _, updated_policy, diff = plan_managed_authz_policy_reconcile(
+            record_store=_AuthzPolicyStore((_active_record_for_policy(current_policy),)),
+            request=request,
+        )
+
+        self.assertEqual(diff.added_rule_count, 1)
+        self.assertEqual(diff.removed_rule_count, 0)
+        self.assertTrue(
+            updated_policy.allows(
+                identity=new_identity,
+                action="authz_policy_grant.write",
+                product="launchplane",
+                context="launchplane",
+            )
+        )
+        self.assertEqual(len(updated_policy.github_actions), 2)
+
     def test_active_summary_reports_managed_migration_readiness_counts(self) -> None:
         unpinned_privileged_rule = GitHubActionsPolicyRule(
             repository="cbusillo/launchplane",

--- a/tests/test_authz_operator_workflow.py
+++ b/tests/test_authz_operator_workflow.py
@@ -31,6 +31,7 @@ class AuthzOperatorWorkflowTests(unittest.TestCase):
             managed_set_input["options"],
             [
                 "primary",
+                "authz-policy-reconcile",
                 "manager-preview-approval",
                 "product-health-monitoring",
                 "odoo-route-binding",
@@ -49,6 +50,10 @@ class AuthzOperatorWorkflowTests(unittest.TestCase):
             "reconcile-primary": (
                 "${{ inputs.managed_set == 'primary' }}",
                 "${{ secrets.LAUNCHPLANE_AUTHZ_MANAGED_SET_JSON }}",
+            ),
+            "reconcile-authz-policy-reconcile": (
+                "${{ inputs.managed_set == 'authz-policy-reconcile' }}",
+                "${{ secrets.LAUNCHPLANE_AUTHZ_POLICY_RECONCILE_MANAGED_SET_JSON }}",
             ),
             "reconcile-manager-preview-approval": (
                 "${{ inputs.managed_set == 'manager-preview-approval' }}",
@@ -116,10 +121,14 @@ class AuthzOperatorWorkflowTests(unittest.TestCase):
                 self.assertEqual(dispatch_job["if"], condition)
                 dispatch_inputs = dispatch_job["with"]
                 assert isinstance(dispatch_inputs, dict)
-                if job_name == "reconcile-manager-preview-approval":
+                expected_managed_set_ids = {
+                    "reconcile-authz-policy-reconcile": "operator.authz-policy-reconcile",
+                    "reconcile-manager-preview-approval": "operator.manager-preview-approval",
+                }
+                if job_name in expected_managed_set_ids:
                     self.assertEqual(
                         dispatch_inputs["expected_managed_set_id"],
-                        "operator.manager-preview-approval",
+                        expected_managed_set_ids[job_name],
                     )
                 else:
                     self.assertNotIn("expected_managed_set_id", dispatch_inputs)
@@ -138,6 +147,13 @@ class AuthzOperatorWorkflowTests(unittest.TestCase):
         dispatch_inputs = workflow_dispatch["inputs"]
         assert isinstance(dispatch_inputs, dict)
         self.assertFalse(any(name.startswith("authz_grants_") for name in dispatch_inputs))
+        managed_set_input = dispatch_inputs["authz_managed_set"]
+        assert isinstance(managed_set_input, dict)
+        self.assertEqual(managed_set_input["default"], "primary")
+        self.assertEqual(
+            managed_set_input["options"],
+            ["primary", "authz-policy-reconcile"],
+        )
         managed_job = self.deploy_workflow.job("operator-authz-managed")
         self.assertEqual(
             self.deploy_workflow.job_uses("operator-authz-managed"),
@@ -145,6 +161,7 @@ class AuthzOperatorWorkflowTests(unittest.TestCase):
             "4dbef2945b0a297a6edaa949a42d8c7d4cbc01cd",
         )
         self.assertEqual(managed_job["needs"], "operator-authz-managed-validate")
+        self.assertIn("inputs.authz_managed_set == 'primary'", str(managed_job["if"]))
         self.assertEqual(
             self.deploy_workflow.job_permissions("operator-authz-managed"),
             {"contents": "read", "id-token": "write"},
@@ -162,6 +179,31 @@ class AuthzOperatorWorkflowTests(unittest.TestCase):
             managed_inputs["reviewed_plan_sha256"],
             "${{ inputs.authz_managed_reviewed_plan_sha256 }}",
         )
+        bootstrap_job = self.deploy_workflow.job("operator-authz-policy-reconcile-bootstrap")
+        self.assertEqual(
+            self.deploy_workflow.job_uses("operator-authz-policy-reconcile-bootstrap"),
+            "cbusillo/launchplane/.github/workflows/reusable-authz-policy-reconcile.yml@"
+            "4dbef2945b0a297a6edaa949a42d8c7d4cbc01cd",
+        )
+        self.assertEqual(bootstrap_job["needs"], "operator-authz-managed-validate")
+        self.assertIn(
+            "inputs.authz_managed_set == 'authz-policy-reconcile'",
+            str(bootstrap_job["if"]),
+        )
+        self.assertEqual(
+            self.deploy_workflow.job_permissions("operator-authz-policy-reconcile-bootstrap"),
+            {"contents": "read", "id-token": "write"},
+        )
+        bootstrap_secrets = bootstrap_job["secrets"]
+        assert isinstance(bootstrap_secrets, dict)
+        self.assertEqual(
+            bootstrap_secrets["managed_set_json"],
+            "${{ secrets.LAUNCHPLANE_AUTHZ_POLICY_RECONCILE_MANAGED_SET_JSON }}",
+        )
+        bootstrap_inputs = bootstrap_job["with"]
+        assert isinstance(bootstrap_inputs, dict)
+        self.assertEqual(bootstrap_inputs["mode"], "${{ inputs.authz_managed_mode }}")
+        self.assertNotIn("expected_managed_set_id", bootstrap_inputs)
         validation_step = self.deploy_workflow.step_named(
             "operator-authz-managed-validate", "Validate managed authz isolation"
         )


### PR DESCRIPTION
## Summary
- add a durable `authz-policy-reconcile` managed-set slot on the current reusable worker
- add a bounded temporary deploy authz-only selector that uses the still-authorized previous worker
- keep primary and manager-preview secrets isolated
- test the old-worker-denied/new-worker-authorized policy expansion
- document bootstrap cleanup and future expand/repin/contract rotations

## Validation
- 2,486 unit tests passed
- full mypy passed across 597 files
- targeted Ruff and format checks passed
- actionlint passed for both workflows
- config-authority audit passed
- JetBrains changed-file inspection passed
- independent review found no blocker/high/medium findings

Related to #1922 and blocks #1919.