### PR TITLE
Accept identified Trivy packages missing from inventory

### DIFF
--- a/control_plane/contracts/dependency_health_trivy.py
+++ b/control_plane/contracts/dependency_health_trivy.py
@@ -5,7 +5,6 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime
 import hashlib
 import re
-from urllib.parse import unquote
 
 from control_plane.contracts.artifact_dependency_provenance import (
     normalize_artifact_relative_path,
@@ -172,7 +171,7 @@ def dependency_health_snapshot_from_trivy_report(
             ) in package_inventory
             has_embedded_package_evidence = _trivy_vulnerability_has_embedded_package_evidence(
                 vulnerability,
-                result_class=result_class,
+                package_name=package_name,
                 installed_version=installed_version,
             )
             if not has_package_inventory_evidence and not has_embedded_package_evidence:
@@ -218,10 +217,11 @@ def dependency_health_snapshot_from_trivy_report(
 def _trivy_vulnerability_has_embedded_package_evidence(
     vulnerability: Mapping[str, object],
     *,
-    result_class: str,
+    package_name: str,
     installed_version: str,
 ) -> bool:
-    if result_class != "lang-pkgs":
+    package_id = vulnerability.get("PkgID")
+    if package_id != f"{package_name}@{installed_version}":
         return False
     package_identifier = vulnerability.get("PkgIdentifier")
     if not isinstance(package_identifier, Mapping):
@@ -232,11 +232,7 @@ def _trivy_vulnerability_has_embedded_package_evidence(
         return False
     if not isinstance(uid, str) or not uid.strip():
         return False
-    purl_without_fragment = purl.split("#", 1)[0]
-    purl_without_qualifiers = purl_without_fragment.split("?", 1)[0]
-    if "@" not in purl_without_qualifiers:
-        return False
-    return unquote(purl_without_qualifiers.rsplit("@", 1)[1]) == installed_version
+    return purl.startswith("pkg:")
 
 
 def _trivy_advisory_aliases(

--- a/docs/dependency-health-contract.md
+++ b/docs/dependency-health-contract.md
@@ -142,10 +142,10 @@ and rejects Trivy modified/ignored findings. Reports must contain only
 `lang-pkgs` and `os-pkgs` vulnerability results; mixed scanner output is
 rejected rather than partially normalized. Trivy can report a bundled language
 package vulnerability without repeating that package in the result's
-`Packages` inventory. The adapter accepts that narrow case only when the
-vulnerability carries a non-empty `PkgIdentifier` UID and a PURL whose version
-matches `InstalledVersion`; operating-system findings and unidentified or
-mismatched language packages remain fail-closed.
+`Packages` inventory. The adapter accepts that narrow case for language and
+operating-system packages only when `PkgID` exactly matches
+`PkgName@InstalledVersion` and `PkgIdentifier` carries both a non-empty UID and
+a package URL. Unidentified or mismatched findings remain fail-closed.
 
 Assess one snapshot absolutely:
 

--- a/tests/test_dependency_health_trivy.py
+++ b/tests/test_dependency_health_trivy.py
@@ -316,6 +316,7 @@ class DependencyHealthTrivyAdapterTests(unittest.TestCase):
             "PURL": "pkg:npm/brace-expansion@5.0.7",
             "UID": "identified-bundled-package",
         }
+        vulnerability["PkgID"] = "brace-expansion@5.0.7"
         report = _report([vulnerability])
         result = report["Results"]
         assert isinstance(result, list)
@@ -331,16 +332,17 @@ class DependencyHealthTrivyAdapterTests(unittest.TestCase):
         self.assertEqual(snapshot.findings[0].package, "brace-expansion")
         self.assertEqual(snapshot.findings[0].versions, ("5.0.7",))
 
-    def test_adapter_rejects_bundled_package_with_mismatched_identifier(self) -> None:
+    def test_adapter_rejects_bundled_package_with_mismatched_package_id(self) -> None:
         vulnerability = _vulnerability(
             "CVE-2026-14257",
             package="brace-expansion",
             version="5.0.7",
         )
         vulnerability["PkgIdentifier"] = {
-            "PURL": "pkg:npm/brace-expansion@5.0.9",
+            "PURL": "pkg:npm/brace-expansion@5.0.7",
             "UID": "mismatched-bundled-package",
         }
+        vulnerability["PkgID"] = "brace-expansion@5.0.9"
         report = _report([vulnerability])
         result = report["Results"]
         assert isinstance(result, list)
@@ -354,7 +356,7 @@ class DependencyHealthTrivyAdapterTests(unittest.TestCase):
                 provenance=_provenance(),
             )
 
-    def test_adapter_rejects_os_package_missing_from_inventory(self) -> None:
+    def test_adapter_accepts_identified_os_package_missing_from_inventory(self) -> None:
         vulnerability = _vulnerability(
             "CVE-2026-14257",
             package="libexample",
@@ -364,6 +366,7 @@ class DependencyHealthTrivyAdapterTests(unittest.TestCase):
             "PURL": "pkg:deb/debian/libexample@1.0.0",
             "UID": "identified-os-package",
         }
+        vulnerability["PkgID"] = "libexample@1.0.0"
         report = _report([vulnerability], ecosystem="debian")
         result = report["Results"]
         assert isinstance(result, list)
@@ -372,11 +375,13 @@ class DependencyHealthTrivyAdapterTests(unittest.TestCase):
         result_payload["Class"] = "os-pkgs"
         result_payload["Packages"] = [{"Name": "other-package", "Version": "1.0.0"}]
 
-        with self.assertRaisesRegex(ValueError, "absent from Packages evidence"):
-            dependency_health_snapshot_from_trivy_report(
-                report=report,
-                provenance=_provenance(),
-            )
+        snapshot = dependency_health_snapshot_from_trivy_report(
+            report=report,
+            provenance=_provenance(),
+        )
+
+        self.assertEqual(snapshot.findings[0].package, "libexample")
+        self.assertEqual(snapshot.findings[0].versions, ("1.0.0",))
 
     def test_adapter_rejects_modified_findings(self) -> None:
         report = _report([])


### PR DESCRIPTION
## Summary

- accept Trivy findings omitted from `Packages` only when `PkgID` exactly matches `PkgName@InstalledVersion`
- require a non-empty package URL and UID for the fallback evidence
- support the behavior for both language and operating-system packages while keeping mismatches fail-closed

## Validation

- targeted dependency-health tests passed
- full local unittest gate passed: 2,703 targets across 12/12 shards
- targeted Ruff, format, and mypy passed
- PyCharm inspection reported only 10 pre-existing warnings on unchanged lines; no finding points to this diff

Follow-up to #1985 based on live Trivy 0.70 image evidence from VeriReel.