### PR TITLE
Fix manager preview projection after replacement refresh

### DIFF
--- a/control_plane/manager_preview_approval.py
+++ b/control_plane/manager_preview_approval.py
@@ -20,6 +20,9 @@ from control_plane.contracts.preview_record import PreviewRecord
 from control_plane.service_auth import AuthorizationTarget, GitHubHumanIdentity
 
 
+_TERMINAL_APPROVAL_ACTIONS = frozenset({"invalidated", "superseded"})
+
+
 class ManagerPreviewApprovalEvidenceError(ValueError):
     def __init__(self, *, code: ManagerPreviewApprovalReasonCode, message: str) -> None:
         super().__init__(message)
@@ -325,18 +328,47 @@ def evaluate_manager_preview_approval(
     )
     if not exact_events:
         if subject_events:
-            return _decision(
-                status="stale",
-                reason_code="approval_stale",
-                reason="Prior approval evidence does not match the current preview.",
-                binding=binding,
-                evaluated_at=evaluated_at,
+            latest_subject_event = max(
+                subject_events,
+                key=lambda event: (event.occurred_at, event.event_id),
             )
+            latest_binding_events = tuple(
+                event
+                for event in subject_events
+                if event.binding.binding_sha256 == latest_subject_event.binding.binding_sha256
+            )
+            if not any(
+                event.action in _TERMINAL_APPROVAL_ACTIONS for event in latest_binding_events
+            ):
+                return _decision(
+                    status="stale",
+                    reason_code="approval_stale",
+                    reason="Prior approval evidence does not match the current preview.",
+                    binding=binding,
+                    evaluated_at=evaluated_at,
+                )
         return _decision(
             status="pending",
             reason_code="approval_missing",
             reason="The current preview has not been approved by the manager.",
             binding=binding,
+            evaluated_at=evaluated_at,
+        )
+
+    terminal_events = tuple(
+        event for event in exact_events if event.action in _TERMINAL_APPROVAL_ACTIONS
+    )
+    if terminal_events:
+        latest_terminal_event = max(
+            terminal_events,
+            key=lambda event: (event.occurred_at, event.event_id),
+        )
+        return _decision(
+            status="stale",
+            reason_code="approval_stale",
+            reason="The current preview approval was superseded or invalidated.",
+            binding=binding,
+            event=latest_terminal_event,
             evaluated_at=evaluated_at,
         )
 

--- a/docs/preview-workflow-contract.md
+++ b/docs/preview-workflow-contract.md
@@ -182,6 +182,11 @@ unavailable evidence, verification failure, destroy, PR close, preview-label
 removal, or authorization-policy drift. Required code-review approvals remain a
 separate repository rule and may remain zero.
 
+When a recorded destroy or supersession ends the prior serving binding, a later
+verified replacement generation starts pending for its own exact fingerprint.
+The terminal event remains append-only audit evidence, but it does not carry a
+stale decision forward onto the replacement generation.
+
 Preview refresh, destroy, and verification must never depend on manager
 approval. They persist their own lifecycle evidence first, then attempt status
 reconciliation. If GitHub is degraded, the lifecycle operation still completes

--- a/tests/test_manager_preview_approval.py
+++ b/tests/test_manager_preview_approval.py
@@ -230,6 +230,24 @@ class ManagerPreviewApprovalTests(unittest.TestCase):
             decision = _decision(events=(approved, changes_requested, revoked, invalidated))
             self.assertEqual(decision.status, "stale")
 
+            late_approval = record_manager_preview_approval_event(
+                record_store=store,
+                identity=_manager_identity(),
+                policy_record=_policy_record(),
+                product=PRODUCT,
+                preview=_preview(),
+                generation=_generation(),
+                action="approved",
+                occurred_at="2026-07-30T12:05:00Z",
+                source_event_kind="github_issue_comment",
+                source_event_id="comment-104",
+            ).record
+            decision = _decision(
+                events=(approved, changes_requested, revoked, invalidated, late_approval)
+            )
+            self.assertEqual(decision.status, "stale")
+            self.assertEqual(decision.event_id, invalidated.event_id)
+
             superseded = build_manager_preview_approval_system_event(
                 binding=approved.binding,
                 action="superseded",
@@ -295,6 +313,53 @@ class ManagerPreviewApprovalTests(unittest.TestCase):
                         events=(approved,),
                     )
                     self.assertEqual(decision.status, "stale")
+
+    def test_terminal_prior_binding_yields_pending_for_replacement_preview(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name))
+            approved = _approved_event(store)
+            replacement_preview = _preview(
+                active_generation_id="generation-18",
+                serving_generation_id="generation-18",
+                latest_generation_id="generation-18",
+                latest_manifest_fingerprint="manifest-18",
+            )
+            replacement_generation = _generation(
+                generation_id="generation-18",
+                sequence=2,
+                resolved_manifest_fingerprint="manifest-18",
+                artifact_id="artifact-18",
+                runtime_identity=_runtime_identity(
+                    deployment_record_id="deployment-18",
+                    artifact_id="artifact-18",
+                    image_reference=f"ghcr.io/example/site@sha256:{'b' * 64}",
+                    preview_generation_id="generation-18",
+                ),
+            )
+
+            for action in ("invalidated", "superseded"):
+                with self.subTest(action=action):
+                    terminal = build_manager_preview_approval_system_event(
+                        binding=approved.binding,
+                        action=action,
+                        occurred_at="2026-07-30T11:59:00Z",
+                        source_event_kind="preview_lifecycle",
+                        source_event_id=f"generation-17:{action}",
+                        reason="The prior serving generation is no longer current.",
+                    )
+
+                    decision = _decision(
+                        preview=replacement_preview,
+                        generation=replacement_generation,
+                        events=(approved, terminal),
+                    )
+
+                    self.assertEqual(decision.status, "pending")
+                    self.assertEqual(decision.reason_code, "approval_missing")
+                    self.assertNotEqual(
+                        decision.current_binding_sha256,
+                        approved.binding.binding_sha256,
+                    )
 
     def test_policy_change_makes_prior_approval_stale(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:

--- a/tests/test_manager_preview_approval_github_webhook.py
+++ b/tests/test_manager_preview_approval_github_webhook.py
@@ -30,12 +30,15 @@ from control_plane.contracts.runtime_identity import RuntimeIdentity
 from control_plane.manager_preview_approval import (
     ManagerPreviewApprovalEventConflictError,
     build_current_manager_preview_approval_binding,
+    build_manager_preview_approval_system_event,
 )
 from control_plane.manager_preview_approval_github_webhook import (
     ManagerPreviewApprovalGitHubDependencies,
     handle_manager_preview_approval_github_webhook_request,
     invalidate_manager_preview_approval_for_pr,
     parse_manager_preview_approval_command,
+    reconcile_manager_preview_approval_for_pr,
+    reconcile_manager_preview_approval_for_pr_best_effort,
 )
 from control_plane.manager_preview_approval_projection import (
     build_manager_preview_approval_projection,
@@ -149,12 +152,23 @@ class _GitHubApi:
         self.comments: list[dict[str, object]] = []
         self.statuses: list[dict[str, object]] = []
         self.calls: list[tuple[str, str, object]] = []
+        self.fail_projection_writes = False
 
     def __call__(self, **kwargs: object) -> object:
         path = str(kwargs.get("path") or "")
         method = str(kwargs.get("method") or "GET")
         body = kwargs.get("body")
         self.calls.append((method, path, body))
+        if (
+            self.fail_projection_writes
+            and method in {"PATCH", "POST"}
+            and (
+                "/issues/comments/" in path
+                or path.endswith(f"/issues/{PR_NUMBER}/comments")
+                or "/statuses/" in path
+            )
+        ):
+            raise click.ClickException("GitHub projection is temporarily unavailable.")
         if path == "/user":
             return {"id": self.projection_actor_id, "login": "launchplane"}
         if path == f"/repos/{REPOSITORY}/issues/comments/501" and method == "GET":
@@ -485,6 +499,94 @@ class ManagerPreviewApprovalGitHubWebhookTests(unittest.TestCase):
         self.assertEqual(event.action, "invalidated")
         self.assertEqual(event.binding.binding_sha256, binding.binding_sha256)
         self.assertEqual(github.statuses[-1]["state"], "error")
+
+    def test_reconcile_recovers_pending_projection_after_destroy_and_replacement(self) -> None:
+        store = _Store()
+        prior_binding = build_current_manager_preview_approval_binding(
+            product=PRODUCT,
+            preview=store.preview,
+            generation=store.generation,
+        )
+        store.write_manager_preview_approval_event_record(
+            build_manager_preview_approval_system_event(
+                binding=prior_binding,
+                action="invalidated",
+                occurred_at="2026-07-31T11:45:00Z",
+                source_event_kind="preview_destroy",
+                source_event_id="destroy-generation-17",
+                reason="The prior serving preview was destroyed.",
+            )
+        )
+        assert store.generation.runtime_identity is not None
+        store.preview = store.preview.model_copy(
+            update={
+                "updated_at": "2026-07-31T11:50:00Z",
+                "active_generation_id": "generation-18",
+                "serving_generation_id": "generation-18",
+                "latest_generation_id": "generation-18",
+                "latest_manifest_fingerprint": "manifest-18",
+            }
+        )
+        store.generation = store.generation.model_copy(
+            update={
+                "generation_id": "generation-18",
+                "sequence": 2,
+                "requested_at": "2026-07-31T11:46:00Z",
+                "started_at": "2026-07-31T11:47:00Z",
+                "ready_at": "2026-07-31T11:50:00Z",
+                "finished_at": "2026-07-31T11:50:00Z",
+                "resolved_manifest_fingerprint": "manifest-18",
+                "artifact_id": "artifact-18",
+                "runtime_identity": store.generation.runtime_identity.model_copy(
+                    update={
+                        "deployment_record_id": "deployment-18",
+                        "artifact_id": "artifact-18",
+                        "image_reference": f"ghcr.io/example/site@sha256:{'b' * 64}",
+                        "preview_generation_id": "generation-18",
+                    }
+                ),
+            }
+        )
+        github = _GitHubApi()
+        dependencies = _dependencies(github)
+        github.fail_projection_writes = True
+
+        self.assertFalse(
+            reconcile_manager_preview_approval_for_pr_best_effort(
+                repository=REPOSITORY,
+                pr_number=PR_NUMBER,
+                record_store=store,
+                control_plane_root=Path("/tmp/launchplane"),
+                dependencies=dependencies,
+            )
+        )
+        self.assertEqual(github.statuses, [])
+        github.fail_projection_writes = False
+
+        result = reconcile_manager_preview_approval_for_pr(
+            repository=REPOSITORY,
+            pr_number=PR_NUMBER,
+            record_store=store,
+            control_plane_root=Path("/tmp/launchplane"),
+            dependencies=dependencies,
+        )
+        replayed_result = reconcile_manager_preview_approval_for_pr(
+            repository=REPOSITORY,
+            pr_number=PR_NUMBER,
+            record_store=store,
+            control_plane_root=Path("/tmp/launchplane"),
+            dependencies=dependencies,
+        )
+
+        self.assertEqual(result["status"], "pending")
+        self.assertEqual(result["check_state"], "pending")
+        self.assertNotEqual(result["fingerprint"], prior_binding.binding_sha256)
+        self.assertEqual(replayed_result["fingerprint"], result["fingerprint"])
+        self.assertEqual(replayed_result["status"], "pending")
+        self.assertEqual(len(store.events), 1)
+        self.assertEqual(len(github.comments), 1)
+        self.assertEqual(github.statuses[-1]["state"], "pending")
+        self.assertIn(str(result["fingerprint"]), str(github.comments[-1]["body"]))
 
 
 def _dependencies(github: _GitHubApi) -> ManagerPreviewApprovalGitHubDependencies:


### PR DESCRIPTION
## Summary

- Reset manager preview approval to `pending` for a replacement serving binding after the prior binding is terminally invalidated or superseded.
- Make terminal lifecycle evidence dominate later manager-authored events for the same exact binding, regardless of timestamp skew.
- Add recovery coverage for failed GitHub projection followed by idempotent reconcile, and document the replacement-generation lifecycle contract.

## Root cause

The evaluator treated any PR-level approval history without an exact event for the current binding as `stale`. After a successful destroy, the old binding's terminal invalidation therefore poisoned a later ready replacement generation instead of allowing a fresh `pending` decision for its exact fingerprint.

## Validation

- `uv run --extra dev python -m unittest tests.test_manager_preview_approval tests.test_manager_preview_approval_github_webhook` — 24 passed
- Focused Odoo destroy/refresh, replay, provider-outcome, and cleanup tests — 6 passed
- `uv run --extra dev launchplane ci unittest-shard local` — 2,492 targets passed
- `uv run --extra dev mypy control_plane tests` — clean across 597 files
- `uv run --extra dev ruff check .` — passed
- Changed-file `ruff format --check` — passed
- Config-authority audit — `status: ok`
- JetBrains changed-file inspection — clean
- Gemini/Antigravity final review — approved with no blocking findings

## Boundaries

- GitHub projection remains best-effort; preview lifecycle persistence remains authoritative.
- No tenant workflow workaround or duplicate tenant projection logic is introduced.
- Repository-wide format check still reports pre-existing drift in 25 untouched files; every file changed here passes formatting.

Follow-up to #1926.
Closes #1929.