### PR TITLE
fix: centralize preview lifecycle timeout handling

### DIFF
--- a/.github/workflows/reusable-generic-web-preview-lifecycle.yml
+++ b/.github/workflows/reusable-generic-web-preview-lifecycle.yml
@@ -111,6 +111,7 @@ jobs:
       operation: ${{ steps.request.outputs.operation }}
       product: ${{ steps.request.outputs.product }}
       run_url: ${{ steps.request.outputs.run_url }}
+      timeout_seconds: ${{ steps.request.outputs.timeout_seconds }}
     runs-on: ubuntu-latest
     steps:
       - name: Resolve Launchplane preview request
@@ -202,6 +203,7 @@ jobs:
             echo "operation=$OPERATION"
             echo "product=$PRODUCT"
             echo "run_url=$run_url"
+            echo "timeout_seconds=$TIMEOUT_SECONDS"
           } >>"$GITHUB_OUTPUT"
 
   refresh:
@@ -237,7 +239,7 @@ jobs:
             refresh.anchor_head_sha=${{ inputs.anchor_head_sha }}
             refresh.image_reference=${{ inputs.image_reference }}
             refresh.source=${{ needs.resolve.outputs.run_url }}
-            refresh.timeout_seconds=${{ inputs['timeout-seconds'] }}
+            refresh.timeout_seconds=${{ needs.resolve.outputs.timeout_seconds }}
           idempotency-key: >-
             ${{ needs.resolve.outputs.idempotency_key }}
           timeout-ms: ${{ inputs['timeout-ms'] }}
@@ -315,7 +317,7 @@ jobs:
             destroy.product=${{ needs.resolve.outputs.product }}
             destroy.anchor_pr_number=${{ needs.resolve.outputs.anchor_pr_number }}
             destroy.destroy_reason=${{ needs.resolve.outputs.destroy_reason }}
-            destroy.timeout_seconds=${{ inputs['timeout-seconds'] }}
+            destroy.timeout_seconds=${{ needs.resolve.outputs.timeout_seconds }}
           idempotency-key: >-
             ${{ needs.resolve.outputs.idempotency_key }}
           timeout-ms: ${{ inputs['timeout-ms'] }}

--- a/.github/workflows/reusable-generic-web-preview.yml
+++ b/.github/workflows/reusable-generic-web-preview.yml
@@ -278,7 +278,7 @@ jobs:
       anchor_pr_url: ${{ needs.resolve.outputs.anchor_pr_url }}
       anchor_head_sha: ${{ needs.resolve.outputs.head_sha }}
       image_reference: ${{ needs.build.outputs.image_reference }}
-      timeout-seconds: ${{ inputs['timeout-seconds'] || '300' }}
+      timeout-seconds: ${{ inputs['timeout-seconds'] }}
       timeout-ms: ${{ inputs['timeout-ms'] }}
       launchplane_url: ${{ inputs.launchplane_url }}
       launchplane_audience: ${{ inputs.launchplane_audience }}
@@ -377,7 +377,7 @@ jobs:
       verification_status: fail
       verified_at: ${{ needs.verify.outputs.verified_at }}
       checked_urls: ${{ needs.verify.outputs.checked_urls }}
-      timeout-seconds: ${{ inputs['timeout-seconds'] }}
+      timeout-seconds: ${{ inputs['timeout-seconds'] || '300' }}
       failure_summary: ${{ needs.verify.outputs.failure_summary }}
       timeout-ms: ${{ inputs['timeout-ms'] }}
       launchplane_url: ${{ inputs.launchplane_url }}

--- a/.github/workflows/reusable-preview-request-notice.yml
+++ b/.github/workflows/reusable-preview-request-notice.yml
@@ -66,6 +66,8 @@ jobs:
       should_cleanup: ${{ steps.notice.outputs.should_cleanup }}
       should_record: ${{ steps.notice.outputs.should_record }}
       status: ${{ steps.notice.outputs.status }}
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Resolve preview request notice

--- a/docs/preview-workflow-contract.md
+++ b/docs/preview-workflow-contract.md
@@ -107,8 +107,10 @@ default, derives a run-scoped idempotency key, calls the correct Launchplane
 route, and exposes the returned preview slug, preview URL, refresh status,
 destroy status, or feedback status as job outputs. Callers should omit preview
 context so Launchplane can derive it from the product profile before
-authorization and recording. It does not accept `preview_slug`, `preview_url`,
-provider target ids, feedback markdown, or idempotency keys as caller inputs.
+authorization and recording. The lifecycle boundary normalizes an omitted or
+empty driver timeout to 300 seconds before constructing refresh or destroy
+requests. It does not accept `preview_slug`, `preview_url`, provider target ids,
+feedback markdown, or idempotency keys as caller inputs.
 For generic-web application previews, `preview.domain_certificate_type="none"`
 means TLS terminates at the edge ingress: Launchplane creates the Dokploy domain
 on HTTP only, while the public preview URL remains HTTPS. `"letsencrypt"`
@@ -116,7 +118,10 @@ instead makes Dokploy terminate TLS for that domain. This keeps one TLS owner
 per preview route and avoids publishing an inner TLS route when Dokploy has no
 certificate to serve.
 
-When a generic-web refresh receives `403`, the lifecycle worker makes one
+The generic-web preview-refresh route may return `200` or `202` for a successful
+provider mutation. The reusable lifecycle worker accepts both responses and
+still validates the returned refresh and readiness statuses. When a generic-web
+refresh receives `403`, the lifecycle worker makes one
 same-identity call to the redacted GitHub Actions authz diagnostic route before
 failing the original refresh. That diagnostic still requires a separate,
 narrow `authz_diagnostic.evaluate` grant; without it, the workflow retains the

--- a/tests/test_preview_workflow_contract.py
+++ b/tests/test_preview_workflow_contract.py
@@ -263,6 +263,7 @@ class PreviewWorkflowContractTests(unittest.TestCase):
             parsed_workflow.job_uses("feedback-cleanup"),
             "./.github/workflows/reusable-preview-feedback-status.yml",
         )
+        self.assertEqual(parsed_workflow.job_permissions("resolve"), {"contents": "read"})
         self.assertIn("status: ${{ needs.resolve.outputs.status }}", workflow)
         self.assertIn("operation: destroy", workflow)
         self.assertIn("mode: cleanup", workflow)
@@ -283,27 +284,59 @@ class PreviewWorkflowContractTests(unittest.TestCase):
 
     def test_reusable_generic_web_preview_lifecycle_derives_preview_slug(self) -> None:
         workflow_path = REPO_ROOT / ".github/workflows/reusable-generic-web-preview-lifecycle.yml"
-        workflow = (workflow_path).read_text(encoding="utf-8")
-        workflow_inputs = workflow_call_inputs(load_workflow(workflow_path))
+        workflow_text = workflow_path.read_text(encoding="utf-8")
+        workflow = load_workflow(workflow_path)
+        workflow_inputs = workflow_call_inputs(workflow)
 
-        self.assertIn("route-path: /v1/drivers/generic-web/preview-refresh", workflow)
-        self.assertIn("route-path: /v1/drivers/generic-web/preview-destroy", workflow)
-        self.assertIn("route-path: /v1/authz-diagnostics/github-actions/evaluate", workflow)
-        self.assertIn('"action": "preview_refresh.execute"', workflow)
-        self.assertIn("expected-status: 200,202,403", workflow)
+        self.assertIn("route-path: /v1/drivers/generic-web/preview-refresh", workflow_text)
+        self.assertIn("route-path: /v1/drivers/generic-web/preview-destroy", workflow_text)
+        self.assertIn("route-path: /v1/authz-diagnostics/github-actions/evaluate", workflow_text)
+        self.assertIn('"action": "preview_refresh.execute"', workflow_text)
+        self.assertIn("expected-status: 200,202,403", workflow_text)
         self.assertIn(
-            "refresh.anchor_pr_number=${{ needs.resolve.outputs.anchor_pr_number }}", workflow
+            "refresh.anchor_pr_number=${{ needs.resolve.outputs.anchor_pr_number }}",
+            workflow_text,
         )
         self.assertIn(
-            "destroy.anchor_pr_number=${{ needs.resolve.outputs.anchor_pr_number }}", workflow
+            "destroy.anchor_pr_number=${{ needs.resolve.outputs.anchor_pr_number }}",
+            workflow_text,
         )
+
+        resolve_outputs = cast(dict[str, object], workflow.job("resolve")["outputs"])
+        self.assertEqual(
+            resolve_outputs["timeout_seconds"],
+            "${{ steps.request.outputs.timeout_seconds }}",
+        )
+        resolver = workflow.step_named("resolve", "Resolve Launchplane preview request")
+        self.assertIsNotNone(resolver)
+        assert resolver is not None
+        self.assertIn('echo "timeout_seconds=$TIMEOUT_SECONDS"', resolver.run)
+        for job_id, field_name in (
+            ("refresh", "refresh.timeout_seconds"),
+            ("destroy", "destroy.timeout_seconds"),
+        ):
+            request = workflow.step_named(
+                job_id,
+                f"Request Launchplane generic-web preview {job_id}",
+            )
+            self.assertIsNotNone(request)
+            assert request is not None
+            payload_fields = cast(str, request.with_values["payload-fields"])
+            self.assertIn(
+                f"{field_name}=${{{{ needs.resolve.outputs.timeout_seconds }}}}",
+                payload_fields,
+            )
+            self.assertNotIn(
+                f"{field_name}=${{{{ inputs['timeout-seconds'] }}}}",
+                payload_fields,
+            )
 
         self.assertNotIn("preview_slug", workflow_inputs)
         self.assertNotIn("preview_url", workflow_inputs)
-        self.assertNotIn('CONTEXT="$PRODUCT"', workflow)
-        self.assertNotIn("PRODUCT CONTEXT ANCHOR_PR_NUMBER", workflow)
-        self.assertNotIn("refresh.preview_slug=", workflow)
-        self.assertNotIn("destroy.preview_slug=", workflow)
+        self.assertNotIn('CONTEXT="$PRODUCT"', workflow_text)
+        self.assertNotIn("PRODUCT CONTEXT ANCHOR_PR_NUMBER", workflow_text)
+        self.assertNotIn("refresh.preview_slug=", workflow_text)
+        self.assertNotIn("destroy.preview_slug=", workflow_text)
 
     def test_reusable_generic_web_preview_lifecycle_feedback_maps_record_status(
         self,
@@ -413,7 +446,6 @@ class PreviewWorkflowContractTests(unittest.TestCase):
     def test_reusable_generic_web_preview_facade_composes_typed_stages(self) -> None:
         workflow_path = REPO_ROOT / ".github/workflows/reusable-generic-web-preview.yml"
         workflow = load_workflow(workflow_path)
-        workflow_text = workflow_path.read_text(encoding="utf-8")
 
         self.assertEqual(
             workflow.job_uses("provision"),
@@ -424,10 +456,18 @@ class PreviewWorkflowContractTests(unittest.TestCase):
                 workflow.job_uses(job_id),
                 "./.github/workflows/reusable-generic-web-preview-verification.yml",
             )
+        provision_inputs = cast(dict[str, object], workflow.job("provision")["with"])
         self.assertEqual(
-            workflow_text.count("timeout-seconds: ${{ inputs['timeout-seconds'] || '300' }}"),
-            2,
+            provision_inputs["timeout-seconds"],
+            "${{ inputs['timeout-seconds'] }}",
         )
+        for job_id in ("record-verification-pass", "record-verification-fail"):
+            verification_inputs = cast(dict[str, object], workflow.job(job_id)["with"])
+            self.assertEqual(
+                verification_inputs["timeout-seconds"],
+                "${{ inputs['timeout-seconds'] || '300' }}",
+                job_id,
+            )
         self.assertEqual(
             workflow.job_uses("feedback-refresh"),
             "./.github/workflows/reusable-preview-feedback-status.yml",
@@ -442,6 +482,7 @@ class PreviewWorkflowContractTests(unittest.TestCase):
         self.assertIn("author !== 'dependabot[bot]'", resolver_script)
         self.assertNotIn("action === 'closed'", resolver_script)
         self.assertNotIn("action === 'unlabeled'", resolver_script)
+        workflow_text = workflow_path.read_text(encoding="utf-8")
         self.assertNotIn("pull_request_target", workflow_text)
         self.assertIn("image_reference=${IMAGE_REPOSITORY}@${IMAGE_DIGEST}", workflow_text)
         self.assertLess(

--- a/tests/test_preview_workflow_contract.py
+++ b/tests/test_preview_workflow_contract.py
@@ -310,6 +310,7 @@ class PreviewWorkflowContractTests(unittest.TestCase):
         resolver = workflow.step_named("resolve", "Resolve Launchplane preview request")
         self.assertIsNotNone(resolver)
         assert resolver is not None
+        self.assertIn('TIMEOUT_SECONDS="300"', resolver.run)
         self.assertIn('echo "timeout_seconds=$TIMEOUT_SECONDS"', resolver.run)
         for job_id, field_name in (
             ("refresh", "refresh.timeout_seconds"),


### PR DESCRIPTION
## Summary
- normalize empty preview lifecycle timeouts at the reusable lifecycle boundary
- keep verification pass/fail timeout evidence consistent
- narrow the notice resolver to contents-read permissions
- document successful 200/202 preview refresh outcomes

## Verification
- `uv run --extra dev python -m unittest tests.test_preview_workflow_contract`
- `uv run --extra dev launchplane ci unittest-shard local`
- `uv run --extra dev ruff check tests/test_preview_workflow_contract.py`
- `uv run --extra dev ruff format --check tests/test_preview_workflow_contract.py`

## Context
Follow-up closeout hardening for #1981 after the canary preview lifecycle workstream.