### PR TITLE
Fix bundled package evidence in Trivy comparisons

### DIFF
--- a/control_plane/contracts/dependency_health_trivy.py
+++ b/control_plane/contracts/dependency_health_trivy.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime
 import hashlib
 import re
+from urllib.parse import unquote
 
 from control_plane.contracts.artifact_dependency_provenance import (
     normalize_artifact_relative_path,
@@ -165,7 +166,16 @@ def dependency_health_snapshot_from_trivy_report(
                 "InstalledVersion",
                 label="Trivy vulnerability installed version",
             )
-            if (package_name, installed_version) not in package_inventory:
+            has_package_inventory_evidence = (
+                package_name,
+                installed_version,
+            ) in package_inventory
+            has_embedded_package_evidence = _trivy_vulnerability_has_embedded_package_evidence(
+                vulnerability,
+                result_class=result_class,
+                installed_version=installed_version,
+            )
+            if not has_package_inventory_evidence and not has_embedded_package_evidence:
                 raise ValueError(
                     "Trivy vulnerability package/version is absent from Packages evidence"
                 )
@@ -203,6 +213,30 @@ def dependency_health_snapshot_from_trivy_report(
         provenance=provenance,
         findings=tuple(accumulator.build() for accumulator in accumulators.values()),
     )
+
+
+def _trivy_vulnerability_has_embedded_package_evidence(
+    vulnerability: Mapping[str, object],
+    *,
+    result_class: str,
+    installed_version: str,
+) -> bool:
+    if result_class != "lang-pkgs":
+        return False
+    package_identifier = vulnerability.get("PkgIdentifier")
+    if not isinstance(package_identifier, Mapping):
+        return False
+    purl = package_identifier.get("PURL")
+    uid = package_identifier.get("UID")
+    if not isinstance(purl, str) or not purl.strip():
+        return False
+    if not isinstance(uid, str) or not uid.strip():
+        return False
+    purl_without_fragment = purl.split("#", 1)[0]
+    purl_without_qualifiers = purl_without_fragment.split("?", 1)[0]
+    if "@" not in purl_without_qualifiers:
+        return False
+    return unquote(purl_without_qualifiers.rsplit("@", 1)[1]) == installed_version
 
 
 def _trivy_advisory_aliases(

--- a/docs/dependency-health-contract.md
+++ b/docs/dependency-health-contract.md
@@ -140,7 +140,12 @@ silently discarded. Reports must be generated with `--list-all-pkgs`; the
 adapter requires non-empty package inventory evidence even for clean results
 and rejects Trivy modified/ignored findings. Reports must contain only
 `lang-pkgs` and `os-pkgs` vulnerability results; mixed scanner output is
-rejected rather than partially normalized.
+rejected rather than partially normalized. Trivy can report a bundled language
+package vulnerability without repeating that package in the result's
+`Packages` inventory. The adapter accepts that narrow case only when the
+vulnerability carries a non-empty `PkgIdentifier` UID and a PURL whose version
+matches `InstalledVersion`; operating-system findings and unidentified or
+mismatched language packages remain fail-closed.
 
 Assess one snapshot absolutely:
 

--- a/tests/test_dependency_health_trivy.py
+++ b/tests/test_dependency_health_trivy.py
@@ -306,6 +306,78 @@ class DependencyHealthTrivyAdapterTests(unittest.TestCase):
                 provenance=_provenance(),
             )
 
+    def test_adapter_accepts_identified_bundled_language_package(self) -> None:
+        vulnerability = _vulnerability(
+            "CVE-2026-14257",
+            package="brace-expansion",
+            version="5.0.7",
+        )
+        vulnerability["PkgIdentifier"] = {
+            "PURL": "pkg:npm/brace-expansion@5.0.7",
+            "UID": "identified-bundled-package",
+        }
+        report = _report([vulnerability])
+        result = report["Results"]
+        assert isinstance(result, list)
+        result_payload = result[0]
+        assert isinstance(result_payload, dict)
+        result_payload["Packages"] = [{"Name": "npm", "Version": "11.18.0"}]
+
+        snapshot = dependency_health_snapshot_from_trivy_report(
+            report=report,
+            provenance=_provenance(),
+        )
+
+        self.assertEqual(snapshot.findings[0].package, "brace-expansion")
+        self.assertEqual(snapshot.findings[0].versions, ("5.0.7",))
+
+    def test_adapter_rejects_bundled_package_with_mismatched_identifier(self) -> None:
+        vulnerability = _vulnerability(
+            "CVE-2026-14257",
+            package="brace-expansion",
+            version="5.0.7",
+        )
+        vulnerability["PkgIdentifier"] = {
+            "PURL": "pkg:npm/brace-expansion@5.0.9",
+            "UID": "mismatched-bundled-package",
+        }
+        report = _report([vulnerability])
+        result = report["Results"]
+        assert isinstance(result, list)
+        result_payload = result[0]
+        assert isinstance(result_payload, dict)
+        result_payload["Packages"] = [{"Name": "npm", "Version": "11.18.0"}]
+
+        with self.assertRaisesRegex(ValueError, "absent from Packages evidence"):
+            dependency_health_snapshot_from_trivy_report(
+                report=report,
+                provenance=_provenance(),
+            )
+
+    def test_adapter_rejects_os_package_missing_from_inventory(self) -> None:
+        vulnerability = _vulnerability(
+            "CVE-2026-14257",
+            package="libexample",
+            version="1.0.0",
+        )
+        vulnerability["PkgIdentifier"] = {
+            "PURL": "pkg:deb/debian/libexample@1.0.0",
+            "UID": "identified-os-package",
+        }
+        report = _report([vulnerability], ecosystem="debian")
+        result = report["Results"]
+        assert isinstance(result, list)
+        result_payload = result[0]
+        assert isinstance(result_payload, dict)
+        result_payload["Class"] = "os-pkgs"
+        result_payload["Packages"] = [{"Name": "other-package", "Version": "1.0.0"}]
+
+        with self.assertRaisesRegex(ValueError, "absent from Packages evidence"):
+            dependency_health_snapshot_from_trivy_report(
+                report=report,
+                provenance=_provenance(),
+            )
+
     def test_adapter_rejects_modified_findings(self) -> None:
         report = _report([])
         result = report["Results"]


### PR DESCRIPTION
## Summary

- accept Trivy language-package findings omitted from `Packages` only when `PkgIdentifier` supplies a non-empty UID and a PURL version matching `InstalledVersion`
- keep operating-system and unidentified or mismatched package findings fail-closed
- document the narrow bundled-package evidence contract

## Validation

- `uv run --extra dev python -m unittest tests.test_dependency_health_trivy`
- `uv run --extra dev launchplane ci unittest-shard local` (2,703 targets, 12/12 shards passed)
- targeted Ruff check and format check
- targeted mypy passed

Unblocks VeriReel dependency-health runtime comparisons.