### PR TITLE
Project manager approval after Odoo preview lifecycle

### DIFF
--- a/control_plane/contracts/idempotency_record.py
+++ b/control_plane/contracts/idempotency_record.py
@@ -154,6 +154,33 @@ def build_launchplane_idempotency_record_id(*, response_trace_id: str) -> str:
     return f"idempotency-{normalized_trace_id}"
 
 
+def build_launchplane_mutation_reservation_id(
+    *,
+    scope: str,
+    route_path: str,
+    idempotency_key: str,
+) -> str:
+    normalized_scope = _normalize_required(scope, "Mutation reservation requires scope.")
+    normalized_route_path = _normalize_required(
+        route_path,
+        "Mutation reservation requires route_path.",
+    )
+    normalized_idempotency_key = _normalize_required(
+        idempotency_key,
+        "Mutation reservation requires idempotency_key.",
+    )
+    record_digest = hashlib.sha256(
+        "\x1f".join(
+            (
+                normalized_scope,
+                normalized_route_path,
+                normalized_idempotency_key,
+            )
+        ).encode("utf-8")
+    ).hexdigest()
+    return f"mutation-reservation-{record_digest}"
+
+
 def build_launchplane_mutation_reservation(
     *,
     scope: str,
@@ -175,17 +202,12 @@ def build_launchplane_mutation_reservation(
         idempotency_key,
         "Mutation reservation requires idempotency_key.",
     )
-    record_digest = hashlib.sha256(
-        "\x1f".join(
-            (
-                normalized_scope,
-                normalized_route_path,
-                normalized_idempotency_key,
-            )
-        ).encode("utf-8")
-    ).hexdigest()
     return LaunchplaneIdempotencyRecord(
-        record_id=f"mutation-reservation-{record_digest}",
+        record_id=build_launchplane_mutation_reservation_id(
+            scope=normalized_scope,
+            route_path=normalized_route_path,
+            idempotency_key=normalized_idempotency_key,
+        ),
         scope=normalized_scope,
         route_path=normalized_route_path,
         idempotency_key=normalized_idempotency_key,

--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -145,7 +145,9 @@ from control_plane.contracts.every_code_work_request import (
 from control_plane.contracts.idempotency_record import (
     LaunchplaneIdempotencyRecord,
     build_launchplane_idempotency_record_id,
+    build_launchplane_mutation_reservation_id,
     complete_launchplane_mutation_reservation,
+    format_launchplane_mutation_timestamp,
 )
 from control_plane.contracts.manager_preview_approval import (
     MANAGER_PREVIEW_APPROVAL_READ_ACTION,
@@ -156,8 +158,10 @@ from control_plane.contracts.manager_preview_approval_projection import (
 from control_plane.manager_preview_approval_github_webhook import (
     MANAGER_PREVIEW_APPROVAL_RECONCILE_ROUTE,
     MANAGER_PREVIEW_APPROVAL_WEBHOOK_ROUTE,
+    record_manager_preview_approval_invalidation_for_pr,
     reconcile_all_manager_preview_approvals_best_effort,
     reconcile_manager_preview_approval_for_pr,
+    reconcile_manager_preview_approval_for_pr_best_effort,
 )
 from control_plane.provider_operations import (
     DurableProviderMutationAdapter,
@@ -336,8 +340,10 @@ from control_plane.odoo_preview_apply_http import (
     OdooPreviewApplyProductMismatchError,
     OdooPreviewApplyRouteDependencyError,
     OdooPreviewPlanProvenanceError,
+    apply_odoo_preview_lifecycle_evidence,
     build_odoo_preview_apply_inputs_result,
     build_odoo_preview_plan_id,
+    build_odoo_preview_runtime_identity,
     driver_result_contains_status,
     execute_odoo_preview_apply_result,
     issue_odoo_preview_apply_plan,
@@ -345,6 +351,8 @@ from control_plane.odoo_preview_apply_http import (
     odoo_preview_destroy_supersession_is_quiescent,
     resolve_odoo_preview_apply_profile,
     validate_odoo_preview_issued_plan,
+    validate_odoo_preview_lifecycle_response_current,
+    validate_odoo_preview_profile_authority,
 )
 from control_plane.odoo_post_deploy_http import (
     ODOO_CONFIG_PARAMETER_OVERRIDE_ROUTE as _ODOO_CONFIG_PARAMETER_OVERRIDE_ROUTE,
@@ -482,6 +490,7 @@ from control_plane.workflows.odoo_prod_backup_restore import (
 from control_plane.workflows.odoo_preview_runtime import (
     ODOO_PREVIEW_DESTROY_SUPERSESSION_GRACE_SECONDS,
     OdooPreviewApplyInputsResult,
+    OdooPreviewDokployApplyResult,
 )
 from control_plane.contracts.product_environment_read_model import (
     ActionAllowed,
@@ -1384,6 +1393,7 @@ class _OdooPreviewProviderMutationAdapter:
         issued_plan: OdooPreviewApplyInputsResult,
         database_url: str | None,
         trace_id: str,
+        deployment_record_id: str,
     ) -> None:
         self._control_plane_root = control_plane_root
         self._record_store = record_store
@@ -1392,6 +1402,16 @@ class _OdooPreviewProviderMutationAdapter:
         self._issued_plan = issued_plan
         self._database_url = database_url
         self._trace_id = trace_id
+        self._deployment_record_id = deployment_record_id
+        self._runtime_identity = (
+            build_odoo_preview_runtime_identity(
+                profile=profile,
+                issued_plan=issued_plan,
+                deployment_record_id=deployment_record_id,
+            )
+            if issued_plan.operation == "refresh"
+            else None
+        )
 
     def reconciliation_key(self) -> str:
         plan = self._apply_request.apply.dry_run_plan
@@ -1402,6 +1422,57 @@ class _OdooPreviewProviderMutationAdapter:
     def target_key(self) -> str:
         reconciliation_key = self.reconciliation_key()
         return f"dokploy-provider-target:{hashlib.sha256(reconciliation_key.encode('utf-8')).hexdigest()}"
+
+    def _destroy_invalidation_records(self) -> dict[str, object]:
+        provenance = self._issued_plan.plan_provenance
+        if provenance is None:
+            raise ValueError("Odoo preview destroy requires issued plan provenance.")
+        result = record_manager_preview_approval_invalidation_for_pr(
+            repository=self._profile.repository,
+            pr_number=self._issued_plan.plan_request.pr_number,
+            reason="The serving preview was destroyed.",
+            source_event_kind="preview_destroy",
+            source_event_id=f"odoo-preview-destroy:{provenance.plan_id}",
+            record_store=cast(Any, self._record_store),
+            occurred_at=format_launchplane_mutation_timestamp(provenance.issued_at),
+        )
+        return {
+            "manager_preview_approval_required": bool(result.get("required")),
+            "manager_preview_invalidation_event_status": str(result.get("event_status") or ""),
+        }
+
+    def _finalize_successful_result(
+        self,
+        driver_result: dict[str, object],
+    ) -> tuple[dict[str, object], dict[str, object], int]:
+        lifecycle_records = apply_odoo_preview_lifecycle_evidence(
+            control_plane_root_path=self._control_plane_root,
+            record_store=self._record_store,
+            profile=self._profile,
+            issued_plan=self._issued_plan,
+            driver_result=driver_result,
+            runtime_identity=self._runtime_identity,
+            before_destroy=(
+                self._destroy_invalidation_records
+                if self._issued_plan.operation == "destroy"
+                else None
+            ),
+        )
+        lifecycle_status = str(lifecycle_records.get("lifecycle_evidence_status") or "").strip()
+        if lifecycle_status == "stale":
+            blocked_result = OdooPreviewDokployApplyResult.model_validate(driver_result).model_copy(
+                update={
+                    "status": "blocked",
+                    "error_message": (
+                        "The Odoo preview operation completed at the provider but was "
+                        "superseded by newer Launchplane lifecycle authority."
+                    ),
+                }
+            )
+            return blocked_result.model_dump(mode="json"), lifecycle_records, 409
+        if lifecycle_status not in {"applied", "replayed"}:
+            raise ValueError("Successful Odoo preview apply requires lifecycle evidence.")
+        return driver_result, lifecycle_records, 202
 
     def observe(
         self,
@@ -1424,13 +1495,19 @@ class _OdooPreviewProviderMutationAdapter:
                 retry_safe=retry_safe,
             )
         driver_result.pop("provider_effect_attempted", None)
+        response_status_code = 202
+        records: dict[str, object] = {}
+        if str(driver_result.get("status", "")).strip() == "pass":
+            driver_result, records, response_status_code = self._finalize_successful_result(
+                driver_result
+            )
         terminal_failure = str(driver_result.get("status", "")).strip() == "fail"
         return ProviderObservation(
             outcome="present",
-            response_status_code=502 if terminal_failure else 202,
+            response_status_code=502 if terminal_failure else response_status_code,
             response_payload=_provider_operation_response_payload(
                 trace_id=self._trace_id,
-                records={},
+                records=records,
                 result=driver_result,
             ),
         )
@@ -1449,6 +1526,8 @@ class _OdooPreviewProviderMutationAdapter:
                 provider_operation_title=provider_operation_title(provider_operation_key),
                 provider_effect_checkpoint=lease.checkpoint_effect,
                 provider_lease_check=lease.assert_current,
+                deployment_record_id=self._deployment_record_id,
+                runtime_identity=self._runtime_identity,
             )
         except (
             OdooPreviewApplyConfigError,
@@ -1464,15 +1543,28 @@ class _OdooPreviewProviderMutationAdapter:
                 str(driver_result.get("error_message", "")).strip()
                 or "Odoo preview provider outcome requires reconciliation."
             )
+        response_status_code = 202
+        records: dict[str, object] = {}
+        lifecycle_finalized = driver_status == "pass"
+        if lifecycle_finalized:
+            lease.assert_current()
+            driver_result, records, response_status_code = self._finalize_successful_result(
+                driver_result
+            )
+            lease.assert_current()
+            driver_status = str(driver_result.get("status", "")).strip()
         return ProviderMutationOutcome(
-            response_status_code=202,
+            response_status_code=response_status_code,
             response_payload=_provider_operation_response_payload(
                 trace_id=self._trace_id,
-                records={},
+                records=records,
                 result=driver_result,
             ),
-            durable=not driver_result_contains_status(driver_result, "blocked")
-            and driver_status != "fail",
+            durable=lifecycle_finalized
+            or (
+                not driver_result_contains_status(driver_result, "blocked")
+                and driver_status != "fail"
+            ),
             provider_effect_performed=provider_effect_attempted,
         )
 
@@ -5659,6 +5751,10 @@ def create_launchplane_fastapi_app(
                 issued_plan=issued_plan,
                 request=apply_request,
             )
+            validate_odoo_preview_profile_authority(
+                profile=product_profile,
+                issued_plan=issued_plan,
+            )
         except ValidationError as error:
             raise _launchplane_http_error(
                 status_code=409,
@@ -5685,6 +5781,11 @@ def create_launchplane_fastapi_app(
             issued_plan=issued_plan,
             database_url=getattr(record_store, "database_url", None),
             trace_id=trace_id,
+            deployment_record_id=build_launchplane_mutation_reservation_id(
+                scope=idempotency_scope(identity),
+                route_path=_ODOO_PREVIEW_APPLY_ROUTE,
+                idempotency_key=normalized_idempotency_key,
+            ),
         )
         target_supersession = None
         if service_apply_request.apply.dry_run_plan.operation == "destroy":
@@ -5711,7 +5812,7 @@ def create_launchplane_fastapi_app(
                 ),
             )
         try:
-            return await run_provider_mutation(
+            response = await run_provider_mutation(
                 record_store=record_store,
                 identity=identity,
                 route_path=_ODOO_PREVIEW_APPLY_ROUTE,
@@ -5726,6 +5827,23 @@ def create_launchplane_fastapi_app(
                 reconcile_message=("The Odoo preview apply requires reconciliation before retry."),
                 target_supersession=target_supersession,
             )
+            driver_result = response.result or {}
+            if str(driver_result.get("status") or "").strip() != "pass":
+                return response
+            validate_odoo_preview_lifecycle_response_current(
+                record_store=record_store,
+                profile=product_profile,
+                issued_plan=issued_plan,
+                records=response.records,
+            )
+            pr_number = issued_plan.plan_request.pr_number
+            reconcile_manager_preview_approval_for_pr_best_effort(
+                repository=product_profile.repository,
+                pr_number=pr_number,
+                record_store=record_store,
+                control_plane_root=resolved_control_plane_root,
+            )
+            return response
         except OdooPreviewPlanProvenanceError as error:
             raise _launchplane_http_error(
                 status_code=409,

--- a/control_plane/manager_preview_approval_github_webhook.py
+++ b/control_plane/manager_preview_approval_github_webhook.py
@@ -12,6 +12,7 @@ from typing import Protocol, cast
 
 import click
 
+from control_plane.contracts.manager_preview_approval import ManagerPreviewApprovalBinding
 from control_plane.contracts.manager_preview_approval_projection import (
     ManagerPreviewApprovalCommand,
     ManagerPreviewApprovalCommandAction,
@@ -271,48 +272,23 @@ def invalidate_manager_preview_approval_for_pr(
     record_store: ManagerPreviewApprovalGitHubStore,
     control_plane_root: Path,
     occurred_at: str = "",
+    binding: ManagerPreviewApprovalBinding | None = None,
     dependencies: ManagerPreviewApprovalGitHubDependencies | None = None,
 ) -> dict[str, object]:
     resolved_dependencies = dependencies or ManagerPreviewApprovalGitHubDependencies()
     resolved_occurred_at = occurred_at.strip() or resolved_dependencies.now_timestamp()
-    profile = _product_profile(record_store, repository)
-    policy_record = read_active_authz_policy_record(record_store)
-    if not manager_preview_approval_required(
-        policy_record=policy_record,
-        product=profile.product,
-        context=profile.preview.context,
-    ):
-        return {"required": False, "event_status": "not_required"}
-    event_status: str
-    try:
-        preview, generation = _preview_and_generation(
-            record_store=record_store,
-            profile=profile,
-            repository=repository,
-            pr_number=pr_number,
-        )
-        binding = build_current_manager_preview_approval_binding(
-            product=profile.product,
-            preview=preview,
-            generation=generation,
-        )
-        event_status = record_store.write_manager_preview_approval_event_record(
-            build_manager_preview_approval_system_event(
-                binding=binding,
-                action="invalidated",
-                occurred_at=resolved_occurred_at,
-                source_event_kind=source_event_kind,
-                source_event_id=source_event_id,
-                reason=reason,
-            )
-        )
-    except (
-        FileNotFoundError,
-        LookupError,
-        ManagerPreviewApprovalEvidenceError,
-        ValueError,
-    ):
-        event_status = "unavailable"
+    event_result = record_manager_preview_approval_invalidation_for_pr(
+        repository=repository,
+        pr_number=pr_number,
+        reason=reason,
+        source_event_kind=source_event_kind,
+        source_event_id=source_event_id,
+        record_store=record_store,
+        occurred_at=resolved_occurred_at,
+        binding=binding,
+    )
+    if not event_result["required"]:
+        return event_result
     projection = reconcile_manager_preview_approval_for_pr(
         repository=repository,
         pr_number=pr_number,
@@ -321,7 +297,76 @@ def invalidate_manager_preview_approval_for_pr(
         evaluated_at=resolved_occurred_at,
         dependencies=resolved_dependencies,
     )
-    return {"required": True, "event_status": event_status, **projection}
+    return {**event_result, **projection}
+
+
+def record_manager_preview_approval_invalidation_for_pr(
+    *,
+    repository: str,
+    pr_number: int,
+    reason: str,
+    source_event_kind: str,
+    source_event_id: str,
+    record_store: ManagerPreviewApprovalGitHubStore,
+    occurred_at: str,
+    binding: ManagerPreviewApprovalBinding | None = None,
+) -> dict[str, object]:
+    try:
+        profile = _product_profile(record_store, repository)
+        policy_record = read_active_authz_policy_record(record_store)
+    except (FileNotFoundError, LookupError, ValueError):
+        return {"required": False, "event_status": "unavailable"}
+    if not manager_preview_approval_required(
+        policy_record=policy_record,
+        product=profile.product,
+        context=profile.preview.context,
+    ):
+        return {"required": False, "event_status": "not_required"}
+    try:
+        resolved_binding = binding or current_manager_preview_approval_binding_for_pr(
+            repository=repository,
+            pr_number=pr_number,
+            record_store=record_store,
+        )
+    except (
+        FileNotFoundError,
+        LookupError,
+        ManagerPreviewApprovalEvidenceError,
+        ValueError,
+    ):
+        return {"required": True, "event_status": "unavailable"}
+    event_status = record_store.write_manager_preview_approval_event_record(
+        build_manager_preview_approval_system_event(
+            binding=resolved_binding,
+            action="invalidated",
+            occurred_at=occurred_at,
+            source_event_kind=source_event_kind,
+            source_event_id=source_event_id,
+            reason=reason,
+        )
+    )
+    return {"required": True, "event_status": event_status}
+
+
+def current_manager_preview_approval_binding_for_pr(
+    *,
+    repository: str,
+    pr_number: int,
+    record_store: object,
+) -> ManagerPreviewApprovalBinding:
+    store = cast(ManagerPreviewApprovalGitHubStore, record_store)
+    profile = _product_profile(store, repository)
+    preview, generation = _preview_and_generation(
+        record_store=store,
+        profile=profile,
+        repository=repository,
+        pr_number=pr_number,
+    )
+    return build_current_manager_preview_approval_binding(
+        product=profile.product,
+        preview=preview,
+        generation=generation,
+    )
 
 
 def reconcile_manager_preview_approval_for_pr_best_effort(
@@ -373,6 +418,8 @@ def invalidate_manager_preview_approval_for_pr_best_effort(
     source_event_id: str,
     record_store: object,
     control_plane_root: Path,
+    occurred_at: str = "",
+    binding: ManagerPreviewApprovalBinding | None = None,
     dependencies: ManagerPreviewApprovalGitHubDependencies | None = None,
 ) -> bool:
     try:
@@ -384,6 +431,8 @@ def invalidate_manager_preview_approval_for_pr_best_effort(
             source_event_id=source_event_id,
             record_store=cast(ManagerPreviewApprovalGitHubStore, record_store),
             control_plane_root=control_plane_root,
+            occurred_at=occurred_at,
+            binding=binding,
             dependencies=dependencies,
         )
     except Exception:

--- a/control_plane/odoo_preview_apply_http.py
+++ b/control_plane/odoo_preview_apply_http.py
@@ -9,10 +9,30 @@ import click
 from pydantic import Field, model_validator
 
 from control_plane import runtime_environments as control_plane_runtime_environments
+from control_plane.contracts.artifact_dependency_provenance import (
+    normalize_artifact_git_commit,
+    normalize_artifact_sha256_digest,
+)
+from control_plane.contracts.idempotency_record import (
+    format_launchplane_mutation_timestamp,
+    parse_launchplane_mutation_timestamp,
+)
+from control_plane.contracts.preview_generation_record import PreviewGenerationRecord
+from control_plane.contracts.preview_mutation_request import (
+    PreviewGenerationMutationRequest,
+    PreviewMutationRequest,
+)
+from control_plane.contracts.preview_record import PreviewRecord
 from control_plane.contracts.product_profile_record import LaunchplaneProductProfileRecord
+from control_plane.contracts.runtime_identity import RuntimeIdentity, runtime_identity_env
 from control_plane.drivers.dispatch import (
     _ProductRouteEnvelope,
     _validate_driver_envelope_product,
+)
+from control_plane.launchplane_mutations import (
+    LaunchplaneMutationStore,
+    apply_launchplane_generation_evidence,
+    build_launchplane_preview_from_request,
 )
 from control_plane.odoo_product_driver_http import (
     OdooProductMismatchError,
@@ -25,17 +45,24 @@ from control_plane.workflows.odoo_preview_runtime import (
     OdooPreviewApplyPlanProvenance,
     OdooPreviewApplyInputsRequest,
     OdooPreviewDokployApplyRequest,
+    OdooPreviewDokployApplyResult,
     build_odoo_preview_apply_inputs,
     execute_odoo_preview_dokploy_apply,
     observe_odoo_preview_dokploy_apply,
     odoo_preview_destroy_target_is_quiescent,
     odoo_preview_apply_plan_sha256,
 )
+from control_plane.workflows.launchplane import (
+    apply_preview_destroyed_transition,
+    find_preview_record,
+    generate_preview_id,
+)
 
 
 ODOO_PREVIEW_APPLY_ROUTE = "/v1/drivers/odoo/preview-apply"
 ODOO_PREVIEW_APPLY_INPUTS_ROUTE = "/v1/drivers/odoo/preview-apply-inputs"
 ODOO_PREVIEW_PLAN_TTL_SECONDS = 30 * 60
+_ODOO_PREVIEW_DESTROY_REASON_PREFIX = "odoo_preview_destroy"
 
 
 class OdooPreviewApplyProductMismatchError(ValueError):
@@ -210,6 +237,33 @@ def validate_odoo_preview_issued_plan(
     return request.model_copy(update={"apply": service_apply_request})
 
 
+def validate_odoo_preview_profile_authority(
+    *,
+    profile: LaunchplaneProductProfileRecord,
+    issued_plan: OdooPreviewApplyInputsResult,
+) -> None:
+    if profile.product != issued_plan.product:
+        raise OdooPreviewPlanProvenanceError(
+            code="odoo_preview_plan_stale",
+            message="Odoo preview plan product no longer matches current service authority.",
+        )
+    if profile.repository != issued_plan.repository:
+        raise OdooPreviewPlanProvenanceError(
+            code="odoo_preview_plan_stale",
+            message="Odoo preview plan repository no longer matches current service authority.",
+        )
+    if profile.preview.context != issued_plan.context:
+        raise OdooPreviewPlanProvenanceError(
+            code="odoo_preview_plan_stale",
+            message="Odoo preview plan context no longer matches current service authority.",
+        )
+    if profile.preview.template_instance != issued_plan.template_instance:
+        raise OdooPreviewPlanProvenanceError(
+            code="odoo_preview_plan_stale",
+            message="Odoo preview plan template no longer matches current service authority.",
+        )
+
+
 def refresh_odoo_preview_issued_plan(
     *,
     control_plane_root: Path,
@@ -282,6 +336,8 @@ def execute_odoo_preview_apply_result(
     provider_operation_title: str = "",
     provider_effect_checkpoint: Callable[[str], None] | None = None,
     provider_lease_check: Callable[[], None] | None = None,
+    deployment_record_id: str,
+    runtime_identity: RuntimeIdentity | None = None,
 ) -> dict[str, object]:
     current_request = refresh_odoo_preview_issued_plan(
         control_plane_root=control_plane_root_path,
@@ -299,6 +355,20 @@ def execute_odoo_preview_apply_result(
         apply_request=current_request.apply,
         database_url=database_url,
     )
+    resolved_runtime_identity = runtime_identity
+    if current_request.apply.dry_run_plan.operation == "refresh":
+        expected_runtime_identity = build_odoo_preview_runtime_identity(
+            profile=profile,
+            issued_plan=issued_plan,
+            deployment_record_id=deployment_record_id,
+        )
+        if resolved_runtime_identity is None:
+            resolved_runtime_identity = expected_runtime_identity
+        elif resolved_runtime_identity != expected_runtime_identity:
+            raise ValueError("Odoo preview runtime identity does not match issued authority.")
+        resolved_environment_values.update(runtime_identity_env(resolved_runtime_identity))
+    elif resolved_runtime_identity is not None:
+        raise ValueError("Odoo preview destroy cannot include runtime identity.")
     service_dry_run_plan = current_request.apply.dry_run_plan.model_copy(
         update={
             "domain_certificate_type": profile.preview.domain_certificate_type,
@@ -308,6 +378,7 @@ def execute_odoo_preview_apply_result(
         update={
             "dry_run_plan": service_dry_run_plan,
             "environment_values": resolved_environment_values,
+            "smoke_check": service_dry_run_plan.operation == "refresh",
         }
     )
     driver_result = execute_odoo_preview_dokploy_apply(
@@ -317,6 +388,7 @@ def execute_odoo_preview_apply_result(
         provider_operation_title=provider_operation_title,
         provider_effect_checkpoint=provider_effect_checkpoint,
         provider_lease_check=provider_lease_check,
+        expected_runtime_identity=resolved_runtime_identity,
     )
     return driver_result.model_dump(mode="json")
 
@@ -343,6 +415,430 @@ def observe_odoo_preview_apply_result(
     return observation.outcome, observation.result.model_dump(mode="json"), False
 
 
+def apply_odoo_preview_lifecycle_evidence(
+    *,
+    control_plane_root_path: Path,
+    record_store: object,
+    profile: LaunchplaneProductProfileRecord,
+    issued_plan: OdooPreviewApplyInputsResult,
+    driver_result: dict[str, object],
+    runtime_identity: RuntimeIdentity | None = None,
+    before_destroy: Callable[[], dict[str, object]] | None = None,
+) -> dict[str, object]:
+    result = OdooPreviewDokployApplyResult.model_validate(driver_result)
+    if result.status != "pass":
+        return {}
+    if result.operation != issued_plan.operation:
+        raise ValueError("Odoo preview result operation does not match the issued plan.")
+    if result.repository != profile.repository:
+        raise ValueError("Odoo preview result repository does not match the product profile.")
+    if result.compose_name != issued_plan.dry_run_plan.compose_name:
+        raise ValueError("Odoo preview result compose does not match the issued plan.")
+    if result.preview_url != issued_plan.preview_url:
+        raise ValueError("Odoo preview result URL does not match the issued plan.")
+
+    provenance = issued_plan.plan_provenance
+    if provenance is None:
+        raise ValueError("Ready Odoo preview apply requires issued plan provenance.")
+    anchor_repo = _odoo_preview_anchor_repo(profile.repository)
+    pr_number = issued_plan.plan_request.pr_number
+    preview_id = generate_preview_id(
+        context_name=profile.preview.context,
+        anchor_repo=anchor_repo,
+        anchor_pr_number=pr_number,
+    )
+    requested_at = format_launchplane_mutation_timestamp(provenance.issued_at)
+    completed_at = requested_at
+    typed_record_store = cast(LaunchplaneMutationStore, record_store)
+    existing_preview = find_preview_record(
+        record_store=typed_record_store,
+        context_name=profile.preview.context,
+        anchor_repo=anchor_repo,
+        anchor_pr_number=pr_number,
+    )
+    if result.operation == "destroy":
+        destroy_reason = _odoo_preview_destroy_reason(
+            plan_id=provenance.plan_id,
+            issued_at=requested_at,
+        )
+        if existing_preview is not None and existing_preview.destroy_reason == destroy_reason:
+            return _odoo_preview_lifecycle_records(
+                preview=existing_preview,
+                status="replayed",
+                transition="destroyed",
+            )
+        if existing_preview is not None and _odoo_preview_operation_is_stale(
+            record_store=typed_record_store,
+            preview=existing_preview,
+            issued_at=requested_at,
+        ):
+            return _odoo_preview_lifecycle_records(
+                preview=existing_preview,
+                status="stale",
+                transition=existing_preview.state,
+            )
+        destroy_records = before_destroy() if before_destroy is not None else {}
+        preview_request = PreviewMutationRequest(
+            context=profile.preview.context,
+            anchor_repo=anchor_repo,
+            anchor_pr_number=pr_number,
+            anchor_pr_url=f"https://github.com/{profile.repository}/pull/{pr_number}",
+            canonical_url=issued_plan.preview_url,
+            state="active",
+            created_at=requested_at,
+            updated_at=completed_at,
+            eligible_at=requested_at,
+        )
+        preview_record = build_launchplane_preview_from_request(
+            control_plane_root_path=control_plane_root_path,
+            record_store=typed_record_store,
+            request=preview_request,
+        )
+        transitioned_preview = apply_preview_destroyed_transition(
+            preview=preview_record,
+            destroyed_at=completed_at,
+            destroy_reason=destroy_reason,
+        )
+        preview_path = typed_record_store.write_preview_record(transitioned_preview)
+        return {
+            **destroy_records,
+            **_odoo_preview_lifecycle_records(
+                preview=transitioned_preview,
+                status="applied",
+                transition="destroyed",
+            ),
+            "preview_path": (
+                transitioned_preview.preview_id
+                if preview_path is None
+                else str(preview_path).strip() or transitioned_preview.preview_id
+            ),
+        }
+
+    if runtime_identity is None:
+        raise ValueError("Successful Odoo preview refresh requires verified runtime identity.")
+    expected_runtime_identity = build_odoo_preview_runtime_identity(
+        profile=profile,
+        issued_plan=issued_plan,
+        deployment_record_id=runtime_identity.deployment_record_id,
+    )
+    if runtime_identity != expected_runtime_identity:
+        raise ValueError("Verified Odoo preview runtime identity does not match issued authority.")
+    generation_id = runtime_identity.preview_generation_id
+    existing_generation = next(
+        (
+            generation
+            for generation in typed_record_store.list_preview_generation_records(
+                preview_id=preview_id
+            )
+            if generation.generation_id == generation_id
+        ),
+        None,
+    )
+    if (
+        existing_generation is not None
+        and existing_preview is not None
+        and existing_preview.state == "active"
+        and existing_preview.serving_generation_id == generation_id
+    ):
+        return _odoo_preview_lifecycle_records(
+            preview=existing_preview,
+            generation=existing_generation,
+            status="replayed",
+            transition=existing_generation.state,
+        )
+    if existing_preview is not None and _odoo_preview_operation_is_stale(
+        record_store=typed_record_store,
+        preview=existing_preview,
+        issued_at=requested_at,
+    ):
+        return _odoo_preview_lifecycle_records(
+            preview=existing_preview,
+            status="stale",
+            transition=existing_preview.state,
+        )
+    if existing_generation is not None and existing_preview is not None:
+        return _odoo_preview_lifecycle_records(
+            preview=existing_preview,
+            generation=existing_generation,
+            status="replayed",
+            transition=existing_generation.state,
+        )
+
+    anchor_pr_url = f"https://github.com/{profile.repository}/pull/{pr_number}"
+    preview_request = PreviewMutationRequest(
+        context=profile.preview.context,
+        anchor_repo=anchor_repo,
+        anchor_pr_number=pr_number,
+        anchor_pr_url=anchor_pr_url,
+        canonical_url=issued_plan.preview_url,
+        state="active",
+        created_at=requested_at,
+        updated_at=completed_at,
+        eligible_at=requested_at,
+    )
+    generation_request = PreviewGenerationMutationRequest(
+        context=profile.preview.context,
+        anchor_repo=anchor_repo,
+        anchor_pr_number=pr_number,
+        anchor_pr_url=anchor_pr_url,
+        anchor_head_sha=runtime_identity.source_git_ref,
+        generation_id=generation_id,
+        state="ready",
+        requested_reason="odoo_preview_refresh",
+        requested_at=requested_at,
+        started_at=requested_at,
+        ready_at=completed_at,
+        finished_at=completed_at,
+        resolved_manifest_fingerprint=f"odoo-preview-plan-{provenance.plan_sha256}",
+        artifact_id=runtime_identity.artifact_id,
+        deploy_status="pass",
+        verify_status="pass",
+        overall_health_status="pass",
+        runtime_identity=runtime_identity,
+    )
+    records = apply_launchplane_generation_evidence(
+        control_plane_root_path=control_plane_root_path,
+        record_store=typed_record_store,
+        preview_request=preview_request,
+        generation_request=generation_request,
+    )
+    return {**records, "lifecycle_evidence_status": "applied"}
+
+
+def validate_odoo_preview_lifecycle_response_current(
+    *,
+    record_store: object,
+    profile: LaunchplaneProductProfileRecord,
+    issued_plan: OdooPreviewApplyInputsResult,
+    records: dict[str, object],
+) -> None:
+    lifecycle_status = str(records.get("lifecycle_evidence_status") or "").strip()
+    if lifecycle_status not in {"applied", "replayed"}:
+        raise OdooPreviewPlanProvenanceError(
+            code="odoo_preview_lifecycle_evidence_missing",
+            message="Odoo preview apply did not produce current lifecycle evidence.",
+        )
+    provenance = issued_plan.plan_provenance
+    if provenance is None:
+        raise OdooPreviewPlanProvenanceError(
+            code="odoo_preview_plan_not_issued",
+            message="Odoo preview lifecycle validation requires issued plan provenance.",
+        )
+    anchor_repo = _odoo_preview_anchor_repo(profile.repository)
+    pr_number = issued_plan.plan_request.pr_number
+    preview_id = generate_preview_id(
+        context_name=profile.preview.context,
+        anchor_repo=anchor_repo,
+        anchor_pr_number=pr_number,
+    )
+    if str(records.get("preview_id") or "").strip() != preview_id:
+        raise OdooPreviewPlanProvenanceError(
+            code="odoo_preview_lifecycle_evidence_missing",
+            message="Odoo preview lifecycle evidence does not match the issued preview.",
+        )
+    typed_record_store = cast(LaunchplaneMutationStore, record_store)
+    preview = find_preview_record(
+        record_store=typed_record_store,
+        context_name=profile.preview.context,
+        anchor_repo=anchor_repo,
+        anchor_pr_number=pr_number,
+    )
+    if preview is None:
+        raise OdooPreviewPlanProvenanceError(
+            code="odoo_preview_operation_superseded",
+            message="Odoo preview lifecycle ownership is no longer current.",
+        )
+    if issued_plan.operation == "destroy":
+        expected_destroy_reason = _odoo_preview_destroy_reason(
+            plan_id=provenance.plan_id,
+            issued_at=format_launchplane_mutation_timestamp(provenance.issued_at),
+        )
+        if preview.state == "destroyed" and preview.destroy_reason == expected_destroy_reason:
+            return
+        raise OdooPreviewPlanProvenanceError(
+            code="odoo_preview_operation_superseded",
+            message="Odoo preview destroy is no longer the current lifecycle owner.",
+        )
+    generation_id = _odoo_preview_generation_id(
+        preview_id=preview_id,
+        plan_id=provenance.plan_id,
+    )
+    if str(records.get("generation_id") or "").strip() != generation_id:
+        raise OdooPreviewPlanProvenanceError(
+            code="odoo_preview_lifecycle_evidence_missing",
+            message="Odoo preview lifecycle evidence does not match the issued generation.",
+        )
+    generation = next(
+        (
+            candidate
+            for candidate in typed_record_store.list_preview_generation_records(
+                preview_id=preview_id
+            )
+            if candidate.generation_id == generation_id
+        ),
+        None,
+    )
+    if (
+        preview.state == "active"
+        and preview.serving_generation_id == generation_id
+        and generation is not None
+        and generation.state == "ready"
+    ):
+        return
+    raise OdooPreviewPlanProvenanceError(
+        code="odoo_preview_operation_superseded",
+        message="Odoo preview refresh is no longer the current serving generation.",
+    )
+
+
+def build_odoo_preview_runtime_identity(
+    *,
+    profile: LaunchplaneProductProfileRecord,
+    issued_plan: OdooPreviewApplyInputsResult,
+    deployment_record_id: str,
+) -> RuntimeIdentity:
+    if issued_plan.operation != "refresh":
+        raise ValueError("Odoo preview runtime identity requires a refresh plan.")
+    provenance = issued_plan.plan_provenance
+    if provenance is None:
+        raise ValueError("Ready Odoo preview apply requires issued plan provenance.")
+    normalized_deployment_record_id = deployment_record_id.strip()
+    if not normalized_deployment_record_id:
+        raise ValueError("Odoo preview runtime identity requires deployment_record_id.")
+    anchor_repo = _odoo_preview_anchor_repo(profile.repository)
+    pr_number = issued_plan.plan_request.pr_number
+    preview_id = generate_preview_id(
+        context_name=profile.preview.context,
+        anchor_repo=anchor_repo,
+        anchor_pr_number=pr_number,
+    )
+    generation_id = _odoo_preview_generation_id(
+        preview_id=preview_id,
+        plan_id=provenance.plan_id,
+    )
+    manifest = issued_plan.plan_request.manifest
+    image_reference = (
+        f"{manifest.image.repository}@{manifest.image.digest}"
+        if manifest is not None
+        else issued_plan.plan_request.image_reference
+    )
+    image_digest = image_reference.rpartition("@")[2]
+    normalize_artifact_sha256_digest(
+        image_digest,
+        label="Odoo preview runtime image digest",
+    )
+    source_git_ref = normalize_artifact_git_commit(
+        manifest.source_commit if manifest is not None else issued_plan.plan_request.source_git_ref,
+        label="Odoo preview runtime source_git_ref",
+    )
+    artifact_id = manifest.artifact_id if manifest is not None else image_reference
+    return RuntimeIdentity(
+        product=profile.product,
+        context=profile.preview.context,
+        instance=issued_plan.dry_run_plan.compose_name,
+        environment_kind="preview",
+        deployment_record_id=normalized_deployment_record_id,
+        artifact_id=artifact_id,
+        source_git_ref=source_git_ref,
+        image_reference=image_reference,
+        preview_id=preview_id,
+        preview_generation_id=generation_id,
+        deployed_at=format_launchplane_mutation_timestamp(provenance.issued_at),
+    )
+
+
+def _odoo_preview_generation_id(*, preview_id: str, plan_id: str) -> str:
+    return f"{preview_id}-odoo-{_odoo_preview_operation_token(plan_id)}"
+
+
+def _odoo_preview_operation_token(plan_id: str) -> str:
+    normalized_plan_id = plan_id.strip()
+    if not normalized_plan_id:
+        raise ValueError("Odoo preview lifecycle evidence requires plan_id.")
+    return hashlib.sha256(normalized_plan_id.encode("utf-8")).hexdigest()[:20]
+
+
+def _odoo_preview_destroy_reason(*, plan_id: str, issued_at: str) -> str:
+    return (
+        f"{_ODOO_PREVIEW_DESTROY_REASON_PREFIX}:"
+        f"{_odoo_preview_operation_token(plan_id)}:{issued_at}"
+    )
+
+
+def _odoo_preview_lifecycle_records(
+    *,
+    preview: PreviewRecord,
+    status: str,
+    transition: str,
+    generation: PreviewGenerationRecord | None = None,
+) -> dict[str, object]:
+    records: dict[str, object] = {
+        "preview_id": preview.preview_id,
+        "preview_path": preview.preview_id,
+        "transition": transition,
+        "lifecycle_evidence_status": status,
+    }
+    if generation is not None:
+        records.update(
+            {
+                "generation_id": generation.generation_id,
+                "generation_path": generation.generation_id,
+            }
+        )
+    return records
+
+
+def _odoo_preview_operation_is_stale(
+    *,
+    record_store: LaunchplaneMutationStore,
+    preview: PreviewRecord,
+    issued_at: str,
+) -> bool:
+    existing_issued_at = _odoo_preview_existing_operation_issued_at(
+        record_store=record_store,
+        preview=preview,
+    )
+    if not existing_issued_at:
+        return True
+    current_issued_at = parse_launchplane_mutation_timestamp(
+        issued_at,
+        field_name="Odoo preview lifecycle issued_at",
+    )
+    parsed_existing_issued_at = parse_launchplane_mutation_timestamp(
+        existing_issued_at,
+        field_name="existing preview lifecycle issued_at",
+    )
+    return current_issued_at <= parsed_existing_issued_at
+
+
+def _odoo_preview_existing_operation_issued_at(
+    *,
+    record_store: LaunchplaneMutationStore,
+    preview: PreviewRecord,
+) -> str:
+    if preview.state == "destroyed":
+        prefix = f"{_ODOO_PREVIEW_DESTROY_REASON_PREFIX}:"
+        if preview.destroy_reason.startswith(prefix):
+            _token, separator, issued_at = preview.destroy_reason[len(prefix) :].partition(":")
+            if separator:
+                return issued_at
+        return ""
+    generation_id = preview.serving_generation_id or preview.latest_generation_id
+    if not generation_id:
+        return ""
+    generation = next(
+        (
+            record
+            for record in record_store.list_preview_generation_records(
+                preview_id=preview.preview_id
+            )
+            if record.generation_id == generation_id
+        ),
+        None,
+    )
+    return generation.requested_at if generation is not None else ""
+
+
 def odoo_preview_destroy_supersession_is_quiescent(
     *,
     control_plane_root_path: Path,
@@ -354,6 +850,13 @@ def odoo_preview_destroy_supersession_is_quiescent(
         request=request.apply,
         database_url=database_url,
     )
+
+
+def _odoo_preview_anchor_repo(repository: str) -> str:
+    _owner, separator, repo = repository.strip().partition("/")
+    if not separator or not repo.strip():
+        raise ValueError("Odoo preview repository must use owner/repo format.")
+    return repo.strip()
 
 
 def driver_result_contains_status(

--- a/control_plane/workflows/odoo_preview_runtime.py
+++ b/control_plane/workflows/odoo_preview_runtime.py
@@ -36,6 +36,10 @@ from control_plane.contracts.odoo_stable_target_replacement import (
     merge_odoo_install_modules,
 )
 from control_plane.contracts.product_profile_record import LaunchplaneProductProfileRecord
+from control_plane.contracts.runtime_identity import (
+    RuntimeIdentity,
+    health_payload_runtime_identity_status,
+)
 from control_plane.contracts.runtime_environment_record import RuntimeEnvironmentRecord
 from control_plane.contracts.secret_record import SecretBinding
 from control_plane.secrets import RUNTIME_ENVIRONMENT_SECRET_INTEGRATION
@@ -1248,6 +1252,7 @@ def execute_odoo_preview_dokploy_apply(
     provider_operation_title: str = "",
     provider_effect_checkpoint: Callable[[str], None] | None = None,
     provider_lease_check: Callable[[], None] | None = None,
+    expected_runtime_identity: RuntimeIdentity | None = None,
 ) -> OdooPreviewDokployApplyResult:
     plan = request.dry_run_plan
     if plan.status != "ready":
@@ -1288,6 +1293,7 @@ def execute_odoo_preview_dokploy_apply(
         provider_operation_title=provider_operation_title,
         provider_effect_checkpoint=provider_effect_checkpoint,
         provider_lease_check=provider_lease_check,
+        expected_runtime_identity=expected_runtime_identity,
     )
 
 
@@ -1487,6 +1493,7 @@ def _execute_refresh(
     provider_operation_title: str,
     provider_effect_checkpoint: Callable[[str], None] | None,
     provider_lease_check: Callable[[], None] | None,
+    expected_runtime_identity: RuntimeIdentity | None,
 ) -> OdooPreviewDokployApplyResult:
     plan = request.dry_run_plan
     creating_compose = plan.compose_ref.startswith("${created.composeId:")
@@ -1645,6 +1652,7 @@ def _execute_refresh(
                 preview_url=plan.preview_url,
                 health_path=request.health_path,
                 timeout_seconds=request.timeout_seconds,
+                expected_runtime_identity=expected_runtime_identity,
             )
             steps.append(_step("smoke_check", plan.preview_url))
         return _apply_result(
@@ -1961,7 +1969,13 @@ def _rollback_created_runtime(
     return tuple(errors)
 
 
-def _wait_for_smoke_check(*, preview_url: str, health_path: str, timeout_seconds: int) -> None:
+def _wait_for_smoke_check(
+    *,
+    preview_url: str,
+    health_path: str,
+    timeout_seconds: int,
+    expected_runtime_identity: RuntimeIdentity | None = None,
+) -> None:
     parsed = urlparse(preview_url.rstrip("/"))
     smoke_url = parsed._replace(path=health_path, params="", query="", fragment="").geturl()
     request = Request(
@@ -1971,28 +1985,63 @@ def _wait_for_smoke_check(*, preview_url: str, health_path: str, timeout_seconds
     deadline = time.monotonic() + timeout_seconds
     last_http_status: int | None = None
     last_transport_error = ""
+    last_identity_error = ""
     while True:
         remaining_seconds = deadline - time.monotonic()
         if remaining_seconds <= 0:
             break
         try:
             with urlopen(request, timeout=min(15, remaining_seconds)) as response:
-                response.read()
+                body = response.read().decode("utf-8")
                 status = response.status
             if 200 <= status < 400:
-                return
+                last_http_status = None
+                last_transport_error = ""
+                if expected_runtime_identity is None:
+                    return
+                try:
+                    payload = json.loads(body)
+                except json.JSONDecodeError:
+                    last_identity_error = (
+                        "health endpoint did not return parseable JSON runtime identity evidence"
+                    )
+                else:
+                    if isinstance(payload, dict) and payload.get("ok") is False:
+                        last_identity_error = "health endpoint reported ok=false"
+                    else:
+                        runtime_status, detail, _observed = health_payload_runtime_identity_status(
+                            expected=expected_runtime_identity,
+                            payload=payload,
+                        )
+                        if runtime_status == "match":
+                            strict_mismatches = _runtime_identity_mismatched_fields(
+                                expected=expected_runtime_identity,
+                                observed=_observed,
+                            )
+                            if not strict_mismatches:
+                                return
+                            last_identity_error = (
+                                "Runtime identity mismatched fields: "
+                                + ", ".join(strict_mismatches)
+                            )
+                        else:
+                            last_identity_error = detail
         except HTTPError as exc:
             last_http_status = exc.code
             last_transport_error = ""
+            last_identity_error = ""
         except TimeoutError as exc:
             last_http_status = None
             last_transport_error = str(exc).strip() or "request timed out"
+            last_identity_error = ""
         except URLError as exc:
             last_http_status = None
             last_transport_error = str(exc.reason).strip() or str(exc).strip()
+            last_identity_error = ""
         except ValueError as exc:
             last_http_status = None
             last_transport_error = str(exc).strip()
+            last_identity_error = ""
         remaining_seconds = deadline - time.monotonic()
         if remaining_seconds <= 0:
             break
@@ -2000,12 +2049,30 @@ def _wait_for_smoke_check(*, preview_url: str, health_path: str, timeout_seconds
         time.sleep(sleep_seconds)
     if last_http_status is not None:
         raise click.ClickException(f"Odoo preview smoke check returned HTTP {last_http_status}.")
+    if last_identity_error:
+        raise click.ClickException(
+            "Odoo preview runtime identity verification failed: " + last_identity_error
+        )
     if last_transport_error:
         raise click.ClickException(
             f"Timed out waiting for Odoo preview smoke check {smoke_url}. "
             f"Last transport error: {last_transport_error}."
         )
     raise click.ClickException(f"Timed out waiting for Odoo preview smoke check {smoke_url}.")
+
+
+def _runtime_identity_mismatched_fields(
+    *,
+    expected: RuntimeIdentity,
+    observed: RuntimeIdentity | None,
+) -> tuple[str, ...]:
+    if observed is None:
+        return ("runtime_identity",)
+    return tuple(
+        field_name
+        for field_name in RuntimeIdentity.model_fields
+        if getattr(expected, field_name) != getattr(observed, field_name)
+    )
 
 
 def _step(name: OdooPreviewDokployOperationName, target: str) -> OdooPreviewDokployApplyStep:

--- a/docs/preview-workflow-contract.md
+++ b/docs/preview-workflow-contract.md
@@ -188,6 +188,20 @@ reconciliation. If GitHub is degraded, the lifecycle operation still completes
 and an authorized operator retries `POST /v1/manager-preview-approval/reconcile`
 with `repository` and `pr_number` after GitHub recovers.
 
+Generic-web routes write lifecycle records as part of refresh, destroy, and
+verification. Odoo preview apply finalizes the serving preview and generation
+evidence after the provider result is `pass` but before the durable provider
+reservation releases its target fence. The completed provider response stores
+those lifecycle record identities, so exact replay never synthesizes new
+evidence under changed profile authority. Successful completion, adoption, and
+current exact replay then retry manager projection without repeating the
+provider mutation. The service uses the issued plan as the stable generation
+identity and returns a non-passing conflict when a delayed refresh or destroy no
+longer owns the preview. Odoo destroy writes the approval invalidation event
+before its destroyed tombstone when a serving binding is available; this keeps
+the append-only event crash-durable while the GitHub call remains best-effort
+after the provider reservation completes.
+
 Rollback removes the repository's required `manager-preview-approval` status
 and removes or narrows the managed approval rule. This disables merge/promotion
 enforcement while preserving the append-only approval ledger and normal preview
@@ -279,9 +293,16 @@ provider inventory for refresh reuse and destroy planning, and it blocks destroy
 when the matching preview compose and hostname cannot be proven. After refresh,
 Launchplane owns `/launchplane/health`, `/web/health`, `/cm-website/health`, `/cell-mechanic`,
 artifact/revision evidence, and module install/update evidence. Product
-workflows should treat the Odoo refresh route's `refresh_status="pass"` as the
-ready-to-comment signal instead of independently deciding readiness from raw
-health checks. Refresh merges the artifact manifest's declared Odoo modules
+workflows should treat the Odoo refresh response's `result.status="pass"` (the
+reusable workflow aliases it to `refresh_status`) as the ready-to-comment signal
+instead of independently deciding readiness from raw health checks. A passing
+result persists the active preview, ready serving generation, immutable artifact
+identity, and verified runtime identity before manager approval projection. The
+service requires an exact lowercase 40-character source commit and lowercase
+64-character `sha256` image digest, injects its runtime identity into the preview
+environment, and requires `/launchplane/health` to echo the matching identity;
+callers cannot disable that verification on a refresh request.
+Refresh merges the artifact manifest's declared Odoo modules
 with Launchplane-required modules into both `ODOO_INSTALL_MODULES` and the
 explicit maintenance-only `ODOO_UPDATE_MODULES` input. It also merges the
 managed Launchplane and Enterprise addon roots into `ODOO_ADDONS_PATH` so a
@@ -307,11 +328,14 @@ match exactly, rejects missing, mismatched, or expired provenance, and rebuilds
 the plan from current Launchplane records and current provider discovery before
 the first provider effect. Any changed profile, runtime routing, template target,
 environment id, or discovered preview target makes the plan stale and requires
-new apply inputs. Completed exact retries replay the stored apply response, and
-uncertain operations reconcile against the originally issued plan instead of
+new apply inputs. Completed exact retries replay the stored apply response only
+while its stored lifecycle evidence remains the current preview owner. A changed
+product profile, missing legacy lifecycle evidence, newer serving generation, or
+newer destroy returns a conflict and does not publish ready/destroyed feedback.
+Uncertain operations reconcile against the originally issued plan instead of
 replanning into another effect. Blocked apply-inputs responses have no apply
-provenance and are not persisted as issued plans, so a later retry can re-evaluate
-recovered dependencies.
+provenance and are not persisted as issued plans, so a later retry can
+re-evaluate recovered dependencies.
 If a later browser or product-specific smoke workflow needs to publish common
 preview evidence, it should call
 `cbusillo/launchplane/.github/workflows/reusable-generic-web-preview-verification.yml@main`

--- a/tests/test_http_app_driver_odoo.py
+++ b/tests/test_http_app_driver_odoo.py
@@ -25,13 +25,20 @@ from control_plane.contracts.promotion_record import (
     DeploymentEvidence,
 )
 from control_plane.contracts.runtime_environment_record import RuntimeEnvironmentRecord
+from control_plane.contracts.runtime_identity import parse_runtime_identity_payload
 from control_plane.dokploy import DokploySourceOfTruth, DokployTargetDefinition
 from control_plane.contracts.product_profile_record import LaunchplaneProductProfileRecord
 from control_plane.http_app import create_launchplane_fastapi_app, idempotency_scope
+from control_plane.manager_preview_approval import build_current_manager_preview_approval_binding
 from control_plane.odoo_preview_apply_http import (
     ODOO_PREVIEW_PLAN_TTL_SECONDS,
     OdooPreviewApplyEnvelope,
+    OdooPreviewPlanProvenanceError,
+    apply_odoo_preview_lifecycle_evidence,
+    build_odoo_preview_runtime_identity,
     issue_odoo_preview_apply_plan,
+    validate_odoo_preview_lifecycle_response_current,
+    validate_odoo_preview_profile_authority,
 )
 from control_plane.service_auth import GitHubActionsIdentity, LaunchplaneAuthzPolicy
 from control_plane.storage.filesystem import FilesystemRecordStore
@@ -86,6 +93,13 @@ from tests.support.stores import (
 )
 
 
+_TEST_PREVIEW_HEAD_SHA = "c" * 40
+_TEST_PREVIEW_IMAGE_DIGEST = "a" * 64
+_TEST_PREVIEW_IMAGE_REFERENCE = (
+    f"ghcr.io/cbusillo/odoo-tenant-cm@sha256:{_TEST_PREVIEW_IMAGE_DIGEST}"
+)
+
+
 def _ready_odoo_preview_apply_payload(*, include_manifest: bool = False) -> dict[str, object]:
     payload: dict[str, object] = {
         "schema_version": 1,
@@ -105,7 +119,7 @@ def _ready_odoo_preview_apply_payload(*, include_manifest: bool = False) -> dict
                 "template_compose_id": "compose-cm-testing",
                 "summary": "ready isolated Odoo preview apply",
             },
-            "image_reference": "ghcr.io/cbusillo/odoo-tenant-cm@sha256:abc123",
+            "image_reference": _TEST_PREVIEW_IMAGE_REFERENCE,
             "wait_for_deploy": True,
             "smoke_check": True,
         },
@@ -114,11 +128,11 @@ def _ready_odoo_preview_apply_payload(*, include_manifest: bool = False) -> dict
         apply = cast(dict[str, object], payload["apply"])
         apply["manifest"] = {
             "artifact_id": "artifact-cm-preview",
-            "source_commit": "abc123",
+            "source_commit": _TEST_PREVIEW_HEAD_SHA,
             "enterprise_base_digest": "sha256:enterprise",
             "image": {
                 "repository": "ghcr.io/cbusillo/odoo-tenant-cm",
-                "digest": "sha256:abc123",
+                "digest": f"sha256:{_TEST_PREVIEW_IMAGE_DIGEST}",
             },
         }
     return payload
@@ -1169,7 +1183,7 @@ class FastApiOdooPreviewApplyTests(unittest.IsolatedAsyncioTestCase):
             preview_url=dry_run_plan.preview_url,
             image_reference=apply_request.apply.image_reference,
             manifest=apply_request.apply.manifest,
-            source_git_ref="abc123" if dry_run_plan.operation == "refresh" else "",
+            source_git_ref=_TEST_PREVIEW_HEAD_SHA if dry_run_plan.operation == "refresh" else "",
             source="test-issued-plan",
         )
         return OdooPreviewApplyInputsResult(
@@ -1233,6 +1247,42 @@ class FastApiOdooPreviewApplyTests(unittest.IsolatedAsyncioTestCase):
             )
         )
         return plan_id
+
+    def _issued_preview_plan(
+        self,
+        *,
+        payload: dict[str, object],
+        plan_id: str,
+        issued_at: datetime,
+    ) -> OdooPreviewApplyInputsResult:
+        return issue_odoo_preview_apply_plan(
+            result=self._planned_preview_result(payload),
+            plan_id=plan_id,
+            issued_at=issued_at,
+        )
+
+    @staticmethod
+    def _provider_operation_record(
+        *,
+        plan_id: str,
+        recorded_at: str,
+    ) -> LaunchplaneIdempotencyRecord:
+        return LaunchplaneIdempotencyRecord(
+            record_id=f"idempotency-{plan_id}",
+            scope="test:odoo-preview-lifecycle",
+            route_path="/v1/drivers/odoo/preview-apply",
+            idempotency_key=plan_id,
+            request_fingerprint=f"fingerprint-{plan_id}",
+            response_status_code=202,
+            response_trace_id=f"trace-{plan_id}",
+            recorded_at=recorded_at,
+            response_payload={
+                "status": "accepted",
+                "trace_id": f"trace-{plan_id}",
+                "records": {},
+                "result": {"status": "pass"},
+            },
+        )
 
     async def test_odoo_preview_apply_inputs_derives_runtime_and_dry_run_plans(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
@@ -1474,7 +1524,7 @@ class FastApiOdooPreviewApplyTests(unittest.IsolatedAsyncioTestCase):
                         "inputs": {
                             "product": "odoo-tenant-cm",
                             "pr_number": 42,
-                            "image_reference": "ghcr.io/cbusillo/odoo-tenant-cm@sha256:abc123",
+                            "image_reference": _TEST_PREVIEW_IMAGE_REFERENCE,
                         },
                     },
                     idempotency_key="odoo-preview-inputs-test-file-miss",
@@ -1502,7 +1552,7 @@ class FastApiOdooPreviewApplyTests(unittest.IsolatedAsyncioTestCase):
                 "inputs": {
                     "product": "odoo-tenant-cm",
                     "pr_number": 42,
-                    "image_reference": "ghcr.io/cbusillo/odoo-tenant-cm@sha256:abc123",
+                    "image_reference": _TEST_PREVIEW_IMAGE_REFERENCE,
                 },
             }
             planned_result = self._planned_preview_result(_ready_odoo_preview_apply_payload())
@@ -1841,7 +1891,7 @@ class FastApiOdooPreviewApplyTests(unittest.IsolatedAsyncioTestCase):
                                 "template_compose_id": "compose-cm-testing",
                                 "summary": "ready isolated Odoo preview apply",
                             },
-                            "image_reference": "ghcr.io/cbusillo/odoo-tenant-cm@sha256:abc123",
+                            "image_reference": _TEST_PREVIEW_IMAGE_REFERENCE,
                             "wait_for_deploy": False,
                             "smoke_check": False,
                         },
@@ -1955,14 +2005,14 @@ class FastApiOdooPreviewApplyTests(unittest.IsolatedAsyncioTestCase):
                                 "template_compose_id": "compose-cm-testing",
                                 "summary": "ready isolated Odoo preview apply",
                             },
-                            "image_reference": "ghcr.io/cbusillo/odoo-tenant-cm@sha256:abc123",
+                            "image_reference": _TEST_PREVIEW_IMAGE_REFERENCE,
                             "manifest": {
                                 "artifact_id": "artifact-cm-preview",
-                                "source_commit": "abc123",
+                                "source_commit": _TEST_PREVIEW_HEAD_SHA,
                                 "enterprise_base_digest": "sha256:enterprise",
                                 "image": {
                                     "repository": "ghcr.io/cbusillo/odoo-tenant-cm",
-                                    "digest": "sha256:abc123",
+                                    "digest": f"sha256:{_TEST_PREVIEW_IMAGE_DIGEST}",
                                 },
                             },
                             "environment_values": {
@@ -1985,7 +2035,7 @@ class FastApiOdooPreviewApplyTests(unittest.IsolatedAsyncioTestCase):
         applied_request = apply_driver.call_args.kwargs["request"]
         self.assertEqual(
             applied_request.image_reference,
-            "ghcr.io/cbusillo/odoo-tenant-cm@sha256:abc123",
+            _TEST_PREVIEW_IMAGE_REFERENCE,
         )
         self.assertEqual(applied_request.dry_run_plan.environment_id, "env-cm-preview")
         self.assertEqual(
@@ -2024,6 +2074,278 @@ class FastApiOdooPreviewApplyTests(unittest.IsolatedAsyncioTestCase):
             applied_request.environment_values["ODOO_DB_PASSWORD"],
             "caller-secret-must-not-win",
         )
+        expected_runtime_identity = apply_driver.call_args.kwargs["expected_runtime_identity"]
+        self.assertIsNotNone(expected_runtime_identity)
+        observed_runtime_identity = parse_runtime_identity_payload(
+            applied_request.environment_values["LAUNCHPLANE_RUNTIME_IDENTITY_JSON"]
+        )
+        self.assertEqual(observed_runtime_identity, expected_runtime_identity)
+        self.assertEqual(
+            applied_request.environment_values["LAUNCHPLANE_DEPLOYMENT_RECORD_ID"],
+            expected_runtime_identity.deployment_record_id,
+        )
+        self.assertEqual(expected_runtime_identity.source_git_ref, _TEST_PREVIEW_HEAD_SHA)
+        self.assertTrue(expected_runtime_identity.preview_generation_id)
+        provider_operation_record = store.read_idempotency_record(
+            scope=idempotency_scope(identity),
+            route_path="/v1/drivers/odoo/preview-apply",
+            idempotency_key=plan_id,
+        )
+        assert provider_operation_record is not None
+        self.assertEqual(
+            expected_runtime_identity.deployment_record_id,
+            provider_operation_record.record_id,
+        )
+
+    def test_odoo_preview_runtime_identity_rejects_non_exact_source_commit(self) -> None:
+        payload = _ready_odoo_preview_apply_payload(include_manifest=True)
+        apply_payload = cast(dict[str, object], payload["apply"])
+        manifest = cast(dict[str, object], apply_payload["manifest"])
+        manifest["source_commit"] = "abc123"
+        issued_plan = self._issued_preview_plan(
+            payload=payload,
+            plan_id="odoo-preview-plan-invalid-source",
+            issued_at=datetime(2026, 7, 31, 12, 0, tzinfo=timezone.utc),
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "source_git_ref must be an exact lowercase 40-character git commit",
+        ):
+            build_odoo_preview_runtime_identity(
+                profile=LaunchplaneProductProfileRecord.model_validate(
+                    _odoo_preview_profile_payload()
+                ),
+                issued_plan=issued_plan,
+                deployment_record_id="idempotency-invalid-source",
+            )
+
+    def test_odoo_preview_lifecycle_replay_preserves_destroy_and_generation_evidence(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = self._reservation_store(root)
+            profile = LaunchplaneProductProfileRecord.model_validate(
+                _odoo_preview_profile_payload()
+            )
+            refresh_plan = self._issued_preview_plan(
+                payload=_ready_odoo_preview_apply_payload(include_manifest=True),
+                plan_id="odoo-preview-plan-refresh-old",
+                issued_at=datetime(2026, 7, 31, 12, 0, tzinfo=timezone.utc),
+            )
+            refresh_operation = self._provider_operation_record(
+                plan_id="odoo-preview-plan-refresh-old",
+                recorded_at="2026-07-31T12:01:00Z",
+            )
+            refresh_runtime_identity = build_odoo_preview_runtime_identity(
+                profile=profile,
+                issued_plan=refresh_plan,
+                deployment_record_id=refresh_operation.record_id,
+            )
+            refresh_result: dict[str, object] = {
+                "status": "pass",
+                "operation": "refresh",
+                "product": "odoo-tenant-cm",
+                "repository": "cbusillo/odoo-tenant-cm",
+                "preview_slug": "pr-42",
+                "preview_url": "https://pr-42.cm-preview.example.test",
+                "domain_host": "pr-42.cm-preview.example.test",
+                "compose_name": "cm-odoo-preview-pr-42",
+            }
+
+            first_records = apply_odoo_preview_lifecycle_evidence(
+                control_plane_root_path=root,
+                record_store=store,
+                profile=profile,
+                issued_plan=refresh_plan,
+                driver_result=refresh_result,
+                runtime_identity=refresh_runtime_identity,
+            )
+            generation_id = str(first_records["generation_id"])
+            generation = store.read_preview_generation_record(generation_id)
+            store.write_preview_generation_record(
+                generation.model_copy(update={"ready_at": "2026-07-31T12:01:30Z"})
+            )
+
+            replay_records = apply_odoo_preview_lifecycle_evidence(
+                control_plane_root_path=root,
+                record_store=store,
+                profile=profile,
+                issued_plan=refresh_plan,
+                driver_result=refresh_result,
+                runtime_identity=refresh_runtime_identity,
+            )
+
+            self.assertEqual(replay_records["lifecycle_evidence_status"], "replayed")
+            generations = store.list_preview_generation_records(
+                preview_id=str(first_records["preview_id"])
+            )
+            self.assertEqual(len(generations), 1)
+            self.assertEqual(generations[0].ready_at, "2026-07-31T12:01:30Z")
+
+            destroy_plan = self._issued_preview_plan(
+                payload=_ready_odoo_preview_destroy_payload(),
+                plan_id="odoo-preview-plan-destroy-new",
+                issued_at=datetime(2026, 7, 31, 12, 2, tzinfo=timezone.utc),
+            )
+            destroy_result: dict[str, object] = {
+                "status": "pass",
+                "operation": "destroy",
+                "product": "odoo-tenant-cm",
+                "repository": "cbusillo/odoo-tenant-cm",
+                "preview_slug": "pr-42",
+                "preview_url": "https://pr-42.cm-preview.example.test",
+                "domain_host": "pr-42.cm-preview.example.test",
+                "compose_name": "cm-odoo-preview-pr-42",
+            }
+            destroy_callback_states: list[str] = []
+
+            def before_destroy() -> dict[str, object]:
+                current_preview = store.read_preview_record(str(first_records["preview_id"]))
+                destroy_callback_states.append(current_preview.state)
+                return {"manager_preview_invalidation_event_status": "written"}
+
+            destroy_records = apply_odoo_preview_lifecycle_evidence(
+                control_plane_root_path=root,
+                record_store=store,
+                profile=profile,
+                issued_plan=destroy_plan,
+                driver_result=destroy_result,
+                before_destroy=before_destroy,
+            )
+
+            delayed_replay = apply_odoo_preview_lifecycle_evidence(
+                control_plane_root_path=root,
+                record_store=store,
+                profile=profile,
+                issued_plan=refresh_plan,
+                driver_result=refresh_result,
+                runtime_identity=refresh_runtime_identity,
+            )
+            preview = store.read_preview_record(str(first_records["preview_id"]))
+            with self.assertRaises(OdooPreviewPlanProvenanceError) as error_context:
+                validate_odoo_preview_lifecycle_response_current(
+                    record_store=store,
+                    profile=profile,
+                    issued_plan=refresh_plan,
+                    records=first_records,
+                )
+
+        self.assertEqual(delayed_replay["lifecycle_evidence_status"], "stale")
+        self.assertEqual(destroy_callback_states, ["active"])
+        self.assertEqual(destroy_records["manager_preview_invalidation_event_status"], "written")
+        self.assertEqual(preview.state, "destroyed")
+        self.assertEqual(preview.serving_generation_id, "")
+        self.assertEqual(error_context.exception.code, "odoo_preview_operation_superseded")
+
+    def test_odoo_preview_profile_authority_rejects_changed_repository(self) -> None:
+        profile = LaunchplaneProductProfileRecord.model_validate(_odoo_preview_profile_payload())
+        issued_plan = self._issued_preview_plan(
+            payload=_ready_odoo_preview_apply_payload(include_manifest=True),
+            plan_id="odoo-preview-plan-profile-authority",
+            issued_at=datetime(2026, 7, 31, 12, 0, tzinfo=timezone.utc),
+        )
+        changed_profile = profile.model_copy(update={"repository": "cbusillo/replacement-tenant"})
+
+        with self.assertRaises(OdooPreviewPlanProvenanceError) as error_context:
+            validate_odoo_preview_profile_authority(
+                profile=changed_profile,
+                issued_plan=issued_plan,
+            )
+
+        self.assertEqual(error_context.exception.code, "odoo_preview_plan_stale")
+
+    def test_odoo_preview_lifecycle_ignores_old_destroy_after_newer_refresh(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = self._reservation_store(root)
+            profile = LaunchplaneProductProfileRecord.model_validate(
+                _odoo_preview_profile_payload()
+            )
+            refresh_result: dict[str, object] = {
+                "status": "pass",
+                "operation": "refresh",
+                "product": "odoo-tenant-cm",
+                "repository": "cbusillo/odoo-tenant-cm",
+                "preview_slug": "pr-42",
+                "preview_url": "https://pr-42.cm-preview.example.test",
+                "domain_host": "pr-42.cm-preview.example.test",
+                "compose_name": "cm-odoo-preview-pr-42",
+            }
+            destroy_result: dict[str, object] = {
+                **refresh_result,
+                "operation": "destroy",
+            }
+            refresh_old = self._issued_preview_plan(
+                payload=_ready_odoo_preview_apply_payload(include_manifest=True),
+                plan_id="odoo-preview-plan-refresh-first",
+                issued_at=datetime(2026, 7, 31, 12, 0, tzinfo=timezone.utc),
+            )
+            destroy_old = self._issued_preview_plan(
+                payload=_ready_odoo_preview_destroy_payload(),
+                plan_id="odoo-preview-plan-destroy-old",
+                issued_at=datetime(2026, 7, 31, 12, 2, tzinfo=timezone.utc),
+            )
+            refresh_new = self._issued_preview_plan(
+                payload=_ready_odoo_preview_apply_payload(include_manifest=True),
+                plan_id="odoo-preview-plan-refresh-new",
+                issued_at=datetime(2026, 7, 31, 12, 4, tzinfo=timezone.utc),
+            )
+            refresh_old_operation = self._provider_operation_record(
+                plan_id="odoo-preview-plan-refresh-first",
+                recorded_at="2026-07-31T12:01:00Z",
+            )
+            refresh_new_operation = self._provider_operation_record(
+                plan_id="odoo-preview-plan-refresh-new",
+                recorded_at="2026-07-31T12:05:00Z",
+            )
+            refresh_old_runtime_identity = build_odoo_preview_runtime_identity(
+                profile=profile,
+                issued_plan=refresh_old,
+                deployment_record_id=refresh_old_operation.record_id,
+            )
+            refresh_new_runtime_identity = build_odoo_preview_runtime_identity(
+                profile=profile,
+                issued_plan=refresh_new,
+                deployment_record_id=refresh_new_operation.record_id,
+            )
+
+            first_records = apply_odoo_preview_lifecycle_evidence(
+                control_plane_root_path=root,
+                record_store=store,
+                profile=profile,
+                issued_plan=refresh_old,
+                driver_result=refresh_result,
+                runtime_identity=refresh_old_runtime_identity,
+            )
+            apply_odoo_preview_lifecycle_evidence(
+                control_plane_root_path=root,
+                record_store=store,
+                profile=profile,
+                issued_plan=destroy_old,
+                driver_result=destroy_result,
+            )
+            new_records = apply_odoo_preview_lifecycle_evidence(
+                control_plane_root_path=root,
+                record_store=store,
+                profile=profile,
+                issued_plan=refresh_new,
+                driver_result=refresh_result,
+                runtime_identity=refresh_new_runtime_identity,
+            )
+            stale_records = apply_odoo_preview_lifecycle_evidence(
+                control_plane_root_path=root,
+                record_store=store,
+                profile=profile,
+                issued_plan=destroy_old,
+                driver_result=destroy_result,
+            )
+            preview = store.read_preview_record(str(first_records["preview_id"]))
+
+        self.assertEqual(stale_records["lifecycle_evidence_status"], "stale")
+        self.assertEqual(preview.state, "active")
+        self.assertEqual(preview.serving_generation_id, new_records["generation_id"])
 
     async def test_odoo_preview_apply_keeps_health_responsive_during_provider_wait(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
@@ -2355,6 +2677,13 @@ class FastApiOdooPreviewApplyTests(unittest.IsolatedAsyncioTestCase):
                         compose_name="cm-odoo-preview-pr-42",
                     ),
                 ) as apply_driver,
+                patch(
+                    "control_plane.http_app.record_manager_preview_approval_invalidation_for_pr",
+                    return_value={"required": True, "event_status": "written"},
+                ) as record_manager_invalidation,
+                patch(
+                    "control_plane.http_app.reconcile_manager_preview_approval_for_pr_best_effort"
+                ) as reconcile_manager_approval,
             ):
                 response = await _post_odoo_preview_apply(
                     app,
@@ -2380,13 +2709,39 @@ class FastApiOdooPreviewApplyTests(unittest.IsolatedAsyncioTestCase):
                     },
                     idempotency_key=plan_id,
                 )
+                replayed_response = await _post_odoo_preview_apply(
+                    app,
+                    _ready_odoo_preview_destroy_payload(),
+                    idempotency_key=plan_id,
+                )
 
         self.assertEqual(response.status_code, 202)
         self.assertEqual(response.json()["result"]["status"], "pass")
+        self.assertEqual(replayed_response.status_code, 202)
+        self.assertTrue(replayed_response.json()["replayed"])
         apply_driver.assert_called_once()
         applied_request = apply_driver.call_args.kwargs["request"]
         self.assertEqual(applied_request.dry_run_plan.operation, "destroy")
         self.assertEqual(applied_request.image_reference, "")
+        self.assertEqual(reconcile_manager_approval.call_count, 2)
+        record_manager_invalidation.assert_called_once()
+        invalidation_call = record_manager_invalidation.call_args.kwargs
+        self.assertEqual(invalidation_call["repository"], "cbusillo/odoo-tenant-cm")
+        self.assertEqual(invalidation_call["pr_number"], 42)
+        self.assertEqual(invalidation_call["source_event_kind"], "preview_destroy")
+        self.assertEqual(
+            invalidation_call["source_event_id"],
+            f"odoo-preview-destroy:{plan_id}",
+        )
+        self.assertTrue(invalidation_call["occurred_at"])
+        self.assertEqual(
+            response.json()["records"]["manager_preview_invalidation_event_status"],
+            "written",
+        )
+        self.assertEqual(
+            replayed_response.json()["records"]["manager_preview_invalidation_event_status"],
+            "written",
+        )
 
     async def test_odoo_preview_destroy_supersedes_expired_reconciled_refresh(
         self,
@@ -2534,7 +2889,7 @@ class FastApiOdooPreviewApplyTests(unittest.IsolatedAsyncioTestCase):
                         "template_compose_id": "compose-cm-testing",
                         "summary": "ready isolated Odoo preview apply",
                     },
-                    "image_reference": "ghcr.io/cbusillo/odoo-tenant-cm@sha256:abc123",
+                    "image_reference": _TEST_PREVIEW_IMAGE_REFERENCE,
                     "wait_for_deploy": False,
                     "smoke_check": False,
                 },
@@ -2545,37 +2900,44 @@ class FastApiOdooPreviewApplyTests(unittest.IsolatedAsyncioTestCase):
                 payload=payload,
             )
 
-            with patch(
-                "control_plane.http_app.execute_odoo_preview_apply_result",
-                side_effect=(
-                    {
-                        "status": "blocked",
-                        "operation": "refresh",
-                        "product": "odoo-tenant-cm",
-                        "repository": "cbusillo/odoo-tenant-cm",
-                        "preview_slug": "pr-42",
-                        "preview_url": "https://pr-42.cm-preview.example.test",
-                        "domain_host": "pr-42.cm-preview.example.test",
-                        "compose_name": "cm-odoo-preview-pr-42",
-                        "error_message": "provider dependency is not ready",
-                    },
-                    {
-                        "status": "pass",
-                        "operation": "refresh",
-                        "product": "odoo-tenant-cm",
-                        "repository": "cbusillo/odoo-tenant-cm",
-                        "preview_slug": "pr-42",
-                        "preview_url": "https://pr-42.cm-preview.example.test",
-                        "domain_host": "pr-42.cm-preview.example.test",
-                        "compose_name": "cm-odoo-preview-pr-42",
-                    },
-                ),
-            ) as apply_driver:
+            with (
+                patch(
+                    "control_plane.http_app.execute_odoo_preview_apply_result",
+                    side_effect=(
+                        {
+                            "status": "blocked",
+                            "operation": "refresh",
+                            "product": "odoo-tenant-cm",
+                            "repository": "cbusillo/odoo-tenant-cm",
+                            "preview_slug": "pr-42",
+                            "preview_url": "https://pr-42.cm-preview.example.test",
+                            "domain_host": "pr-42.cm-preview.example.test",
+                            "compose_name": "cm-odoo-preview-pr-42",
+                            "error_message": "provider dependency is not ready",
+                        },
+                        {
+                            "status": "pass",
+                            "operation": "refresh",
+                            "product": "odoo-tenant-cm",
+                            "repository": "cbusillo/odoo-tenant-cm",
+                            "preview_slug": "pr-42",
+                            "preview_url": "https://pr-42.cm-preview.example.test",
+                            "domain_host": "pr-42.cm-preview.example.test",
+                            "compose_name": "cm-odoo-preview-pr-42",
+                        },
+                    ),
+                ) as apply_driver,
+                patch(
+                    "control_plane.http_app.reconcile_manager_preview_approval_for_pr_best_effort",
+                    return_value=True,
+                ) as reconcile_manager_approval,
+            ):
                 first_response = await _post_odoo_preview_apply(
                     app,
                     payload,
                     idempotency_key=plan_id,
                 )
+                reconcile_manager_approval.assert_not_called()
                 second_response = await _post_odoo_preview_apply(
                     app,
                     payload,
@@ -2587,10 +2949,14 @@ class FastApiOdooPreviewApplyTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(second_response.status_code, 202)
         self.assertEqual(second_response.json()["result"]["status"], "pass")
         self.assertEqual(apply_driver.call_count, 2)
+        reconcile_manager_approval.assert_called_once()
 
     async def test_odoo_preview_apply_replays_non_blocked_idempotency(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)
+            image_digest = "a" * 64
+            changed_image_digest = "b" * 64
+            head_sha = "c" * 40
             store = self._reservation_store(root)
             identity = self._identity(
                 repository="cbusillo/launchplane",
@@ -2629,34 +2995,53 @@ class FastApiOdooPreviewApplyTests(unittest.IsolatedAsyncioTestCase):
                         "template_compose_id": "compose-cm-testing",
                         "summary": "ready isolated Odoo preview apply",
                     },
-                    "image_reference": "ghcr.io/cbusillo/odoo-tenant-cm@sha256:abc123",
+                    "image_reference": (f"ghcr.io/cbusillo/odoo-tenant-cm@sha256:{image_digest}"),
+                    "manifest": {
+                        "artifact_id": "artifact-cm-preview",
+                        "source_commit": head_sha,
+                        "enterprise_base_digest": "sha256:enterprise",
+                        "image": {
+                            "repository": "ghcr.io/cbusillo/odoo-tenant-cm",
+                            "digest": f"sha256:{image_digest}",
+                        },
+                    },
                     "wait_for_deploy": False,
                     "smoke_check": False,
                 },
             }
             changed_payload = json.loads(json.dumps(payload))
-            cast(dict[str, object], changed_payload["apply"])["image_reference"] = (
-                "ghcr.io/cbusillo/odoo-tenant-cm@sha256:def456"
+            changed_apply = cast(dict[str, object], changed_payload["apply"])
+            changed_apply["image_reference"] = (
+                f"ghcr.io/cbusillo/odoo-tenant-cm@sha256:{changed_image_digest}"
             )
+            changed_manifest = cast(dict[str, object], changed_apply["manifest"])
+            changed_manifest_image = cast(dict[str, object], changed_manifest["image"])
+            changed_manifest_image["digest"] = f"sha256:{changed_image_digest}"
             plan_id = self._store_issued_preview_plan(
                 store=store,
                 identity=identity,
                 payload=payload,
             )
 
-            with patch(
-                "control_plane.http_app.execute_odoo_preview_apply_result",
-                return_value={
-                    "status": "pass",
-                    "operation": "refresh",
-                    "product": "odoo-tenant-cm",
-                    "repository": "cbusillo/odoo-tenant-cm",
-                    "preview_slug": "pr-42",
-                    "preview_url": "https://pr-42.cm-preview.example.test",
-                    "domain_host": "pr-42.cm-preview.example.test",
-                    "compose_name": "cm-odoo-preview-pr-42",
-                },
-            ) as apply_driver:
+            with (
+                patch(
+                    "control_plane.http_app.execute_odoo_preview_apply_result",
+                    return_value={
+                        "status": "pass",
+                        "operation": "refresh",
+                        "product": "odoo-tenant-cm",
+                        "repository": "cbusillo/odoo-tenant-cm",
+                        "preview_slug": "pr-42",
+                        "preview_url": "https://pr-42.cm-preview.example.test",
+                        "domain_host": "pr-42.cm-preview.example.test",
+                        "compose_name": "cm-odoo-preview-pr-42",
+                    },
+                ) as apply_driver,
+                patch(
+                    "control_plane.http_app.reconcile_manager_preview_approval_for_pr_best_effort",
+                    side_effect=(False, True),
+                ) as reconcile_manager_approval,
+            ):
                 first_response = await _post_odoo_preview_apply(
                     app,
                     payload,
@@ -2681,6 +3066,45 @@ class FastApiOdooPreviewApplyTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(conflict_response.status_code, 409)
         self.assertEqual(conflict_response.json()["error"]["code"], "odoo_preview_plan_mismatch")
         apply_driver.assert_called_once()
+        self.assertEqual(reconcile_manager_approval.call_count, 2)
+        previews = store.list_preview_records(
+            context_name="cm",
+            anchor_repo="odoo-tenant-cm",
+            anchor_pr_number=42,
+        )
+        self.assertEqual(len(previews), 1)
+        preview = previews[0]
+        self.assertEqual(preview.state, "active")
+        self.assertEqual(preview.canonical_url, "https://pr-42.cm-preview.example.test")
+        generation = store.read_preview_generation_record(preview.serving_generation_id)
+        self.assertEqual(generation.state, "ready")
+        self.assertEqual(generation.anchor_summary.head_sha, head_sha)
+        self.assertEqual(generation.deploy_status, "pass")
+        self.assertEqual(generation.verify_status, "pass")
+        self.assertEqual(generation.overall_health_status, "pass")
+        assert generation.runtime_identity is not None
+        provider_operation_record = store.read_idempotency_record(
+            scope=idempotency_scope(identity),
+            route_path="/v1/drivers/odoo/preview-apply",
+            idempotency_key=plan_id,
+        )
+        assert provider_operation_record is not None
+        self.assertEqual(
+            generation.runtime_identity.deployment_record_id,
+            provider_operation_record.record_id,
+        )
+        self.assertEqual(
+            generation.runtime_identity.image_reference,
+            f"ghcr.io/cbusillo/odoo-tenant-cm@sha256:{image_digest}",
+        )
+        binding = build_current_manager_preview_approval_binding(
+            product="odoo-tenant-cm",
+            preview=preview,
+            generation=generation,
+        )
+        self.assertEqual(binding.head_sha, head_sha)
+        self.assertEqual(binding.preview_url, "https://pr-42.cm-preview.example.test")
+        self.assertEqual(binding.artifact_image_digest, f"sha256:{image_digest}")
 
     async def test_odoo_preview_apply_handler_file_miss_is_not_found(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
@@ -2735,7 +3159,7 @@ class FastApiOdooPreviewApplyTests(unittest.IsolatedAsyncioTestCase):
                                 "template_compose_id": "compose-cm-testing",
                                 "summary": "ready isolated Odoo preview apply",
                             },
-                            "image_reference": "ghcr.io/cbusillo/odoo-tenant-cm@sha256:abc123",
+                            "image_reference": _TEST_PREVIEW_IMAGE_REFERENCE,
                         },
                     },
                     idempotency_key=plan_id,
@@ -2793,7 +3217,7 @@ class FastApiOdooPreviewApplyTests(unittest.IsolatedAsyncioTestCase):
                             "template_compose_id": "compose-cm-testing",
                             "summary": "ready isolated Odoo preview apply",
                         },
-                        "image_reference": "ghcr.io/cbusillo/odoo-tenant-cm@sha256:abc123",
+                        "image_reference": _TEST_PREVIEW_IMAGE_REFERENCE,
                     },
                 },
                 idempotency_key="odoo-preview-apply:odoo-tenant-cm:pr-42:refresh:abc123",

--- a/tests/test_manager_preview_approval_github_webhook.py
+++ b/tests/test_manager_preview_approval_github_webhook.py
@@ -455,8 +455,13 @@ class ManagerPreviewApprovalGitHubWebhookTests(unittest.TestCase):
         self.assertEqual(len(store.events), 2)
         self.assertEqual(github.statuses[-1]["state"], "failure")
 
-    def test_destroyed_preview_still_reprojects_non_success(self) -> None:
+    def test_destroyed_preview_records_invalidation_from_captured_binding(self) -> None:
         store = _Store()
+        binding = build_current_manager_preview_approval_binding(
+            product=PRODUCT,
+            preview=store.preview,
+            generation=store.generation,
+        )
         store.preview = store.preview.model_copy(update={"state": "destroyed"})
         github = _GitHubApi()
 
@@ -469,11 +474,16 @@ class ManagerPreviewApprovalGitHubWebhookTests(unittest.TestCase):
             record_store=store,
             control_plane_root=Path("/tmp/launchplane"),
             occurred_at=NOW,
+            binding=binding,
             dependencies=_dependencies(github),
         )
 
-        self.assertEqual(result["event_status"], "unavailable")
+        self.assertEqual(result["event_status"], "written")
         self.assertEqual(result["status"], "unavailable")
+        self.assertEqual(len(store.events), 1)
+        event = next(iter(store.events.values()))
+        self.assertEqual(event.action, "invalidated")
+        self.assertEqual(event.binding.binding_sha256, binding.binding_sha256)
         self.assertEqual(github.statuses[-1]["state"], "error")
 
 

--- a/tests/test_odoo_preview_runtime.py
+++ b/tests/test_odoo_preview_runtime.py
@@ -1,4 +1,5 @@
 import unittest
+import json
 from email.message import Message
 from contextlib import ExitStack, contextmanager
 from pathlib import Path
@@ -17,6 +18,7 @@ from control_plane.contracts.product_profile_record import (
     ProductPreviewProfile,
 )
 from control_plane.contracts.runtime_environment_record import RuntimeEnvironmentRecord
+from control_plane.contracts.runtime_identity import RuntimeIdentity
 from control_plane.contracts.secret_record import SecretBinding
 from control_plane.secrets import RUNTIME_ENVIRONMENT_SECRET_INTEGRATION
 from control_plane.contracts.odoo_preview_runtime_plan import (
@@ -2519,6 +2521,85 @@ class OdooPreviewDokployDryRunTests(unittest.TestCase):
 
         sleep.assert_not_called()
 
+    def test_smoke_check_requires_matching_runtime_identity(self) -> None:
+        clock = _FakeClock(start=0)
+        expected = RuntimeIdentity(
+            product="odoo-tenant-cm",
+            context="cm",
+            instance="cm-odoo-preview-pr-45",
+            environment_kind="preview",
+            deployment_record_id="idempotency-preview-45",
+            artifact_id="artifact-preview-45",
+            source_git_ref="a" * 40,
+            image_reference=f"ghcr.io/example/odoo@sha256:{'b' * 64}",
+            preview_id="preview-cm-pr-45",
+            preview_generation_id="preview-cm-pr-45-odoo-test",
+        )
+        body = json.dumps(
+            {"ok": True, "runtime_identity": expected.model_dump(mode="json")}
+        ).encode("utf-8")
+        with (
+            patch(
+                "control_plane.workflows.odoo_preview_runtime.urlopen",
+                return_value=_SmokeResponse(status=200, body=body),
+            ),
+            patch(
+                "control_plane.workflows.odoo_preview_runtime.time.monotonic",
+                side_effect=clock.monotonic,
+            ),
+            patch("control_plane.workflows.odoo_preview_runtime.time.sleep") as sleep,
+        ):
+            _wait_for_smoke_check(
+                preview_url="https://pr-45.cm-preview.example.test/",
+                health_path="/launchplane/health",
+                timeout_seconds=10,
+                expected_runtime_identity=expected,
+            )
+
+        sleep.assert_not_called()
+
+    def test_smoke_check_rejects_mismatched_runtime_identity(self) -> None:
+        clock = _FakeClock(start=0)
+        expected = RuntimeIdentity(
+            product="odoo-tenant-cm",
+            context="cm",
+            instance="cm-odoo-preview-pr-45",
+            environment_kind="preview",
+            deployment_record_id="idempotency-preview-45",
+            artifact_id="artifact-preview-45",
+            source_git_ref="a" * 40,
+            preview_id="preview-cm-pr-45",
+            preview_generation_id="preview-cm-pr-45-generation-a",
+        )
+        observed = expected.model_copy(
+            update={"preview_generation_id": "preview-cm-pr-45-generation-b"}
+        )
+        body = json.dumps(
+            {"ok": True, "runtime_identity": observed.model_dump(mode="json")}
+        ).encode("utf-8")
+        with (
+            patch(
+                "control_plane.workflows.odoo_preview_runtime.urlopen",
+                return_value=_SmokeResponse(status=200, body=body),
+            ),
+            patch(
+                "control_plane.workflows.odoo_preview_runtime.time.monotonic",
+                side_effect=clock.monotonic,
+            ),
+            patch("control_plane.workflows.odoo_preview_runtime.time.sleep") as sleep,
+            self.assertRaisesRegex(
+                click.ClickException,
+                "runtime identity verification failed.*preview_generation_id",
+            ),
+        ):
+            sleep.side_effect = clock.sleep
+            _wait_for_smoke_check(
+                preview_url="https://pr-45.cm-preview.example.test/",
+                health_path="/launchplane/health",
+                timeout_seconds=2,
+                expected_runtime_identity=expected,
+            )
+
     def test_smoke_check_raises_timeout_when_attempts_are_exhausted(self) -> None:
         clock = _FakeClock(start=0)
         with (
@@ -2556,9 +2637,16 @@ class _FakeClock:
 
 
 class _SmokeResponse:
-    def __init__(self, *, status: int, clear_status_on_exit: bool = False) -> None:
+    def __init__(
+        self,
+        *,
+        status: int,
+        clear_status_on_exit: bool = False,
+        body: bytes = b"ok",
+    ) -> None:
         self.status = status
         self._clear_status_on_exit = clear_status_on_exit
+        self._body = body
 
     def __enter__(self) -> "_SmokeResponse":
         return self
@@ -2568,9 +2656,8 @@ class _SmokeResponse:
             self.status = 0
         return None
 
-    @staticmethod
-    def read() -> bytes:
-        return b"ok"
+    def read(self) -> bytes:
+        return self._body
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- persist Odoo preview/generation lifecycle evidence while the durable provider reservation still fences the target
- bind refresh health to one service-derived runtime identity and reject stale, changed-authority, or legacy evidence replays
- record manager-approval invalidation before destroy tombstones while keeping GitHub projection best-effort after provider completion
- document the Odoo lifecycle ownership contract and add focused refresh, destroy, replay, failure, and runtime-identity coverage

## Validation

- `uv run --extra dev python -m unittest tests.test_http_app_driver_odoo tests.test_manager_preview_approval_github_webhook tests.test_odoo_preview_runtime` — 239 tests passed
- `uv run --extra dev launchplane ci unittest-shard local` — 2,492 tests passed across 12 shards
- `uv run --extra dev ruff check .` — passed
- `uv run --extra dev mypy control_plane tests` — 597 source files passed
- changed-file `ruff format --check` — passed
- JetBrains `inspect-closeout --scope changed_files` — clean, 0 findings

Closes #1926
