### PR TITLE
Classify product repository review metadata correctly

### DIFF
--- a/control_plane/config_authority_audit.py
+++ b/control_plane/config_authority_audit.py
@@ -2778,14 +2778,14 @@ def _allow_reason(
     allow_context = allow_context or {}
     normalized = path.replace("\\", "/")
     key_text = _semantic_full_key_text(key)
+    if _is_codeowners_path(normalized):
+        return ALLOW_REASON_REPO_METADATA_ERGONOMICS
     if normalized.startswith("docs/") or normalized in {"README.md", "AGENTS.md", "handoff.md"}:
         return ALLOW_REASON_DOCS_EXAMPLE
     if normalized.startswith("tests/") or "/test" in normalized:
         return ALLOW_REASON_TEST_FIXTURE
     if normalized.startswith("addons/") or "/addons/" in normalized:
         return ALLOW_REASON_PRODUCT_OWNED_ADDON
-    if _is_codeowners_path(normalized):
-        return ALLOW_REASON_REPO_METADATA_ERGONOMICS
     if normalized == ".github/github.json" and _is_repo_metadata_ergonomics_key(key):
         return ALLOW_REASON_REPO_METADATA_ERGONOMICS
     if normalized.endswith(".py") and (
@@ -3701,10 +3701,15 @@ def _is_codeowners_path(path: str) -> bool:
 
 
 def _owner_repo_reference_matches(value: str) -> Iterable[re.Match[str]]:
-    for match in OWNER_REPO_PATTERN.finditer(value):
-        if match.start() > 0 and value[match.start() - 1] in "./\\":
+    offset = 0
+    while match := OWNER_REPO_PATTERN.search(value, offset):
+        preceded_by_path_separator = match.start() > 0 and value[match.start() - 1] in "./\\"
+        github_api_repository = value[: match.start()].endswith("/repos/")
+        if preceded_by_path_separator and not github_api_repository:
+            offset = match.start() + 1
             continue
         yield match
+        offset = match.end()
 
 
 def _contains_owner_repo_reference(value: str) -> bool:

--- a/control_plane/config_authority_audit.py
+++ b/control_plane/config_authority_audit.py
@@ -2554,8 +2554,8 @@ def _script_line_candidates(text: str) -> list[tuple[int, str, object]]:
         )
         for url in URL_PATTERN.findall(line):
             candidates.append((index, "url", url))
-        for repo in OWNER_REPO_PATTERN.findall(line):
-            candidates.append((index, "repository", repo))
+        for match in _owner_repo_reference_matches(line):
+            candidates.append((index, "repository", match.group(0)))
     return candidates
 
 
@@ -2655,9 +2655,14 @@ def _candidate_is_interesting(*, path: str, key: str, value: object) -> bool:
         return True
     if any(part in key_text.split("_") for part in SECRET_SHAPED_KEY_PARTS):
         return True
+    repository_reference = (
+        _contains_owner_repo_reference(value_text)
+        if normalized == "package.json" and key.startswith("scripts.")
+        else OWNER_REPO_PATTERN.search(value_text) is not None
+    )
     return bool(
         URL_PATTERN.search(value_text)
-        or OWNER_REPO_PATTERN.search(value_text)
+        or repository_reference
         or PROVIDER_TARGET_PATTERN.search(value_text)
     )
 
@@ -2779,6 +2784,8 @@ def _allow_reason(
         return ALLOW_REASON_TEST_FIXTURE
     if normalized.startswith("addons/") or "/addons/" in normalized:
         return ALLOW_REASON_PRODUCT_OWNED_ADDON
+    if _is_codeowners_path(normalized):
+        return ALLOW_REASON_REPO_METADATA_ERGONOMICS
     if normalized == ".github/github.json" and _is_repo_metadata_ergonomics_key(key):
         return ALLOW_REASON_REPO_METADATA_ERGONOMICS
     if normalized.endswith(".py") and (
@@ -3684,8 +3691,24 @@ def _is_repo_metadata_ergonomics_key(key: str) -> bool:
             "qaLabels",
             "qualityGate.",
             "relatedRepos[",
+            "reviewPolicy.",
         )
     )
+
+
+def _is_codeowners_path(path: str) -> bool:
+    return path in {".github/CODEOWNERS", "CODEOWNERS", "docs/CODEOWNERS"}
+
+
+def _owner_repo_reference_matches(value: str) -> Iterable[re.Match[str]]:
+    for match in OWNER_REPO_PATTERN.finditer(value):
+        if match.start() > 0 and value[match.start() - 1] in "./\\":
+            continue
+        yield match
+
+
+def _contains_owner_repo_reference(value: str) -> bool:
+    return next(iter(_owner_repo_reference_matches(value)), None) is not None
 
 
 def _repo_metadata(root: Path) -> dict[str, object]:

--- a/docs/product-repo-contract.md
+++ b/docs/product-repo-contract.md
@@ -133,6 +133,13 @@ resolve `origin/main` or `main`; when no merge base or dirty local comparison is
 available, the gate fails closed rather than silently passing. Docs, tests,
 schema fixtures, bootstrap wiring, and explicitly allowed thin connector
 mechanics are reported with allow reasons instead of blocking the default gate.
+Repository review metadata such as CODEOWNERS and `.github/github.json`
+`reviewPolicy` fields is classified as repository ergonomics rather than
+runtime authority. Shell-local filesystem paths such as
+`/var/run/docker.sock` and `/dev/null` are not interpreted as GitHub
+owner/repository identities, while package scripts using explicit local paths
+such as `./node_modules/.bin/...` are not treated as repository authority.
+Real owner/repository literals remain audited.
 The `product-repo` profile keeps ordinary
 product-owned test fixtures allowed, but also rejects test fixtures that carry
 Launchplane lifecycle authority such as authz policy, provider target,

--- a/docs/product-repo-contract.md
+++ b/docs/product-repo-contract.md
@@ -139,7 +139,8 @@ runtime authority. Shell-local filesystem paths such as
 `/var/run/docker.sock` and `/dev/null` are not interpreted as GitHub
 owner/repository identities, while package scripts using explicit local paths
 such as `./node_modules/.bin/...` are not treated as repository authority.
-Real owner/repository literals remain audited.
+Real owner/repository literals and GitHub API paths such as
+`/repos/owner/repository` remain audited.
 The `product-repo` profile keeps ordinary
 product-owned test fixtures allowed, but also rejects test fixtures that carry
 Launchplane lifecycle authority such as authz policy, provider target,

--- a/tests/test_config_authority_audit.py
+++ b/tests/test_config_authority_audit.py
@@ -1107,7 +1107,8 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
             script.write_text(
                 "#!/usr/bin/env bash\n"
                 "docker run --rm -v /var/run/docker.sock:/var/run/docker.sock tool "
-                "--ignorefile /dev/null\n",
+                "--ignorefile /dev/null\n"
+                "gh api /repos/example/production/actions/runs\n",
                 encoding="utf-8",
             )
             _commit_all(root)
@@ -1129,9 +1130,12 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
         self.assertEqual(len(package_findings), 1)
         self.assertEqual(package_findings[0]["key"], "scripts.deploy")
         self.assertEqual(package_findings[0]["classification"], "needs_classification")
-        self.assertFalse(
-            any(finding["path"] == "scripts/scan-runtime-image.sh" for finding in findings)
-        )
+        script_findings = [
+            finding for finding in findings if finding["path"] == "scripts/scan-runtime-image.sh"
+        ]
+        self.assertEqual(len(script_findings), 1)
+        self.assertEqual(script_findings[0]["key"], "repository")
+        self.assertEqual(script_findings[0]["classification"], "needs_classification")
 
     def test_hashes_are_stable_for_same_inputs_and_findings(self) -> None:
         with TemporaryDirectory() as temp_dir:

--- a/tests/test_config_authority_audit.py
+++ b/tests/test_config_authority_audit.py
@@ -1006,6 +1006,7 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
                         "docs": {"operations": "docs/operations.md"},
                         "importantWorkflows": ["CI"],
                         "pullRequests": {"preferredMergeMethod": "merge"},
+                        "reviewPolicy": {"codeOwners": ".github/CODEOWNERS"},
                         "qualityGate": {
                             "security": {"secretScan": "docker run ghcr.io/example/gitleaks:latest"}
                         },
@@ -1053,6 +1054,10 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
             "repo_metadata_ergonomics",
         )
         self.assertEqual(
+            by_key["reviewPolicy.codeOwners"]["allow_reason"],
+            "repo_metadata_ergonomics",
+        )
+        self.assertEqual(
             by_key["qualityGate.security.secretScan"]["allow_reason"],
             "repo_metadata_ergonomics",
         )
@@ -1070,6 +1075,63 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
         self.assertEqual(by_key["product.owner"]["evidence"], "<redacted-runtime-identity>")
         self.assertEqual(by_key["launchplane.lanes.testing.url"]["allow_reason"], "")
         self.assertEqual(by_key["launchplane.lanes.testing.deployRoute"]["allow_reason"], "")
+
+    def test_codeowners_and_local_filesystem_paths_are_repo_mechanics(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            _init_repo(root)
+            codeowners = root / ".github" / "CODEOWNERS"
+            codeowners.parent.mkdir()
+            codeowners.write_text(
+                "src/domains/billing/ @example-owner @example-reviewer\n"
+                "/.github/CODEOWNERS @example-owner @example-reviewer\n",
+                encoding="utf-8",
+            )
+            package_json = root / "package.json"
+            package_json.write_text(
+                json.dumps(
+                    {
+                        "scripts": {
+                            "docker:migrate": (
+                                "docker compose run --rm app "
+                                "./node_modules/.bin/prisma migrate deploy"
+                            ),
+                            "deploy": "./scripts/deploy.sh --repo example/production",
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+            script = root / "scripts" / "scan-runtime-image.sh"
+            script.parent.mkdir()
+            script.write_text(
+                "#!/usr/bin/env bash\n"
+                "docker run --rm -v /var/run/docker.sock:/var/run/docker.sock tool "
+                "--ignorefile /dev/null\n",
+                encoding="utf-8",
+            )
+            _commit_all(root)
+
+            payload = build_config_authority_audit(control_plane_root=root)
+
+        findings = _findings(payload)
+        codeowner_findings = [
+            finding for finding in findings if finding["path"] == ".github/CODEOWNERS"
+        ]
+        self.assertTrue(codeowner_findings)
+        self.assertTrue(
+            all(
+                finding["allow_reason"] == "repo_metadata_ergonomics"
+                for finding in codeowner_findings
+            )
+        )
+        package_findings = [finding for finding in findings if finding["path"] == "package.json"]
+        self.assertEqual(len(package_findings), 1)
+        self.assertEqual(package_findings[0]["key"], "scripts.deploy")
+        self.assertEqual(package_findings[0]["classification"], "needs_classification")
+        self.assertFalse(
+            any(finding["path"] == "scripts/scan-runtime-image.sh" for finding in findings)
+        )
 
     def test_hashes_are_stable_for_same_inputs_and_findings(self) -> None:
         with TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
## Summary
- treat CODEOWNERS and `reviewPolicy` metadata as repository ergonomics
- stop interpreting local filesystem path segments as GitHub repositories
- preserve rejection of genuine owner/repository literals in package scripts

## Validation
- `uv run --extra dev python -m unittest tests.test_config_authority_audit` (107 passed)
- `uv run --extra dev launchplane ci unittest-shard local` (2,712 tests, 12/12 shards passed)
- `uv run --extra dev ruff check control_plane/config_authority_audit.py tests/test_config_authority_audit.py`
- `uv run --extra dev ruff format --check control_plane/config_authority_audit.py tests/test_config_authority_audit.py`
- VeriReel PR #299 and #305 changed-file product-repo audits both pass with zero rejected findings

## Inspection
JetBrains inspection was attempted but remained UNKNOWN because PyCharm could not open the isolated worktree (`project_open_blocked`); the helper disallowed retry.

Refs cbusillo/verireel#302