### PR TITLE
Fix Odoo preview website bootstrap parity

### DIFF
--- a/control_plane/dokploy/post_deploy.py
+++ b/control_plane/dokploy/post_deploy.py
@@ -82,6 +82,7 @@ ODOO_POST_DEPLOY_BOOLEAN_READBACK_MARKERS = frozenset(
         "odoo_instance_overrides_payload_present",
         "website_bootstrap_domain_set",
         "website_bootstrap_domain_matches_canonical",
+        "website_bootstrap_web_base_url_matches",
         "website_bootstrap_homepage_url_set",
         "website_bootstrap_homepage_url_matches",
         "website_bootstrap_homepage_page_found",
@@ -99,6 +100,11 @@ ODOO_MODULE_UPDATE_REQUIRED_READBACK_MARKERS = (
     "odoo_module_update_completed",
     "odoo_module_update_image_match",
     "odoo_module_update_modules_configured",
+)
+ODOO_WEBSITE_BOOTSTRAP_REQUIRED_READBACK_MARKERS = (
+    "website_bootstrap_applied",
+    "website_bootstrap_domain_matches_canonical",
+    "website_bootstrap_web_base_url_matches",
 )
 ODOO_BACKUP_GATE_RESULT_MARKER = "LAUNCHPLANE_ODOO_BACKUP_GATE_RESULT_B64"
 ODOO_BACKUP_GATE_RESULT_FIELDS = frozenset(
@@ -2020,6 +2026,23 @@ def require_odoo_module_update_readback_evidence(evidence: Mapping[str, str]) ->
     if missing_markers:
         raise click.ClickException(
             "Odoo module install/update evidence did not prove the current runtime update: "
+            + ", ".join(missing_markers)
+        )
+
+
+def require_odoo_website_bootstrap_readback_evidence(evidence: Mapping[str, str]) -> None:
+    if evidence.get("log_available") != "true":
+        raise click.ClickException(
+            "Odoo website bootstrap evidence is unavailable from the provider schedule logs."
+        )
+    missing_markers = tuple(
+        marker
+        for marker in ODOO_WEBSITE_BOOTSTRAP_REQUIRED_READBACK_MARKERS
+        if evidence.get(marker) != "true"
+    )
+    if missing_markers:
+        raise click.ClickException(
+            "Odoo website bootstrap evidence did not prove the current preview bootstrap: "
             + ", ".join(missing_markers)
         )
 

--- a/control_plane/odoo_instance_overrides.py
+++ b/control_plane/odoo_instance_overrides.py
@@ -287,6 +287,28 @@ def build_post_deploy_environment(
     )
 
 
+def build_preview_website_bootstrap_environment(
+    record: OdooInstanceOverrideRecord | None,
+    *,
+    preview_url: str,
+) -> PostDeployOverrideEnvironment | None:
+    if record is None or "deploy" not in record.apply_on or record.website_bootstrap is None:
+        return None
+    normalized_preview_url = preview_url.strip().rstrip("/")
+    if not normalized_preview_url:
+        raise click.ClickException("Odoo preview website bootstrap requires preview_url.")
+    preview_record = record.model_copy(
+        update={
+            "config_parameters": (),
+            "addon_settings": (),
+            "website_bootstrap": record.website_bootstrap.model_copy(
+                update={"canonical_url": normalized_preview_url}
+            ),
+        }
+    )
+    return build_post_deploy_environment(preview_record, workflow_intent="deploy")
+
+
 def render_post_deploy_environment(
     record: OdooInstanceOverrideRecord,
     *,

--- a/control_plane/odoo_preview_apply_http.py
+++ b/control_plane/odoo_preview_apply_http.py
@@ -8,6 +8,7 @@ import re
 import click
 from pydantic import Field, model_validator
 
+from control_plane import odoo_instance_overrides as control_plane_odoo_instance_overrides
 from control_plane import runtime_environments as control_plane_runtime_environments
 from control_plane.contracts.artifact_dependency_provenance import (
     normalize_artifact_git_commit,
@@ -351,6 +352,7 @@ def execute_odoo_preview_apply_result(
         raise ValueError("Odoo preview apply repository does not match product profile.")
     resolved_environment_values = _odoo_preview_service_environment_values(
         control_plane_root_path=control_plane_root_path,
+        record_store=record_store,
         profile=profile,
         apply_request=current_request.apply,
         database_url=database_url,
@@ -888,6 +890,7 @@ def driver_result_contains_status(
 def _odoo_preview_service_environment_values(
     *,
     control_plane_root_path: Path,
+    record_store: object,
     profile: LaunchplaneProductProfileRecord,
     apply_request: OdooPreviewDokployApplyRequest,
     database_url: str | None,
@@ -904,6 +907,21 @@ def _odoo_preview_service_environment_values(
         database_url=database_url,
     )
     environment_values.update(preview_profile.override_env)
+    try:
+        template_override_record = cast(Any, record_store).read_odoo_instance_override_record(
+            context_name=preview_profile.context,
+            instance_name=template_instance,
+        )
+    except FileNotFoundError:
+        template_override_record = None
+    preview_bootstrap_environment = (
+        control_plane_odoo_instance_overrides.build_preview_website_bootstrap_environment(
+            template_override_record,
+            preview_url=plan.preview_url,
+        )
+    )
+    if preview_bootstrap_environment is not None:
+        environment_values.update(preview_bootstrap_environment.inline_environment)
     environment_values["ODOO_PROJECT_NAME"] = plan.compose_name
     environment_values["ODOO_STACK_NAME"] = plan.compose_name
     environment_values["ODOO_DB_NAME"] = _odoo_preview_identifier(plan.compose_name, suffix="db")

--- a/control_plane/workflows/odoo_preview_runtime.py
+++ b/control_plane/workflows/odoo_preview_runtime.py
@@ -1628,6 +1628,11 @@ def _execute_refresh(
                     timeout_seconds=request.timeout_seconds,
                 )
         module_install_update_status = "fail"
+        runtime_override_environment = {
+            key: request.environment_values[key]
+            for key in dokploy_post_deploy.ODOO_RUNTIME_OVERRIDE_TARGET_ENV_KEYS
+            if request.environment_values.get(key, "").strip()
+        }
         module_install_update_evidence = dokploy_post_deploy.run_compose_post_deploy_update(
             host=host,
             token=token,
@@ -1639,12 +1644,23 @@ def _execute_refresh(
                 deploy_timeout_seconds=request.timeout_seconds,
             ),
             env_file=None,
+            workflow_environment_overrides=runtime_override_environment,
             before_provider_mutation=checkpoint_provider_effect,
             deployment_title=provider_operation_title,
         )
         dokploy_post_deploy.require_odoo_module_update_readback_evidence(
             module_install_update_evidence
         )
+        if (
+            runtime_override_environment.get(
+                dokploy_post_deploy.LAUNCHPLANE_WEBSITE_BOOTSTRAP_REQUIRED_ENV_KEY,
+                "",
+            ).lower()
+            == "true"
+        ):
+            dokploy_post_deploy.require_odoo_website_bootstrap_readback_evidence(
+                module_install_update_evidence
+            )
         module_install_update_status = "pass"
         steps.append(_step("module_install_update", compose_id))
         if request.smoke_check:

--- a/docs/preview-workflow-contract.md
+++ b/docs/preview-workflow-contract.md
@@ -337,6 +337,19 @@ false, or unavailable schedule-log evidence fails the refresh. A terminal
 provider deployment alone remains an unknown recovery outcome because it does
 not prove that database-backed views were upgraded.
 
+When the preview template instance has a deploy-enabled website-bootstrap
+record, refresh also renders a preview-scoped copy of that website intent,
+replaces its canonical URL with the exact preview URL, and passes it through the
+same devkit application/readback path used by stable lanes. The copy excludes
+stable config parameters, addon settings, and secret bindings, and never writes
+the PR-specific canonical URL back to the stable record. The refresh fails when
+the required website-bootstrap application and canonical readback markers are
+missing or false.
+Like resolved runtime-environment values and managed secrets, the bootstrap
+contents come from current DB authority during apply; plan provenance binds the
+preview route, target, and artifact facts rather than freezing mutable runtime
+configuration values for the plan lifetime.
+
 Ready Odoo apply-inputs responses also include the normalized `plan_request`
 and `plan_provenance`: a service-derived plan id, canonical SHA-256 fingerprint,
 issuance time, and 30-minute expiry. Launchplane persists that response under the

--- a/docs/records.md
+++ b/docs/records.md
@@ -1668,6 +1668,11 @@ run` is the foreground loop intended for an external process supervisor, and
   to the Launchplane-resolved stable target base URL before post-deploy renders
   the payload, so local tenant bootstrap defaults do not become stable lane URL
   authority.
+- Isolated Odoo previews inherit only `website_bootstrap` from the preview
+  template instance when that record applies on deploy. Launchplane renders an
+  ephemeral payload with the preview URL as `canonical_url`; it does not persist
+  the PR-specific URL or inherit stable config parameters, addon settings, or
+  their secret bindings into the preview.
 - `apply_on` records the phases where the override is intended to apply, and
   `last_apply` records the latest driver result without making the addon layer
   the durable audit surface.

--- a/tests/test_dokploy.py
+++ b/tests/test_dokploy.py
@@ -2300,6 +2300,30 @@ domains = ["cm-testing.shinycomputers.com"]
                 }
             )
 
+    def test_require_odoo_website_bootstrap_readback_evidence_accepts_complete_proof(
+        self,
+    ) -> None:
+        dokploy_post_deploy.require_odoo_website_bootstrap_readback_evidence(
+            {
+                "log_available": "true",
+                "website_bootstrap_applied": "true",
+                "website_bootstrap_domain_matches_canonical": "true",
+                "website_bootstrap_web_base_url_matches": "true",
+            }
+        )
+
+    def test_require_odoo_website_bootstrap_readback_evidence_rejects_missing_marker(
+        self,
+    ) -> None:
+        with self.assertRaisesRegex(click.ClickException, "did not prove"):
+            dokploy_post_deploy.require_odoo_website_bootstrap_readback_evidence(
+                {
+                    "log_available": "true",
+                    "website_bootstrap_applied": "true",
+                    "website_bootstrap_domain_matches_canonical": "true",
+                }
+            )
+
     def test_compose_data_workflow_quiescence_rejects_running_schedule(self) -> None:
         target_definition = control_plane_dokploy.DokployTargetDefinition(
             context="odoo-tenant-cm",

--- a/tests/test_http_app_driver_odoo.py
+++ b/tests/test_http_app_driver_odoo.py
@@ -1,4 +1,5 @@
 import asyncio
+import base64
 from datetime import datetime, timedelta, timezone
 import hashlib
 import json
@@ -16,6 +17,7 @@ from control_plane.contracts.odoo_instance_override_record import (
     OdooConfigParameterOverride,
     OdooInstanceOverrideRecord,
     OdooOverrideValue,
+    OdooWebsiteBootstrapPayload,
 )
 from control_plane.contracts.idempotency_record import LaunchplaneIdempotencyRecord
 from control_plane.contracts.odoo_preview_runtime_plan import OdooPreviewRuntimePlan
@@ -30,6 +32,11 @@ from control_plane.dokploy import DokploySourceOfTruth, DokployTargetDefinition
 from control_plane.contracts.product_profile_record import LaunchplaneProductProfileRecord
 from control_plane.http_app import create_launchplane_fastapi_app, idempotency_scope
 from control_plane.manager_preview_approval import build_current_manager_preview_approval_binding
+from control_plane.odoo_instance_overrides import (
+    LAUNCHPLANE_INSTANCE_OVERRIDES_REQUIRED_ENV_KEY,
+    LAUNCHPLANE_WEBSITE_BOOTSTRAP_REQUIRED_ENV_KEY,
+    ODOO_INSTANCE_OVERRIDES_PAYLOAD_ENV_KEY,
+)
 from control_plane.odoo_preview_apply_http import (
     ODOO_PREVIEW_PLAN_TTL_SECONDS,
     OdooPreviewApplyEnvelope,
@@ -1932,6 +1939,29 @@ class FastApiOdooPreviewApplyTests(unittest.IsolatedAsyncioTestCase):
                     source_label="test",
                 )
             )
+            store.write_odoo_instance_override_record(
+                OdooInstanceOverrideRecord(
+                    context="cm",
+                    instance="testing",
+                    apply_on=("deploy", "promotion"),
+                    config_parameters=(
+                        OdooConfigParameterOverride(
+                            key="web.base.url",
+                            value=OdooOverrideValue(
+                                source="literal",
+                                value="https://cm-testing.example.com",
+                            ),
+                        ),
+                    ),
+                    website_bootstrap=OdooWebsiteBootstrapPayload(
+                        tenant="cm",
+                        name="Cell Mechanic",
+                        canonical_url="https://cm-testing.example.com",
+                    ),
+                    updated_at="2026-07-31T18:00:00Z",
+                    source_label="test",
+                )
+            )
             identity = self._identity(
                 repository="cbusillo/launchplane",
                 workflow_ref=(
@@ -2083,6 +2113,38 @@ class FastApiOdooPreviewApplyTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(
             applied_request.environment_values["LAUNCHPLANE_DEPLOYMENT_RECORD_ID"],
             expected_runtime_identity.deployment_record_id,
+        )
+        decoded_override_payload = json.loads(
+            base64.b64decode(
+                applied_request.environment_values[ODOO_INSTANCE_OVERRIDES_PAYLOAD_ENV_KEY]
+            ).decode("utf-8")
+        )
+        self.assertEqual(decoded_override_payload["config_parameters"], [])
+        self.assertEqual(decoded_override_payload["addon_settings"], [])
+        self.assertEqual(
+            decoded_override_payload["website_bootstrap"]["name"],
+            "Cell Mechanic",
+        )
+        self.assertEqual(
+            decoded_override_payload["website_bootstrap"]["canonical_url"],
+            "https://pr-42.cm-preview.example.test",
+        )
+        self.assertEqual(
+            applied_request.environment_values[LAUNCHPLANE_WEBSITE_BOOTSTRAP_REQUIRED_ENV_KEY],
+            "true",
+        )
+        self.assertNotIn(
+            LAUNCHPLANE_INSTANCE_OVERRIDES_REQUIRED_ENV_KEY,
+            applied_request.environment_values,
+        )
+        stored_override_record = store.read_odoo_instance_override_record(
+            context_name="cm",
+            instance_name="testing",
+        )
+        assert stored_override_record.website_bootstrap is not None
+        self.assertEqual(
+            stored_override_record.website_bootstrap.canonical_url,
+            "https://cm-testing.example.com",
         )
         self.assertEqual(expected_runtime_identity.source_git_ref, _TEST_PREVIEW_HEAD_SHA)
         self.assertTrue(expected_runtime_identity.preview_generation_id)

--- a/tests/test_odoo_instance_overrides.py
+++ b/tests/test_odoo_instance_overrides.py
@@ -10,6 +10,7 @@ from control_plane.odoo_instance_overrides import LAUNCHPLANE_INSTANCE_OVERRIDES
 from control_plane.odoo_instance_overrides import LAUNCHPLANE_WEBSITE_BOOTSTRAP_REQUIRED_ENV_KEY
 from control_plane.odoo_instance_overrides import ODOO_INSTANCE_OVERRIDES_PAYLOAD_ENV_KEY
 from control_plane.odoo_instance_overrides import build_post_deploy_environment
+from control_plane.odoo_instance_overrides import build_preview_website_bootstrap_environment
 from control_plane.odoo_instance_overrides import render_post_deploy_payload
 from control_plane.odoo_post_deploy_http import OdooWebsiteBootstrapOverrideRequest
 from click.testing import CliRunner, Result
@@ -376,6 +377,93 @@ class OdooInstanceOverrideTests(unittest.TestCase):
         self.assertNotIn(
             LAUNCHPLANE_INSTANCE_OVERRIDES_REQUIRED_ENV_KEY,
             environment.inline_environment,
+        )
+
+    def test_preview_website_bootstrap_environment_inherits_only_deploy_bootstrap(self) -> None:
+        record = OdooInstanceOverrideRecord(
+            context="cm",
+            instance="testing",
+            apply_on=("deploy", "promotion"),
+            config_parameters=(
+                OdooConfigParameterOverride(
+                    key="web.base.url",
+                    value=OdooOverrideValue(
+                        source="literal",
+                        value="https://cm-testing.example.com",
+                    ),
+                ),
+            ),
+            addon_settings=(
+                OdooAddonSettingOverride(
+                    addon="openai",
+                    setting="api_key",
+                    value=OdooOverrideValue(
+                        source="secret_binding",
+                        secret_binding_id="secret-cm-openai",
+                    ),
+                ),
+            ),
+            website_bootstrap=OdooWebsiteBootstrapPayload(
+                tenant="cm",
+                name="Cell Mechanic",
+                canonical_url="https://cm-testing.example.com",
+            ),
+            updated_at="2026-07-31T18:00:00Z",
+        )
+
+        environment = build_preview_website_bootstrap_environment(
+            record,
+            preview_url="https://pr-70.cm-preview.example.test/",
+        )
+
+        self.assertIsNotNone(environment)
+        assert environment is not None
+        decoded_payload = json.loads(
+            base64.b64decode(
+                environment.inline_environment[ODOO_INSTANCE_OVERRIDES_PAYLOAD_ENV_KEY]
+            ).decode("utf-8")
+        )
+        self.assertEqual(decoded_payload["config_parameters"], [])
+        self.assertEqual(decoded_payload["addon_settings"], [])
+        self.assertEqual(decoded_payload["website_bootstrap"]["name"], "Cell Mechanic")
+        self.assertEqual(
+            decoded_payload["website_bootstrap"]["canonical_url"],
+            "https://pr-70.cm-preview.example.test",
+        )
+        self.assertEqual(
+            environment.inline_environment[LAUNCHPLANE_WEBSITE_BOOTSTRAP_REQUIRED_ENV_KEY],
+            "true",
+        )
+        self.assertNotIn(
+            LAUNCHPLANE_INSTANCE_OVERRIDES_REQUIRED_ENV_KEY,
+            environment.inline_environment,
+        )
+        assert record.website_bootstrap is not None
+        self.assertEqual(
+            record.website_bootstrap.canonical_url,
+            "https://cm-testing.example.com",
+        )
+
+    def test_preview_website_bootstrap_environment_requires_deploy_bootstrap(self) -> None:
+        preview_only_record = OdooInstanceOverrideRecord(
+            context="cm",
+            instance="testing",
+            apply_on=("preview",),
+            website_bootstrap=OdooWebsiteBootstrapPayload(name="Cell Mechanic"),
+            updated_at="2026-07-31T18:00:00Z",
+        )
+
+        self.assertIsNone(
+            build_preview_website_bootstrap_environment(
+                None,
+                preview_url="https://pr-70.cm-preview.example.test",
+            )
+        )
+        self.assertIsNone(
+            build_preview_website_bootstrap_environment(
+                preview_only_record,
+                preview_url="https://pr-70.cm-preview.example.test",
+            )
         )
 
     def test_cli_put_config_param_does_not_echo_plaintext_value(self) -> None:

--- a/tests/test_odoo_preview_runtime.py
+++ b/tests/test_odoo_preview_runtime.py
@@ -11,6 +11,7 @@ import click
 
 from control_plane.dokploy import DokploySourceOfTruth, DokployTargetDefinition
 from control_plane.dokploy import api as dokploy_api
+from control_plane.dokploy import post_deploy as dokploy_post_deploy
 from control_plane.contracts.product_profile_record import (
     LaunchplaneProductProfileRecord,
     ProductImageProfile,
@@ -132,6 +133,9 @@ def _module_update_evidence() -> dict[str, str]:
         "odoo_module_update_completed": "true",
         "odoo_module_update_image_match": "true",
         "odoo_module_update_modules_configured": "true",
+        "website_bootstrap_applied": "true",
+        "website_bootstrap_domain_matches_canonical": "true",
+        "website_bootstrap_web_base_url_matches": "true",
     }
 
 
@@ -1734,6 +1738,8 @@ class OdooPreviewDokployDryRunTests(unittest.TestCase):
                     manifest=manifest,
                     environment_values={
                         **_environment_values(),
+                        dokploy_post_deploy.ODOO_INSTANCE_OVERRIDES_PAYLOAD_ENV_KEY: "payload",
+                        dokploy_post_deploy.LAUNCHPLANE_WEBSITE_BOOTSTRAP_REQUIRED_ENV_KEY: "true",
                         "ODOO_ADDONS_PATH": (
                             "/opt/project/addons,/opt/launchplane/addons,/odoo/addons"
                         ),
@@ -1792,6 +1798,13 @@ class OdooPreviewDokployDryRunTests(unittest.TestCase):
         )
         wait_deploy.assert_called_once()
         module_update.assert_called_once()
+        self.assertEqual(
+            module_update.call_args.kwargs["workflow_environment_overrides"],
+            {
+                dokploy_post_deploy.ODOO_INSTANCE_OVERRIDES_PAYLOAD_ENV_KEY: "payload",
+                dokploy_post_deploy.LAUNCHPLANE_WEBSITE_BOOTSTRAP_REQUIRED_ENV_KEY: "true",
+            },
+        )
         self.assertEqual(result.module_install_update_status, "pass")
         self.assertEqual(result.module_install_update_evidence, _module_update_evidence())
         self.assertIn("module_install_update", [step.name for step in result.steps])


### PR DESCRIPTION
## Summary
- inherit only deploy-enabled `website_bootstrap` intent from the preview template instance
- rewrite the canonical URL ephemerally for each preview without copying stable config, addon settings, or secret bindings
- preserve the payload through managed post-deploy and require bootstrap/canonical readback evidence
- document the apply-time runtime-authority boundary

## Validation
- targeted regression suite: 6 tests passed
- affected modules: 377 tests passed
- official local unittest shard gate: 2,649 targets passed across 12 shards
- Ruff: passed
- mypy: passed across 629 source files
- changed-file format check: passed
- PyCharm changed-file inspection: clean
- Odoo ownership check: passed
- config-authority audit: status ok
- GPT review completed; Gemini final review: no actionable findings

Full-repo Ruff format check still reports pre-existing drift in 25 untouched files; all changed Python files are formatted.

Closes #1965