### PR TITLE
Add generic preview authz managed set

### DIFF
--- a/.github/workflows/authz-policy-reconcile.yml
+++ b/.github/workflows/authz-policy-reconcile.yml
@@ -21,6 +21,7 @@ name: Manage Launchplane Authorization
           - primary
           - authz-policy-reconcile
           - manager-preview-approval
+          - generic-web-preview
           - product-health-monitoring
           - odoo-route-binding
           - odoo-external-route-binding
@@ -84,6 +85,18 @@ jobs:
       related_issue: ${{ inputs.related_issue }}
     secrets:
       managed_set_json: ${{ secrets.LAUNCHPLANE_AUTHZ_MANAGER_PREVIEW_APPROVAL_MANAGED_SET_JSON }}
+
+  reconcile-generic-web-preview:
+    if: ${{ inputs.managed_set == 'generic-web-preview' }}
+    uses: cbusillo/launchplane/.github/workflows/reusable-authz-policy-reconcile.yml@39aecc250d6dee91204e24673725bd1ea1ca6bda # main
+    with:
+      mode: ${{ inputs.mode }}
+      expected_managed_set_id: operator.generic-web-preview
+      reviewed_plan_sha256: ${{ inputs.reviewed_plan_sha256 }}
+      reason: ${{ inputs.reason }}
+      related_issue: ${{ inputs.related_issue }}
+    secrets:
+      managed_set_json: ${{ secrets.LAUNCHPLANE_AUTHZ_GENERIC_WEB_PREVIEW_MANAGED_SET_JSON }}
 
   reconcile-product-health-monitoring:
     if: ${{ inputs.managed_set == 'product-health-monitoring' }}

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -422,6 +422,15 @@ policy-admin worker rules for the standalone authz wrapper and must declare the
 `LAUNCHPLANE_AUTHZ_MANAGER_PREVIEW_APPROVAL_MANAGED_SET_JSON` owns the generic
 GitHub-human manager preview approval writer set and must declare the exact
 `operator.manager-preview-approval` managed-set identity;
+`LAUNCHPLANE_AUTHZ_GENERIC_WEB_PREVIEW_MANAGED_SET_JSON` owns generic-web
+product preview caller grants and must declare the exact
+`operator.generic-web-preview` managed-set identity. Keep product repositories,
+numeric repository identities, caller workflow refs, immutable Launchplane
+worker refs, products, contexts, events, and actions inside that protected
+desired set rather than adding product-specific wrapper jobs. Relative nested
+reusable-workflow calls resolve at the caller's immutable Launchplane commit,
+so rotate lifecycle, verification, notice, and feedback worker rules through
+the reviewed overlap procedure before repinning product callers;
 `LAUNCHPLANE_AUTHZ_PRODUCT_HEALTH_MONITORING_MANAGED_SET_JSON` owns the generic
 Product Health Monitoring wrapper's exact immutable worker grant;
 `LAUNCHPLANE_AUTHZ_ODOO_ROUTE_BINDING_MANAGED_SET_JSON` owns the independent

--- a/tests/test_authz_operator_workflow.py
+++ b/tests/test_authz_operator_workflow.py
@@ -33,6 +33,7 @@ class AuthzOperatorWorkflowTests(unittest.TestCase):
                 "primary",
                 "authz-policy-reconcile",
                 "manager-preview-approval",
+                "generic-web-preview",
                 "product-health-monitoring",
                 "odoo-route-binding",
                 "odoo-external-route-binding",
@@ -58,6 +59,10 @@ class AuthzOperatorWorkflowTests(unittest.TestCase):
             "reconcile-manager-preview-approval": (
                 "${{ inputs.managed_set == 'manager-preview-approval' }}",
                 "${{ secrets.LAUNCHPLANE_AUTHZ_MANAGER_PREVIEW_APPROVAL_MANAGED_SET_JSON }}",
+            ),
+            "reconcile-generic-web-preview": (
+                "${{ inputs.managed_set == 'generic-web-preview' }}",
+                "${{ secrets.LAUNCHPLANE_AUTHZ_GENERIC_WEB_PREVIEW_MANAGED_SET_JSON }}",
             ),
             "reconcile-product-health-monitoring": (
                 "${{ inputs.managed_set == 'product-health-monitoring' }}",
@@ -124,6 +129,7 @@ class AuthzOperatorWorkflowTests(unittest.TestCase):
                 expected_managed_set_ids = {
                     "reconcile-authz-policy-reconcile": "operator.authz-policy-reconcile",
                     "reconcile-manager-preview-approval": "operator.manager-preview-approval",
+                    "reconcile-generic-web-preview": "operator.generic-web-preview",
                 }
                 if job_name in expected_managed_set_ids:
                     self.assertEqual(


### PR DESCRIPTION
## Goal

Unblock the disposable generic-web preview canary without merging the still-unproven facade or adding product-specific Launchplane code.

Part of #1967. The permanent one-action onboarding follow-up is #1970.

## Changes

- add one `generic-web-preview` selector to the protected managed-authz wrapper
- bind it to the exact `operator.generic-web-preview` managed-set identity
- consume one protected runtime secret rather than adding per-product workflow jobs
- document nested reusable-workflow SHA rotation
- cover the selector, secret mapping, immutable worker, permissions, and managed-set identity in the existing workflow contract test

## Runtime Boundary

`LAUNCHPLANE_AUTHZ_GENERIC_WEB_PREVIEW_MANAGED_SET_JSON` is operator-supplied runtime authority and is already stored as a protected repository secret. The checked-in workflow contains no product, repository, branch, context, or caller identity.

The initial protected desired set contains least-privilege rules for the disposable canary only: refresh, destroy, verification evidence, pull-request feedback, and pull-request-target notice feedback. Every rule is constrained by immutable repository IDs, product/context, event, caller workflow path, action, and immutable Launchplane worker SHA.

## Cleanup Contract

This is a bounded bridge for the canary. #1970 owns composing product records and preview authorization into one reviewed onboarding action and deleting any superseded manual setup/docs in that migration.

## Validation

- `actionlint .github/workflows/*.yml`
- `uv run --extra dev ruff format --check tests/test_authz_operator_workflow.py`
- `uv run --extra dev ruff check tests/test_authz_operator_workflow.py`
- `uv run --extra dev mypy tests/test_authz_operator_workflow.py`
- `uv run --extra dev python -m unittest tests.test_authz_operator_workflow tests.test_authz_grant_service` — 37 tests pass
- Gemini architecture review — approve the generic managed-set bridge
- Sonnet security review — exact managed-set binding/test coverage present; nested worker SHA rotation documented
