### PR TITLE
Land exact tenant admission merge controller

### DIFF
--- a/control_plane/contracts/merge_train_controller_state.py
+++ b/control_plane/contracts/merge_train_controller_state.py
@@ -13,6 +13,10 @@ class MergeTrainControllerLeaseHeldError(RuntimeError):
     pass
 
 
+class MergeTrainControllerAdoptionRejectedError(RuntimeError):
+    pass
+
+
 class MergeTrainControllerLeaseLostError(RuntimeError):
     pass
 

--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -95,6 +95,7 @@ from control_plane.http_routes import (
     register_protected_artifact_read_routes,
     register_runner_host_hygiene_read_routes,
     REPOSITORY_HUMAN_ROLE_POLICY_APPLY_ROUTE,
+    TENANT_ADMISSION_CONTROLLER_RUN_ONCE_ROUTE,
     TENANT_ADMISSION_STATUS_RECONCILE_ROUTE,
     TENANT_TECHNICAL_HUMAN_WAIVER_APPLY_ROUTE,
     TENANT_REPOSITORY_CLASSIFICATION_APPLY_ROUTE,
@@ -210,6 +211,7 @@ from control_plane.merge_train_batch_candidate import (
     require_merge_train_batch_candidate_record_store,
 )
 from control_plane.contracts.merge_train_controller_state import (
+    MergeTrainControllerAdoptionRejectedError,
     MergeTrainControllerLeaseHeldError,
     MergeTrainControllerLeaseLostError,
     MergeTrainControllerReconciliationRequiredError,
@@ -719,6 +721,7 @@ _SECRET_REENCRYPT_MAX_BODY_BYTES = 64 * 1024
 _TENANT_REPOSITORY_CLASSIFICATION_MAX_BODY_BYTES = 64 * 1024
 _REPOSITORY_HUMAN_ROLE_POLICY_MAX_BODY_BYTES = 64 * 1024
 _TENANT_TECHNICAL_HUMAN_WAIVER_MAX_BODY_BYTES = 64 * 1024
+_TENANT_ADMISSION_CONTROLLER_RUN_ONCE_MAX_BODY_BYTES = 64 * 1024
 _TENANT_ADMISSION_STATUS_RECONCILE_MAX_BODY_BYTES = 64 * 1024
 _TRUSTED_MAINTENANCE_POLICY_MAX_BODY_BYTES = 64 * 1024
 _PRODUCT_HEALTH_MONITORING_APPLY_ROUTE = "/v1/product-profiles/health-monitoring/apply"
@@ -785,6 +788,12 @@ _BOUNDED_REQUEST_BODY_CONTRACTS: dict[str, tuple[str, int, bool, bool]] = {
     TENANT_TECHNICAL_HUMAN_WAIVER_APPLY_ROUTE: (
         "Tenant technical human waiver",
         _TENANT_TECHNICAL_HUMAN_WAIVER_MAX_BODY_BYTES,
+        True,
+        True,
+    ),
+    TENANT_ADMISSION_CONTROLLER_RUN_ONCE_ROUTE: (
+        "Tenant admission controller run",
+        _TENANT_ADMISSION_CONTROLLER_RUN_ONCE_MAX_BODY_BYTES,
         True,
         True,
     ),
@@ -5054,6 +5063,7 @@ def create_launchplane_fastapi_app(
             MergeTrainControllerLeaseHeldError,
             MergeTrainControllerLeaseLostError,
             MergeTrainControllerReconciliationRequiredError,
+            MergeTrainControllerAdoptionRejectedError,
         ) as error:
             raise merge_train_controller_fence_http_error(trace_id=trace_id, error=error) from error
         except MergeTrainBatchCandidateRecordNotFoundError as error:
@@ -5219,6 +5229,7 @@ def create_launchplane_fastapi_app(
             MergeTrainControllerLeaseHeldError,
             MergeTrainControllerLeaseLostError,
             MergeTrainControllerReconciliationRequiredError,
+            MergeTrainControllerAdoptionRejectedError,
         ) as error:
             raise merge_train_controller_fence_http_error(trace_id=trace_id, error=error) from error
         except (MergeTrainControllerRequestError, ValueError, click.ClickException) as error:
@@ -8821,6 +8832,7 @@ def create_launchplane_fastapi_app(
             MergeTrainControllerLeaseHeldError,
             MergeTrainControllerLeaseLostError,
             MergeTrainControllerReconciliationRequiredError,
+            MergeTrainControllerAdoptionRejectedError,
         ) as error:
             raise merge_train_controller_fence_http_error(trace_id=trace_id, error=error) from error
         except MergeTrainStackCollapseBatchCandidateStoreMissingError as error:
@@ -9014,6 +9026,7 @@ def create_launchplane_fastapi_app(
             MergeTrainControllerLeaseHeldError,
             MergeTrainControllerLeaseLostError,
             MergeTrainControllerReconciliationRequiredError,
+            MergeTrainControllerAdoptionRejectedError,
         ) as error:
             raise merge_train_controller_fence_http_error(trace_id=trace_id, error=error) from error
         except (
@@ -9204,6 +9217,7 @@ def create_launchplane_fastapi_app(
             MergeTrainControllerLeaseHeldError,
             MergeTrainControllerLeaseLostError,
             MergeTrainControllerReconciliationRequiredError,
+            MergeTrainControllerAdoptionRejectedError,
         ) as error:
             raise merge_train_controller_fence_http_error(trace_id=trace_id, error=error) from error
         if controller_state_store is None:
@@ -20708,14 +20722,17 @@ def merge_train_controller_fence_http_error(
         MergeTrainControllerLeaseHeldError
         | MergeTrainControllerLeaseLostError
         | MergeTrainControllerReconciliationRequiredError
+        | MergeTrainControllerAdoptionRejectedError
     ),
 ) -> HTTPException:
     if isinstance(error, MergeTrainControllerLeaseHeldError):
         code = "merge_train_controller_lease_held"
     elif isinstance(error, MergeTrainControllerLeaseLostError):
         code = "merge_train_controller_lease_lost"
-    else:
+    elif isinstance(error, MergeTrainControllerReconciliationRequiredError):
         code = "merge_train_controller_reconciliation_required"
+    else:
+        code = "merge_train_controller_foreign_action"
     return _launchplane_http_error(
         status_code=409,
         trace_id=trace_id,

--- a/control_plane/http_routes/__init__.py
+++ b/control_plane/http_routes/__init__.py
@@ -65,6 +65,7 @@ from control_plane.http_routes.products import (
 from control_plane.http_routes.support import ReadRouteDependencies
 from control_plane.http_routes.tenant_admission import (
     REPOSITORY_HUMAN_ROLE_POLICY_APPLY_ROUTE,
+    TENANT_ADMISSION_CONTROLLER_RUN_ONCE_ROUTE,
     TENANT_ADMISSION_STATUS_RECONCILE_ROUTE,
     TENANT_TECHNICAL_HUMAN_WAIVER_APPLY_ROUTE,
     TENANT_REPOSITORY_CLASSIFICATION_APPLY_ROUTE,
@@ -93,6 +94,7 @@ __all__ = (
     "ProductReadRouteDependencies",
     "PromotionEvidenceRequest",
     "REPOSITORY_HUMAN_ROLE_POLICY_APPLY_ROUTE",
+    "TENANT_ADMISSION_CONTROLLER_RUN_ONCE_ROUTE",
     "TENANT_ADMISSION_STATUS_RECONCILE_ROUTE",
     "TENANT_TECHNICAL_HUMAN_WAIVER_APPLY_ROUTE",
     "TRUSTED_MAINTENANCE_POLICY_APPLY_ROUTE",

--- a/control_plane/http_routes/tenant_admission.py
+++ b/control_plane/http_routes/tenant_admission.py
@@ -7,6 +7,11 @@ import click
 from fastapi import Depends, Header, Query, Request
 from pydantic import BaseModel, ConfigDict, Field
 
+from control_plane.contracts.merge_train_controller_state import (
+    MergeTrainControllerAdoptionRejectedError,
+    MergeTrainControllerLeaseHeldError,
+    MergeTrainControllerLeaseLostError,
+)
 from control_plane.http_routes.mutation_support import (
     idempotency_scope,
     request_fingerprint,
@@ -53,6 +58,17 @@ from control_plane.service_auth import (
 )
 from control_plane.service_auth import AuthorizationTarget
 from control_plane.storage.postgres import DbOnlyMutationRequest, PostgresRecordStore
+from control_plane.merge_train_github import MergeTrainGitHubError
+from control_plane.tenant_admission_controller import (
+    TENANT_ADMISSION_CONTROLLER_RUN_ONCE_ACTION,
+    TenantAdmissionControllerError,
+    TenantAdmissionControllerReconciliationError,
+    TenantAdmissionControllerRunOnceEnvelope,
+    TenantAdmissionControllerRunOnceResult,
+    TenantAdmissionControllerStaleCandidateError,
+    execute_tenant_admission_controller_run_once,
+    require_tenant_admission_controller_store,
+)
 from control_plane.tenant_repository_classification import (
     TenantRepositoryClassificationApplyEnvelope,
     TenantRepositoryClassificationApplyResult,
@@ -109,6 +125,7 @@ TRUSTED_MAINTENANCE_POLICY_APPLY_ROUTE = "/v1/tenant-admission/trusted-maintenan
 TENANT_TECHNICAL_HUMAN_WAIVER_APPLY_ROUTE = "/v1/tenant-admission/technical-human-waivers/apply"
 TENANT_ADMISSION_STATUS_READ_ROUTE = "/v1/work-graph/tenant-admission/status"
 TENANT_ADMISSION_STATUS_RECONCILE_ROUTE = "/v1/tenant-admission/status/reconcile"
+TENANT_ADMISSION_CONTROLLER_RUN_ONCE_ROUTE = "/v1/work-graph/tenant-admission/controller/run-once"
 
 
 @dataclass(frozen=True, slots=True)
@@ -240,6 +257,14 @@ class TenantAdmissionStatusReconcileResponse(BaseModel):
     status: Literal["ok"] = "ok"
     trace_id: str
     result: TenantAdmissionStatusReconcileResult
+
+
+class TenantAdmissionControllerRunOnceResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["accepted"] = "accepted"
+    trace_id: str
+    result: TenantAdmissionControllerRunOnceResult
 
 
 def register_tenant_admission_read_routes(
@@ -539,6 +564,100 @@ def register_tenant_admission_write_routes(
 ) -> None:
     def _human_waiver_idempotency_scope(identity: GitHubHumanIdentity) -> str:
         return f"github-human-id|{identity.github_id}"
+
+    async def run_tenant_admission_controller_once_route(
+        envelope: TenantAdmissionControllerRunOnceEnvelope,
+        identity: Annotated[LaunchplaneIdentity, Depends(dependencies.read_write_identity)],
+        record_store: Annotated[object, Depends(dependencies.get_record_store)],
+    ) -> TenantAdmissionControllerRunOnceResponse:
+        trace_id = dependencies.next_trace_id()
+        candidate = envelope.candidate
+        if not dependencies.authorization_allows(
+            identity=identity,
+            action=TENANT_ADMISSION_CONTROLLER_RUN_ONCE_ACTION,
+            product=candidate.product,
+            context=candidate.context,
+            target=AuthorizationTarget(scope="context"),
+        ):
+            raise dependencies.http_error(
+                status_code=403,
+                trace_id=trace_id,
+                code="authorization_denied",
+                message="Caller cannot run the tenant admission controller for this context.",
+            )
+        try:
+            store = require_tenant_admission_controller_store(record_store)
+        except TypeError as error:
+            raise dependencies.http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="record_storage_unavailable",
+                message=str(error),
+            ) from error
+        token = dependencies.github_token(
+            control_plane_root=dependencies.control_plane_root,
+            context_name=candidate.context,
+        ).strip()
+        if not token:
+            raise dependencies.http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="github_token_unavailable",
+                message="Tenant admission controller cannot resolve a GitHub token.",
+            )
+        try:
+            result = execute_tenant_admission_controller_run_once(
+                request=envelope,
+                store=store,
+                token=token,
+                trace_id=trace_id,
+            )
+        except TenantAdmissionControllerStaleCandidateError as error:
+            raise dependencies.http_error(
+                status_code=409,
+                trace_id=trace_id,
+                code="tenant_admission_stale_candidate",
+                message=str(error),
+            ) from error
+        except MergeTrainControllerLeaseHeldError as error:
+            raise dependencies.http_error(
+                status_code=409,
+                trace_id=trace_id,
+                code="tenant_admission_controller_busy",
+                message=str(error),
+            ) from error
+        except MergeTrainControllerAdoptionRejectedError as error:
+            raise dependencies.http_error(
+                status_code=409,
+                trace_id=trace_id,
+                code="tenant_admission_reconciliation_required",
+                message=str(error),
+            ) from error
+        except TenantAdmissionControllerReconciliationError as error:
+            raise dependencies.http_error(
+                status_code=409,
+                trace_id=trace_id,
+                code="tenant_admission_reconciliation_required",
+                message=str(error),
+            ) from error
+        except (
+            TenantAdmissionControllerError,
+            MergeTrainControllerLeaseLostError,
+            MergeTrainGitHubError,
+            LookupError,
+            TypeError,
+            ValueError,
+        ) as error:
+            raise dependencies.http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="tenant_admission_controller_unavailable",
+                message="Tenant admission controller could not verify or complete the exact merge.",
+            ) from error
+        return TenantAdmissionControllerRunOnceResponse(
+            trace_id=trace_id,
+            result=result,
+        )
 
     async def reconcile_tenant_admission_status_route(
         envelope: TenantAdmissionStatusReconcileEnvelope,
@@ -1508,6 +1627,23 @@ def register_tenant_admission_write_routes(
             trace_id=trace_id,
             result=result,
         )
+
+    app.add_api_route(
+        TENANT_ADMISSION_CONTROLLER_RUN_ONCE_ROUTE,
+        run_tenant_admission_controller_once_route,
+        methods=["POST"],
+        status_code=202,
+        response_model=TenantAdmissionControllerRunOnceResponse,
+        operation_id="run_tenant_admission_controller_once",
+        summary="Re-evaluate and merge one exact admitted tenant pull request",
+        responses={
+            400: {"model": dependencies.error_response_model},
+            401: {"model": dependencies.error_response_model},
+            403: {"model": dependencies.error_response_model},
+            409: {"model": dependencies.error_response_model},
+            503: {"model": dependencies.error_response_model},
+        },
+    )
 
     app.add_api_route(
         TENANT_ADMISSION_STATUS_RECONCILE_ROUTE,

--- a/control_plane/merge_train_controller_run_once.py
+++ b/control_plane/merge_train_controller_run_once.py
@@ -68,6 +68,19 @@ from control_plane.workflows.merge_train_controller import (
 
 _LOGGER = logging.getLogger(__name__)
 DEFAULT_MERGE_TRAIN_CONTROLLER_LEASE_SECONDS = 300
+MERGE_TRAIN_CONTROLLER_ACTIVE_ACTION = "merge_train_controller_run_once"
+MERGE_TRAIN_CONTROLLER_ADOPTABLE_ACTIVE_ACTIONS = (
+    "admit_collapsed_root",
+    "build_candidate",
+    "execute_stack_collapse",
+    "land_batch",
+    MERGE_TRAIN_CONTROLLER_ACTIVE_ACTION,
+    "observe_candidate",
+    "plan_candidate",
+    "plan_landing",
+    "plan_stack_collapse",
+    "reflow_candidate",
+)
 
 
 class MergeTrainControllerRunOnceEnvelope(BaseModel):
@@ -116,6 +129,9 @@ class MergeTrainControllerStateRecordStore(Protocol):
         policy_sha256: str,
         lease_owner: str,
         lease_seconds: int,
+        initial_active_action: str,
+        initial_active_phase: str,
+        adoptable_active_actions: tuple[str, ...],
     ) -> MergeTrainControllerStateRecord: ...
 
     def compare_and_set_merge_train_controller_state_record(
@@ -204,6 +220,9 @@ def merge_train_controller_mutation_fence(
         policy_sha256=policy_sha256,
         lease_owner=lease_owner,
         lease_seconds=DEFAULT_MERGE_TRAIN_CONTROLLER_LEASE_SECONDS,
+        initial_active_action=active_action,
+        initial_active_phase=active_phase,
+        adoptable_active_actions=(active_action,),
     )
     lease = MergeTrainControllerLeaseContext(
         record=controller_state,
@@ -280,6 +299,9 @@ def execute_merge_train_controller_run_once(
             policy_sha256=policy_sha256,
             lease_owner=lease_owner,
             lease_seconds=DEFAULT_MERGE_TRAIN_CONTROLLER_LEASE_SECONDS,
+            initial_active_action=MERGE_TRAIN_CONTROLLER_ACTIVE_ACTION,
+            initial_active_phase="select_next_action",
+            adoptable_active_actions=MERGE_TRAIN_CONTROLLER_ADOPTABLE_ACTIVE_ACTIONS,
         )
         lease = MergeTrainControllerLeaseContext(
             record=controller_state,

--- a/control_plane/repository_human_admission.py
+++ b/control_plane/repository_human_admission.py
@@ -664,11 +664,11 @@ def build_tenant_technical_human_waiver_apply_result(
         recorded_at=normalized_observed_at,
         expires_at=envelope.expires_at,
     )
-    append_plan = plan_tenant_technical_human_waiver_event_append(
-        records=events,
-        record=captured.record,
-    )
     if envelope.action == "created":
+        append_plan = plan_tenant_technical_human_waiver_event_append(
+            records=events,
+            record=captured.record,
+        )
         if append_plan.status == "replayed":
             _require_replayed_create_current(
                 path_result=current_path,
@@ -686,6 +686,10 @@ def build_tenant_technical_human_waiver_apply_result(
         _require_expected_current_waiver(
             path_result=current_path,
             expected_current=envelope.expected_current,
+        )
+        append_plan = plan_tenant_technical_human_waiver_event_append(
+            records=events,
+            record=captured.record,
         )
     all_events = (
         tuple(events) if append_plan.status == "replayed" else tuple(events) + (captured.record,)

--- a/control_plane/storage/filesystem.py
+++ b/control_plane/storage/filesystem.py
@@ -48,6 +48,7 @@ from control_plane.contracts.manager_preview_approval import (
 from control_plane.contracts.merge_train_batch import MergeTrainBatchCandidateRecord
 from control_plane.contracts.merge_train_batch import MergeTrainBatchLandingPlanRecord
 from control_plane.contracts.merge_train_controller_state import (
+    MergeTrainControllerAdoptionRejectedError,
     MergeTrainControllerLeaseHeldError,
     MergeTrainControllerLeaseLostError,
     MergeTrainControllerStateRecord,
@@ -1236,12 +1237,26 @@ class FilesystemRecordStore:
         policy_sha256: str,
         lease_owner: str,
         lease_seconds: int,
+        initial_active_action: str,
+        initial_active_phase: str,
+        adoptable_active_actions: tuple[str, ...],
     ) -> MergeTrainControllerStateRecord:
         from control_plane.contracts.merge_train_controller_state import (
             build_merge_train_controller_key,
             build_merge_train_controller_state_record,
         )
 
+        normalized_initial_action = initial_active_action.strip()
+        normalized_initial_phase = initial_active_phase.strip()
+        normalized_adoptable_actions = tuple(
+            dict.fromkeys(action.strip() for action in adoptable_active_actions if action.strip())
+        )
+        if not normalized_initial_action or not normalized_initial_phase:
+            raise ValueError("merge train controller acquisition requires initial action and phase")
+        if normalized_initial_action not in normalized_adoptable_actions:
+            raise ValueError(
+                "initial controller action must be adoptable by the acquiring controller"
+            )
         record_type = "launchplane_merge_train_controller_states"
         controller_key = build_merge_train_controller_key(
             repository=repository,
@@ -1277,6 +1292,10 @@ class FilesystemRecordStore:
             adopting = current_record.status == "reconcile_required" or bool(
                 current_record.active_action and current_record.active_phase
             )
+            if adopting and current_record.active_action not in normalized_adoptable_actions:
+                raise MergeTrainControllerAdoptionRejectedError(
+                    "merge train controller state belongs to a different active action"
+                )
             leased_record = current_record.model_copy(
                 update={
                     "policy_key": policy_key,
@@ -1290,8 +1309,8 @@ class FilesystemRecordStore:
                         lease_seconds=lease_seconds,
                     ),
                     "heartbeat_at": observed_at,
-                    "active_action": current_record.active_action or "controller_run_once",
-                    "active_phase": current_record.active_phase or "select_next_action",
+                    "active_action": current_record.active_action or normalized_initial_action,
+                    "active_phase": current_record.active_phase or normalized_initial_phase,
                     "reconciliation_status": "adopted" if adopting else "clean",
                     "reconciliation_detail": (
                         build_merge_train_controller_resume_detail(current_record)

--- a/control_plane/storage/postgres.py
+++ b/control_plane/storage/postgres.py
@@ -78,6 +78,7 @@ from control_plane.contracts.merge_train_batch import (
     MergeTrainBatchLandingPlanRecord,
 )
 from control_plane.contracts.merge_train_controller_state import (
+    MergeTrainControllerAdoptionRejectedError,
     MergeTrainControllerLeaseHeldError,
     MergeTrainControllerLeaseLostError,
     MergeTrainControllerStateRecord,
@@ -10598,7 +10599,21 @@ class PostgresRecordStore(HumanSessionStore):
         policy_sha256: str,
         lease_owner: str,
         lease_seconds: int,
+        initial_active_action: str,
+        initial_active_phase: str,
+        adoptable_active_actions: tuple[str, ...],
     ) -> MergeTrainControllerStateRecord:
+        normalized_initial_action = initial_active_action.strip()
+        normalized_initial_phase = initial_active_phase.strip()
+        normalized_adoptable_actions = tuple(
+            dict.fromkeys(action.strip() for action in adoptable_active_actions if action.strip())
+        )
+        if not normalized_initial_action or not normalized_initial_phase:
+            raise ValueError("merge train controller acquisition requires initial action and phase")
+        if normalized_initial_action not in normalized_adoptable_actions:
+            raise ValueError(
+                "initial controller action must be adoptable by the acquiring controller"
+            )
         controller_key = build_merge_train_controller_key(
             repository=repository,
             base_branch=base_branch,
@@ -10631,8 +10646,8 @@ class PostgresRecordStore(HumanSessionStore):
                         "lease_acquired_at": observed_at,
                         "lease_expires_at": lease_expires_at,
                         "heartbeat_at": observed_at,
-                        "active_action": "controller_run_once",
-                        "active_phase": "select_next_action",
+                        "active_action": normalized_initial_action,
+                        "active_phase": normalized_initial_phase,
                     }
                 )
                 leased_record = MergeTrainControllerStateRecord.model_validate(
@@ -10671,6 +10686,10 @@ class PostgresRecordStore(HumanSessionStore):
             adopting = current_record.status == "reconcile_required" or bool(
                 current_record.active_action and current_record.active_phase
             )
+            if adopting and current_record.active_action not in normalized_adoptable_actions:
+                raise MergeTrainControllerAdoptionRejectedError(
+                    "merge train controller state belongs to a different active action"
+                )
             leased_record = current_record.model_copy(
                 update={
                     "policy_key": policy_key,
@@ -10681,8 +10700,8 @@ class PostgresRecordStore(HumanSessionStore):
                     "lease_acquired_at": observed_at,
                     "lease_expires_at": lease_expires_at,
                     "heartbeat_at": observed_at,
-                    "active_action": current_record.active_action or "controller_run_once",
-                    "active_phase": current_record.active_phase or "select_next_action",
+                    "active_action": current_record.active_action or normalized_initial_action,
+                    "active_phase": current_record.active_phase or normalized_initial_phase,
                     "reconciliation_status": "adopted" if adopting else "clean",
                     "reconciliation_detail": (
                         build_merge_train_controller_resume_detail(current_record)

--- a/control_plane/tenant_admission_controller.py
+++ b/control_plane/tenant_admission_controller.py
@@ -1,0 +1,1243 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+import hashlib
+import json
+from typing import Literal, Protocol, cast
+from urllib.parse import quote, urlencode
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from control_plane.contracts.manager_preview_approval_projection import (
+    MANAGER_PREVIEW_APPROVAL_CHECK_NAME,
+)
+from control_plane.contracts.merge_train_policy import MergeTrainMergeMethod
+from control_plane.contracts.tenant_merge_eligibility import (
+    TenantMergeCandidate,
+    _normalize_utc_timestamp,
+)
+from control_plane.github_payload import json_object, required_positive_int, required_string_text
+from control_plane.merge_train_controller_run_once import (
+    DEFAULT_MERGE_TRAIN_CONTROLLER_LEASE_SECONDS,
+    MergeTrainControllerLeaseContext,
+    MergeTrainControllerStateRecordStore,
+    merge_train_controller_lease_owner,
+)
+from control_plane.merge_train_github import (
+    GitHubMergeTrainClient,
+    MergeTrainGitHubError,
+    MergeTrainGitHubStaleHeadError,
+    MergeTrainGitHubTransport,
+    UrllibMergeTrainGitHubTransport,
+)
+from control_plane.tenant_admission_status import (
+    TENANT_ADMISSION_STATUS_CONTEXT,
+    TenantAdmissionStatusReadModel,
+    TenantAdmissionStatusStore,
+    get_tenant_admission_status,
+)
+from control_plane.workflows.ship import utc_now_timestamp
+
+
+TENANT_ADMISSION_CONTROLLER_RUN_ONCE_ACTION = "tenant_admission.controller.run_once"
+TENANT_ADMISSION_CONTROLLER_ACTIVE_ACTION = "tenant_admission_merge"
+
+TenantAdmissionControllerOutcome = Literal[
+    "ready",
+    "merged",
+    "adopted",
+    "already_merged",
+    "blocked",
+    "not_applicable",
+]
+TenantAdmissionTechnicalCheckSource = Literal["commit_status", "check_run"]
+TenantAdmissionTechnicalCheckState = Literal["pass", "pending", "fail", "unavailable"]
+
+_ADMITTED_CATEGORIES = frozenset({"manager-approved", "technical-waived", "maintenance-admitted"})
+_EXCLUDED_TECHNICAL_CONTEXTS = frozenset(
+    {
+        TENANT_ADMISSION_STATUS_CONTEXT.casefold(),
+        MANAGER_PREVIEW_APPROVAL_CHECK_NAME.casefold(),
+    }
+)
+_PROVIDER_EFFECT_PHASES = frozenset({"merge_pull_request", "confirm_merge"})
+
+
+class TenantAdmissionControllerError(ValueError):
+    pass
+
+
+class TenantAdmissionControllerStaleCandidateError(TenantAdmissionControllerError):
+    pass
+
+
+class TenantAdmissionControllerReconciliationError(TenantAdmissionControllerError):
+    pass
+
+
+class TenantAdmissionControllerRunOnceEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    candidate: TenantMergeCandidate
+    base_branch: str
+    merge_method: MergeTrainMergeMethod = "merge"
+    mutate: bool = False
+
+    @model_validator(mode="after")
+    def _validate_envelope(self) -> "TenantAdmissionControllerRunOnceEnvelope":
+        if self.schema_version != 1:
+            raise ValueError("Unsupported tenant admission controller schema version.")
+        self.base_branch = self.base_branch.strip()
+        if not self.base_branch:
+            raise ValueError("Tenant admission controller requires base_branch.")
+        return self
+
+
+class TenantAdmissionPullRequestFacts(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    repository: str
+    pull_request_number: int = Field(ge=1)
+    pull_request_url: str
+    state: Literal["open", "closed"]
+    merged: bool
+    draft: bool = False
+    mergeable: bool | None = None
+    head_sha: str
+    base_branch: str
+    base_sha: str
+    merge_commit_sha: str = ""
+
+    @model_validator(mode="after")
+    def _validate_facts(self) -> "TenantAdmissionPullRequestFacts":
+        self.repository = self.repository.strip().lower()
+        self.pull_request_url = self.pull_request_url.strip()
+        self.head_sha = self.head_sha.strip().lower()
+        self.base_branch = self.base_branch.strip()
+        self.base_sha = self.base_sha.strip().lower()
+        self.merge_commit_sha = self.merge_commit_sha.strip().lower()
+        if self.merged and (self.state != "closed" or not self.merge_commit_sha):
+            raise ValueError("Merged tenant admission PR facts require closed state and merge SHA.")
+        if not self.merged and self.state != "open":
+            raise ValueError("Unmerged tenant admission PR facts must remain open.")
+        return self
+
+
+class TenantAdmissionTechnicalCheckSignal(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    source: TenantAdmissionTechnicalCheckSource
+    name: str
+    app_id: int | None = Field(default=None, ge=1)
+    state: TenantAdmissionTechnicalCheckState
+
+    @model_validator(mode="after")
+    def _validate_signal(self) -> "TenantAdmissionTechnicalCheckSignal":
+        self.name = self.name.strip()
+        if not self.name:
+            raise ValueError("Tenant admission technical check signal requires name.")
+        return self
+
+
+class TenantAdmissionRequiredTechnicalCheck(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    app_id: int | None = Field(default=None, ge=1)
+
+    @model_validator(mode="after")
+    def _validate_required_check(self) -> "TenantAdmissionRequiredTechnicalCheck":
+        self.name = self.name.strip()
+        if not self.name:
+            raise ValueError("Required tenant admission technical check requires name.")
+        return self
+
+
+class TenantAdmissionTechnicalChecks(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    head_sha: str
+    base_sha: str
+    strict: bool
+    base_up_to_date: bool | None = None
+    status: TenantAdmissionTechnicalCheckState
+    required_checks: tuple[TenantAdmissionRequiredTechnicalCheck, ...] = ()
+    signals: tuple[TenantAdmissionTechnicalCheckSignal, ...] = ()
+    excluded_contexts: tuple[str, ...] = (
+        MANAGER_PREVIEW_APPROVAL_CHECK_NAME,
+        TENANT_ADMISSION_STATUS_CONTEXT,
+    )
+    evaluated_at: str
+    binding_sha256: str = ""
+
+    @model_validator(mode="after")
+    def _validate_checks(self) -> "TenantAdmissionTechnicalChecks":
+        if self.schema_version != 1:
+            raise ValueError("Unsupported tenant admission technical checks schema version.")
+        self.head_sha = self.head_sha.strip().lower()
+        self.base_sha = self.base_sha.strip().lower()
+        self.evaluated_at = _normalize_utc_timestamp(self.evaluated_at, "evaluated_at")
+        if self.strict and self.base_up_to_date is None:
+            raise ValueError("Strict tenant admission checks require base freshness evidence.")
+        expected_digest = _model_sha256(self, exclude={"binding_sha256"})
+        if self.binding_sha256:
+            self.binding_sha256 = self.binding_sha256.strip().lower()
+            if self.binding_sha256 != expected_digest:
+                raise ValueError("Tenant admission technical checks digest does not match payload.")
+        else:
+            self.binding_sha256 = expected_digest
+        if self.status == "pass" and (not self.required_checks or not self.signals):
+            raise ValueError(
+                "Passing tenant admission technical checks require policy and signals."
+            )
+        if self.status == "pass" and self.strict and not self.base_up_to_date:
+            raise ValueError("Passing strict tenant admission checks require an up-to-date base.")
+        return self
+
+
+class TenantAdmissionControllerRunOnceResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    outcome: TenantAdmissionControllerOutcome
+    mutated: bool = False
+    candidate: TenantMergeCandidate
+    base_branch: str
+    merge_method: MergeTrainMergeMethod
+    pull_request_facts: TenantAdmissionPullRequestFacts
+    admission: TenantAdmissionStatusReadModel | None = None
+    technical_checks: TenantAdmissionTechnicalChecks | None = None
+    merge_commit_sha: str = ""
+    detail: str
+
+    @model_validator(mode="after")
+    def _validate_result(self) -> "TenantAdmissionControllerRunOnceResult":
+        if self.schema_version != 1:
+            raise ValueError("Unsupported tenant admission controller result schema version.")
+        self.base_branch = self.base_branch.strip()
+        self.merge_commit_sha = self.merge_commit_sha.strip().lower()
+        self.detail = self.detail.strip()
+        if not self.detail:
+            raise ValueError("Tenant admission controller result requires detail.")
+        if self.outcome in {"merged", "adopted", "already_merged"}:
+            if not self.pull_request_facts.merged or not self.merge_commit_sha:
+                raise ValueError(
+                    "Completed tenant admission merge result requires merged PR facts."
+                )
+        if self.outcome == "merged" and not self.mutated:
+            raise ValueError("Merged tenant admission result must report mutation.")
+        return self
+
+
+class TenantAdmissionControllerCheckpoint(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    operation_id: str
+    request: TenantAdmissionControllerRunOnceEnvelope
+    pull_request_facts: TenantAdmissionPullRequestFacts | None = None
+    admission: TenantAdmissionStatusReadModel | None = None
+    technical_checks: TenantAdmissionTechnicalChecks | None = None
+    merge_commit_sha: str = ""
+
+    @model_validator(mode="after")
+    def _validate_checkpoint(self) -> "TenantAdmissionControllerCheckpoint":
+        if self.schema_version != 1:
+            raise ValueError("Unsupported tenant admission controller checkpoint schema version.")
+        self.operation_id = self.operation_id.strip()
+        self.merge_commit_sha = self.merge_commit_sha.strip().lower()
+        if self.operation_id != tenant_admission_controller_operation_id(self.request):
+            raise ValueError("Tenant admission controller checkpoint operation ID does not match.")
+        return self
+
+
+class TenantAdmissionControllerStore(
+    TenantAdmissionStatusStore,
+    MergeTrainControllerStateRecordStore,
+    Protocol,
+):
+    pass
+
+
+TransportFactory = Callable[[str], MergeTrainGitHubTransport]
+
+
+class TenantAdmissionControllerGitHubClient:
+    def __init__(self, *, transport: MergeTrainGitHubTransport) -> None:
+        self.transport = transport
+        self.merge_client = GitHubMergeTrainClient(transport=transport)
+
+    def read_pull_request(
+        self,
+        *,
+        expected: TenantMergeCandidate,
+        base_branch: str,
+    ) -> TenantAdmissionPullRequestFacts:
+        owner, repo = expected.repository.split("/", 1)
+        payload = json_object(
+            self.transport.request(
+                method="GET",
+                path=(
+                    f"/repos/{quote(owner, safe='')}/{quote(repo, safe='')}/pulls/"
+                    f"{expected.pull_request_number}"
+                ),
+            ),
+            "GitHub pull request response",
+            error_type=TenantAdmissionControllerError,
+        )
+        if (
+            required_positive_int(
+                payload.get("number"),
+                "GitHub pull request response requires a positive number.",
+                error_type=TenantAdmissionControllerError,
+            )
+            != expected.pull_request_number
+        ):
+            raise TenantAdmissionControllerStaleCandidateError(
+                "GitHub pull request number changed from the expected candidate."
+            )
+        state = required_string_text(
+            payload.get("state"),
+            "GitHub pull request response requires state.",
+            error_type=TenantAdmissionControllerError,
+        ).lower()
+        raw_merged = payload.get("merged")
+        if not isinstance(raw_merged, bool):
+            raise TenantAdmissionControllerError(
+                "GitHub pull request response merged must be boolean."
+            )
+        merged = raw_merged
+        raw_draft = payload.get("draft")
+        if not isinstance(raw_draft, bool):
+            raise TenantAdmissionControllerError(
+                "GitHub pull request response draft must be boolean."
+            )
+        draft = raw_draft
+        raw_mergeable = payload.get("mergeable")
+        if raw_mergeable is not None and not isinstance(raw_mergeable, bool):
+            raise TenantAdmissionControllerError(
+                "GitHub pull request response mergeable must be boolean or null."
+            )
+        mergeable = raw_mergeable
+        if state not in {"open", "closed"} or (state == "closed" and not merged):
+            raise TenantAdmissionControllerStaleCandidateError(
+                "GitHub pull request is neither open nor an exact merged result."
+            )
+        base = json_object(
+            payload.get("base"),
+            "GitHub pull request base",
+            error_type=TenantAdmissionControllerError,
+        )
+        base_repo = json_object(
+            base.get("repo"),
+            "GitHub pull request base repository",
+            error_type=TenantAdmissionControllerError,
+        )
+        base_owner = json_object(
+            base_repo.get("owner"),
+            "GitHub pull request base repository owner",
+            error_type=TenantAdmissionControllerError,
+        )
+        head = json_object(
+            payload.get("head"),
+            "GitHub pull request head",
+            error_type=TenantAdmissionControllerError,
+        )
+        head_repo = json_object(
+            head.get("repo"),
+            "GitHub pull request head repository",
+            error_type=TenantAdmissionControllerError,
+        )
+        head_owner = json_object(
+            head_repo.get("owner"),
+            "GitHub pull request head repository owner",
+            error_type=TenantAdmissionControllerError,
+        )
+        current_repository_id = str(
+            required_positive_int(
+                base_repo.get("id"),
+                "GitHub base repository requires a positive id.",
+                error_type=TenantAdmissionControllerError,
+            )
+        )
+        current_owner_id = str(
+            required_positive_int(
+                base_owner.get("id"),
+                "GitHub base repository owner requires a positive id.",
+                error_type=TenantAdmissionControllerError,
+            )
+        )
+        current_repository = required_string_text(
+            base_repo.get("full_name"),
+            "GitHub base repository requires full_name.",
+            error_type=TenantAdmissionControllerError,
+        ).lower()
+        current_head_sha = required_string_text(
+            head.get("sha"),
+            "GitHub pull request head requires sha.",
+            error_type=TenantAdmissionControllerError,
+        ).lower()
+        current_base_branch = required_string_text(
+            base.get("ref"),
+            "GitHub pull request base requires ref.",
+            error_type=TenantAdmissionControllerError,
+        )
+        current_base_sha = required_string_text(
+            base.get("sha"),
+            "GitHub pull request base requires sha.",
+            error_type=TenantAdmissionControllerError,
+        ).lower()
+        head_repository_id = str(
+            required_positive_int(
+                head_repo.get("id"),
+                "GitHub head repository requires a positive id.",
+                error_type=TenantAdmissionControllerError,
+            )
+        )
+        head_owner_id = str(
+            required_positive_int(
+                head_owner.get("id"),
+                "GitHub head repository owner requires a positive id.",
+                error_type=TenantAdmissionControllerError,
+            )
+        )
+        head_repository = required_string_text(
+            head_repo.get("full_name"),
+            "GitHub head repository requires full_name.",
+            error_type=TenantAdmissionControllerError,
+        ).lower()
+        if (
+            current_repository_id != expected.repository_id
+            or current_owner_id != expected.repository_owner_id
+            or current_repository != expected.repository
+            or current_head_sha != expected.head_sha
+            or current_base_branch != base_branch
+            or head_repository_id != expected.repository_id
+            or head_owner_id != expected.repository_owner_id
+            or head_repository != expected.repository
+        ):
+            raise TenantAdmissionControllerStaleCandidateError(
+                "GitHub repository, branch, or head identity changed from the expected candidate."
+            )
+        merge_commit_sha = (
+            str(payload.get("merge_commit_sha") or "").strip().lower() if merged else ""
+        )
+        return TenantAdmissionPullRequestFacts(
+            repository=current_repository,
+            pull_request_number=expected.pull_request_number,
+            pull_request_url=required_string_text(
+                payload.get("html_url"),
+                "GitHub pull request response requires html_url.",
+                error_type=TenantAdmissionControllerError,
+            ),
+            state=cast(Literal["open", "closed"], state),
+            merged=merged,
+            draft=draft,
+            mergeable=mergeable,
+            head_sha=current_head_sha,
+            base_branch=current_base_branch,
+            base_sha=current_base_sha,
+            merge_commit_sha=merge_commit_sha,
+        )
+
+    def read_technical_checks(
+        self,
+        *,
+        repository: str,
+        base_branch: str,
+        base_sha: str,
+        head_sha: str,
+        evaluated_at: str,
+    ) -> TenantAdmissionTechnicalChecks:
+        owner, repo = repository.split("/", 1)
+        repository_path = f"{quote(owner, safe='')}/{quote(repo, safe='')}"
+        encoded_head_sha = quote(head_sha, safe="")
+        encoded_base_branch = quote(base_branch, safe="")
+        try:
+            required_checks_payload = json_object(
+                self.transport.request(
+                    method="GET",
+                    path=(
+                        f"/repos/{repository_path}/branches/{encoded_base_branch}/protection/"
+                        "required_status_checks"
+                    ),
+                ),
+                "GitHub required status checks response",
+                error_type=TenantAdmissionControllerError,
+            )
+        except MergeTrainGitHubError as error:
+            if error.status_code != 404:
+                raise
+            required_checks_payload = {"strict": False, "checks": [], "contexts": []}
+        strict, required_checks = _required_technical_checks(required_checks_payload)
+        base_up_to_date = (
+            self.merge_client.branch_contains_commit(
+                repository=repository,
+                branch_ref=head_sha,
+                commit_sha=base_sha,
+            )
+            if strict
+            else None
+        )
+        status_payload = json_object(
+            self.transport.request(
+                method="GET",
+                path=f"/repos/{repository_path}/commits/{encoded_head_sha}/status",
+            ),
+            "GitHub combined status response",
+            error_type=TenantAdmissionControllerError,
+        )
+        current_status_sha = required_string_text(
+            status_payload.get("sha"),
+            "GitHub combined status response requires sha.",
+            error_type=TenantAdmissionControllerError,
+        ).lower()
+        if current_status_sha != head_sha:
+            raise TenantAdmissionControllerStaleCandidateError(
+                "GitHub commit status response does not match the expected head."
+            )
+        signals = list(_technical_status_signals(status_payload))
+        page = 1
+        while True:
+            query = urlencode({"filter": "latest", "per_page": "100", "page": str(page)})
+            check_runs_payload = json_object(
+                self.transport.request(
+                    method="GET",
+                    path=(
+                        f"/repos/{repository_path}/commits/{encoded_head_sha}/check-runs?{query}"
+                    ),
+                ),
+                "GitHub check runs response",
+                error_type=TenantAdmissionControllerError,
+            )
+            raw_check_runs = check_runs_payload.get("check_runs")
+            if not isinstance(raw_check_runs, list):
+                raise TenantAdmissionControllerError(
+                    "GitHub check runs response must include check_runs."
+                )
+            signals.extend(
+                _technical_check_run_signals(
+                    raw_check_runs,
+                    expected_head_sha=head_sha,
+                )
+            )
+            if len(raw_check_runs) < 100:
+                break
+            page += 1
+        normalized_signals = tuple(
+            sorted(
+                signals,
+                key=lambda signal: (
+                    signal.source,
+                    signal.name.casefold(),
+                    signal.app_id or 0,
+                ),
+            )
+        )
+        return TenantAdmissionTechnicalChecks(
+            head_sha=head_sha,
+            base_sha=base_sha,
+            strict=strict,
+            base_up_to_date=base_up_to_date,
+            status=_required_technical_check_state(
+                required_checks=required_checks,
+                signals=normalized_signals,
+                strict=strict,
+                base_up_to_date=base_up_to_date,
+            ),
+            required_checks=required_checks,
+            signals=normalized_signals,
+            evaluated_at=evaluated_at,
+        )
+
+    def merge_pull_request(
+        self,
+        *,
+        request: TenantAdmissionControllerRunOnceEnvelope,
+    ) -> str:
+        return self.merge_client.merge_pull_request(
+            repository=request.candidate.repository,
+            pull_request_number=request.candidate.pull_request_number,
+            head_sha=request.candidate.head_sha,
+            merge_method=request.merge_method,
+        )
+
+    def branch_contains_commit(
+        self,
+        *,
+        repository: str,
+        base_branch: str,
+        commit_sha: str,
+    ) -> bool:
+        return self.merge_client.branch_contains_commit(
+            repository=repository,
+            branch_ref=base_branch,
+            commit_sha=commit_sha,
+        )
+
+
+def require_tenant_admission_controller_store(
+    record_store: object,
+) -> TenantAdmissionControllerStore:
+    required_methods = (
+        "list_tenant_repository_classification_records",
+        "list_repository_human_role_policy_records",
+        "list_tenant_technical_human_waiver_event_records",
+        "list_trusted_maintenance_policy_records",
+        "list_trusted_maintenance_evidence_records",
+        "list_authz_policy_records",
+        "list_preview_records",
+        "read_preview_generation_record",
+        "list_manager_preview_approval_event_records",
+        "list_merge_train_controller_state_records",
+        "acquire_merge_train_controller_state_record",
+        "compare_and_set_merge_train_controller_state_record",
+    )
+    missing_methods = tuple(
+        name for name in required_methods if not callable(getattr(record_store, name, None))
+    )
+    if missing_methods:
+        raise TypeError(
+            "Launchplane record store does not support tenant admission controller runs: "
+            + ", ".join(missing_methods)
+        )
+    return cast(TenantAdmissionControllerStore, record_store)
+
+
+def tenant_admission_controller_operation_id(
+    request: TenantAdmissionControllerRunOnceEnvelope,
+) -> str:
+    digest = hashlib.sha256(
+        json.dumps(
+            request.model_dump(mode="json"),
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()
+    return f"tenant-admission-merge-{digest}"
+
+
+def execute_tenant_admission_controller_run_once(
+    *,
+    request: TenantAdmissionControllerRunOnceEnvelope,
+    store: TenantAdmissionControllerStore,
+    token: str,
+    trace_id: str,
+    transport_factory: TransportFactory = lambda value: UrllibMergeTrainGitHubTransport(
+        token=value
+    ),
+) -> TenantAdmissionControllerRunOnceResult:
+    client = TenantAdmissionControllerGitHubClient(transport=transport_factory(token))
+    if not request.mutate:
+        return _evaluate_tenant_admission_candidate(
+            request=request,
+            store=store,
+            client=client,
+        )
+
+    operation_id = tenant_admission_controller_operation_id(request)
+    lease_owner = merge_train_controller_lease_owner(trace_id=trace_id)
+    controller_state = store.acquire_merge_train_controller_state_record(
+        repository=request.candidate.repository,
+        base_branch=request.base_branch,
+        policy_key=(
+            f"tenant-admission:{request.candidate.repository_id}:"
+            f"{request.candidate.product}:{request.candidate.context}"
+        ),
+        policy_sha256=_controller_scope_sha256(request),
+        lease_owner=lease_owner,
+        lease_seconds=DEFAULT_MERGE_TRAIN_CONTROLLER_LEASE_SECONDS,
+        initial_active_action=TENANT_ADMISSION_CONTROLLER_ACTIVE_ACTION,
+        initial_active_phase="evaluate_candidate",
+        adoptable_active_actions=(TENANT_ADMISSION_CONTROLLER_ACTIVE_ACTION,),
+    )
+    lease = MergeTrainControllerLeaseContext(record=controller_state, record_store=store)
+    try:
+        if controller_state.reconciliation_status == "adopted":
+            return _resume_tenant_admission_controller(
+                request=request,
+                operation_id=operation_id,
+                store=store,
+                client=client,
+                lease=lease,
+            )
+        lease.checkpoint(
+            active_action=TENANT_ADMISSION_CONTROLLER_ACTIVE_ACTION,
+            active_phase="evaluate_candidate",
+            active_record_id=operation_id,
+            active_pull_request_number=request.candidate.pull_request_number,
+            step_payload=TenantAdmissionControllerCheckpoint(
+                operation_id=operation_id,
+                request=request,
+            ).model_dump(mode="json"),
+        )
+        return _execute_tenant_admission_merge(
+            request=request,
+            operation_id=operation_id,
+            store=store,
+            client=client,
+            lease=lease,
+        )
+    except Exception as error:
+        _release_tenant_controller_after_error(lease=lease, error=error)
+        raise
+
+
+def _resume_tenant_admission_controller(
+    *,
+    request: TenantAdmissionControllerRunOnceEnvelope,
+    operation_id: str,
+    store: TenantAdmissionControllerStore,
+    client: TenantAdmissionControllerGitHubClient,
+    lease: MergeTrainControllerLeaseContext,
+) -> TenantAdmissionControllerRunOnceResult:
+    if (
+        lease.record.active_action == TENANT_ADMISSION_CONTROLLER_ACTIVE_ACTION
+        and not lease.record.active_record_id
+    ):
+        lease.checkpoint(
+            active_action=TENANT_ADMISSION_CONTROLLER_ACTIVE_ACTION,
+            active_phase="evaluate_candidate",
+            active_record_id=operation_id,
+            active_pull_request_number=request.candidate.pull_request_number,
+            step_payload=TenantAdmissionControllerCheckpoint(
+                operation_id=operation_id,
+                request=request,
+            ).model_dump(mode="json"),
+        )
+        return _execute_tenant_admission_merge(
+            request=request,
+            operation_id=operation_id,
+            store=store,
+            client=client,
+            lease=lease,
+        )
+    if (
+        lease.record.active_action != TENANT_ADMISSION_CONTROLLER_ACTIVE_ACTION
+        or lease.record.active_record_id != operation_id
+    ):
+        raise TenantAdmissionControllerReconciliationError(
+            "A different durable controller effect already owns this repository and base branch."
+        )
+    checkpoint = TenantAdmissionControllerCheckpoint.model_validate(lease.record.step_payload)
+    if checkpoint.request != request:
+        raise TenantAdmissionControllerReconciliationError(
+            "Tenant admission controller retry does not match the durable request."
+        )
+    facts = client.read_pull_request(
+        expected=request.candidate,
+        base_branch=request.base_branch,
+    )
+    if facts.merged:
+        if not client.branch_contains_commit(
+            repository=request.candidate.repository,
+            base_branch=request.base_branch,
+            commit_sha=facts.merge_commit_sha,
+        ):
+            raise TenantAdmissionControllerReconciliationError(
+                "Merged pull request commit is not contained by the target branch."
+            )
+        if checkpoint.merge_commit_sha and checkpoint.merge_commit_sha != facts.merge_commit_sha:
+            raise TenantAdmissionControllerReconciliationError(
+                "Merged pull request commit differs from the durable controller checkpoint."
+            )
+        lease.release()
+        return TenantAdmissionControllerRunOnceResult(
+            outcome="adopted",
+            mutated=False,
+            candidate=request.candidate,
+            base_branch=request.base_branch,
+            merge_method=request.merge_method,
+            pull_request_facts=facts,
+            admission=checkpoint.admission,
+            technical_checks=checkpoint.technical_checks,
+            merge_commit_sha=facts.merge_commit_sha,
+            detail="Adopted the exact merged pull request after durable reconciliation.",
+        )
+    return _execute_tenant_admission_merge(
+        request=request,
+        operation_id=operation_id,
+        store=store,
+        client=client,
+        lease=lease,
+    )
+
+
+def _execute_tenant_admission_merge(
+    *,
+    request: TenantAdmissionControllerRunOnceEnvelope,
+    operation_id: str,
+    store: TenantAdmissionControllerStore,
+    client: TenantAdmissionControllerGitHubClient,
+    lease: MergeTrainControllerLeaseContext,
+) -> TenantAdmissionControllerRunOnceResult:
+    first_result = _evaluate_tenant_admission_candidate(
+        request=request,
+        store=store,
+        client=client,
+    )
+    if first_result.outcome != "ready":
+        lease.release()
+        return first_result
+    lease.checkpoint(active_phase="pre_merge_recheck")
+    fresh_result = _evaluate_tenant_admission_candidate(
+        request=request,
+        store=store,
+        client=client,
+    )
+    if fresh_result.outcome != "ready":
+        lease.release()
+        return fresh_result
+    if first_result.pull_request_facts.base_sha != fresh_result.pull_request_facts.base_sha:
+        raise TenantAdmissionControllerStaleCandidateError(
+            "Pull request base moved between controller evaluation and merge."
+        )
+    checkpoint = TenantAdmissionControllerCheckpoint(
+        operation_id=operation_id,
+        request=request,
+        pull_request_facts=fresh_result.pull_request_facts,
+        admission=fresh_result.admission,
+        technical_checks=fresh_result.technical_checks,
+    )
+    lease.checkpoint(
+        active_phase="merge_pull_request",
+        step_payload=checkpoint.model_dump(mode="json"),
+    )
+    try:
+        merge_commit_sha = client.merge_pull_request(request=request)
+    except MergeTrainGitHubStaleHeadError as error:
+        lease.release()
+        raise TenantAdmissionControllerStaleCandidateError(
+            "GitHub rejected the merge because the exact pull request head moved."
+        ) from error
+    checkpoint = checkpoint.model_copy(update={"merge_commit_sha": merge_commit_sha})
+    lease.checkpoint(
+        active_phase="confirm_merge",
+        step_payload=checkpoint.model_dump(mode="json"),
+    )
+    merged_facts = client.read_pull_request(
+        expected=request.candidate,
+        base_branch=request.base_branch,
+    )
+    if not merged_facts.merged or merged_facts.merge_commit_sha != merge_commit_sha:
+        raise TenantAdmissionControllerReconciliationError(
+            "GitHub did not confirm the requested exact pull request merge."
+        )
+    if not client.branch_contains_commit(
+        repository=request.candidate.repository,
+        base_branch=request.base_branch,
+        commit_sha=merge_commit_sha,
+    ):
+        raise TenantAdmissionControllerReconciliationError(
+            "GitHub target branch does not contain the confirmed merge commit."
+        )
+    lease.release()
+    return TenantAdmissionControllerRunOnceResult(
+        outcome="merged",
+        mutated=True,
+        candidate=request.candidate,
+        base_branch=request.base_branch,
+        merge_method=request.merge_method,
+        pull_request_facts=merged_facts,
+        admission=fresh_result.admission,
+        technical_checks=fresh_result.technical_checks,
+        merge_commit_sha=merge_commit_sha,
+        detail="Merged the exact admitted tenant pull request after fresh technical checks.",
+    )
+
+
+def _evaluate_tenant_admission_candidate(
+    *,
+    request: TenantAdmissionControllerRunOnceEnvelope,
+    store: TenantAdmissionControllerStore,
+    client: TenantAdmissionControllerGitHubClient,
+) -> TenantAdmissionControllerRunOnceResult:
+    facts = client.read_pull_request(
+        expected=request.candidate,
+        base_branch=request.base_branch,
+    )
+    if facts.merged:
+        if not client.branch_contains_commit(
+            repository=request.candidate.repository,
+            base_branch=request.base_branch,
+            commit_sha=facts.merge_commit_sha,
+        ):
+            raise TenantAdmissionControllerReconciliationError(
+                "Merged pull request commit is not contained by the target branch."
+            )
+        return TenantAdmissionControllerRunOnceResult(
+            outcome="already_merged",
+            mutated=False,
+            candidate=request.candidate,
+            base_branch=request.base_branch,
+            merge_method=request.merge_method,
+            pull_request_facts=facts,
+            merge_commit_sha=facts.merge_commit_sha,
+            detail="The exact pull request was already merged into the target branch.",
+        )
+    evaluated_at = utc_now_timestamp()
+    admission = get_tenant_admission_status(
+        store=store,
+        candidate=request.candidate,
+        evaluated_at=evaluated_at,
+    )
+    if admission.category == "engineering":
+        return TenantAdmissionControllerRunOnceResult(
+            outcome="not_applicable",
+            candidate=request.candidate,
+            base_branch=request.base_branch,
+            merge_method=request.merge_method,
+            pull_request_facts=facts,
+            admission=admission,
+            detail="Engineering repositories retain their existing merge flow.",
+        )
+    if admission.category not in _ADMITTED_CATEGORIES or not admission.decision.admitted:
+        return TenantAdmissionControllerRunOnceResult(
+            outcome="blocked",
+            candidate=request.candidate,
+            base_branch=request.base_branch,
+            merge_method=request.merge_method,
+            pull_request_facts=facts,
+            admission=admission,
+            detail=f"Tenant admission is {admission.category} for the exact current head.",
+        )
+    if facts.draft or facts.mergeable is not True:
+        mergeability = "draft" if facts.draft else "unavailable or conflicting"
+        return TenantAdmissionControllerRunOnceResult(
+            outcome="blocked",
+            candidate=request.candidate,
+            base_branch=request.base_branch,
+            merge_method=request.merge_method,
+            pull_request_facts=facts,
+            admission=admission,
+            detail=f"GitHub mergeability is {mergeability} for the exact current head.",
+        )
+    checks = client.read_technical_checks(
+        repository=request.candidate.repository,
+        base_branch=request.base_branch,
+        base_sha=facts.base_sha,
+        head_sha=request.candidate.head_sha,
+        evaluated_at=utc_now_timestamp(),
+    )
+    if checks.status != "pass":
+        return TenantAdmissionControllerRunOnceResult(
+            outcome="blocked",
+            candidate=request.candidate,
+            base_branch=request.base_branch,
+            merge_method=request.merge_method,
+            pull_request_facts=facts,
+            admission=admission,
+            technical_checks=checks,
+            detail=f"Technical checks are {checks.status} for the exact current head.",
+        )
+    return TenantAdmissionControllerRunOnceResult(
+        outcome="ready",
+        candidate=request.candidate,
+        base_branch=request.base_branch,
+        merge_method=request.merge_method,
+        pull_request_facts=facts,
+        admission=admission,
+        technical_checks=checks,
+        detail="Tenant admission and technical checks are current for the exact head.",
+    )
+
+
+def _release_tenant_controller_after_error(
+    *,
+    lease: MergeTrainControllerLeaseContext,
+    error: Exception,
+) -> None:
+    if not lease.owner:
+        return
+    phase = lease.record.active_phase
+    active_action = lease.record.active_action or TENANT_ADMISSION_CONTROLLER_ACTIVE_ACTION
+    try:
+        if isinstance(error, TenantAdmissionControllerReconciliationError):
+            lease.release(
+                reconciliation_status="required",
+                reconciliation_detail=(
+                    f"operator_required:{active_action}:{phase}:{type(error).__name__}"
+                ),
+                clear_active_state=False,
+            )
+        elif phase in _PROVIDER_EFFECT_PHASES:
+            lease.release(
+                reconciliation_status="required",
+                reconciliation_detail=(f"retryable:{active_action}:{phase}:{type(error).__name__}"),
+                clear_active_state=False,
+            )
+        else:
+            lease.release()
+    except Exception:
+        return
+
+
+def _technical_status_signals(
+    payload: dict[str, object],
+) -> tuple[TenantAdmissionTechnicalCheckSignal, ...]:
+    raw_statuses = payload.get("statuses")
+    if not isinstance(raw_statuses, list):
+        raise TenantAdmissionControllerError(
+            "GitHub combined status response must include statuses."
+        )
+    signals: list[TenantAdmissionTechnicalCheckSignal] = []
+    seen_contexts: set[str] = set()
+    for raw_status in raw_statuses:
+        status = json_object(
+            raw_status,
+            "GitHub commit status",
+            error_type=TenantAdmissionControllerError,
+        )
+        context = required_string_text(
+            status.get("context"),
+            "GitHub commit status requires context.",
+            error_type=TenantAdmissionControllerError,
+        )
+        normalized_context = context.casefold()
+        if (
+            normalized_context in _EXCLUDED_TECHNICAL_CONTEXTS
+            or normalized_context in seen_contexts
+        ):
+            continue
+        seen_contexts.add(normalized_context)
+        signals.append(
+            TenantAdmissionTechnicalCheckSignal(
+                source="commit_status",
+                name=context,
+                app_id=_optional_github_app_id(status),
+                state=_commit_status_state(str(status.get("state") or "")),
+            )
+        )
+    return tuple(signals)
+
+
+def _technical_check_run_signals(
+    raw_check_runs: list[object],
+    *,
+    expected_head_sha: str,
+) -> tuple[TenantAdmissionTechnicalCheckSignal, ...]:
+    signals: list[TenantAdmissionTechnicalCheckSignal] = []
+    for raw_check_run in raw_check_runs:
+        check_run = json_object(
+            raw_check_run,
+            "GitHub check run",
+            error_type=TenantAdmissionControllerError,
+        )
+        name = required_string_text(
+            check_run.get("name"),
+            "GitHub check run requires name.",
+            error_type=TenantAdmissionControllerError,
+        )
+        current_head_sha = required_string_text(
+            check_run.get("head_sha"),
+            "GitHub check run requires head_sha.",
+            error_type=TenantAdmissionControllerError,
+        ).lower()
+        if current_head_sha != expected_head_sha:
+            raise TenantAdmissionControllerStaleCandidateError(
+                "GitHub check run does not match the expected head."
+            )
+        app = json_object(
+            check_run.get("app"),
+            "GitHub check run app",
+            error_type=TenantAdmissionControllerError,
+        )
+        app_id = required_positive_int(
+            app.get("id"),
+            "GitHub check run app requires a positive id.",
+            error_type=TenantAdmissionControllerError,
+        )
+        if name.casefold() in _EXCLUDED_TECHNICAL_CONTEXTS:
+            continue
+        signals.append(
+            TenantAdmissionTechnicalCheckSignal(
+                source="check_run",
+                name=name,
+                app_id=app_id,
+                state=_check_run_state(check_run),
+            )
+        )
+    return tuple(signals)
+
+
+def _required_technical_checks(
+    payload: dict[str, object],
+) -> tuple[bool, tuple[TenantAdmissionRequiredTechnicalCheck, ...]]:
+    strict = payload.get("strict")
+    if not isinstance(strict, bool):
+        raise TenantAdmissionControllerError(
+            "GitHub required status checks response strict must be boolean."
+        )
+    raw_checks = payload.get("checks")
+    raw_contexts = payload.get("contexts")
+    if not isinstance(raw_checks, list) or not isinstance(raw_contexts, list):
+        raise TenantAdmissionControllerError(
+            "GitHub required status checks response must include checks and contexts."
+        )
+    required_checks: dict[tuple[str, int | None], TenantAdmissionRequiredTechnicalCheck] = {}
+    detailed_contexts: set[str] = set()
+    for raw_check in raw_checks:
+        check = json_object(
+            raw_check,
+            "GitHub required status check",
+            error_type=TenantAdmissionControllerError,
+        )
+        context = required_string_text(
+            check.get("context"),
+            "GitHub required status check requires context.",
+            error_type=TenantAdmissionControllerError,
+        )
+        normalized_context = context.casefold()
+        if normalized_context in _EXCLUDED_TECHNICAL_CONTEXTS:
+            continue
+        raw_app_id = check.get("app_id")
+        if raw_app_id is None:
+            app_id = None
+        else:
+            app_id = required_positive_int(
+                raw_app_id,
+                "GitHub required status check app_id must be positive or null.",
+                error_type=TenantAdmissionControllerError,
+            )
+        detailed_contexts.add(normalized_context)
+        required_checks[(normalized_context, app_id)] = TenantAdmissionRequiredTechnicalCheck(
+            name=context,
+            app_id=app_id,
+        )
+    for raw_context in raw_contexts:
+        context = required_string_text(
+            raw_context,
+            "GitHub required status check context must be text.",
+            error_type=TenantAdmissionControllerError,
+        )
+        normalized_context = context.casefold()
+        if (
+            normalized_context in _EXCLUDED_TECHNICAL_CONTEXTS
+            or normalized_context in detailed_contexts
+        ):
+            continue
+        required_checks[(normalized_context, None)] = TenantAdmissionRequiredTechnicalCheck(
+            name=context,
+        )
+    return strict, tuple(
+        sorted(
+            required_checks.values(),
+            key=lambda required: (required.name.casefold(), required.app_id or 0),
+        )
+    )
+
+
+def _optional_github_app_id(payload: dict[str, object]) -> int | None:
+    raw_app = payload.get("app")
+    if raw_app is None:
+        return None
+    app = json_object(
+        raw_app,
+        "GitHub commit status app",
+        error_type=TenantAdmissionControllerError,
+    )
+    return required_positive_int(
+        app.get("id"),
+        "GitHub commit status app requires a positive id.",
+        error_type=TenantAdmissionControllerError,
+    )
+
+
+def _commit_status_state(value: str) -> TenantAdmissionTechnicalCheckState:
+    normalized = value.strip().lower()
+    if normalized == "success":
+        return "pass"
+    if normalized == "pending":
+        return "pending"
+    if normalized in {"failure", "error"}:
+        return "fail"
+    return "unavailable"
+
+
+def _check_run_state(check_run: dict[str, object]) -> TenantAdmissionTechnicalCheckState:
+    status = str(check_run.get("status") or "").strip().lower()
+    if status != "completed":
+        return "pending" if status in {"queued", "in_progress", "pending"} else "unavailable"
+    conclusion = str(check_run.get("conclusion") or "").strip().lower()
+    if conclusion in {"success", "neutral", "skipped"}:
+        return "pass"
+    if conclusion in {
+        "failure",
+        "timed_out",
+        "cancelled",
+        "action_required",
+        "startup_failure",
+        "stale",
+    }:
+        return "fail"
+    return "unavailable"
+
+
+def _combine_technical_check_states(
+    signals: tuple[TenantAdmissionTechnicalCheckSignal, ...],
+) -> TenantAdmissionTechnicalCheckState:
+    if not signals:
+        return "unavailable"
+    states = {signal.state for signal in signals}
+    if "fail" in states:
+        return "fail"
+    if "pending" in states:
+        return "pending"
+    if "unavailable" in states:
+        return "unavailable"
+    return "pass"
+
+
+def _required_technical_check_state(
+    *,
+    required_checks: tuple[TenantAdmissionRequiredTechnicalCheck, ...],
+    signals: tuple[TenantAdmissionTechnicalCheckSignal, ...],
+    strict: bool,
+    base_up_to_date: bool | None,
+) -> TenantAdmissionTechnicalCheckState:
+    if not required_checks:
+        return "unavailable"
+    if strict and not base_up_to_date:
+        return "fail"
+    required_states: list[TenantAdmissionTechnicalCheckState] = []
+    for required_check in required_checks:
+        matches = tuple(
+            signal
+            for signal in signals
+            if signal.name.casefold() == required_check.name.casefold()
+            and (required_check.app_id is None or signal.app_id == required_check.app_id)
+        )
+        required_states.append(_combine_technical_check_states(matches))
+    if "fail" in required_states:
+        return "fail"
+    if "pending" in required_states:
+        return "pending"
+    if "unavailable" in required_states:
+        return "unavailable"
+    return "pass"
+
+
+def _controller_scope_sha256(request: TenantAdmissionControllerRunOnceEnvelope) -> str:
+    payload = {
+        "repository_id": request.candidate.repository_id,
+        "repository_owner_id": request.candidate.repository_owner_id,
+        "repository": request.candidate.repository,
+        "product": request.candidate.product,
+        "context": request.candidate.context,
+        "base_branch": request.base_branch,
+    }
+    return hashlib.sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+
+
+def _model_sha256(model: BaseModel, *, exclude: set[str]) -> str:
+    return hashlib.sha256(
+        json.dumps(
+            model.model_dump(mode="json", exclude=exclude, exclude_none=True),
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()

--- a/docs/merge-train-policy.md
+++ b/docs/merge-train-policy.md
@@ -39,7 +39,9 @@ Tenant merge eligibility (`evaluate_tenant_merge_eligibility`) and repository cl
 - Repository classifications explicitly categorize repositories as `engineering` (taking the normal engineering fast path) or `tenant_ui` (requiring one exact-head manager-preview, technical-human-waiver, or trusted-maintenance path).
 - Repository classifications use exact immutable identity and CAS operator recovery without heuristics or PR label fallback.
 - Unified tenant admission is recomputed from DB records. The GitHub `tenant-admission` commit status is a public projection, not merge authority.
-- Pure tenant merge evaluation is kept separate from scheduler merge train admission and does not alter queueing or batch landing semantics. A later controller slice must independently re-fetch the exact current candidate and re-evaluate admission immediately before landing instead of trusting a previously green status.
+- The tenant admission controller is a separate exact-PR landing path. It re-fetches current GitHub identity/head/mergeability facts, recomputes admission, reads the live required-status-check policy, filters admission projection contexts out of that policy, enforces strict base freshness when configured, and rechecks all three immediately before an expected-SHA merge. Missing or malformed required-check policy or evidence fails closed. It does not enqueue work or reuse scheduler ordering, labels, batch candidates, stack collapse, or failure policy.
+- The tenant controller and merge train share the repository/base controller-state row only as a mutual-exclusion and crash-reconciliation fence. Acquisition writes a controller-specific initial action atomically and adoption is action-aware, so one controller cannot rewrite another controller's unfinished recovery state even before its first checkpoint. The row cannot make a tenant admission decision and a green GitHub status is never merge authority.
+- Engineering repositories remain on their existing flow; invoking the tenant controller for an engineering classification returns not-applicable without merging.
 
 ## Controller Lease And Resume State
 

--- a/docs/records.md
+++ b/docs/records.md
@@ -429,6 +429,16 @@ an ORM column/table or remains only in the evidence payload.
   database clock for lease expiry; a stale owner cannot overwrite or release a
   successor lease. Runtime repository/base authority still comes from the active
   merge-train policy record and live request scope, not from checked-in config.
+  The tenant admission controller reuses this repository/base row only as a
+  shared mutation fence. Its `tenant_admission_merge` checkpoint carries the
+  exact request candidate, base branch, admission decision, technical-check
+  digest, and provider phase needed to reconcile an uncertain merge. That state
+  does not become admission authority, does not enqueue the PR, and is cleared
+  only after an exact merged result is confirmed or a pre-effect block is
+  recorded cleanly. Every shared-fence acquisition atomically writes a
+  controller-specific initial action and declares which active actions it can
+  resume, so either controller rejects an unfinished foreign action before any
+  row fields are rewritten.
 - Dokploy target id: modeled fields are `context`, `instance`, `target_id`, and
   `updated_at`. Provider lookup/import evidence stays payload-only.
 - Dokploy target: modeled fields are `context`, `instance`, and `updated_at`.

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -3059,12 +3059,57 @@ target URL replay without another write. A provider failure or mismatched write
 response never returns success. Engineering is reported as not requiring the
 tenant status and performs no status write.
 
-The GitHub status is projection only. Merge-controller enforcement, branch
-protection, portfolio rollout, UI, and checked-in real repository or actor
-policy values remain deferred. Trusted maintenance is never inferred from a Bot
-type alone, and no admission decision uses changed files, repository names,
-branches, titles, labels, or commit text. Preview refresh, verification, destroy,
-and cleanup remain independent from admission and projection delivery.
+`POST /v1/work-graph/tenant-admission/controller/run-once` accepts a strict
+schema-v1 candidate plus exact base branch, merge method, and `mutate` intent.
+It is bearer-only, requires `tenant_admission.controller.run_once` authorization
+for the candidate product/context, and is covered by the exact-length JSON body
+guard at 64 KiB. An explicitly authorized terminal agent may invoke this route:
+the caller cannot create manager, waiver, or maintenance authority, and the
+controller independently recomputes those DB-backed records before every merge
+effect. This is a dedicated privileged controller action: its context-scoped
+grant intentionally authorizes a central controller or operator whose source
+repository need not equal the target tenant repository. The submitted target
+still gains no authority from the caller and must independently satisfy exact
+GitHub identity, DB admission, mergeability, and required-check policy.
+
+The controller is tenant-only. An `engineering` classification returns
+`not_applicable` without a merge call. For `tenant_ui`, only
+`manager-approved`, `technical-waived`, or `maintenance-admitted` may proceed.
+Launchplane re-fetches the open PR and requires exact numeric base repository
+ID, numeric owner ID, full repository name, same-repository head, requested base
+branch, and head SHA. It then evaluates technical commit statuses and check runs
+on that exact head against the target branch's live GitHub required-status-check
+policy while excluding only the `tenant-admission` and
+`manager-preview-approval` contexts. App-bound required checks must be produced
+by the exact numeric GitHub App. At least one non-excluded required check must
+exist, and every required check must have a matching current passing signal;
+missing policy, missing signals, pending, failed, app-mismatched, or
+unrecognized evidence blocks without a provider mutation. Open PRs must also be
+non-draft and currently mergeable. When the live required-check policy is
+strict, the exact PR head must also contain the current base SHA; missing or
+malformed strict-policy and draft evidence fails closed.
+
+For `mutate=true`, Launchplane uses the existing repository/base controller
+lease only as a shared mutation and crash-reconciliation fence; it does not
+enqueue the PR or borrow merge-train scheduler, label, batch, or stack policy.
+After the first evaluation it re-fetches PR/base facts, recomputes admission,
+and re-reads technical checks immediately before checkpointing and issuing the
+GitHub merge request with the exact expected head SHA. Provider uncertainty
+leaves the exact request, admission decision, technical-check digest, and merge
+phase in durable controller state. A retry adopts success only when GitHub shows
+that exact head merged into the requested base and the target branch contains
+the merge commit; otherwise it re-evaluates the still-open exact candidate or
+remains fail-closed for reconciliation. A reconcile-required row owned by a
+different merge-train action is rejected atomically without rewriting that
+action's policy or recovery evidence.
+
+The GitHub status remains projection only and is never read as controller
+authority. Branch protection, workflow wiring, portfolio rollout, UI, and real
+repository policy values remain deferred to staged rollout. Trusted maintenance
+is never inferred from a Bot type alone, and no admission decision uses changed
+files, repository names, branches, titles, labels, or commit text. Preview
+refresh, verification, destroy, and cleanup remain independent from admission,
+projection delivery, and merge-controller results.
 
 The CM tenant preview workflow uses tenant-product scope for both artifact
 publish input/evidence and preview lifecycle requests. Artifact publish still

--- a/frontend/generated/openapi-canonical.json
+++ b/frontend/generated/openapi-canonical.json
@@ -22062,6 +22062,155 @@
         "title": "StructuredHealthEvidence",
         "type": "object"
       },
+      "TenantAdmissionControllerRunOnceEnvelope": {
+        "additionalProperties": false,
+        "properties": {
+          "base_branch": {
+            "title": "Base Branch",
+            "type": "string"
+          },
+          "candidate": {
+            "$ref": "#/components/schemas/TenantMergeCandidate"
+          },
+          "merge_method": {
+            "default": "merge",
+            "enum": [
+              "merge",
+              "squash",
+              "rebase"
+            ],
+            "title": "Merge Method",
+            "type": "string"
+          },
+          "mutate": {
+            "default": false,
+            "title": "Mutate",
+            "type": "boolean"
+          },
+          "schema_version": {
+            "default": 1,
+            "minimum": 1.0,
+            "title": "Schema Version",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "candidate",
+          "base_branch"
+        ],
+        "title": "TenantAdmissionControllerRunOnceEnvelope",
+        "type": "object"
+      },
+      "TenantAdmissionControllerRunOnceResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "result": {
+            "$ref": "#/components/schemas/TenantAdmissionControllerRunOnceResult"
+          },
+          "status": {
+            "const": "accepted",
+            "default": "accepted",
+            "title": "Status",
+            "type": "string"
+          },
+          "trace_id": {
+            "title": "Trace Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "trace_id",
+          "result"
+        ],
+        "title": "TenantAdmissionControllerRunOnceResponse",
+        "type": "object"
+      },
+      "TenantAdmissionControllerRunOnceResult": {
+        "additionalProperties": false,
+        "properties": {
+          "admission": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/TenantAdmissionStatusReadModel"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "base_branch": {
+            "title": "Base Branch",
+            "type": "string"
+          },
+          "candidate": {
+            "$ref": "#/components/schemas/TenantMergeCandidate"
+          },
+          "detail": {
+            "title": "Detail",
+            "type": "string"
+          },
+          "merge_commit_sha": {
+            "default": "",
+            "title": "Merge Commit Sha",
+            "type": "string"
+          },
+          "merge_method": {
+            "enum": [
+              "merge",
+              "squash",
+              "rebase"
+            ],
+            "title": "Merge Method",
+            "type": "string"
+          },
+          "mutated": {
+            "default": false,
+            "title": "Mutated",
+            "type": "boolean"
+          },
+          "outcome": {
+            "enum": [
+              "ready",
+              "merged",
+              "adopted",
+              "already_merged",
+              "blocked",
+              "not_applicable"
+            ],
+            "title": "Outcome",
+            "type": "string"
+          },
+          "pull_request_facts": {
+            "$ref": "#/components/schemas/TenantAdmissionPullRequestFacts"
+          },
+          "schema_version": {
+            "default": 1,
+            "minimum": 1.0,
+            "title": "Schema Version",
+            "type": "integer"
+          },
+          "technical_checks": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/TenantAdmissionTechnicalChecks"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "outcome",
+          "candidate",
+          "base_branch",
+          "merge_method",
+          "pull_request_facts",
+          "detail"
+        ],
+        "title": "TenantAdmissionControllerRunOnceResult",
+        "type": "object"
+      },
       "TenantAdmissionGitHubProjection": {
         "additionalProperties": false,
         "properties": {
@@ -22263,6 +22412,107 @@
         "title": "TenantAdmissionProjectionWriteResult",
         "type": "object"
       },
+      "TenantAdmissionPullRequestFacts": {
+        "additionalProperties": false,
+        "properties": {
+          "base_branch": {
+            "title": "Base Branch",
+            "type": "string"
+          },
+          "base_sha": {
+            "title": "Base Sha",
+            "type": "string"
+          },
+          "draft": {
+            "default": false,
+            "title": "Draft",
+            "type": "boolean"
+          },
+          "head_sha": {
+            "title": "Head Sha",
+            "type": "string"
+          },
+          "merge_commit_sha": {
+            "default": "",
+            "title": "Merge Commit Sha",
+            "type": "string"
+          },
+          "mergeable": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mergeable"
+          },
+          "merged": {
+            "title": "Merged",
+            "type": "boolean"
+          },
+          "pull_request_number": {
+            "minimum": 1.0,
+            "title": "Pull Request Number",
+            "type": "integer"
+          },
+          "pull_request_url": {
+            "title": "Pull Request Url",
+            "type": "string"
+          },
+          "repository": {
+            "title": "Repository",
+            "type": "string"
+          },
+          "state": {
+            "enum": [
+              "open",
+              "closed"
+            ],
+            "title": "State",
+            "type": "string"
+          }
+        },
+        "required": [
+          "repository",
+          "pull_request_number",
+          "pull_request_url",
+          "state",
+          "merged",
+          "head_sha",
+          "base_branch",
+          "base_sha"
+        ],
+        "title": "TenantAdmissionPullRequestFacts",
+        "type": "object"
+      },
+      "TenantAdmissionRequiredTechnicalCheck": {
+        "additionalProperties": false,
+        "properties": {
+          "app_id": {
+            "anyOf": [
+              {
+                "minimum": 1.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "App Id"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "title": "TenantAdmissionRequiredTechnicalCheck",
+        "type": "object"
+      },
       "TenantAdmissionStatusReadModel": {
         "additionalProperties": false,
         "properties": {
@@ -22424,6 +22674,141 @@
           "write_result"
         ],
         "title": "TenantAdmissionStatusReconcileResult",
+        "type": "object"
+      },
+      "TenantAdmissionTechnicalCheckSignal": {
+        "additionalProperties": false,
+        "properties": {
+          "app_id": {
+            "anyOf": [
+              {
+                "minimum": 1.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "App Id"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "source": {
+            "enum": [
+              "commit_status",
+              "check_run"
+            ],
+            "title": "Source",
+            "type": "string"
+          },
+          "state": {
+            "enum": [
+              "pass",
+              "pending",
+              "fail",
+              "unavailable"
+            ],
+            "title": "State",
+            "type": "string"
+          }
+        },
+        "required": [
+          "source",
+          "name",
+          "state"
+        ],
+        "title": "TenantAdmissionTechnicalCheckSignal",
+        "type": "object"
+      },
+      "TenantAdmissionTechnicalChecks": {
+        "additionalProperties": false,
+        "properties": {
+          "base_sha": {
+            "title": "Base Sha",
+            "type": "string"
+          },
+          "base_up_to_date": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Base Up To Date"
+          },
+          "binding_sha256": {
+            "default": "",
+            "title": "Binding Sha256",
+            "type": "string"
+          },
+          "evaluated_at": {
+            "title": "Evaluated At",
+            "type": "string"
+          },
+          "excluded_contexts": {
+            "default": [
+              "manager-preview-approval",
+              "tenant-admission"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "title": "Excluded Contexts",
+            "type": "array"
+          },
+          "head_sha": {
+            "title": "Head Sha",
+            "type": "string"
+          },
+          "required_checks": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/TenantAdmissionRequiredTechnicalCheck"
+            },
+            "title": "Required Checks",
+            "type": "array"
+          },
+          "schema_version": {
+            "default": 1,
+            "minimum": 1.0,
+            "title": "Schema Version",
+            "type": "integer"
+          },
+          "signals": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/TenantAdmissionTechnicalCheckSignal"
+            },
+            "title": "Signals",
+            "type": "array"
+          },
+          "status": {
+            "enum": [
+              "pass",
+              "pending",
+              "fail",
+              "unavailable"
+            ],
+            "title": "Status",
+            "type": "string"
+          },
+          "strict": {
+            "title": "Strict",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "head_sha",
+          "base_sha",
+          "strict",
+          "status",
+          "evaluated_at"
+        ],
+        "title": "TenantAdmissionTechnicalChecks",
         "type": "object"
       },
       "TenantMergeCandidate": {
@@ -55694,6 +56079,96 @@
           }
         },
         "summary": "Read Launchplane work graph snapshot"
+      }
+    },
+    "/v1/work-graph/tenant-admission/controller/run-once": {
+      "post": {
+        "operationId": "run_tenant_admission_controller_once",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Authorization",
+            "required": false,
+            "schema": {
+              "default": "",
+              "title": "Authorization",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TenantAdmissionControllerRunOnceEnvelope"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TenantAdmissionControllerRunOnceResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "summary": "Re-evaluate and merge one exact admitted tenant pull request"
       }
     },
     "/v1/work-graph/tenant-admission/repository-classification": {

--- a/tests/test_filesystem_store.py
+++ b/tests/test_filesystem_store.py
@@ -2427,6 +2427,9 @@ class FilesystemRecordStoreTests(unittest.TestCase):
                 policy_sha256="policy-sha",
                 lease_owner="controller-a",
                 lease_seconds=30,
+                initial_active_action="filesystem_store_test",
+                initial_active_phase="acquire",
+                adoptable_active_actions=("filesystem_store_test",),
             )
 
             listed_records = store.list_merge_train_controller_state_records(
@@ -2452,6 +2455,9 @@ class FilesystemRecordStoreTests(unittest.TestCase):
                         policy_sha256="policy-sha",
                         lease_owner=owner,
                         lease_seconds=30,
+                        initial_active_action="filesystem_store_test",
+                        initial_active_phase="acquire",
+                        adoptable_active_actions=("filesystem_store_test",),
                     )
                 except BaseException as error:  # noqa: BLE001
                     return error
@@ -2488,6 +2494,9 @@ class FilesystemRecordStoreTests(unittest.TestCase):
                     policy_sha256="policy-sha",
                     lease_owner="controller-a",
                     lease_seconds=1,
+                    initial_active_action="filesystem_store_test",
+                    initial_active_phase="acquire",
+                    adoptable_active_actions=("filesystem_store_test",),
                 )
             with (
                 patch(
@@ -2530,6 +2539,9 @@ class FilesystemRecordStoreTests(unittest.TestCase):
                     policy_sha256="policy-sha",
                     lease_owner="controller-a",
                     lease_seconds=30,
+                    initial_active_action="filesystem_store_test",
+                    initial_active_phase="acquire",
+                    adoptable_active_actions=("filesystem_store_test",),
                 )
                 store.compare_and_set_merge_train_controller_state_record(
                     record=acquired.model_copy(
@@ -2556,6 +2568,12 @@ class FilesystemRecordStoreTests(unittest.TestCase):
                     policy_sha256="policy-sha",
                     lease_owner="controller-b",
                     lease_seconds=30,
+                    initial_active_action="filesystem_store_test",
+                    initial_active_phase="acquire",
+                    adoptable_active_actions=(
+                        "filesystem_store_test",
+                        "execute_stack_collapse",
+                    ),
                 )
 
         self.assertEqual(adopted.lease_owner, "controller-b")

--- a/tests/test_http_app_browser_mutation.py
+++ b/tests/test_http_app_browser_mutation.py
@@ -56,6 +56,7 @@ class FastApiBrowserMutationBoundaryTests(unittest.IsolatedAsyncioTestCase):
             "/v1/tenant-admission/repository-classifications/apply",
             "/v1/tenant-admission/repository-human-role-policies/apply",
             "/v1/tenant-admission/status/reconcile",
+            "/v1/work-graph/tenant-admission/controller/run-once",
         }
         actual_routes = {"/auth/logout"}
         actual_bearer_only_routes: set[str] = set()

--- a/tests/test_http_app_merge_train.py
+++ b/tests/test_http_app_merge_train.py
@@ -18,6 +18,7 @@ from control_plane.contracts.merge_train_stack_collapse import (
     execute_merge_train_stack_collapse_plan,
 )
 from control_plane.http_app import create_launchplane_fastapi_app
+from control_plane.merge_train_controller_run_once import MERGE_TRAIN_CONTROLLER_ACTIVE_ACTION
 from control_plane.service_auth import (
     BearerIdentityConfig,
     LaunchplaneAuthzPolicy,
@@ -2173,6 +2174,58 @@ class FastApiMergeTrainControllerRunOnceTests(unittest.IsolatedAsyncioTestCase):
             "merge_train_controller_lease_held",
         )
 
+    async def test_merge_train_rejects_tenant_reconciliation_state_without_rewrite(self) -> None:
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict("os.environ", {"GH_TOKEN": "token"}, clear=True),
+        ):
+            state_dir = Path(temporary_directory_name) / "state"
+            _seed_merge_train_policy(state_dir)
+            store = FilesystemRecordStore(state_dir=state_dir)
+            tenant_state = build_merge_train_controller_state_record(
+                repository="cbusillo/sellyouroutboard",
+                base_branch="main",
+                policy_key="tenant-policy",
+                policy_sha256="tenant-policy-sha",
+                updated_at="2026-08-02T00:00:00Z",
+            ).model_copy(
+                update={
+                    "status": "reconcile_required",
+                    "active_action": "tenant_admission_merge",
+                    "active_phase": "confirm_merge",
+                    "active_record_id": "tenant-operation",
+                    "reconciliation_status": "required",
+                    "reconciliation_detail": ("retryable:tenant_admission_merge:confirm_merge"),
+                }
+            )
+            store.write_merge_train_controller_state_record(tenant_state)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_merge_train_service_identity()),
+                authz_policy=_merge_train_service_policy(),
+                record_store_factory=lambda: store,
+            )
+
+            response = await _post_merge_train_controller_run_once(
+                app,
+                {
+                    "schema_version": 1,
+                    "repository": "cbusillo/sellyouroutboard",
+                    "base_branch": "main",
+                    "mutate": True,
+                },
+            )
+            observed = store.list_merge_train_controller_state_records(
+                repository="cbusillo/sellyouroutboard",
+                base_branch="main",
+            )[0]
+
+        self.assertEqual(response.status_code, 409)
+        self.assertEqual(
+            response.json()["error"]["code"],
+            "merge_train_controller_foreign_action",
+        )
+        self.assertEqual(observed, tenant_state)
+
     async def test_release_failure_does_not_mask_github_failure(self) -> None:
         with (
             TemporaryDirectory() as temporary_directory_name,
@@ -2268,7 +2321,7 @@ class FastApiMergeTrainControllerRunOnceTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(response.status_code, 502)
         self.assertEqual(controller_state.status, "reconcile_required")
-        self.assertEqual(controller_state.active_action, "controller_run_once")
+        self.assertEqual(controller_state.active_action, MERGE_TRAIN_CONTROLLER_ACTIVE_ACTION)
         self.assertEqual(controller_state.active_phase, "select_next_action")
         self.assertEqual(controller_state.reconciliation_status, "required")
 
@@ -2332,6 +2385,9 @@ class FastApiMergeTrainMutationFenceTests(unittest.IsolatedAsyncioTestCase):
                 policy_sha256=policy_record.policy_sha256,
                 lease_owner="controller-active",
                 lease_seconds=300,
+                initial_active_action="mutation_fence_test",
+                initial_active_phase="hold_lease",
+                adoptable_active_actions=("mutation_fence_test",),
             )
             app = create_launchplane_fastapi_app(
                 verifier=_StubVerifier(_merge_train_service_identity()),

--- a/tests/test_postgres_integration.py
+++ b/tests/test_postgres_integration.py
@@ -39,6 +39,7 @@ from control_plane.contracts.manager_preview_approval import (
     ManagerPreviewApprovalEventRecord,
 )
 from control_plane.contracts.merge_train_controller_state import (
+    MergeTrainControllerAdoptionRejectedError,
     MergeTrainControllerLeaseHeldError,
     MergeTrainControllerLeaseLostError,
     MergeTrainControllerStateRecord,
@@ -3313,6 +3314,9 @@ class RealPostgresStorageConcurrencyTests(unittest.TestCase):
                     policy_sha256="policy-sha",
                     lease_owner="controller-a",
                     lease_seconds=30,
+                    initial_active_action="postgres_store_test",
+                    initial_active_phase="acquire",
+                    adoptable_active_actions=("postgres_store_test",),
                 )
                 with self.assertRaisesRegex(
                     MergeTrainControllerLeaseHeldError,
@@ -3325,6 +3329,9 @@ class RealPostgresStorageConcurrencyTests(unittest.TestCase):
                         policy_sha256="policy-sha",
                         lease_owner="controller-b",
                         lease_seconds=30,
+                        initial_active_action="postgres_store_test",
+                        initial_active_phase="acquire",
+                        adoptable_active_actions=("postgres_store_test",),
                     )
             finally:
                 second_store.close()
@@ -3342,6 +3349,9 @@ class RealPostgresStorageConcurrencyTests(unittest.TestCase):
                     policy_sha256="policy-sha",
                     lease_owner="controller-a",
                     lease_seconds=1,
+                    initial_active_action="postgres_store_test",
+                    initial_active_phase="acquire",
+                    adoptable_active_actions=("postgres_store_test",),
                 )
                 time.sleep(1.1)
                 renewed = second_store.acquire_merge_train_controller_state_record(
@@ -3351,6 +3361,9 @@ class RealPostgresStorageConcurrencyTests(unittest.TestCase):
                     policy_sha256="policy-sha",
                     lease_owner="controller-b",
                     lease_seconds=30,
+                    initial_active_action="postgres_store_test",
+                    initial_active_phase="acquire",
+                    adoptable_active_actions=("postgres_store_test",),
                 )
                 with self.assertRaisesRegex(
                     MergeTrainControllerLeaseLostError,
@@ -3391,6 +3404,9 @@ class RealPostgresStorageConcurrencyTests(unittest.TestCase):
                         policy_sha256="policy-sha",
                         lease_owner=owner,
                         lease_seconds=30,
+                        initial_active_action="postgres_store_test",
+                        initial_active_phase="acquire",
+                        adoptable_active_actions=("postgres_store_test",),
                     )
                 except BaseException as error:  # noqa: BLE001
                     return error
@@ -3420,6 +3436,9 @@ class RealPostgresStorageConcurrencyTests(unittest.TestCase):
                 policy_sha256="policy-sha",
                 lease_owner="controller-a",
                 lease_seconds=1,
+                initial_active_action="postgres_store_test",
+                initial_active_phase="acquire",
+                adoptable_active_actions=("postgres_store_test",),
             )
             checkpointed = store.compare_and_set_merge_train_controller_state_record(
                 record=first.model_copy(
@@ -3442,6 +3461,9 @@ class RealPostgresStorageConcurrencyTests(unittest.TestCase):
                 policy_sha256="policy-sha",
                 lease_owner="controller-b",
                 lease_seconds=30,
+                initial_active_action="postgres_store_test",
+                initial_active_phase="acquire",
+                adoptable_active_actions=("postgres_store_test", "land_batch"),
             )
 
         self.assertEqual(checkpointed.active_phase, "cleanup_candidate_ref")
@@ -3458,6 +3480,9 @@ class RealPostgresStorageConcurrencyTests(unittest.TestCase):
                 policy_sha256="policy-sha",
                 lease_owner="controller-a",
                 lease_seconds=30,
+                initial_active_action="postgres_store_test",
+                initial_active_phase="acquire",
+                adoptable_active_actions=("postgres_store_test",),
             )
             store.compare_and_set_merge_train_controller_state_record(
                 record=acquired.model_copy(
@@ -3485,12 +3510,69 @@ class RealPostgresStorageConcurrencyTests(unittest.TestCase):
                 policy_sha256="policy-sha",
                 lease_owner="controller-b",
                 lease_seconds=30,
+                initial_active_action="postgres_store_test",
+                initial_active_phase="acquire",
+                adoptable_active_actions=(
+                    "postgres_store_test",
+                    "execute_stack_collapse",
+                ),
             )
 
         self.assertEqual(adopted.lease_owner, "controller-b")
         self.assertEqual(adopted.reconciliation_status, "adopted")
         self.assertEqual(adopted.active_phase, "merge_stack_branches")
         self.assertIn("operator_required:github_request_rejected", adopted.reconciliation_detail)
+
+    def test_merge_train_controller_rejects_foreign_action_without_rewrite(self) -> None:
+        with _store_for_fresh_head_database() as store:
+            acquired = store.acquire_merge_train_controller_state_record(
+                repository="cbusillo/sellyouroutboard",
+                base_branch="main",
+                policy_key="merge-train-policy",
+                policy_sha256="merge-train-policy-sha",
+                lease_owner="controller-a",
+                lease_seconds=30,
+                initial_active_action="merge_train_controller_run_once",
+                initial_active_phase="select_next_action",
+                adoptable_active_actions=("merge_train_controller_run_once",),
+            )
+            foreign_state = store.compare_and_set_merge_train_controller_state_record(
+                record=acquired.model_copy(
+                    update={
+                        "status": "reconcile_required",
+                        "lease_owner": "",
+                        "lease_acquired_at": "",
+                        "lease_expires_at": "",
+                        "heartbeat_at": "",
+                        "active_action": "land_batch",
+                        "active_phase": "confirm_merge",
+                        "reconciliation_status": "required",
+                        "reconciliation_detail": "retryable:land_batch:confirm_merge",
+                    }
+                ),
+                expected_lease_owner=acquired.lease_owner,
+                expected_lease_acquired_at=acquired.lease_acquired_at,
+                lease_seconds=30,
+            )
+
+            with self.assertRaises(MergeTrainControllerAdoptionRejectedError):
+                store.acquire_merge_train_controller_state_record(
+                    repository="cbusillo/sellyouroutboard",
+                    base_branch="main",
+                    policy_key="tenant-policy",
+                    policy_sha256="tenant-policy-sha",
+                    lease_owner="controller-b",
+                    lease_seconds=30,
+                    initial_active_action="tenant_admission_merge",
+                    initial_active_phase="evaluate_candidate",
+                    adoptable_active_actions=("tenant_admission_merge",),
+                )
+            observed = store.list_merge_train_controller_state_records(
+                repository="cbusillo/sellyouroutboard",
+                base_branch="main",
+            )[0]
+
+        self.assertEqual(observed, foreign_state)
 
     def test_row_lock_blocks_stale_owner_completion_until_claim_commits(self) -> None:
         with _store_for_fresh_head_database() as store:

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -2938,6 +2938,7 @@ class PostgresRecordStoreTests(unittest.TestCase):
                     response_trace_id="trace-waiver-revoke",
                 ),
             )
+            assert revoked.event_record is not None
             with self.assertRaises(TenantTechnicalHumanWaiverRevokeCurrentError):
                 store.compare_and_write_tenant_technical_human_waiver_event(
                     identity=_tenant_technical_human_waiver_identity(),
@@ -2956,16 +2957,29 @@ class PostgresRecordStoreTests(unittest.TestCase):
                         response_trace_id="trace-waiver-revoke-stale-cas",
                     ),
                 )
-            with self.assertRaises(TenantTechnicalHumanWaiverRevokeCurrentError):
-                store.compare_and_write_tenant_technical_human_waiver_event(
-                    identity=_tenant_technical_human_waiver_identity(),
-                    envelope=revoke_envelope,
-                    mutation=_tenant_technical_human_waiver_mutation(
-                        idempotency_key="tenant-waiver-revoke-stale-event",
-                        request_fingerprint="tenant-waiver-revoke-stale-event-fingerprint",
-                        response_trace_id="trace-waiver-revoke-stale-event",
-                    ),
+            stale_revoke_timestamp = (
+                (
+                    datetime.fromisoformat(revoked.event_record.occurred_at.replace("Z", "+00:00"))
+                    + timedelta(seconds=1)
                 )
+                .isoformat()
+                .replace("+00:00", "Z")
+            )
+            with patch.object(
+                store,
+                "_database_mutation_timestamp",
+                return_value=stale_revoke_timestamp,
+            ):
+                with self.assertRaises(TenantTechnicalHumanWaiverRevokeCurrentError):
+                    store.compare_and_write_tenant_technical_human_waiver_event(
+                        identity=_tenant_technical_human_waiver_identity(),
+                        envelope=revoke_envelope,
+                        mutation=_tenant_technical_human_waiver_mutation(
+                            idempotency_key="tenant-waiver-revoke-stale-event",
+                            request_fingerprint="tenant-waiver-revoke-stale-event-fingerprint",
+                            response_trace_id="trace-waiver-revoke-stale-event",
+                        ),
+                    )
             records = store.list_tenant_technical_human_waiver_event_records(
                 repository_id="1001",
                 product="example-product",

--- a/tests/test_tenant_admission_controller.py
+++ b/tests/test_tenant_admission_controller.py
@@ -1,0 +1,1048 @@
+from __future__ import annotations
+
+from pathlib import Path
+from tempfile import TemporaryDirectory
+import unittest
+from unittest.mock import patch
+
+from control_plane.contracts.merge_train_controller_state import (
+    MergeTrainControllerAdoptionRejectedError,
+)
+from control_plane.merge_train_controller_run_once import (
+    MERGE_TRAIN_CONTROLLER_ACTIVE_ACTION,
+    MERGE_TRAIN_CONTROLLER_ADOPTABLE_ACTIVE_ACTIONS,
+    MergeTrainControllerLeaseContext,
+    merge_train_controller_mutation_fence,
+)
+from control_plane.merge_train_github import MergeTrainGitHubError
+from control_plane.merge_train_github import MergeTrainGitHubStaleHeadError
+from control_plane.storage.filesystem import FilesystemRecordStore
+from control_plane.tenant_admission_controller import (
+    TenantAdmissionControllerRunOnceEnvelope,
+    execute_tenant_admission_controller_run_once,
+)
+from control_plane.tenant_admission_status import get_tenant_admission_status
+from tests.test_tenant_admission_status import (
+    EVALUATED_AT,
+    _candidate,
+    _classification,
+    _classification_only_store,
+    _status_with_path_states,
+)
+
+
+BASE_SHA = "b" * 40
+MERGE_COMMIT_SHA = "c" * 40
+
+
+class TenantAdmissionControllerTests(unittest.TestCase):
+    def test_each_tenant_admission_path_can_be_ready(self) -> None:
+        cases = (
+            _status_with_path_states(
+                trusted_state="satisfied",
+                waiver_state="pending",
+                manager_state="pending",
+            ),
+            _status_with_path_states(
+                trusted_state="pending",
+                waiver_state="satisfied",
+                manager_state="pending",
+            ),
+            _status_with_path_states(
+                trusted_state="pending",
+                waiver_state="pending",
+                manager_state="satisfied",
+            ),
+        )
+        for admission in cases:
+            with self.subTest(category=admission.category), TemporaryDirectory() as temporary_name:
+                transport = _TenantControllerTransport()
+                with patch(
+                    "control_plane.tenant_admission_controller.get_tenant_admission_status",
+                    return_value=admission,
+                ):
+                    result = execute_tenant_admission_controller_run_once(
+                        request=_request(mutate=False),
+                        store=FilesystemRecordStore(state_dir=Path(temporary_name)),
+                        token="token",
+                        trace_id="trace-ready",
+                        transport_factory=lambda _token: transport,
+                    )
+
+                self.assertEqual(result.outcome, "ready")
+                checks = result.technical_checks
+                assert checks is not None
+                self.assertEqual(checks.status, "pass")
+                self.assertFalse(transport.merge_called)
+
+    def test_mutate_merges_exact_head_and_excludes_admission_statuses(self) -> None:
+        with TemporaryDirectory() as temporary_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_name))
+            transport = _TenantControllerTransport()
+            admission = _status_with_path_states(
+                trusted_state="pending",
+                waiver_state="pending",
+                manager_state="satisfied",
+            )
+            with patch(
+                "control_plane.tenant_admission_controller.get_tenant_admission_status",
+                return_value=admission,
+            ) as status_read:
+                result = execute_tenant_admission_controller_run_once(
+                    request=_request(mutate=True),
+                    store=store,
+                    token="token",
+                    trace_id="trace-merge",
+                    transport_factory=lambda _token: transport,
+                )
+
+            self.assertEqual(result.outcome, "merged")
+            self.assertTrue(result.mutated)
+            self.assertEqual(result.merge_commit_sha, MERGE_COMMIT_SHA)
+            self.assertEqual(status_read.call_count, 2)
+            self.assertTrue(transport.merge_called)
+            checks = result.technical_checks
+            assert checks is not None
+            self.assertEqual(
+                {signal.name for signal in checks.signals},
+                {"ci/build", "unit-tests"},
+            )
+            controller_state = store.list_merge_train_controller_state_records(
+                repository=_candidate().repository,
+                base_branch="main",
+            )[0]
+            self.assertEqual(controller_state.status, "idle")
+            self.assertEqual(controller_state.last_action, "tenant_admission_merge")
+
+    def test_engineering_repository_keeps_existing_flow(self) -> None:
+        candidate = _candidate()
+        admission = get_tenant_admission_status(
+            store=_classification_only_store((_classification(kind="engineering"),)),
+            candidate=candidate,
+            evaluated_at=EVALUATED_AT,
+        )
+        with TemporaryDirectory() as temporary_name:
+            transport = _TenantControllerTransport()
+            with patch(
+                "control_plane.tenant_admission_controller.get_tenant_admission_status",
+                return_value=admission,
+            ):
+                result = execute_tenant_admission_controller_run_once(
+                    request=_request(mutate=True),
+                    store=FilesystemRecordStore(state_dir=Path(temporary_name)),
+                    token="token",
+                    trace_id="trace-engineering",
+                    transport_factory=lambda _token: transport,
+                )
+
+        self.assertEqual(result.outcome, "not_applicable")
+        self.assertFalse(transport.merge_called)
+        self.assertFalse(transport.technical_checks_read)
+
+    def test_failed_or_missing_technical_checks_block_merge(self) -> None:
+        admission = _status_with_path_states(
+            trusted_state="pending",
+            waiver_state="satisfied",
+            manager_state="pending",
+        )
+        cases = (
+            _TenantControllerTransport(technical_state="failure"),
+            _TenantControllerTransport(technical_state="pending"),
+            _TenantControllerTransport(technical_state="unknown"),
+            _TenantControllerTransport(include_technical_signals=False),
+            _TenantControllerTransport(include_required_checks=False),
+            _TenantControllerTransport(check_run_app_id=999),
+            _TenantControllerTransport(
+                include_technical_signals=False,
+                include_optional_signal=True,
+            ),
+        )
+        for transport in cases:
+            with self.subTest(transport=transport), TemporaryDirectory() as temporary_name:
+                with patch(
+                    "control_plane.tenant_admission_controller.get_tenant_admission_status",
+                    return_value=admission,
+                ):
+                    result = execute_tenant_admission_controller_run_once(
+                        request=_request(mutate=True),
+                        store=FilesystemRecordStore(state_dir=Path(temporary_name)),
+                        token="token",
+                        trace_id="trace-blocked-checks",
+                        transport_factory=lambda _token: transport,
+                    )
+
+                self.assertEqual(result.outcome, "blocked")
+                self.assertFalse(transport.merge_called)
+                checks = result.technical_checks
+                assert checks is not None
+                self.assertIn(checks.status, {"fail", "pending", "unavailable"})
+
+    def test_optional_failed_check_does_not_replace_required_gate_policy(self) -> None:
+        admission = _status_with_path_states(
+            trusted_state="pending",
+            waiver_state="satisfied",
+            manager_state="pending",
+        )
+        with TemporaryDirectory() as temporary_name:
+            transport = _TenantControllerTransport(
+                include_optional_signal=True,
+                optional_signal_state="failure",
+            )
+            with patch(
+                "control_plane.tenant_admission_controller.get_tenant_admission_status",
+                return_value=admission,
+            ):
+                result = execute_tenant_admission_controller_run_once(
+                    request=_request(mutate=False),
+                    store=FilesystemRecordStore(state_dir=Path(temporary_name)),
+                    token="token",
+                    trace_id="trace-optional-check",
+                    transport_factory=lambda _token: transport,
+                )
+
+        checks = result.technical_checks
+        assert checks is not None
+        self.assertEqual(result.outcome, "ready")
+        self.assertEqual(checks.status, "pass")
+        self.assertEqual(
+            {required.name for required in checks.required_checks},
+            {"ci/build", "unit-tests"},
+        )
+
+    def test_draft_or_unmergeable_pull_request_blocks_before_checks(self) -> None:
+        admission = _status_with_path_states(
+            trusted_state="satisfied",
+            waiver_state="pending",
+            manager_state="pending",
+        )
+        cases = (
+            _pull_request_payload(draft=True),
+            _pull_request_payload(mergeable=False),
+            _pull_request_payload(mergeable=None),
+        )
+        for pull_request_payload in cases:
+            with self.subTest(payload=pull_request_payload), TemporaryDirectory() as temporary_name:
+                transport = _TenantControllerTransport(
+                    pull_request_payloads=(pull_request_payload,)
+                )
+                with patch(
+                    "control_plane.tenant_admission_controller.get_tenant_admission_status",
+                    return_value=admission,
+                ):
+                    result = execute_tenant_admission_controller_run_once(
+                        request=_request(mutate=True),
+                        store=FilesystemRecordStore(state_dir=Path(temporary_name)),
+                        token="token",
+                        trace_id="trace-unmergeable",
+                        transport_factory=lambda _token: transport,
+                    )
+
+                self.assertEqual(result.outcome, "blocked")
+                self.assertFalse(transport.technical_checks_read)
+                self.assertFalse(transport.merge_called)
+
+    def test_missing_or_malformed_draft_and_merged_evidence_fails_closed(self) -> None:
+        admission = _status_with_path_states(
+            trusted_state="satisfied",
+            waiver_state="pending",
+            manager_state="pending",
+        )
+        cases: list[dict[str, object]] = []
+        for field_name, malformed_value in (("draft", "false"), ("merged", "false")):
+            missing_payload = _pull_request_payload()
+            missing_payload.pop(field_name)
+            cases.append(missing_payload)
+            malformed_payload = _pull_request_payload()
+            malformed_payload[field_name] = malformed_value
+            cases.append(malformed_payload)
+        for pull_request_payload in cases:
+            with self.subTest(payload=pull_request_payload), TemporaryDirectory() as temporary_name:
+                transport = _TenantControllerTransport(
+                    pull_request_payloads=(pull_request_payload,)
+                )
+                with (
+                    patch(
+                        "control_plane.tenant_admission_controller.get_tenant_admission_status",
+                        return_value=admission,
+                    ),
+                    self.assertRaisesRegex(ValueError, "must be boolean"),
+                ):
+                    execute_tenant_admission_controller_run_once(
+                        request=_request(mutate=True),
+                        store=FilesystemRecordStore(state_dir=Path(temporary_name)),
+                        token="token",
+                        trace_id="trace-malformed-pr",
+                        transport_factory=lambda _token: transport,
+                    )
+
+                self.assertFalse(transport.merge_called)
+
+    def test_strict_required_checks_require_head_to_contain_current_base(self) -> None:
+        admission = _status_with_path_states(
+            trusted_state="satisfied",
+            waiver_state="pending",
+            manager_state="pending",
+        )
+        with TemporaryDirectory() as temporary_name:
+            strict_transport = _TenantControllerTransport(head_contains_base=False)
+            with patch(
+                "control_plane.tenant_admission_controller.get_tenant_admission_status",
+                return_value=admission,
+            ):
+                blocked = execute_tenant_admission_controller_run_once(
+                    request=_request(mutate=True),
+                    store=FilesystemRecordStore(state_dir=Path(temporary_name)),
+                    token="token",
+                    trace_id="trace-behind-base",
+                    transport_factory=lambda _token: strict_transport,
+                )
+
+        strict_checks = blocked.technical_checks
+        assert strict_checks is not None
+        self.assertEqual(blocked.outcome, "blocked")
+        self.assertEqual(strict_checks.status, "fail")
+        self.assertFalse(strict_checks.base_up_to_date)
+        self.assertFalse(strict_transport.merge_called)
+
+        with TemporaryDirectory() as temporary_name:
+            non_strict_transport = _TenantControllerTransport(
+                strict_required_checks=False,
+                head_contains_base=False,
+            )
+            with patch(
+                "control_plane.tenant_admission_controller.get_tenant_admission_status",
+                return_value=admission,
+            ):
+                ready = execute_tenant_admission_controller_run_once(
+                    request=_request(mutate=False),
+                    store=FilesystemRecordStore(state_dir=Path(temporary_name)),
+                    token="token",
+                    trace_id="trace-nonstrict-base",
+                    transport_factory=lambda _token: non_strict_transport,
+                )
+
+        non_strict_checks = ready.technical_checks
+        assert non_strict_checks is not None
+        self.assertEqual(ready.outcome, "ready")
+        self.assertFalse(non_strict_checks.strict)
+        self.assertIsNone(non_strict_checks.base_up_to_date)
+
+    def test_missing_or_malformed_required_check_strict_policy_fails_closed(self) -> None:
+        admission = _status_with_path_states(
+            trusted_state="satisfied",
+            waiver_state="pending",
+            manager_state="pending",
+        )
+        for strict_policy_value in (None, "true"):
+            with self.subTest(strict=strict_policy_value), TemporaryDirectory() as temporary_name:
+                transport = _TenantControllerTransport(
+                    strict_required_checks=strict_policy_value,
+                )
+                with (
+                    patch(
+                        "control_plane.tenant_admission_controller.get_tenant_admission_status",
+                        return_value=admission,
+                    ),
+                    self.assertRaisesRegex(ValueError, "strict must be boolean"),
+                ):
+                    execute_tenant_admission_controller_run_once(
+                        request=_request(mutate=True),
+                        store=FilesystemRecordStore(state_dir=Path(temporary_name)),
+                        token="token",
+                        trace_id="trace-malformed-strict",
+                        transport_factory=lambda _token: transport,
+                    )
+
+                self.assertFalse(transport.merge_called)
+
+    def test_same_repository_head_identity_is_required(self) -> None:
+        candidate = _candidate()
+        admission = _status_with_path_states(
+            trusted_state="satisfied",
+            waiver_state="pending",
+            manager_state="pending",
+        )
+        transport = _TenantControllerTransport(
+            pull_request_payloads=(
+                _pull_request_payload(head_repository_id=int(candidate.repository_id) + 1),
+            )
+        )
+        with TemporaryDirectory() as temporary_name:
+            with (
+                patch(
+                    "control_plane.tenant_admission_controller.get_tenant_admission_status",
+                    return_value=admission,
+                ),
+                self.assertRaisesRegex(ValueError, "identity changed"),
+            ):
+                execute_tenant_admission_controller_run_once(
+                    request=_request(mutate=True),
+                    store=FilesystemRecordStore(state_dir=Path(temporary_name)),
+                    token="token",
+                    trace_id="trace-fork",
+                    transport_factory=lambda _token: transport,
+                )
+
+        self.assertFalse(transport.merge_called)
+
+    def test_admission_revoked_between_rechecks_blocks_merge(self) -> None:
+        admitted = _status_with_path_states(
+            trusted_state="pending",
+            waiver_state="satisfied",
+            manager_state="pending",
+        )
+        blocked = _status_with_path_states(
+            trusted_state="pending",
+            waiver_state="pending",
+            manager_state="pending",
+        )
+        with TemporaryDirectory() as temporary_name:
+            transport = _TenantControllerTransport()
+            with patch(
+                "control_plane.tenant_admission_controller.get_tenant_admission_status",
+                side_effect=(admitted, blocked),
+            ):
+                result = execute_tenant_admission_controller_run_once(
+                    request=_request(mutate=True),
+                    store=FilesystemRecordStore(state_dir=Path(temporary_name)),
+                    token="token",
+                    trace_id="trace-revoked",
+                    transport_factory=lambda _token: transport,
+                )
+
+        self.assertEqual(result.outcome, "blocked")
+        self.assertFalse(transport.merge_called)
+
+    def test_required_check_policy_drift_between_rechecks_blocks_merge(self) -> None:
+        admission = _status_with_path_states(
+            trusted_state="pending",
+            waiver_state="satisfied",
+            manager_state="pending",
+        )
+        with TemporaryDirectory() as temporary_name:
+            transport = _TenantControllerTransport(required_check_app_ids=(15368, 999))
+            with patch(
+                "control_plane.tenant_admission_controller.get_tenant_admission_status",
+                return_value=admission,
+            ):
+                result = execute_tenant_admission_controller_run_once(
+                    request=_request(mutate=True),
+                    store=FilesystemRecordStore(state_dir=Path(temporary_name)),
+                    token="token",
+                    trace_id="trace-check-policy-drift",
+                    transport_factory=lambda _token: transport,
+                )
+
+        self.assertEqual(result.outcome, "blocked")
+        self.assertFalse(transport.merge_called)
+
+    def test_technical_evidence_must_match_exact_head(self) -> None:
+        admission = _status_with_path_states(
+            trusted_state="satisfied",
+            waiver_state="pending",
+            manager_state="pending",
+        )
+        cases = (
+            _TenantControllerTransport(status_response_sha="d" * 40),
+            _TenantControllerTransport(check_run_head_sha="d" * 40),
+        )
+        for transport in cases:
+            with self.subTest(transport=transport), TemporaryDirectory() as temporary_name:
+                with (
+                    patch(
+                        "control_plane.tenant_admission_controller.get_tenant_admission_status",
+                        return_value=admission,
+                    ),
+                    self.assertRaisesRegex(ValueError, "expected head"),
+                ):
+                    execute_tenant_admission_controller_run_once(
+                        request=_request(mutate=True),
+                        store=FilesystemRecordStore(state_dir=Path(temporary_name)),
+                        token="token",
+                        trace_id="trace-stale-evidence",
+                        transport_factory=lambda _token: transport,
+                    )
+
+                self.assertFalse(transport.merge_called)
+
+    def test_head_move_between_rechecks_fails_before_merge(self) -> None:
+        admission = _status_with_path_states(
+            trusted_state="satisfied",
+            waiver_state="pending",
+            manager_state="pending",
+        )
+        transport = _TenantControllerTransport(
+            pull_request_payloads=(
+                _pull_request_payload(),
+                _pull_request_payload(head_sha="d" * 40),
+            )
+        )
+        with TemporaryDirectory() as temporary_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_name))
+            with (
+                patch(
+                    "control_plane.tenant_admission_controller.get_tenant_admission_status",
+                    return_value=admission,
+                ),
+                self.assertRaisesRegex(ValueError, "identity changed"),
+            ):
+                execute_tenant_admission_controller_run_once(
+                    request=_request(mutate=True),
+                    store=store,
+                    token="token",
+                    trace_id="trace-head-move",
+                    transport_factory=lambda _token: transport,
+                )
+
+            controller_state = store.list_merge_train_controller_state_records(
+                repository=_candidate().repository,
+                base_branch="main",
+            )[0]
+
+        self.assertFalse(transport.merge_called)
+        self.assertEqual(controller_state.status, "idle")
+
+    def test_base_move_between_rechecks_fails_before_merge(self) -> None:
+        admission = _status_with_path_states(
+            trusted_state="satisfied",
+            waiver_state="pending",
+            manager_state="pending",
+        )
+        transport = _TenantControllerTransport(
+            pull_request_payloads=(
+                _pull_request_payload(),
+                _pull_request_payload(base_sha="d" * 40),
+            )
+        )
+        with TemporaryDirectory() as temporary_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_name))
+            with (
+                patch(
+                    "control_plane.tenant_admission_controller.get_tenant_admission_status",
+                    return_value=admission,
+                ),
+                self.assertRaisesRegex(ValueError, "base moved"),
+            ):
+                execute_tenant_admission_controller_run_once(
+                    request=_request(mutate=True),
+                    store=store,
+                    token="token",
+                    trace_id="trace-base-move",
+                    transport_factory=lambda _token: transport,
+                )
+
+        self.assertFalse(transport.merge_called)
+
+    def test_merge_confirmation_mismatch_requires_reconciliation(self) -> None:
+        admission = _status_with_path_states(
+            trusted_state="pending",
+            waiver_state="pending",
+            manager_state="satisfied",
+        )
+        with TemporaryDirectory() as temporary_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_name))
+            transport = _TenantControllerTransport(merge_response_sha="d" * 40)
+            with (
+                patch(
+                    "control_plane.tenant_admission_controller.get_tenant_admission_status",
+                    return_value=admission,
+                ),
+                self.assertRaisesRegex(ValueError, "did not confirm"),
+            ):
+                execute_tenant_admission_controller_run_once(
+                    request=_request(mutate=True),
+                    store=store,
+                    token="token",
+                    trace_id="trace-confirm-mismatch",
+                    transport_factory=lambda _token: transport,
+                )
+            controller_state = store.list_merge_train_controller_state_records(
+                repository=_candidate().repository,
+                base_branch="main",
+            )[0]
+
+        self.assertTrue(transport.merge_called)
+        self.assertEqual(controller_state.status, "reconcile_required")
+
+    def test_expected_sha_rejection_is_stale_without_reconciliation(self) -> None:
+        admission = _status_with_path_states(
+            trusted_state="pending",
+            waiver_state="pending",
+            manager_state="satisfied",
+        )
+        with TemporaryDirectory() as temporary_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_name))
+            transport = _TenantControllerTransport(stale_merge=True)
+            with (
+                patch(
+                    "control_plane.tenant_admission_controller.get_tenant_admission_status",
+                    return_value=admission,
+                ),
+                self.assertRaisesRegex(ValueError, "head moved"),
+            ):
+                execute_tenant_admission_controller_run_once(
+                    request=_request(mutate=True),
+                    store=store,
+                    token="token",
+                    trace_id="trace-stale-merge",
+                    transport_factory=lambda _token: transport,
+                )
+            controller_state = store.list_merge_train_controller_state_records(
+                repository=_candidate().repository,
+                base_branch="main",
+            )[0]
+
+        self.assertTrue(transport.merge_called)
+        self.assertEqual(controller_state.status, "idle")
+
+    def test_exact_already_merged_pull_request_is_idempotent(self) -> None:
+        transport = _TenantControllerTransport(initially_merged=True)
+        with TemporaryDirectory() as temporary_name:
+            with patch(
+                "control_plane.tenant_admission_controller.get_tenant_admission_status"
+            ) as status_read:
+                result = execute_tenant_admission_controller_run_once(
+                    request=_request(mutate=True),
+                    store=FilesystemRecordStore(state_dir=Path(temporary_name)),
+                    token="token",
+                    trace_id="trace-already-merged",
+                    transport_factory=lambda _token: transport,
+                )
+
+        self.assertEqual(result.outcome, "already_merged")
+        self.assertEqual(result.merge_commit_sha, MERGE_COMMIT_SHA)
+        self.assertFalse(transport.merge_called)
+        status_read.assert_not_called()
+
+    def test_foreign_controller_state_remains_attributed_to_original_action(self) -> None:
+        with TemporaryDirectory() as temporary_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_name))
+            foreign_record = store.acquire_merge_train_controller_state_record(
+                repository=_candidate().repository,
+                base_branch="main",
+                policy_key="foreign-policy",
+                policy_sha256="a" * 64,
+                lease_owner="foreign-owner",
+                lease_seconds=300,
+                initial_active_action="merge_train_land",
+                initial_active_phase="confirm_batch",
+                adoptable_active_actions=("merge_train_land",),
+            )
+            foreign_lease = MergeTrainControllerLeaseContext(
+                record=foreign_record,
+                record_store=store,
+            )
+            foreign_lease.checkpoint(
+                active_action="merge_train_land",
+                active_phase="confirm_batch",
+                active_record_id="batch-1",
+            )
+            foreign_lease.release(
+                reconciliation_status="required",
+                reconciliation_detail="retryable:merge_train_land:confirm_batch",
+                clear_active_state=False,
+            )
+
+            original_state = store.list_merge_train_controller_state_records(
+                repository=_candidate().repository,
+                base_branch="main",
+            )[0]
+            transport = _TenantControllerTransport()
+            with self.assertRaises(MergeTrainControllerAdoptionRejectedError):
+                execute_tenant_admission_controller_run_once(
+                    request=_request(mutate=True),
+                    store=store,
+                    token="token",
+                    trace_id="trace-foreign-action",
+                    transport_factory=lambda _token: transport,
+                )
+            controller_state = store.list_merge_train_controller_state_records(
+                repository=_candidate().repository,
+                base_branch="main",
+            )[0]
+
+        self.assertFalse(transport.merge_called)
+        self.assertEqual(controller_state, original_state)
+
+    def test_merge_train_cannot_adopt_tenant_controller_state(self) -> None:
+        with TemporaryDirectory() as temporary_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_name))
+            tenant_record = store.acquire_merge_train_controller_state_record(
+                repository=_candidate().repository,
+                base_branch="main",
+                policy_key="tenant-policy",
+                policy_sha256="a" * 64,
+                lease_owner="tenant-owner",
+                lease_seconds=300,
+                initial_active_action="tenant_admission_merge",
+                initial_active_phase="confirm_merge",
+                adoptable_active_actions=("tenant_admission_merge",),
+            )
+            tenant_lease = MergeTrainControllerLeaseContext(
+                record=tenant_record,
+                record_store=store,
+            )
+            tenant_lease.checkpoint(
+                active_action="tenant_admission_merge",
+                active_phase="confirm_merge",
+                active_record_id="tenant-operation",
+            )
+            tenant_state = tenant_lease.release(
+                reconciliation_status="required",
+                reconciliation_detail="retryable:tenant_admission_merge:confirm_merge",
+                clear_active_state=False,
+            )
+
+            with self.assertRaises(MergeTrainControllerAdoptionRejectedError):
+                store.acquire_merge_train_controller_state_record(
+                    repository=_candidate().repository,
+                    base_branch="main",
+                    policy_key="merge-train-policy",
+                    policy_sha256="b" * 64,
+                    lease_owner="merge-train-owner",
+                    lease_seconds=300,
+                    initial_active_action=MERGE_TRAIN_CONTROLLER_ACTIVE_ACTION,
+                    initial_active_phase="select_next_action",
+                    adoptable_active_actions=MERGE_TRAIN_CONTROLLER_ADOPTABLE_ACTIVE_ACTIONS,
+                )
+            observed = store.list_merge_train_controller_state_records(
+                repository=_candidate().repository,
+                base_branch="main",
+            )[0]
+
+        self.assertEqual(observed, tenant_state)
+
+    def test_tenant_and_generic_fences_cannot_adopt_merge_train_initial_state(self) -> None:
+        with TemporaryDirectory() as temporary_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_name))
+            merge_train_record = store.acquire_merge_train_controller_state_record(
+                repository=_candidate().repository,
+                base_branch="main",
+                policy_key="merge-train-policy",
+                policy_sha256="a" * 64,
+                lease_owner="merge-train-owner",
+                lease_seconds=300,
+                initial_active_action=MERGE_TRAIN_CONTROLLER_ACTIVE_ACTION,
+                initial_active_phase="select_next_action",
+                adoptable_active_actions=MERGE_TRAIN_CONTROLLER_ADOPTABLE_ACTIVE_ACTIONS,
+            )
+            merge_train_lease = MergeTrainControllerLeaseContext(
+                record=merge_train_record,
+                record_store=store,
+            )
+            merge_train_state = merge_train_lease.release(
+                reconciliation_status="required",
+                reconciliation_detail=(
+                    "retryable:merge_train_controller_run_once:select_next_action"
+                ),
+                clear_active_state=False,
+            )
+
+            transport = _TenantControllerTransport()
+            with self.assertRaises(MergeTrainControllerAdoptionRejectedError):
+                execute_tenant_admission_controller_run_once(
+                    request=_request(mutate=True),
+                    store=store,
+                    token="token",
+                    trace_id="trace-main-bootstrap",
+                    transport_factory=lambda _token: transport,
+                )
+            with self.assertRaises(MergeTrainControllerAdoptionRejectedError):
+                with merge_train_controller_mutation_fence(
+                    record_store=store,
+                    repository=_candidate().repository,
+                    base_branch="main",
+                    policy_key="generic-policy",
+                    policy_sha256="b" * 64,
+                    trace_id="trace-generic-bootstrap",
+                    active_action="batch_candidate_run_once",
+                    active_phase="plan",
+                ):
+                    self.fail("Foreign generic mutation fence unexpectedly acquired state.")
+            observed = store.list_merge_train_controller_state_records(
+                repository=_candidate().repository,
+                base_branch="main",
+            )[0]
+
+        self.assertFalse(transport.merge_called)
+        self.assertEqual(observed, merge_train_state)
+
+    def test_merge_train_can_adopt_every_main_controller_checkpoint_action(self) -> None:
+        expected_actions = {
+            "admit_collapsed_root",
+            "build_candidate",
+            "execute_stack_collapse",
+            "land_batch",
+            MERGE_TRAIN_CONTROLLER_ACTIVE_ACTION,
+            "observe_candidate",
+            "plan_candidate",
+            "plan_landing",
+            "plan_stack_collapse",
+            "reflow_candidate",
+        }
+        self.assertEqual(set(MERGE_TRAIN_CONTROLLER_ADOPTABLE_ACTIVE_ACTIONS), expected_actions)
+
+        for active_action in sorted(expected_actions):
+            with self.subTest(active_action=active_action), TemporaryDirectory() as temporary_name:
+                store = FilesystemRecordStore(state_dir=Path(temporary_name))
+                initial = store.acquire_merge_train_controller_state_record(
+                    repository=_candidate().repository,
+                    base_branch="main",
+                    policy_key="merge-train-policy",
+                    policy_sha256="a" * 64,
+                    lease_owner="merge-train-owner-a",
+                    lease_seconds=300,
+                    initial_active_action=MERGE_TRAIN_CONTROLLER_ACTIVE_ACTION,
+                    initial_active_phase="select_next_action",
+                    adoptable_active_actions=MERGE_TRAIN_CONTROLLER_ADOPTABLE_ACTIVE_ACTIONS,
+                )
+                first_lease = MergeTrainControllerLeaseContext(
+                    record=initial,
+                    record_store=store,
+                )
+                first_lease.checkpoint(
+                    active_action=active_action,
+                    active_phase="checkpointed",
+                )
+                first_lease.release(
+                    reconciliation_status="required",
+                    reconciliation_detail=f"retryable:{active_action}:checkpointed",
+                    clear_active_state=False,
+                )
+
+                adopted = store.acquire_merge_train_controller_state_record(
+                    repository=_candidate().repository,
+                    base_branch="main",
+                    policy_key="merge-train-policy",
+                    policy_sha256="a" * 64,
+                    lease_owner="merge-train-owner-b",
+                    lease_seconds=300,
+                    initial_active_action=MERGE_TRAIN_CONTROLLER_ACTIVE_ACTION,
+                    initial_active_phase="select_next_action",
+                    adoptable_active_actions=MERGE_TRAIN_CONTROLLER_ADOPTABLE_ACTIVE_ACTIONS,
+                )
+
+            self.assertEqual(adopted.reconciliation_status, "adopted")
+            self.assertEqual(adopted.active_action, active_action)
+
+    def test_provider_uncertainty_adopts_exact_merged_pull_request(self) -> None:
+        admission = _status_with_path_states(
+            trusted_state="pending",
+            waiver_state="pending",
+            manager_state="satisfied",
+        )
+        request = _request(mutate=True)
+        with TemporaryDirectory() as temporary_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_name))
+            uncertain_transport = _TenantControllerTransport(uncertain_merge=True)
+            with (
+                patch(
+                    "control_plane.tenant_admission_controller.get_tenant_admission_status",
+                    return_value=admission,
+                ),
+                self.assertRaises(MergeTrainGitHubError),
+            ):
+                execute_tenant_admission_controller_run_once(
+                    request=request,
+                    store=store,
+                    token="token",
+                    trace_id="trace-uncertain",
+                    transport_factory=lambda _token: uncertain_transport,
+                )
+            uncertain_state = store.list_merge_train_controller_state_records(
+                repository=_candidate().repository,
+                base_branch="main",
+            )[0]
+            self.assertEqual(uncertain_state.status, "reconcile_required")
+
+            adoption_transport = _TenantControllerTransport(initially_merged=True)
+            adopted = execute_tenant_admission_controller_run_once(
+                request=request,
+                store=store,
+                token="token",
+                trace_id="trace-adopt",
+                transport_factory=lambda _token: adoption_transport,
+            )
+            adopted_state = store.list_merge_train_controller_state_records(
+                repository=_candidate().repository,
+                base_branch="main",
+            )[0]
+
+        self.assertEqual(adopted.outcome, "adopted")
+        self.assertEqual(adopted.merge_commit_sha, MERGE_COMMIT_SHA)
+        self.assertFalse(adoption_transport.merge_called)
+        self.assertEqual(adopted_state.status, "idle")
+
+
+class _TenantControllerTransport:
+    def __init__(
+        self,
+        *,
+        technical_state: str = "success",
+        include_technical_signals: bool = True,
+        pull_request_payloads: tuple[dict[str, object], ...] = (),
+        uncertain_merge: bool = False,
+        initially_merged: bool = False,
+        merge_response_sha: str = MERGE_COMMIT_SHA,
+        status_response_sha: str = "",
+        check_run_head_sha: str = "",
+        check_run_app_id: int = 15368,
+        stale_merge: bool = False,
+        include_required_checks: bool = True,
+        include_optional_signal: bool = False,
+        optional_signal_state: str = "success",
+        required_check_app_ids: tuple[int, ...] = (),
+        strict_required_checks: object = True,
+        head_contains_base: bool = True,
+    ) -> None:
+        self.technical_state = technical_state
+        self.include_technical_signals = include_technical_signals
+        self.pull_request_payloads = list(pull_request_payloads)
+        self.uncertain_merge = uncertain_merge
+        self.merged = initially_merged
+        self.merge_response_sha = merge_response_sha
+        self.status_response_sha = status_response_sha
+        self.check_run_head_sha = check_run_head_sha
+        self.check_run_app_id = check_run_app_id
+        self.stale_merge = stale_merge
+        self.include_required_checks = include_required_checks
+        self.include_optional_signal = include_optional_signal
+        self.optional_signal_state = optional_signal_state
+        self.required_check_app_ids = list(required_check_app_ids)
+        self.strict_required_checks = strict_required_checks
+        self.head_contains_base = head_contains_base
+        self.merge_called = False
+        self.technical_checks_read = False
+        self.requests: list[tuple[str, str, dict[str, object] | None]] = []
+
+    def request(
+        self,
+        *,
+        method: str,
+        path: str,
+        body: dict[str, object] | None = None,
+    ) -> object:
+        self.requests.append((method, path, body))
+        if method == "GET" and "/pulls/" in path:
+            if self.pull_request_payloads:
+                return self.pull_request_payloads.pop(0)
+            return _pull_request_payload(merged=self.merged)
+        if method == "GET" and path.endswith("/protection/required_status_checks"):
+            self.technical_checks_read = True
+            if not self.include_required_checks:
+                return {"strict": True, "contexts": [], "checks": []}
+            required_check_app_id = (
+                self.required_check_app_ids.pop(0) if self.required_check_app_ids else 15368
+            )
+            return {
+                **(
+                    {"strict": self.strict_required_checks}
+                    if self.strict_required_checks is not None
+                    else {}
+                ),
+                "contexts": ["ci/build", "unit-tests"],
+                "checks": [
+                    {"context": "ci/build", "app_id": None},
+                    {"context": "unit-tests", "app_id": required_check_app_id},
+                ],
+            }
+        if method == "GET" and path.endswith("/status"):
+            self.technical_checks_read = True
+            statuses: list[dict[str, object]] = [
+                {"context": "tenant-admission", "state": "failure"},
+                {"context": "manager-preview-approval", "state": "failure"},
+            ]
+            if self.include_technical_signals:
+                statuses.append({"context": "ci/build", "state": self.technical_state, "app": None})
+            if self.include_optional_signal:
+                statuses.append(
+                    {
+                        "context": "optional-lint",
+                        "state": self.optional_signal_state,
+                        "app": None,
+                    }
+                )
+            return {
+                "sha": self.status_response_sha or _candidate().head_sha,
+                "total_count": len(statuses),
+                "statuses": statuses,
+            }
+        if method == "GET" and "/check-runs?" in path:
+            self.technical_checks_read = True
+            check_runs = (
+                [
+                    {
+                        "name": "unit-tests",
+                        "head_sha": self.check_run_head_sha or _candidate().head_sha,
+                        "app": {"id": self.check_run_app_id},
+                        "status": "completed",
+                        "conclusion": "success",
+                    }
+                ]
+                if self.include_technical_signals
+                else []
+            )
+            return {"total_count": len(check_runs), "check_runs": check_runs}
+        if method == "PUT" and path.endswith("/merge"):
+            self.merge_called = True
+            if self.stale_merge:
+                raise MergeTrainGitHubStaleHeadError("head moved", status_code=409)
+            self.merged = True
+            if self.uncertain_merge:
+                raise MergeTrainGitHubError("provider response lost")
+            return {"sha": self.merge_response_sha, "merged": True}
+        if method == "GET" and "/compare/" in path:
+            if f"/compare/{BASE_SHA}...{_candidate().head_sha}" in path:
+                return {"status": "ahead" if self.head_contains_base else "diverged"}
+            return {"status": "ahead"}
+        raise AssertionError(f"Unexpected GitHub request: {method} {path} {body}")
+
+
+def _request(*, mutate: bool) -> TenantAdmissionControllerRunOnceEnvelope:
+    return TenantAdmissionControllerRunOnceEnvelope(
+        candidate=_candidate(),
+        base_branch="main",
+        merge_method="merge",
+        mutate=mutate,
+    )
+
+
+def _pull_request_payload(
+    *,
+    head_sha: str = "",
+    base_sha: str = BASE_SHA,
+    head_repository_id: int | None = None,
+    draft: bool = False,
+    mergeable: bool | None = True,
+    merged: bool = False,
+) -> dict[str, object]:
+    candidate = _candidate()
+    effective_head_sha = head_sha or candidate.head_sha
+    return {
+        "number": candidate.pull_request_number,
+        "state": "closed" if merged else "open",
+        "merged": merged,
+        "draft": draft,
+        "mergeable": mergeable,
+        "merge_commit_sha": MERGE_COMMIT_SHA if merged else None,
+        "html_url": (
+            f"https://github.com/{candidate.repository}/pull/{candidate.pull_request_number}"
+        ),
+        "base": {
+            "ref": "main",
+            "sha": base_sha,
+            "repo": {
+                "id": int(candidate.repository_id),
+                "full_name": candidate.repository,
+                "owner": {"id": int(candidate.repository_owner_id)},
+            },
+        },
+        "head": {
+            "sha": effective_head_sha,
+            "repo": {
+                "id": head_repository_id or int(candidate.repository_id),
+                "full_name": candidate.repository,
+                "owner": {"id": int(candidate.repository_owner_id)},
+            },
+        },
+    }

--- a/tests/test_tenant_admission_http.py
+++ b/tests/test_tenant_admission_http.py
@@ -2038,7 +2038,7 @@ class TenantAdmissionHttpTests(unittest.IsolatedAsyncioTestCase):
             "Tenant technical human waiver request body is too large.",
         )
 
-    async def test_no_unified_controller_or_legacy_trusted_maintenance_route(self) -> None:
+    async def test_no_legacy_trusted_maintenance_route(self) -> None:
         with TemporaryDirectory() as tmp_dir:
             store = _postgres_store(Path(tmp_dir))
             app = create_launchplane_fastapi_app(
@@ -2051,22 +2051,14 @@ class TenantAdmissionHttpTests(unittest.IsolatedAsyncioTestCase):
                 ),
                 record_store_factory=lambda: store,
             )
-            routes = [
-                ("POST", "/v1/work-graph/tenant-admission/controller/run-once"),
-                ("GET", "/v1/work-graph/tenant-admission/trusted-maintenance"),
-            ]
-            results = []
-            for method, path in routes:
-                res = await _asgi_request(
-                    app,
-                    method,
-                    path,
-                    headers={"Authorization": "Bearer valid-token"},
-                )
-                results.append(res.status_code)
+            response = await _asgi_request(
+                app,
+                "GET",
+                "/v1/work-graph/tenant-admission/trusted-maintenance",
+                headers={"Authorization": "Bearer valid-token"},
+            )
 
-        for status_code in results:
-            self.assertEqual(status_code, 404)
+        self.assertEqual(response.status_code, 404)
 
 
 def _authz_policy(*, actions: tuple[str, ...]) -> LaunchplaneAuthzPolicy:

--- a/tests/test_tenant_admission_status_http.py
+++ b/tests/test_tenant_admission_status_http.py
@@ -6,11 +6,20 @@ import unittest
 from unittest.mock import patch
 from urllib.parse import urlencode
 
+from control_plane.contracts.merge_train_controller_state import (
+    MergeTrainControllerAdoptionRejectedError,
+)
 from control_plane.contracts.tenant_merge_eligibility import (
+    TenantMergeCandidate,
     TenantRepositoryClassificationKind,
     TenantRepositoryClassificationRecord,
 )
 from control_plane.http_app import create_launchplane_fastapi_app
+from control_plane.tenant_admission_controller import (
+    TenantAdmissionControllerRunOnceResult,
+    TenantAdmissionControllerStaleCandidateError,
+    TenantAdmissionPullRequestFacts,
+)
 from control_plane.tenant_admission_projection import TenantAdmissionProjectionError
 from tests.http_app_test_support import _asgi_get, _asgi_request
 from tests.support.auth import _StubVerifier, _identity
@@ -30,6 +39,135 @@ PULL_REQUEST_NUMBER = 17
 
 
 class TenantAdmissionStatusHttpTests(unittest.IsolatedAsyncioTestCase):
+    async def test_controller_run_once_requires_scoped_authorization(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = _postgres_store(Path(temporary_directory_name), actions=())
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_authz_policy(actions=()),
+                record_store_factory=lambda: store,
+            )
+            response = await _asgi_request(
+                app,
+                "POST",
+                "/v1/work-graph/tenant-admission/controller/run-once",
+                headers={"Authorization": "Bearer valid-token"},
+                payload=_controller_payload(),
+            )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.json()["error"]["code"], "authorization_denied")
+
+    async def test_controller_run_once_returns_public_result(self) -> None:
+        expected_result = _controller_result()
+        with TemporaryDirectory() as temporary_directory_name:
+            store = _postgres_store(
+                Path(temporary_directory_name),
+                actions=("tenant_admission.controller.run_once",),
+            )
+            with (
+                patch(
+                    "control_plane.http_app.resolve_launchplane_github_token",
+                    return_value="managed-token",
+                ),
+                patch(
+                    "control_plane.http_routes.tenant_admission."
+                    "execute_tenant_admission_controller_run_once",
+                    return_value=expected_result,
+                ) as execute,
+            ):
+                app = create_launchplane_fastapi_app(
+                    verifier=_StubVerifier(_identity()),
+                    authz_policy=_authz_policy(actions=("tenant_admission.controller.run_once",)),
+                    record_store_factory=lambda: store,
+                )
+                response = await _asgi_request(
+                    app,
+                    "POST",
+                    "/v1/work-graph/tenant-admission/controller/run-once",
+                    headers={"Authorization": "Bearer valid-token"},
+                    payload=_controller_payload(),
+                )
+
+        self.assertEqual(response.status_code, 202)
+        self.assertEqual(response.json()["result"]["outcome"], "not_applicable")
+        self.assertEqual(execute.call_args.kwargs["token"], "managed-token")
+        self.assertFalse(execute.call_args.kwargs["request"].mutate)
+
+    async def test_controller_run_once_maps_stale_candidate_to_conflict(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = _postgres_store(
+                Path(temporary_directory_name),
+                actions=("tenant_admission.controller.run_once",),
+            )
+            with (
+                patch(
+                    "control_plane.http_app.resolve_launchplane_github_token",
+                    return_value="managed-token",
+                ),
+                patch(
+                    "control_plane.http_routes.tenant_admission."
+                    "execute_tenant_admission_controller_run_once",
+                    side_effect=TenantAdmissionControllerStaleCandidateError("head moved"),
+                ),
+            ):
+                app = create_launchplane_fastapi_app(
+                    verifier=_StubVerifier(_identity()),
+                    authz_policy=_authz_policy(actions=("tenant_admission.controller.run_once",)),
+                    record_store_factory=lambda: store,
+                )
+                response = await _asgi_request(
+                    app,
+                    "POST",
+                    "/v1/work-graph/tenant-admission/controller/run-once",
+                    headers={"Authorization": "Bearer valid-token"},
+                    payload=_controller_payload(mutate=True),
+                )
+
+        self.assertEqual(response.status_code, 409)
+        self.assertEqual(
+            response.json()["error"]["code"],
+            "tenant_admission_stale_candidate",
+        )
+
+    async def test_controller_run_once_preserves_foreign_reconciliation_state(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = _postgres_store(
+                Path(temporary_directory_name),
+                actions=("tenant_admission.controller.run_once",),
+            )
+            with (
+                patch(
+                    "control_plane.http_app.resolve_launchplane_github_token",
+                    return_value="managed-token",
+                ),
+                patch(
+                    "control_plane.http_routes.tenant_admission."
+                    "execute_tenant_admission_controller_run_once",
+                    side_effect=MergeTrainControllerAdoptionRejectedError(
+                        "state belongs to a different active action"
+                    ),
+                ),
+            ):
+                app = create_launchplane_fastapi_app(
+                    verifier=_StubVerifier(_identity()),
+                    authz_policy=_authz_policy(actions=("tenant_admission.controller.run_once",)),
+                    record_store_factory=lambda: store,
+                )
+                response = await _asgi_request(
+                    app,
+                    "POST",
+                    "/v1/work-graph/tenant-admission/controller/run-once",
+                    headers={"Authorization": "Bearer valid-token"},
+                    payload=_controller_payload(mutate=True),
+                )
+
+        self.assertEqual(response.status_code, 409)
+        self.assertEqual(
+            response.json()["error"]["code"],
+            "tenant_admission_reconciliation_required",
+        )
+
     async def test_reads_engineering_status_from_numeric_classification(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             store = _postgres_store(
@@ -218,6 +356,38 @@ def _candidate_payload() -> dict[str, object]:
         "pull_request_number": PULL_REQUEST_NUMBER,
         "head_sha": HEAD_SHA,
     }
+
+
+def _controller_payload(*, mutate: bool = False) -> dict[str, object]:
+    return {
+        "schema_version": 1,
+        "candidate": _candidate_payload(),
+        "base_branch": "main",
+        "merge_method": "merge",
+        "mutate": mutate,
+    }
+
+
+def _controller_result() -> TenantAdmissionControllerRunOnceResult:
+    candidate = TenantMergeCandidate.model_validate(_candidate_payload())
+    facts = TenantAdmissionPullRequestFacts(
+        repository=REPOSITORY,
+        pull_request_number=PULL_REQUEST_NUMBER,
+        pull_request_url=f"https://github.com/{REPOSITORY}/pull/{PULL_REQUEST_NUMBER}",
+        state="open",
+        merged=False,
+        head_sha=HEAD_SHA,
+        base_branch="main",
+        base_sha="b" * 40,
+    )
+    return TenantAdmissionControllerRunOnceResult(
+        outcome="not_applicable",
+        candidate=candidate,
+        base_branch="main",
+        merge_method="merge",
+        pull_request_facts=facts,
+        detail="Engineering repositories retain their existing merge flow.",
+    )
 
 
 def _pull_request_payload(*, head_sha: str = HEAD_SHA) -> dict[str, object]:

--- a/tests/test_webhook_body_guard.py
+++ b/tests/test_webhook_body_guard.py
@@ -18,6 +18,7 @@ _JSON_MUTATION_ROUTES = (
     ("/v1/secrets/reencrypt", 64 * 1024),
     ("/v1/tenant-admission/repository-classifications/apply", 64 * 1024),
     ("/v1/tenant-admission/repository-human-role-policies/apply", 64 * 1024),
+    ("/v1/work-graph/tenant-admission/controller/run-once", 64 * 1024),
     ("/v1/tenant-admission/status/reconcile", 64 * 1024),
     ("/v1/tenant-admission/trusted-maintenance-policies/apply", 64 * 1024),
 )


### PR DESCRIPTION
Closes #1957

## Summary
- add the bearer-only tenant admission controller run-once route for one exact repository/PR/head candidate
- recompute DB-backed admission, live required-check policy, strict base freshness, mergeability, and exact check/app bindings before an expected-SHA merge
- make the shared repository/base controller fence action-aware in both directions, including controller-specific pre-checkpoint recovery state
- preserve engineering flow as not-applicable and keep GitHub admission statuses projection-only
- update service/record/merge-policy docs and canonical OpenAPI

## Validation
- `uv run --extra dev launchplane ci unittest-shard local` — 2,637 targets, 12/12 shards passed
- `uv run --extra dev ruff check .` — passed
- `uv run --extra dev mypy control_plane tests` — 627 source files passed
- changed-file `ruff format --check` — passed
- repo-wide `ruff format --check .` — known baseline: 25 untouched files would reformat; no changed file is affected
- `pnpm --dir frontend validate` — 52 tests, OpenAPI drift, typecheck, and production build passed
- `uv run launchplane service audit-config-authority --control-plane-root .` — status `ok`
- PyCharm changed-file inspection — clean, zero findings
- final independent GPT and Gemini reviews — merge approved / LOVE

## Reviewability
This is a large but single ownership-boundary slice: the exact merge effect, its crash fence, HTTP/OpenAPI contract, and fail-closed regression matrix must land together. Generated OpenAPI and exhaustive recovery/security tests account for most of the added lines.