### PR TITLE
Remove authz reconciler bootstrap bridge

### DIFF
--- a/.github/workflows/deploy-launchplane.yml
+++ b/.github/workflows/deploy-launchplane.yml
@@ -21,14 +21,6 @@ on:
           - none
           - dry_run
           - apply
-      authz_managed_set:
-        description: Protected managed set used by the temporary authz bootstrap path.
-        required: false
-        default: primary
-        type: choice
-        options:
-          - primary
-          - authz-policy-reconcile
       authz_managed_reviewed_plan_sha256:
         description: Managed plan SHA-256 returned by the reviewed dry run; required for apply.
         required: false
@@ -1236,8 +1228,7 @@ jobs:
       github.event_name == 'workflow_dispatch' &&
       github.ref_type == 'branch' &&
       github.ref == format('refs/heads/{0}', github.event.repository.default_branch) &&
-      inputs.authz_managed_mode != 'none' &&
-      inputs.authz_managed_set == 'primary'
+      inputs.authz_managed_mode != 'none'
     permissions:
       contents: read
       id-token: write
@@ -1249,26 +1240,6 @@ jobs:
       related_issue: ${{ inputs.authz_managed_related_issue }}
     secrets:
       managed_set_json: ${{ secrets.LAUNCHPLANE_AUTHZ_MANAGED_SET_JSON }}
-
-  operator-authz-policy-reconcile-bootstrap:
-    needs: operator-authz-managed-validate
-    if: >-
-      github.event_name == 'workflow_dispatch' &&
-      github.ref_type == 'branch' &&
-      github.ref == format('refs/heads/{0}', github.event.repository.default_branch) &&
-      inputs.authz_managed_mode != 'none' &&
-      inputs.authz_managed_set == 'authz-policy-reconcile'
-    permissions:
-      contents: read
-      id-token: write
-    uses: cbusillo/launchplane/.github/workflows/reusable-authz-policy-reconcile.yml@4dbef2945b0a297a6edaa949a42d8c7d4cbc01cd # main
-    with:
-      mode: ${{ inputs.authz_managed_mode }}
-      reviewed_plan_sha256: ${{ inputs.authz_managed_reviewed_plan_sha256 }}
-      reason: ${{ inputs.authz_managed_reason }}
-      related_issue: ${{ inputs.authz_managed_related_issue }}
-    secrets:
-      managed_set_json: ${{ secrets.LAUNCHPLANE_AUTHZ_POLICY_RECONCILE_MANAGED_SET_JSON }}
 
   emergency-dokploy-rollback:
     if: >-

--- a/tests/test_authz_operator_workflow.py
+++ b/tests/test_authz_operator_workflow.py
@@ -147,12 +147,10 @@ class AuthzOperatorWorkflowTests(unittest.TestCase):
         dispatch_inputs = workflow_dispatch["inputs"]
         assert isinstance(dispatch_inputs, dict)
         self.assertFalse(any(name.startswith("authz_grants_") for name in dispatch_inputs))
-        managed_set_input = dispatch_inputs["authz_managed_set"]
-        assert isinstance(managed_set_input, dict)
-        self.assertEqual(managed_set_input["default"], "primary")
-        self.assertEqual(
-            managed_set_input["options"],
-            ["primary", "authz-policy-reconcile"],
+        self.assertNotIn("authz_managed_set", dispatch_inputs)
+        self.assertNotIn(
+            "operator-authz-policy-reconcile-bootstrap",
+            self.deploy_workflow.jobs,
         )
         managed_job = self.deploy_workflow.job("operator-authz-managed")
         self.assertEqual(
@@ -161,7 +159,6 @@ class AuthzOperatorWorkflowTests(unittest.TestCase):
             "4dbef2945b0a297a6edaa949a42d8c7d4cbc01cd",
         )
         self.assertEqual(managed_job["needs"], "operator-authz-managed-validate")
-        self.assertIn("inputs.authz_managed_set == 'primary'", str(managed_job["if"]))
         self.assertEqual(
             self.deploy_workflow.job_permissions("operator-authz-managed"),
             {"contents": "read", "id-token": "write"},
@@ -179,31 +176,6 @@ class AuthzOperatorWorkflowTests(unittest.TestCase):
             managed_inputs["reviewed_plan_sha256"],
             "${{ inputs.authz_managed_reviewed_plan_sha256 }}",
         )
-        bootstrap_job = self.deploy_workflow.job("operator-authz-policy-reconcile-bootstrap")
-        self.assertEqual(
-            self.deploy_workflow.job_uses("operator-authz-policy-reconcile-bootstrap"),
-            "cbusillo/launchplane/.github/workflows/reusable-authz-policy-reconcile.yml@"
-            "4dbef2945b0a297a6edaa949a42d8c7d4cbc01cd",
-        )
-        self.assertEqual(bootstrap_job["needs"], "operator-authz-managed-validate")
-        self.assertIn(
-            "inputs.authz_managed_set == 'authz-policy-reconcile'",
-            str(bootstrap_job["if"]),
-        )
-        self.assertEqual(
-            self.deploy_workflow.job_permissions("operator-authz-policy-reconcile-bootstrap"),
-            {"contents": "read", "id-token": "write"},
-        )
-        bootstrap_secrets = bootstrap_job["secrets"]
-        assert isinstance(bootstrap_secrets, dict)
-        self.assertEqual(
-            bootstrap_secrets["managed_set_json"],
-            "${{ secrets.LAUNCHPLANE_AUTHZ_POLICY_RECONCILE_MANAGED_SET_JSON }}",
-        )
-        bootstrap_inputs = bootstrap_job["with"]
-        assert isinstance(bootstrap_inputs, dict)
-        self.assertEqual(bootstrap_inputs["mode"], "${{ inputs.authz_managed_mode }}")
-        self.assertNotIn("expected_managed_set_id", bootstrap_inputs)
         validation_step = self.deploy_workflow.step_named(
             "operator-authz-managed-validate", "Validate managed authz isolation"
         )


### PR DESCRIPTION
## Summary
- remove the temporary deploy-workflow selector and old-worker bootstrap job
- preserve the durable standalone `authz-policy-reconcile` managed-set slot
- pin the cleanup contract in workflow tests

## Validation
- 2,486 unit tests passed
- actionlint passed
- targeted Ruff and format checks passed
- JetBrains changed-file inspection passed
- the standalone `39aecc…` worker dry-run succeeded with one unchanged rule

Related to #1922.