### PR TITLE
Fix generic preview workflow contract

### DIFF
--- a/.github/workflows/reusable-generic-web-preview-lifecycle.yml
+++ b/.github/workflows/reusable-generic-web-preview-lifecycle.yml
@@ -241,7 +241,7 @@ jobs:
           idempotency-key: >-
             ${{ needs.resolve.outputs.idempotency_key }}
           timeout-ms: ${{ inputs['timeout-ms'] }}
-          expected-status: 200,403
+          expected-status: 200,202,403
           fail-result-paths: result.refresh_status,result.readiness.health_status
           output-paths: >-
             trace_id=trace_id,

--- a/.github/workflows/reusable-generic-web-preview.yml
+++ b/.github/workflows/reusable-generic-web-preview.yml
@@ -278,7 +278,7 @@ jobs:
       anchor_pr_url: ${{ needs.resolve.outputs.anchor_pr_url }}
       anchor_head_sha: ${{ needs.resolve.outputs.head_sha }}
       image_reference: ${{ needs.build.outputs.image_reference }}
-      timeout-seconds: ${{ inputs['timeout-seconds'] }}
+      timeout-seconds: ${{ inputs['timeout-seconds'] || '300' }}
       timeout-ms: ${{ inputs['timeout-ms'] }}
       launchplane_url: ${{ inputs.launchplane_url }}
       launchplane_audience: ${{ inputs.launchplane_audience }}
@@ -357,6 +357,7 @@ jobs:
       verification_status: pass
       verified_at: ${{ needs.verify.outputs.verified_at }}
       checked_urls: ${{ needs.verify.outputs.checked_urls }}
+      timeout-seconds: ${{ inputs['timeout-seconds'] || '300' }}
       timeout-ms: ${{ inputs['timeout-ms'] }}
       launchplane_url: ${{ inputs.launchplane_url }}
       launchplane_audience: ${{ inputs.launchplane_audience }}
@@ -376,6 +377,7 @@ jobs:
       verification_status: fail
       verified_at: ${{ needs.verify.outputs.verified_at }}
       checked_urls: ${{ needs.verify.outputs.checked_urls }}
+      timeout-seconds: ${{ inputs['timeout-seconds'] }}
       failure_summary: ${{ needs.verify.outputs.failure_summary }}
       timeout-ms: ${{ inputs['timeout-ms'] }}
       launchplane_url: ${{ inputs.launchplane_url }}

--- a/tests/test_preview_workflow_contract.py
+++ b/tests/test_preview_workflow_contract.py
@@ -290,7 +290,7 @@ class PreviewWorkflowContractTests(unittest.TestCase):
         self.assertIn("route-path: /v1/drivers/generic-web/preview-destroy", workflow)
         self.assertIn("route-path: /v1/authz-diagnostics/github-actions/evaluate", workflow)
         self.assertIn('"action": "preview_refresh.execute"', workflow)
-        self.assertIn("expected-status: 200,403", workflow)
+        self.assertIn("expected-status: 200,202,403", workflow)
         self.assertIn(
             "refresh.anchor_pr_number=${{ needs.resolve.outputs.anchor_pr_number }}", workflow
         )
@@ -424,6 +424,10 @@ class PreviewWorkflowContractTests(unittest.TestCase):
                 workflow.job_uses(job_id),
                 "./.github/workflows/reusable-generic-web-preview-verification.yml",
             )
+        self.assertEqual(
+            workflow_text.count("timeout-seconds: ${{ inputs['timeout-seconds'] || '300' }}"),
+            2,
+        )
         self.assertEqual(
             workflow.job_uses("feedback-refresh"),
             "./.github/workflows/reusable-preview-feedback-status.yml",


### PR DESCRIPTION
## Summary
- accept the asynchronous `202` generic preview refresh response
- forward a non-empty verification timeout whenever checked URLs are recorded
- pin workflow-contract tests to both behaviors

## Validation
- `uv run --extra dev python -m unittest tests.test_preview_workflow_contract`
- `git diff --check`

## Follow-up
After this merges, rotate only `operator.generic-web-preview` to the resulting immutable workflow SHA, then rerun the canary and remove stale pins.