### PR TITLE
Fix generic-web preview runtime onboarding

### DIFF
--- a/.github/workflows/product-onboarding.yml
+++ b/.github/workflows/product-onboarding.yml
@@ -47,6 +47,10 @@ name: Product Onboarding
         required: false
         default: ""
         type: string
+      preview_base_url:
+        description: Root URL whose subdomains host previews, for example https://product-preview.example.com.
+        required: true
+        type: string
       preview_label:
         description: Label that enables preview automation.
         required: false
@@ -128,6 +132,7 @@ jobs:
       HEALTH_PATH: ${{ inputs.health_path }}
       TESTING_CONTEXT: ${{ inputs.testing_context }}
       PREVIEW_CONTEXT: ${{ inputs.preview_context }}
+      PREVIEW_BASE_URL: ${{ inputs.preview_base_url }}
       PREVIEW_LABEL: ${{ inputs.preview_label }}
       TARGET_NAME: ${{ inputs.target_name }}
       PROJECT_NAME: ${{ inputs.project_name }}
@@ -146,6 +151,8 @@ jobs:
           python3 - <<'PY'
           import os
           import re
+          from ipaddress import ip_address
+          from urllib.parse import urlparse
 
           def required(name: str, maximum: int = 300) -> str:
               value = os.environ[name].strip()
@@ -181,6 +188,34 @@ jobs:
           health_path = required("HEALTH_PATH")
           if not health_path.startswith("/"):
               raise SystemExit("health_path must start with '/'.")
+          preview_base_url = required("PREVIEW_BASE_URL")
+          parsed_preview_base_url = urlparse(preview_base_url)
+          if parsed_preview_base_url.scheme not in {"http", "https"}:
+              raise SystemExit("preview_base_url must use http or https.")
+          if not parsed_preview_base_url.hostname:
+              raise SystemExit("preview_base_url requires a hostname.")
+          if parsed_preview_base_url.username or parsed_preview_base_url.password:
+              raise SystemExit("preview_base_url cannot contain credentials.")
+          if parsed_preview_base_url.hostname.startswith("*."):
+              raise SystemExit("preview_base_url must name the base host, not a wildcard.")
+          try:
+              ip_address(parsed_preview_base_url.hostname)
+          except ValueError:
+              pass
+          else:
+              raise SystemExit("preview_base_url must use a DNS hostname, not an IP address.")
+          if (
+              parsed_preview_base_url.path not in {"", "/"}
+              or parsed_preview_base_url.query
+              or parsed_preview_base_url.fragment
+          ):
+              raise SystemExit(
+                  "preview_base_url must be a root URL without path, query, or fragment."
+              )
+          try:
+              parsed_preview_base_url.port
+          except ValueError as error:
+              raise SystemExit("preview_base_url has an invalid port.") from error
           required("DISPLAY_NAME")
           required("IMAGE_REPOSITORY")
           required("PREVIEW_LABEL")
@@ -266,6 +301,7 @@ jobs:
             --arg project_name "$NORMALIZED_PROJECT_NAME" \
             --arg server_id "$SERVER_ID" \
             --arg preview_context "$NORMALIZED_PREVIEW_CONTEXT" \
+            --arg preview_base_url "$PREVIEW_BASE_URL" \
             --arg preview_label "$PREVIEW_LABEL" \
             --arg domain_certificate_type "$DOMAIN_CERTIFICATE_TYPE" \
             --argjson runtime_port "$RUNTIME_PORT" \
@@ -276,7 +312,8 @@ jobs:
               health_path:$health_path, testing_context:$testing_context,
               target_name:$target_name, project_name:$project_name,
               server_id:$server_id,
-              preview_context:$preview_context, preview_label:$preview_label,
+              preview_context:$preview_context, preview_base_url:$preview_base_url,
+              preview_label:$preview_label,
               domain_certificate_type:$domain_certificate_type}' \
             > generic-web-intent.json
           jq -n \
@@ -383,6 +420,7 @@ jobs:
             echo "- Repository: $REPOSITORY"
             echo "- Testing context: $NORMALIZED_TESTING_CONTEXT"
             echo "- Preview context: $NORMALIZED_PREVIEW_CONTEXT"
+            echo "- Preview base URL: $PREVIEW_BASE_URL"
             echo "- Provider operation: create-application"
             echo "- Launchplane worker SHA: \`$GITHUB_SHA\`"
             echo "- Provider plan: \`$target_plan_sha256\`"

--- a/control_plane/generic_web_onboarding.py
+++ b/control_plane/generic_web_onboarding.py
@@ -1,26 +1,72 @@
 from __future__ import annotations
 
 import hashlib
+from ipaddress import ip_address
 import json
 import re
 from typing import Literal
+from urllib.parse import urlparse
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from control_plane.contracts.product_onboarding_manifest import (
+    ProductOnboardingExpectedConfigManifest,
     ProductOnboardingLaneManifest,
     ProductOnboardingManifest,
     ProductOnboardingPreviewManifest,
+    ProductOnboardingRuntimeEnvironmentManifest,
     ProductOnboardingTargetManifest,
 )
 from control_plane.contracts.product_profile_record import (
     PRODUCT_PREVIEW_DEFAULT_ENABLE_LABEL,
+    ProductRuntimeConfigRequirement,
 )
 
 
 _PRODUCT_PATTERN = re.compile(r"^[a-z0-9][a-z0-9-]{0,62}$")
 _REPOSITORY_PATTERN = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
 _GIT_REF_PATTERN = re.compile(r"^[A-Za-z0-9._/-]+$")
+_PREVIEW_BASE_URL_ENV_KEY = "LAUNCHPLANE_PREVIEW_BASE_URL"
+
+
+def _normalize_preview_base_url(value: str) -> str:
+    normalized_value = value.strip()
+    if not normalized_value:
+        raise ValueError("generic-web onboarding requires preview_base_url")
+    if any(character.isspace() for character in normalized_value):
+        raise ValueError("generic-web onboarding preview_base_url cannot contain whitespace")
+    parsed = urlparse(normalized_value)
+    if parsed.scheme not in {"http", "https"}:
+        raise ValueError("generic-web onboarding preview_base_url must use http or https")
+    if not parsed.hostname:
+        raise ValueError("generic-web onboarding preview_base_url requires a hostname")
+    if parsed.username or parsed.password:
+        raise ValueError("generic-web onboarding preview_base_url cannot contain credentials")
+    if parsed.hostname.startswith("*."):
+        raise ValueError(
+            "generic-web onboarding preview_base_url must name the preview base host, not a wildcard"
+        )
+    try:
+        ip_address(parsed.hostname)
+    except ValueError:
+        pass
+    else:
+        raise ValueError(
+            "generic-web onboarding preview_base_url must use a DNS hostname, not an IP address"
+        )
+    if parsed.path not in {"", "/"} or parsed.query or parsed.fragment:
+        raise ValueError(
+            "generic-web onboarding preview_base_url must be a root URL without path, query, or fragment"
+        )
+    try:
+        port = parsed.port
+    except ValueError as error:
+        raise ValueError("generic-web onboarding preview_base_url has an invalid port") from error
+    hostname = parsed.hostname.lower()
+    normalized_host = f"[{hostname}]" if ":" in hostname else hostname
+    if port:
+        normalized_host = f"{normalized_host}:{port}"
+    return f"{parsed.scheme.lower()}://{normalized_host}"
 
 
 class GenericWebOnboardingIntent(BaseModel):
@@ -36,6 +82,7 @@ class GenericWebOnboardingIntent(BaseModel):
     image_repository: str
     runtime_port: int = Field(ge=1, le=65535)
     health_path: str
+    preview_base_url: str
     testing_context: str = ""
     target_name: str = ""
     project_name: str = ""
@@ -55,6 +102,7 @@ class GenericWebOnboardingIntent(BaseModel):
         self.default_branch = self.default_branch.strip()
         self.image_repository = self.image_repository.strip()
         self.health_path = self.health_path.strip()
+        self.preview_base_url = _normalize_preview_base_url(self.preview_base_url)
         self.testing_context = self.testing_context.strip() or f"{self.product}-testing"
         self.target_name = self.target_name.strip() or f"{self.product}-testing"
         self.project_name = self.project_name.strip() or self.product
@@ -155,6 +203,21 @@ def build_generic_web_onboarding_manifest(
                 target_name=intent.target_name,
                 source_git_ref=f"origin/{intent.default_branch}",
                 healthcheck_path=intent.health_path,
+            ),
+        ),
+        runtime_environments=(
+            ProductOnboardingRuntimeEnvironmentManifest(
+                scope="context",
+                context=intent.preview_context,
+                env={_PREVIEW_BASE_URL_ENV_KEY: intent.preview_base_url},
+            ),
+        ),
+        expected_config=ProductOnboardingExpectedConfigManifest(
+            runtime_environment_keys=(
+                ProductRuntimeConfigRequirement(
+                    key=_PREVIEW_BASE_URL_ENV_KEY,
+                    context=intent.preview_context,
+                ),
             ),
         ),
         source_label="service:generic-web-onboarding",

--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -13050,13 +13050,27 @@ def create_launchplane_fastapi_app(
                 onboarding_request.generic_web
             )
             if onboarding_request.mode == "dry_run":
+                try:
+                    planned_manifest = build_generic_web_onboarding_manifest(
+                        intent=onboarding_request.generic_web,
+                        target_id="planned-provider-target",
+                    )
+                except ValueError as error:
+                    raise _launchplane_http_error(
+                        status_code=400,
+                        trace_id=trace_id,
+                        code="invalid_product_onboarding_manifest",
+                        message=str(error),
+                    ) from error
                 return accepted_evidence_response(
                     trace_id=trace_id,
                     records={
-                        "provider_target_count": "1",
-                        "provider_target_id_count": "1",
-                        "runtime_environment_record_count": "0",
-                        "secret_binding_count": "0",
+                        "provider_target_count": str(len(planned_manifest.provider_targets)),
+                        "provider_target_id_count": str(len(planned_manifest.provider_targets)),
+                        "runtime_environment_record_count": str(
+                            len(planned_manifest.runtime_environments)
+                        ),
+                        "secret_binding_count": str(len(planned_manifest.secret_bindings)),
                     },
                     result={
                         "mode": "dry_run",
@@ -13067,6 +13081,7 @@ def create_launchplane_fastapi_app(
                         "default_branch": onboarding_request.generic_web.default_branch,
                         "testing_context": onboarding_request.generic_web.testing_context,
                         "preview_context": onboarding_request.generic_web.preview_context,
+                        "preview_base_url": onboarding_request.generic_web.preview_base_url,
                         "target_operation": "create-application",
                         "plan_sha256": generic_web_plan_sha256,
                     },

--- a/control_plane/runtime_environments.py
+++ b/control_plane/runtime_environments.py
@@ -18,6 +18,10 @@ ScalarValue = str | int | float | bool
 ScalarMap = dict[str, ScalarValue]
 
 
+class MissingRuntimeContextDefinitionError(click.ClickException):
+    pass
+
+
 class RuntimeEnvironmentRecordStore(Protocol):
     def list_runtime_environment_records(
         self, *, context_name: str = "", instance_name: str = ""
@@ -100,7 +104,7 @@ def resolve_values_from_definition(
     merged_values: dict[str, str] = _normalize_scalar_map(definition.shared_env)
     context_definition = definition.contexts.get(context_name)
     if context_definition is None:
-        raise click.ClickException(
+        raise MissingRuntimeContextDefinitionError(
             f"Runtime environments file has no context definition for {context_name!r}."
         )
     merged_values.update(_normalize_scalar_map(context_definition.shared_env))
@@ -144,7 +148,7 @@ def resolve_runtime_context_values(
     merged_values: dict[str, str] = _normalize_scalar_map(definition.shared_env)
     context_definition = definition.contexts.get(context_name)
     if context_definition is None:
-        raise click.ClickException(
+        raise MissingRuntimeContextDefinitionError(
             f"Runtime environments file has no context definition for {context_name!r}."
         )
     merged_values.update(_normalize_scalar_map(context_definition.shared_env))

--- a/control_plane/workflows/generic_web_preview.py
+++ b/control_plane/workflows/generic_web_preview.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from ipaddress import ip_address
 import time
 from pathlib import Path
 from typing import Iterator, Literal, Protocol, runtime_checkable
@@ -23,6 +24,7 @@ from control_plane.contracts.runtime_identity import (
     health_payload_runtime_identity_status,
     runtime_identity_env,
 )
+from control_plane.contracts.runtime_environment_record import RuntimeEnvironmentRecord
 from control_plane.contracts.runtime_key_safety_policy import (
     RuntimeKeySafetyPolicyRecord,
     RuntimeKeySafetyTarget,
@@ -52,6 +54,14 @@ _PREVIEW_BASE_URL_ENV_KEY = "LAUNCHPLANE_PREVIEW_BASE_URL"
 
 class GenericWebPreviewProfileStore(Protocol):
     def read_product_profile_record(self, product: str) -> LaunchplaneProductProfileRecord: ...
+
+    def list_runtime_environment_records(
+        self,
+        *,
+        scope: str = "",
+        context_name: str = "",
+        instance_name: str = "",
+    ) -> tuple[RuntimeEnvironmentRecord, ...]: ...
 
 
 @runtime_checkable
@@ -229,7 +239,11 @@ class GenericWebPreviewRefreshResult(BaseModel):
     error_message: str = ""
 
 
-class MissingPreviewBaseUrlError(click.ClickException):
+class PreviewBaseUrlConfigurationError(click.ClickException):
+    pass
+
+
+class MissingPreviewBaseUrlError(PreviewBaseUrlConfigurationError):
     pass
 
 
@@ -805,25 +819,107 @@ def _preview_host(preview_url: str) -> str:
     parsed = urlparse(preview_url.strip())
     if not parsed.hostname:
         raise click.ClickException("Generic web preview URL is missing a hostname.")
-    if parsed.port:
-        return f"{parsed.hostname}:{parsed.port}"
+    try:
+        port = parsed.port
+    except ValueError as error:
+        raise click.ClickException("Generic web preview URL has an invalid port.") from error
+    if port:
+        return f"{parsed.hostname}:{port}"
     return parsed.hostname
 
 
 def _preview_url_from_base_url(*, preview_slug: str, preview_base_url: str) -> str:
-    parsed = urlparse(preview_base_url.strip())
+    normalized_preview_base_url = preview_base_url.strip()
+    if any(character.isspace() for character in normalized_preview_base_url):
+        raise PreviewBaseUrlConfigurationError(
+            f"{_PREVIEW_BASE_URL_ENV_KEY} cannot contain whitespace."
+        )
+    parsed = urlparse(normalized_preview_base_url)
     if parsed.scheme not in {"http", "https"}:
-        raise click.ClickException(f"{_PREVIEW_BASE_URL_ENV_KEY} must use http or https.")
+        raise PreviewBaseUrlConfigurationError(
+            f"{_PREVIEW_BASE_URL_ENV_KEY} must use http or https."
+        )
     if not parsed.hostname:
-        raise click.ClickException(f"{_PREVIEW_BASE_URL_ENV_KEY} requires a hostname.")
+        raise PreviewBaseUrlConfigurationError(f"{_PREVIEW_BASE_URL_ENV_KEY} requires a hostname.")
+    if parsed.username or parsed.password:
+        raise PreviewBaseUrlConfigurationError(
+            f"{_PREVIEW_BASE_URL_ENV_KEY} cannot contain credentials."
+        )
+    if parsed.hostname.startswith("*."):
+        raise PreviewBaseUrlConfigurationError(
+            f"{_PREVIEW_BASE_URL_ENV_KEY} must name the preview base host, not a wildcard."
+        )
+    try:
+        ip_address(parsed.hostname)
+    except ValueError:
+        pass
+    else:
+        raise PreviewBaseUrlConfigurationError(
+            f"{_PREVIEW_BASE_URL_ENV_KEY} must use a DNS hostname, not an IP address."
+        )
     if parsed.path not in {"", "/"} or parsed.query or parsed.fragment:
-        raise click.ClickException(
+        raise PreviewBaseUrlConfigurationError(
             f"{_PREVIEW_BASE_URL_ENV_KEY} must be a root URL without path, query, or fragment."
         )
+    try:
+        port = parsed.port
+    except ValueError as error:
+        raise PreviewBaseUrlConfigurationError(
+            f"{_PREVIEW_BASE_URL_ENV_KEY} has an invalid port."
+        ) from error
     host = f"{preview_slug.strip()}.{parsed.hostname}"
-    if parsed.port:
-        host = f"{host}:{parsed.port}"
+    if port:
+        host = f"{host}:{port}"
     return f"{parsed.scheme}://{host}"
+
+
+def _resolve_generic_web_preview_base_url(
+    *,
+    control_plane_root: Path,
+    profile: LaunchplaneProductProfileRecord,
+    record_store: GenericWebPreviewProfileStore | None = None,
+    database_url: str | None = None,
+) -> str:
+    if record_store is None:
+        try:
+            context_values = control_plane_runtime_environments.resolve_runtime_context_values(
+                control_plane_root=control_plane_root,
+                context_name=profile.preview.context,
+                database_url=database_url,
+            )
+        except control_plane_runtime_environments.MissingRuntimeContextDefinitionError as error:
+            raise MissingPreviewBaseUrlError(
+                f"Missing {_PREVIEW_BASE_URL_ENV_KEY} in Launchplane runtime-environment records for {profile.preview.context}."
+            ) from error
+    else:
+        runtime_environment_records = (
+            *record_store.list_runtime_environment_records(scope="global"),
+            *record_store.list_runtime_environment_records(context_name=profile.preview.context),
+        )
+        definition = (
+            control_plane_runtime_environments.build_runtime_environment_definition_from_records(
+                runtime_environment_records
+            )
+        )
+        context_definition = definition.contexts.get(profile.preview.context)
+        if context_definition is None:
+            raise MissingPreviewBaseUrlError(
+                f"Missing {_PREVIEW_BASE_URL_ENV_KEY} in Launchplane runtime-environment records for {profile.preview.context}."
+            )
+        context_values = {
+            key: str(value)
+            for key, value in {
+                **definition.shared_env,
+                **context_definition.shared_env,
+            }.items()
+        }
+    preview_base_url = str(context_values.get(_PREVIEW_BASE_URL_ENV_KEY) or "").strip()
+    if not preview_base_url:
+        raise MissingPreviewBaseUrlError(
+            f"Missing {_PREVIEW_BASE_URL_ENV_KEY} in Launchplane runtime-environment records for {profile.preview.context}."
+        )
+    _preview_url_from_base_url(preview_slug="readiness", preview_base_url=preview_base_url)
+    return preview_base_url
 
 
 def resolve_generic_web_preview_url(
@@ -831,21 +927,18 @@ def resolve_generic_web_preview_url(
     control_plane_root: Path,
     profile: LaunchplaneProductProfileRecord,
     request: GenericWebPreviewRefreshRequest,
+    record_store: GenericWebPreviewProfileStore | None = None,
     database_url: str | None = None,
 ) -> str:
     explicit_preview_url = request.preview_url.strip()
     if explicit_preview_url:
         return explicit_preview_url
-    context_values = control_plane_runtime_environments.resolve_runtime_context_values(
+    preview_base_url = _resolve_generic_web_preview_base_url(
         control_plane_root=control_plane_root,
-        context_name=profile.preview.context,
+        profile=profile,
+        record_store=record_store,
         database_url=database_url,
     )
-    preview_base_url = str(context_values.get(_PREVIEW_BASE_URL_ENV_KEY) or "").strip()
-    if not preview_base_url:
-        raise MissingPreviewBaseUrlError(
-            f"Missing {_PREVIEW_BASE_URL_ENV_KEY} in Launchplane runtime-environment records for {profile.preview.context}."
-        )
     return _preview_url_from_base_url(
         preview_slug=resolve_generic_web_preview_slug(
             profile=profile,
@@ -1071,6 +1164,7 @@ def evaluate_generic_web_preview_readiness(
     request: GenericWebPreviewReadinessRequest,
     checked_at: str,
     profile: LaunchplaneProductProfileRecord | None = None,
+    preview_url_override: str = "",
 ) -> GenericWebPreviewReadinessResult:
     resolved_profile = profile
     if resolved_profile is None:
@@ -1079,6 +1173,30 @@ def evaluate_generic_web_preview_readiness(
             product=request.product,
         )
     checks: list[GenericWebPreviewReadinessCheck] = []
+    preview_base_url_error = ""
+    if not preview_url_override.strip():
+        try:
+            _resolve_generic_web_preview_base_url(
+                control_plane_root=control_plane_root,
+                profile=resolved_profile,
+                record_store=record_store,
+            )
+        except PreviewBaseUrlConfigurationError as error:
+            preview_base_url_error = str(error)
+    checks.append(
+        GenericWebPreviewReadinessCheck(
+            check_id="preview_base_url",
+            status="blocked" if preview_base_url_error else "pass",
+            message=(
+                preview_base_url_error
+                or (
+                    "Preview URL is supplied explicitly for this refresh."
+                    if preview_url_override.strip()
+                    else "Preview base URL is configured in Launchplane runtime-environment records."
+                )
+            ),
+        )
+    )
     template_lane = _template_lane(profile=resolved_profile)
     if template_lane is None:
         checks.append(
@@ -1206,7 +1324,9 @@ def evaluate_generic_web_preview_readiness(
         )
     )
     status: Literal["pass", "blocked"] = (
-        "blocked" if missing_env_keys or missing_provider_fields else "pass"
+        "blocked"
+        if preview_base_url_error or missing_env_keys or missing_provider_fields
+        else "pass"
     )
     return GenericWebPreviewReadinessResult(
         readiness_status=status,
@@ -1254,8 +1374,9 @@ def execute_generic_web_preview_refresh(
             control_plane_root=control_plane_root,
             profile=resolved_profile,
             request=request,
+            record_store=record_store,
         )
-    except MissingPreviewBaseUrlError as exc:
+    except PreviewBaseUrlConfigurationError as exc:
         finished_at = utc_now_timestamp()
         return GenericWebPreviewRefreshResult(
             refresh_status="blocked",
@@ -1274,6 +1395,7 @@ def execute_generic_web_preview_refresh(
         request=GenericWebPreviewReadinessRequest(product=request.product, source=request.source),
         checked_at=started_at,
         profile=resolved_profile,
+        preview_url_override=request.preview_url,
     )
     if readiness.readiness_status != "pass":
         finished_at = utc_now_timestamp()

--- a/control_plane/workflows/product_onboarding.py
+++ b/control_plane/workflows/product_onboarding.py
@@ -48,6 +48,14 @@ class ProductOnboardingRecordStore(ProductAuthorityBundleStore, Protocol):
 
     def write_runtime_environment_record(self, record: RuntimeEnvironmentRecord) -> None: ...
 
+    def list_runtime_environment_records(
+        self,
+        *,
+        scope: str = "",
+        context_name: str = "",
+        instance_name: str = "",
+    ) -> tuple[RuntimeEnvironmentRecord, ...]: ...
+
     def list_secret_bindings(
         self,
         *,
@@ -271,19 +279,32 @@ def build_physical_provider_target_records(
 
 
 def build_runtime_environment_records(
-    *, manifest: ProductOnboardingManifest, updated_at: str
+    *,
+    manifest: ProductOnboardingManifest,
+    updated_at: str,
+    existing_records: tuple[RuntimeEnvironmentRecord, ...] = (),
 ) -> tuple[RuntimeEnvironmentRecord, ...]:
-    return tuple(
-        RuntimeEnvironmentRecord(
-            scope=record.scope,
-            context=record.context,
-            instance=record.instance,
-            env=dict(record.env),
-            updated_at=updated_at,
-            source_label=manifest.source_label,
+    existing_records_by_route = {
+        (record.scope, record.context, record.instance): record for record in existing_records
+    }
+    runtime_environment_records: list[RuntimeEnvironmentRecord] = []
+    for record in manifest.runtime_environments:
+        existing_record = existing_records_by_route.get(
+            (record.scope, record.context, record.instance)
         )
-        for record in manifest.runtime_environments
-    )
+        merged_env = dict(existing_record.env) if existing_record is not None else {}
+        merged_env.update(record.env)
+        runtime_environment_records.append(
+            RuntimeEnvironmentRecord(
+                scope=record.scope,
+                context=record.context,
+                instance=record.instance,
+                env=merged_env,
+                updated_at=updated_at,
+                source_label=manifest.source_label,
+            )
+        )
+    return tuple(runtime_environment_records)
 
 
 def build_secret_bindings(
@@ -406,7 +427,9 @@ def plan_product_onboarding_authority_bundle(
         for record in record_store.list_physical_provider_target_records()
     }
     runtime_environments = build_runtime_environment_records(
-        manifest=manifest, updated_at=recorded_at
+        manifest=manifest,
+        updated_at=recorded_at,
+        existing_records=record_store.list_runtime_environment_records(),
     )
     secret_binding_plan = build_secret_bindings(
         manifest=manifest,

--- a/docs/new-product-repo.md
+++ b/docs/new-product-repo.md
@@ -47,11 +47,15 @@ as Discord Blue's Every Code bridge port `8787`.
 ## Launchplane Records
 
 For a conventional generic-web product, dispatch `Product Onboarding` with
-typed product, repository, image, port, health, and optional Dokploy naming
-inputs. The workflow resolves immutable GitHub repository identity, plans one
-new non-production Dokploy application, plans the product record bundle, and
-plans six exact preview authz rules. `mode=apply` then pauses at the protected
-`launchplane-authz-admin` review before applying the three reviewed contracts.
+typed product, repository, image, port, health, preview base URL, and optional
+Dokploy naming inputs. The preview base URL is the root URL whose subdomains
+host previews, such as `https://product-preview.example.com`; wildcard DNS and
+ingress for `*.product-preview.example.com` must already route to the selected
+Dokploy server. The workflow resolves immutable GitHub repository identity,
+plans one new non-production Dokploy application, plans the product record
+bundle, and plans six exact preview authz rules. `mode=apply` then pauses at the
+protected `launchplane-authz-admin` review before applying the three reviewed
+contracts.
 
 The normal path accepts no base64 manifest, copied provider id, authz JSON, or
 database credential. Stable idempotency keys make a same-plan retry replay the
@@ -60,11 +64,12 @@ fails, the product remains safely unauthorized; rerun the same reviewed flow
 instead of deleting records or creating another target.
 
 The reviewed flow writes the generic-web product profile, immutable repository
-identity, one `testing` lane, provider target records, preview policy, and the
-complete `operator.generic-web-preview` desired set. The authz planner retains
-all existing managed rules and sends the resulting desired set through the
-existing digest-bound reconcile route. Product onboarding never writes authz
-policy directly.
+identity, one `testing` lane, provider target records, preview policy, the
+context-scoped `LAUNCHPLANE_PREVIEW_BASE_URL` runtime-environment record, and
+the complete `operator.generic-web-preview` desired set. The authz planner
+retains all existing managed rules and sends the resulting desired set through
+the existing digest-bound reconcile route. Product onboarding never writes
+authz policy directly.
 
 Existing targets, production targets, compose targets, Odoo products, and
 non-generic drivers remain explicit advanced operations. Use `Dokploy Target

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1366,11 +1366,15 @@ Use the manual `Product Onboarding` workflow for a new generic-web product.
 Start with `mode=dry_run` when operator review of the exact plan is useful, or
 use `mode=apply` for one dispatch that pauses at the protected
 `launchplane-authz-admin` environment before any writes. Provide product,
-repository, image repository, runtime port, health path, and a reason/issue
-reference; optional names derive from the product key.
+repository, image repository, runtime port, health path, preview base URL, and a
+reason/issue reference; optional names derive from the product key. The preview
+base URL must be a root URL. Its wildcard DNS and ingress namespace must already
+route to the selected Dokploy server because onboarding owns Launchplane and
+Dokploy records, not public ingress provisioning.
 
 The workflow resolves immutable GitHub identity, plans one non-production
-Dokploy application, plans Launchplane records, and plans the complete
+Dokploy application, plans Launchplane records including the context-scoped
+`LAUNCHPLANE_PREVIEW_BASE_URL`, and plans the complete
 `operator.generic-web-preview` managed authz set. The apply job reuses the
 reviewed plan artifact and digests. Do not copy target ids, manifests, authz
 JSON, or database credentials into the conventional workflow.
@@ -1401,6 +1405,14 @@ rerun; the product remains unauthorized until the existing managed authz
 reconcile succeeds. Use `Product Onboarding Manifest (Advanced)` only when the
 typed generic-web contract does not fit, and use `Dokploy Target Setup` for
 adoption, production, compose, or repair operations.
+
+To change the preview base URL later, rerun `Product Onboarding` with the new
+root URL. Onboarding updates its owned key while preserving unrelated values in
+the same preview-context runtime-environment record.
+
+Products onboarded before this input existed must rerun `Product Onboarding`
+once to record the preview base URL. Until then, preview readiness and refresh
+return a typed blocked result rather than guessing a domain.
 
 - Promotions and deploys reference explicit artifact identifiers.
 - Missing control-plane config is a hard error, not a silent fallback.

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -1982,6 +1982,12 @@ dry-run digest, and requires that exact digest plus the provider-resolved target
 id for apply. The resulting bundle includes the product profile, one testing
 lane, Dokploy-backed target records, target-id records, preview policy, and any
 declared runtime-environment or disabled managed-secret binding placeholders.
+The conventional generic-web contract requires an operator-supplied root
+preview base URL and writes it as the context-scoped
+`LAUNCHPLANE_PREVIEW_BASE_URL` runtime-environment record. The reviewed digest
+binds that mutable runtime value; no real domain becomes checked-in authority.
+Repeated onboarding merges that owned key into the existing preview-context
+record instead of replacing unrelated runtime values.
 Generic-web dry-run requires `generic_web_onboarding.plan`; apply and advanced
 manifest writes require `product_onboarding.apply`, all for product/context
 `launchplane`. The route requires DB-backed storage and returns only sanitized

--- a/frontend/generated/openapi-canonical.json
+++ b/frontend/generated/openapi-canonical.json
@@ -48488,6 +48488,10 @@
                         "title": "Preview App Name Prefix",
                         "type": "string"
                       },
+                      "preview_base_url": {
+                        "title": "Preview Base Url",
+                        "type": "string"
+                      },
                       "preview_context": {
                         "default": "",
                         "title": "Preview Context",
@@ -48555,7 +48559,8 @@
                       "repository_owner_id",
                       "image_repository",
                       "runtime_port",
-                      "health_path"
+                      "health_path",
+                      "preview_base_url"
                     ],
                     "title": "GenericWebOnboardingIntent",
                     "type": "object"

--- a/tests/test_generic_web_onboarding.py
+++ b/tests/test_generic_web_onboarding.py
@@ -19,6 +19,7 @@ class GenericWebOnboardingTests(unittest.TestCase):
             image_repository="ghcr.io/example/demo-web",
             runtime_port=3000,
             health_path="/healthz",
+            preview_base_url="https://demo-preview.example.com",
         )
 
         manifest = build_generic_web_onboarding_manifest(
@@ -36,6 +37,17 @@ class GenericWebOnboardingTests(unittest.TestCase):
         self.assertEqual(manifest.lanes[0].instance, "testing")
         self.assertTrue(manifest.preview.enabled)
         self.assertEqual(manifest.preview.domain_certificate_type, "none")
+        self.assertEqual(len(manifest.runtime_environments), 1)
+        self.assertEqual(manifest.runtime_environments[0].scope, "context")
+        self.assertEqual(manifest.runtime_environments[0].context, "demo-web-preview")
+        self.assertEqual(
+            manifest.runtime_environments[0].env,
+            {"LAUNCHPLANE_PREVIEW_BASE_URL": "https://demo-preview.example.com"},
+        )
+        self.assertEqual(
+            manifest.expected_config.runtime_environment_keys[0].key,
+            "LAUNCHPLANE_PREVIEW_BASE_URL",
+        )
         self.assertEqual(len(manifest.provider_targets), 1)
         self.assertEqual(manifest.provider_targets[0].target_id, "dokploy-app-1")
         self.assertEqual(manifest.provider_targets[0].target_type, "application")
@@ -58,6 +70,7 @@ class GenericWebOnboardingTests(unittest.TestCase):
             image_repository="ghcr.io/example/demo-web",
             runtime_port=3000,
             health_path="/healthz",
+            preview_base_url="https://demo-preview.example.com",
         )
 
         first = generic_web_onboarding_plan_sha256(intent)
@@ -65,9 +78,13 @@ class GenericWebOnboardingTests(unittest.TestCase):
         changed = generic_web_onboarding_plan_sha256(
             intent.model_copy(update={"runtime_port": 8080})
         )
+        changed_preview_base_url = generic_web_onboarding_plan_sha256(
+            intent.model_copy(update={"preview_base_url": "https://other-preview.example.com"})
+        )
 
         self.assertEqual(first, second)
         self.assertNotEqual(first, changed)
+        self.assertNotEqual(first, changed_preview_base_url)
 
     def test_apply_requires_resolved_target_id(self) -> None:
         intent = GenericWebOnboardingIntent(
@@ -79,6 +96,7 @@ class GenericWebOnboardingTests(unittest.TestCase):
             image_repository="ghcr.io/example/demo-web",
             runtime_port=3000,
             health_path="/healthz",
+            preview_base_url="https://demo-preview.example.com",
         )
 
         with self.assertRaisesRegex(ValueError, "resolved target_id"):
@@ -95,7 +113,53 @@ class GenericWebOnboardingTests(unittest.TestCase):
                 image_repository="ghcr.io/example/demo-web",
                 runtime_port=3000,
                 health_path="/healthz",
+                preview_base_url="https://demo-preview.example.com",
             )
+
+    def test_preview_base_url_is_required_and_root_scoped(self) -> None:
+        required_fields = {
+            "product": "demo-web",
+            "display_name": "Demo Web",
+            "repository": "example/demo-web",
+            "repository_id": "123",
+            "repository_owner_id": "456",
+            "image_repository": "ghcr.io/example/demo-web",
+            "runtime_port": 3000,
+            "health_path": "/healthz",
+        }
+
+        for preview_base_url, message in (
+            ("", "requires preview_base_url"),
+            ("demo-preview.example.com", "must use http or https"),
+            ("https://*.demo-preview.example.com", "not a wildcard"),
+            ("https://192.0.2.10", "not an IP address"),
+            ("https://demo-preview.example.com/path", "must be a root URL"),
+            ("https://user:password@demo-preview.example.com", "cannot contain credentials"),
+        ):
+            with self.subTest(preview_base_url=preview_base_url):
+                with self.assertRaisesRegex(ValueError, message):
+                    GenericWebOnboardingIntent.model_validate(
+                        {
+                            **required_fields,
+                            "preview_base_url": preview_base_url,
+                        }
+                    )
+
+    def test_preview_base_url_is_normalized_for_digest_and_storage(self) -> None:
+        intent = GenericWebOnboardingIntent(
+            product="demo-web",
+            display_name="Demo Web",
+            repository="example/demo-web",
+            repository_id="123",
+            repository_owner_id="456",
+            image_repository="ghcr.io/example/demo-web",
+            runtime_port=3000,
+            health_path="/healthz",
+            preview_base_url="HTTPS://Demo-Preview.Example.COM/",
+        )
+
+        self.assertEqual(intent.preview_base_url, "https://demo-preview.example.com")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_generic_web_preview.py
+++ b/tests/test_generic_web_preview.py
@@ -32,6 +32,7 @@ from control_plane.workflows.generic_web_preview import (
     GenericWebPreviewInventoryRequest,
     GenericWebPreviewReadinessRequest,
     GenericWebPreviewRefreshRequest,
+    MissingPreviewBaseUrlError,
     discover_generic_web_preview_desired_state,
     evaluate_generic_web_preview_readiness,
     execute_generic_web_preview_destroy,
@@ -54,10 +55,12 @@ class _GenericWebPreviewStore:
         profile: LaunchplaneProductProfileRecord,
         *,
         runtime_key_safety_policies: tuple[RuntimeKeySafetyPolicyRecord, ...] = (),
+        runtime_environment_records: tuple[RuntimeEnvironmentRecord, ...] | None = None,
         secret_bindings: tuple[SecretBinding, ...] = (),
     ) -> None:
         self.profile = profile
         self.runtime_key_safety_policies = runtime_key_safety_policies
+        self.runtime_environment_records = runtime_environment_records
         self.secret_bindings = secret_bindings
 
     def read_product_profile_record(self, product: str) -> LaunchplaneProductProfileRecord:
@@ -100,21 +103,28 @@ class _GenericWebPreviewStore:
         return bindings
 
     def list_runtime_environment_records(
-        self, *, context_name: str = "", instance_name: str = ""
+        self,
+        *,
+        scope: str = "",
+        context_name: str = "",
+        instance_name: str = "",
     ) -> tuple[RuntimeEnvironmentRecord, ...]:
-        records = (
-            RuntimeEnvironmentRecord(
-                scope="context",
-                context=self.profile.preview.context,
-                env={"LAUNCHPLANE_PREVIEW_BASE_URL": "https://syo-preview.example.test"},
-                updated_at="2026-05-10T05:30:00Z",
-                source_label="test",
-            ),
-        )
+        records = self.runtime_environment_records
+        if records is None:
+            records = (
+                RuntimeEnvironmentRecord(
+                    scope="context",
+                    context=self.profile.preview.context,
+                    env={"LAUNCHPLANE_PREVIEW_BASE_URL": "https://syo-preview.example.test"},
+                    updated_at="2026-05-10T05:30:00Z",
+                    source_label="test",
+                ),
+            )
         return tuple(
             record
             for record in records
-            if (not context_name or record.context == context_name)
+            if (not scope or record.scope == scope)
+            and (not context_name or record.context == context_name)
             and (not instance_name or record.instance == instance_name)
         )
 
@@ -588,7 +598,12 @@ class GenericWebPreviewTests(unittest.TestCase):
         self.assertEqual(result.missing_provider_fields, ("dockerImage", "username"))
         self.assertEqual(
             [check.check_id for check in result.checks],
-            ["template_env", "template_provider_fields", "transport_policy"],
+            [
+                "preview_base_url",
+                "template_env",
+                "template_provider_fields",
+                "transport_policy",
+            ],
         )
 
     def test_evaluate_generic_web_preview_readiness_keeps_template_lane_when_target_id_missing(
@@ -631,8 +646,11 @@ class GenericWebPreviewTests(unittest.TestCase):
         self.assertEqual(result.template_context, "sellyouroutboard-testing")
         self.assertEqual(result.template_instance, "testing")
         self.assertEqual(result.template_target_id, "")
-        self.assertEqual([check.check_id for check in result.checks], ["template_target"])
-        self.assertIn("template lane to have a Dokploy target_id", result.checks[0].message)
+        self.assertEqual(
+            [check.check_id for check in result.checks],
+            ["preview_base_url", "template_target"],
+        )
+        self.assertIn("template lane to have a Dokploy target_id", result.checks[1].message)
         source_of_truth.assert_called_once_with(
             control_plane_root=Path("."),
             allow_incomplete_target_ids=True,
@@ -687,7 +705,7 @@ class GenericWebPreviewTests(unittest.TestCase):
         self.assertEqual(result.template_target_type, "compose")
         self.assertEqual(result.template_target_id, "compose-cm-testing")
         self.assertEqual(
-            result.checks[0].message,
+            result.checks[1].message,
             "Generic web preview readiness requires the template lane to be a Dokploy application.",
         )
         read_dokploy_config.assert_not_called()
@@ -738,7 +756,7 @@ class GenericWebPreviewTests(unittest.TestCase):
         self.assertEqual(result.readiness_status, "blocked")
         self.assertEqual(result.template_target_type, "compose")
         self.assertEqual(
-            result.checks[0].message,
+            result.checks[1].message,
             "Generic web preview readiness requires the template lane to be a Dokploy application.",
         )
         read_dokploy_config.assert_not_called()
@@ -856,7 +874,7 @@ class GenericWebPreviewTests(unittest.TestCase):
                 "preview": _profile().preview.model_copy(update={"slug_template": "pr-{number}"})
             }
         )
-        store = _GenericWebPreviewStore(profile)
+        store = _GenericWebPreviewStore(profile, runtime_environment_records=())
         with (
             patch(
                 "control_plane.workflows.generic_web_preview.control_plane_runtime_environments.load_runtime_environment_definition",
@@ -897,46 +915,152 @@ class GenericWebPreviewTests(unittest.TestCase):
         self.assertIn("Missing LAUNCHPLANE_PREVIEW_BASE_URL", result.error_message)
         dokploy_request.assert_not_called()
 
+    def test_missing_preview_context_is_typed_blocked_configuration(self) -> None:
+        profile = _profile().model_copy(
+            update={
+                "preview": _profile().preview.model_copy(
+                    update={
+                        "context": "sellyouroutboard-preview",
+                        "slug_template": "pr-{number}",
+                    }
+                )
+            }
+        )
+        store = _GenericWebPreviewStore(profile, runtime_environment_records=())
+        runtime_definition = (
+            control_plane_runtime_environments.build_runtime_environment_definition_from_records(
+                (
+                    RuntimeEnvironmentRecord(
+                        scope="context",
+                        context="sellyouroutboard-testing",
+                        env={"OTHER_KEY": "value"},
+                        updated_at="2026-05-10T05:30:00Z",
+                        source_label="test",
+                    ),
+                )
+            )
+        )
+        source = DokploySourceOfTruth(
+            schema_version=1,
+            targets=(
+                DokployTargetDefinition(
+                    context="sellyouroutboard-testing",
+                    instance="testing",
+                    target_type="application",
+                    target_id="app-testing",
+                ),
+            ),
+        )
+        request = GenericWebPreviewRefreshRequest(
+            product="sellyouroutboard",
+            preview_slug="pr-42",
+            image_reference="ghcr.io/cbusillo/sellyouroutboard:sha",
+            anchor_head_sha="abc123",
+        )
+
+        with (
+            patch(
+                "control_plane.workflows.generic_web_preview.control_plane_runtime_environments.load_runtime_environment_definition",
+                return_value=runtime_definition,
+            ),
+            patch(
+                "control_plane.workflows.generic_web_preview.dokploy_source.read_control_plane_dokploy_source_of_truth",
+                return_value=source,
+            ),
+            patch(
+                "control_plane.workflows.generic_web_preview.dokploy_source.read_dokploy_config",
+                return_value=("https://dokploy.example", "token"),
+            ),
+            patch(
+                "control_plane.workflows.generic_web_preview.dokploy_api.fetch_dokploy_target_payload",
+                return_value={
+                    "env": "SMTP_HOST=smtp.example\nSMTP_FROM=hello@example.com\n",
+                    "dockerImage": "ghcr.io/cbusillo/sellyouroutboard:sha",
+                    "username": "github-actions",
+                },
+            ),
+            patch(
+                "control_plane.workflows.generic_web_preview.dokploy_api.dokploy_request"
+            ) as dokploy_request,
+            patch(
+                "control_plane.workflows.generic_web_preview.utc_now_timestamp",
+                side_effect=["2026-05-10T05:30:00Z", "2026-05-10T05:30:01Z"],
+            ),
+        ):
+            with self.assertRaisesRegex(
+                MissingPreviewBaseUrlError,
+                "Missing LAUNCHPLANE_PREVIEW_BASE_URL",
+            ):
+                resolve_generic_web_preview_url(
+                    control_plane_root=Path("."),
+                    profile=profile,
+                    request=request,
+                )
+            readiness = evaluate_generic_web_preview_readiness(
+                control_plane_root=Path("."),
+                record_store=store,
+                request=GenericWebPreviewReadinessRequest(product="sellyouroutboard"),
+                checked_at="2026-05-10T05:30:00Z",
+                profile=profile,
+            )
+            result = execute_generic_web_preview_refresh(
+                control_plane_root=Path("."),
+                record_store=store,
+                request=request,
+                profile=profile,
+            )
+
+        self.assertEqual(readiness.readiness_status, "blocked")
+        self.assertEqual(readiness.checks[0].check_id, "preview_base_url")
+        self.assertEqual(readiness.checks[0].status, "blocked")
+        self.assertEqual(result.refresh_status, "blocked")
+        self.assertIn("Missing LAUNCHPLANE_PREVIEW_BASE_URL", result.error_message)
+        dokploy_request.assert_not_called()
+
     def test_execute_generic_web_preview_refresh_rejects_malformed_base_url(self) -> None:
         profile = _profile().model_copy(
             update={
                 "preview": _profile().preview.model_copy(update={"slug_template": "pr-{number}"})
             }
         )
-        store = _GenericWebPreviewStore(profile)
-        with (
-            patch(
-                "control_plane.workflows.generic_web_preview.control_plane_runtime_environments.load_runtime_environment_definition",
-                return_value=control_plane_runtime_environments.build_runtime_environment_definition_from_records(
-                    (
+        for preview_base_url, expected_error in (
+            ("https://preview.example/path", "root URL"),
+            ("https://preview.example:99999", "invalid port"),
+            ("https://user:password@preview.example", "credentials"),
+            ("https://*.preview.example", "not a wildcard"),
+            ("https://192.0.2.10", "not an IP address"),
+        ):
+            with self.subTest(preview_base_url=preview_base_url):
+                store = _GenericWebPreviewStore(
+                    profile,
+                    runtime_environment_records=(
                         RuntimeEnvironmentRecord(
                             scope="context",
                             context="sellyouroutboard-testing",
-                            env={"LAUNCHPLANE_PREVIEW_BASE_URL": "https://preview.example/path"},
+                            env={"LAUNCHPLANE_PREVIEW_BASE_URL": preview_base_url},
                             updated_at="2026-05-10T05:30:00Z",
                             source_label="test",
                         ),
-                    )
-                ),
-            ),
-            patch(
-                "control_plane.workflows.generic_web_preview.dokploy_api.dokploy_request"
-            ) as dokploy_request,
-        ):
-            with self.assertRaisesRegex(click.ClickException, "root URL"):
-                execute_generic_web_preview_refresh(
-                    control_plane_root=Path("."),
-                    record_store=store,
-                    request=GenericWebPreviewRefreshRequest(
-                        product="sellyouroutboard",
-                        preview_slug="pr-42",
-                        preview_url="",
-                        image_reference="ghcr.io/cbusillo/sellyouroutboard:sha",
-                        anchor_head_sha="abc123",
                     ),
                 )
+                with patch(
+                    "control_plane.workflows.generic_web_preview.dokploy_api.dokploy_request"
+                ) as dokploy_request:
+                    result = execute_generic_web_preview_refresh(
+                        control_plane_root=Path("."),
+                        record_store=store,
+                        request=GenericWebPreviewRefreshRequest(
+                            product="sellyouroutboard",
+                            preview_slug="pr-42",
+                            preview_url="",
+                            image_reference="ghcr.io/cbusillo/sellyouroutboard:sha",
+                            anchor_head_sha="abc123",
+                        ),
+                    )
 
-        dokploy_request.assert_not_called()
+                self.assertEqual(result.refresh_status, "blocked")
+                self.assertIn(expected_error, result.error_message)
+                dokploy_request.assert_not_called()
 
     def test_resolve_preview_url_rejects_non_root_base_url(self) -> None:
         profile = _profile().model_copy(
@@ -1202,7 +1326,7 @@ class GenericWebPreviewTests(unittest.TestCase):
         self.assertEqual(sleeps, [])
 
     def test_execute_generic_web_preview_refresh_creates_application_from_template(self) -> None:
-        store = _GenericWebPreviewStore(_profile())
+        store = _GenericWebPreviewStore(_profile(), runtime_environment_records=())
         source = DokploySourceOfTruth(
             schema_version=1,
             targets=(

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -2319,6 +2319,10 @@ class ProductOnboardingTests(unittest.TestCase):
         self.assertIn("actions/create-github-app-token@", workflow_text)
         self.assertIn("LAUNCHPLANE_ONBOARDING_GITHUB_APP_CLIENT_ID", workflow_text)
         self.assertIn("permission-contents: read", workflow_text)
+        self.assertIn("preview_base_url:", workflow_text)
+        self.assertIn("PREVIEW_BASE_URL: ${{ inputs.preview_base_url }}", workflow_text)
+        self.assertIn("preview_base_url:$preview_base_url", workflow_text)
+        self.assertIn("Preview base URL", workflow_text)
         self.assertIn('gh api "repos/${REPOSITORY}"', workflow_text)
         self.assertIn(
             "uses: cbusillo/launchplane/.github/actions/launchplane-request@",
@@ -2627,6 +2631,17 @@ class ProductOnboardingTests(unittest.TestCase):
                 record_store=store,
                 manifest=manifest,
             )
+            existing_runtime_record = store.list_runtime_environment_records()[0]
+            store.write_runtime_environment_record(
+                existing_runtime_record.model_copy(
+                    update={
+                        "env": {
+                            **existing_runtime_record.env,
+                            "UNRELATED_PREVIEW_SETTING": "preserve-me",
+                        }
+                    }
+                )
+            )
             second_result = apply_product_onboarding_manifest(
                 record_store=store,
                 manifest=manifest,
@@ -2691,6 +2706,10 @@ class ProductOnboardingTests(unittest.TestCase):
             ],
         )
         self.assertEqual(len(runtime_records), 1)
+        self.assertEqual(
+            runtime_records[0].env["UNRELATED_PREVIEW_SETTING"],
+            "preserve-me",
+        )
         self.assertEqual(len(secret_bindings), 1)
         self.assertEqual(secret_bindings[0].binding_key, "SMTP_PASSWORD")
         self.assertEqual(secret_bindings[0].status, "disabled")

--- a/tests/test_product_onboarding_service.py
+++ b/tests/test_product_onboarding_service.py
@@ -47,6 +47,21 @@ class _ProductOnboardingStore:
     def write_runtime_environment_record(self, record: RuntimeEnvironmentRecord) -> None:
         self.runtime_environments.append(record)
 
+    def list_runtime_environment_records(
+        self,
+        *,
+        scope: str = "",
+        context_name: str = "",
+        instance_name: str = "",
+    ) -> tuple[RuntimeEnvironmentRecord, ...]:
+        return tuple(
+            record
+            for record in self.runtime_environments
+            if (not scope or record.scope == scope)
+            and (not context_name or record.context == context_name)
+            and (not instance_name or record.instance == instance_name)
+        )
+
     def list_secret_bindings(
         self,
         *,

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -2729,6 +2729,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 "image_repository": "ghcr.io/example/demo-web",
                 "runtime_port": 3000,
                 "health_path": "/healthz",
+                "preview_base_url": "https://demo-preview.example.com",
             }
             dry_run_status, dry_run_payload = _invoke_app(
                 app,
@@ -2788,11 +2789,19 @@ class LaunchplaneServiceTests(unittest.TestCase):
             try:
                 profiles = store.list_product_profile_records()
                 profile = store.read_product_profile_record("demo-web")
+                runtime_environments = store.list_runtime_environment_records(
+                    context_name="demo-web-preview"
+                )
             finally:
                 store.close()
 
         self.assertEqual(dry_run_status, 202)
         self.assertRegex(plan_sha256, r"^[0-9a-f]{64}$")
+        self.assertEqual(dry_run_payload["records"]["runtime_environment_record_count"], "1")
+        self.assertEqual(
+            dry_run_payload["result"]["preview_base_url"],
+            "https://demo-preview.example.com",
+        )
         self.assertEqual(mismatch_status, 409)
         self.assertEqual(mismatch_payload["error"]["code"], "product_onboarding_plan_mismatch")
         self.assertEqual(apply_status, 202)
@@ -2809,6 +2818,11 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(profile.repository_owner_id, "456")
         self.assertEqual(profile.default_branch, "main")
         self.assertEqual(profile.preview.context, "demo-web-preview")
+        self.assertEqual(len(runtime_environments), 1)
+        self.assertEqual(
+            runtime_environments[0].env,
+            {"LAUNCHPLANE_PREVIEW_BASE_URL": "https://demo-preview.example.com"},
+        )
 
     def test_generic_web_onboarding_planner_cannot_apply_records(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
@@ -2853,6 +2867,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 "image_repository": "ghcr.io/example/demo-web",
                 "runtime_port": 3000,
                 "health_path": "/healthz",
+                "preview_base_url": "https://demo-preview.example.com",
             }
             dry_run_status, dry_run_payload = _invoke_app(
                 app,


### PR DESCRIPTION
## Summary
- require and validate a typed preview base URL in conventional generic-web onboarding
- persist `LAUNCHPLANE_PREVIEW_BASE_URL` in the product preview context and preserve unrelated runtime values on re-onboarding
- make missing or malformed preview URL configuration a typed readiness/refresh blocker instead of a generic 400/500
- derive dry-run record counts from the planned manifest and document the backfill/ingress contract

## Root cause
The one-action onboarding flow created the product profile, provider target, and preview authz rules but no preview runtime-environment record. Fresh preview refreshes therefore failed while resolving the absent preview context.

## Verification
- `uv run --extra dev launchplane ci unittest-shard local` (2,712 targets, 12/12 shards)
- `uv run --extra dev mypy control_plane tests`
- `pnpm --dir frontend validate`
- targeted onboarding/preview/service tests (141 tests)
- Ruff check/format, actionlint, OpenAPI drift, config-authority audit
- Opus final review: GO
- Gemini final review: GO

## Live proof
The disposable canary completed onboarding record apply, preview refresh, runtime verification, and merge-triggered cleanup. The dynamic Dokploy preview application was deleted after merge.

Closes #1970