### PR TITLE
Preserve digest identity with provider deploy references

### DIFF
--- a/.github/workflows/reusable-generic-web-prod-promotion.yml
+++ b/.github/workflows/reusable-generic-web-prod-promotion.yml
@@ -16,6 +16,11 @@ name: Reusable Generic Web Prod Promotion
         required: false
         default: ""
         type: string
+      deploy_reference:
+        description: Optional provider-facing immutable image tag for digest identities.
+        required: false
+        default: ""
+        type: string
       source_git_ref:
         description: >-
           Optional source revision override. Defaults to source inventory.
@@ -190,6 +195,7 @@ jobs:
         id: payload
         env:
           ARTIFACT_ID: ${{ inputs.artifact_id }}
+          DEPLOY_REFERENCE: ${{ inputs.deploy_reference }}
           DRY_RUN: ${{ inputs.dry_run }}
           FROM_INSTANCE: ${{ steps.request.outputs.from_instance }}
           HEALTH_TIMEOUT_SECONDS: ${{ inputs['health-timeout-seconds'] }}
@@ -231,6 +237,7 @@ jobs:
             schema_version: 1,
             product: process.env.PRODUCT,
             artifact_id: requestedArtifact,
+            deploy_reference: String(process.env.DEPLOY_REFERENCE ?? '').trim(),
             source_git_ref: requestedSource,
             from_instance: process.env.FROM_INSTANCE,
             to_instance: process.env.TO_INSTANCE,

--- a/.github/workflows/reusable-generic-web-stable-deploy.yml
+++ b/.github/workflows/reusable-generic-web-stable-deploy.yml
@@ -19,6 +19,11 @@ name: Reusable Generic Web Stable Deploy
         description: Immutable image or Launchplane-resolvable artifact identity.
         required: true
         type: string
+      deploy_reference:
+        description: Optional provider-facing immutable image tag for digest identities.
+        required: false
+        default: ""
+        type: string
       source_git_ref:
         description: Source git ref attached to deployment evidence.
         required: true
@@ -71,6 +76,7 @@ jobs:
         id: request
         env:
           ARTIFACT_ID: ${{ inputs.artifact_id }}
+          DEPLOY_REFERENCE: ${{ inputs.deploy_reference }}
           INSTANCE: ${{ inputs.instance }}
           PRODUCT: ${{ inputs.product }}
           SOURCE_GIT_REF: ${{ inputs.source_git_ref }}
@@ -92,11 +98,13 @@ jobs:
           {
             echo "product=$PRODUCT"
             echo "instance=$INSTANCE"
-            printf '%s=%s:%s:%s:%s\n' \
+            printf '%s=%s:%s:%s:%s:%s:%s\n' \
               idempotency_key \
               generic-web-stable-deploy \
               "$PRODUCT" \
               "$INSTANCE" \
+              "$ARTIFACT_ID" \
+              "$DEPLOY_REFERENCE" \
               "$run_scope"
           } >>"$GITHUB_OUTPUT"
 
@@ -120,6 +128,7 @@ jobs:
             deploy.product=${{ steps.request.outputs.product }}
             deploy.instance=${{ steps.request.outputs.instance }}
             deploy.artifact_id=${{ inputs.artifact_id }}
+            deploy.deploy_reference=${{ inputs.deploy_reference }}
             deploy.source_git_ref=${{ inputs.source_git_ref }}
           idempotency-key: >-
             ${{ steps.request.outputs.idempotency_key }}

--- a/.github/workflows/reusable-product-driver-prod-promotion.yml
+++ b/.github/workflows/reusable-product-driver-prod-promotion.yml
@@ -24,6 +24,11 @@ name: Reusable Product Driver Prod Promotion
         required: false
         default: ""
         type: string
+      deploy_reference:
+        description: Optional provider-facing immutable image tag for digest identities.
+        required: false
+        default: ""
+        type: string
       source_git_ref:
         description: Source git ref attached to promotion evidence.
         required: false
@@ -176,6 +181,7 @@ jobs:
           ARTIFACT_ID: ${{ inputs.artifact_id }}
           BACKUP_RECORD_ID: ${{ inputs.backup_record_id }}
           CONTEXT: ${{ inputs.context }}
+          DEPLOY_REFERENCE: ${{ inputs.deploy_reference }}
           DRIVER: ${{ inputs.driver }}
           FROM_INSTANCE: ${{ inputs.from_instance }}
           PRODUCT: ${{ inputs.product }}
@@ -215,7 +221,7 @@ jobs:
           if [ "$DRIVER" = "odoo" ]; then
             idempotency_key="opp:$CONTEXT:$run_scope"
           else
-            idempotency_key="product-driver-prod-promotion:$PRODUCT:$CONTEXT:$FROM_INSTANCE:$TO_INSTANCE:$PROMOTION_RECORD_ID:$run_scope"
+            idempotency_key="product-driver-prod-promotion:$PRODUCT:$CONTEXT:$FROM_INSTANCE:$TO_INSTANCE:$PROMOTION_RECORD_ID:$DEPLOY_REFERENCE:$run_scope"
           fi
           {
             echo "context=$CONTEXT"
@@ -250,6 +256,7 @@ jobs:
             promotion.from_instance=${{ steps.request.outputs.from_instance }}
             promotion.to_instance=${{ steps.request.outputs.to_instance }}
             promotion.artifact_id=${{ inputs.artifact_id }}
+            promotion.deploy_reference=${{ inputs.deploy_reference }}
             promotion.source_git_ref=${{ inputs.source_git_ref }}
             promotion.backup_record_id=${{ inputs.backup_record_id }}
             promotion.promotion_record_id=${{ inputs.promotion_record_id }}

--- a/.github/workflows/reusable-product-driver-stable-deploy.yml
+++ b/.github/workflows/reusable-product-driver-stable-deploy.yml
@@ -23,6 +23,11 @@ name: Reusable Product Driver Stable Deploy
         description: Immutable image or Launchplane-resolvable artifact identity.
         required: true
         type: string
+      deploy_reference:
+        description: Optional provider-facing immutable image tag for digest identities.
+        required: false
+        default: ""
+        type: string
       source_git_ref:
         description: Source git ref attached to deployment evidence.
         required: true
@@ -106,6 +111,7 @@ jobs:
         env:
           ARTIFACT_ID: ${{ inputs.artifact_id }}
           CONTEXT: ${{ inputs.context }}
+          DEPLOY_REFERENCE: ${{ inputs.deploy_reference }}
           INSTANCE: ${{ inputs.instance }}
           PRODUCT: ${{ inputs.product }}
           SOURCE_GIT_REF: ${{ inputs.source_git_ref }}
@@ -126,13 +132,14 @@ jobs:
           run_scope="${GITHUB_RUN_ID}:${GITHUB_RUN_ATTEMPT}"
           {
             echo "context=$CONTEXT"
-            printf '%s=%s:%s:%s:%s:%s:%s\n' \
+            printf '%s=%s:%s:%s:%s:%s:%s:%s\n' \
               idempotency_key \
               product-driver-stable-deploy \
               "$PRODUCT" \
               "$CONTEXT" \
               "$INSTANCE" \
               "$ARTIFACT_ID" \
+              "$DEPLOY_REFERENCE" \
               "$run_scope"
             echo "instance=$INSTANCE"
             echo "product=$PRODUCT"
@@ -159,6 +166,7 @@ jobs:
             deploy.context=${{ steps.request.outputs.context }}
             deploy.instance=${{ steps.request.outputs.instance }}
             deploy.artifact_id=${{ inputs.artifact_id }}
+            deploy.deploy_reference=${{ inputs.deploy_reference }}
             deploy.source_git_ref=${{ inputs.source_git_ref }}
           idempotency-key: ${{ steps.request.outputs.idempotency_key }}
           timeout-ms: ${{ inputs['timeout-ms'] }}

--- a/control_plane/contracts/deploy_reference.py
+++ b/control_plane/contracts/deploy_reference.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import re
+
+_SHA256_DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+_FLOATING_TAGS = frozenset(
+    {
+        "dev",
+        "development",
+        "latest",
+        "main",
+        "master",
+        "prod",
+        "production",
+        "stable",
+        "testing",
+    }
+)
+
+
+def docker_image_repository(image_reference: str) -> str:
+    normalized_reference = image_reference.strip()
+    if "@" in normalized_reference:
+        return normalized_reference.split("@", 1)[0].rstrip("/")
+    last_component = normalized_reference.rsplit("/", 1)[-1]
+    if ":" not in last_component:
+        return normalized_reference.rstrip("/")
+    return normalized_reference[: -len(last_component.rsplit(":", 1)[-1]) - 1].rstrip("/")
+
+
+def docker_image_tag(image_reference: str) -> str:
+    normalized_reference = image_reference.strip()
+    if "@" in normalized_reference:
+        return ""
+    last_component = normalized_reference.rsplit("/", 1)[-1]
+    if ":" not in last_component:
+        return ""
+    return last_component.rsplit(":", 1)[-1].strip()
+
+
+def docker_image_digest(image_reference: str) -> str:
+    normalized_reference = image_reference.strip()
+    if "@" not in normalized_reference:
+        return normalized_reference if _SHA256_DIGEST_RE.fullmatch(normalized_reference) else ""
+    digest = normalized_reference.rsplit("@", 1)[-1].strip()
+    return digest if _SHA256_DIGEST_RE.fullmatch(digest) else ""
+
+
+def is_digest_pinned_image_reference(image_reference: str) -> bool:
+    return bool(docker_image_digest(image_reference))
+
+
+def is_non_floating_tag_reference(image_reference: str) -> bool:
+    tag = docker_image_tag(image_reference)
+    return bool(tag) and tag.casefold() not in _FLOATING_TAGS
+
+
+def provider_image_reference(*, artifact_id: str, deploy_reference: str = "") -> str:
+    return deploy_reference.strip() or artifact_id.strip()
+
+
+def validate_provider_deploy_reference(
+    *,
+    artifact_id: str,
+    deploy_reference: str,
+    label: str,
+) -> str:
+    normalized_deploy_reference = deploy_reference.strip()
+    if not normalized_deploy_reference:
+        return ""
+    normalized_artifact_id = artifact_id.strip()
+    if not is_digest_pinned_image_reference(normalized_artifact_id):
+        raise ValueError(
+            f"{label} deploy_reference requires artifact_id to be a digest-pinned image "
+            "reference such as repo@sha256:<digest>."
+        )
+    if not is_non_floating_tag_reference(normalized_deploy_reference):
+        raise ValueError(
+            f"{label} deploy_reference must be an immutable, non-floating image tag "
+            "such as repo:sha-<commit>; digest references and floating tags like latest "
+            "are not valid provider deploy references."
+        )
+    artifact_repository = docker_image_repository(normalized_artifact_id)
+    deploy_repository = docker_image_repository(normalized_deploy_reference)
+    if artifact_repository != deploy_repository:
+        raise ValueError(
+            f"{label} deploy_reference must use the same image repository as artifact_id. "
+            f"Artifact repository={artifact_repository!r}; deploy repository={deploy_repository!r}."
+        )
+    return normalized_deploy_reference

--- a/control_plane/contracts/generic_web_rollback.py
+++ b/control_plane/contracts/generic_web_rollback.py
@@ -16,6 +16,7 @@ from control_plane.contracts.promotion_record import (
     HealthcheckEvidence,
 )
 from control_plane.drivers.registry import read_driver_descriptor
+from control_plane.contracts.deploy_reference import is_non_floating_tag_reference
 from control_plane.workflows.ship import utc_now_timestamp
 
 GenericWebRollbackPlanStatus = Literal["ready", "blocked"]
@@ -25,6 +26,7 @@ GenericWebRollbackBlockerCode = Literal[
     "backup_gate_scope_mismatch",
     "deployment_scope_mismatch",
     "health_evidence_failed",
+    "missing_deploy_reference",
     "missing_rollback_target",
     "mutable_artifact_reference",
     "target_deploy_not_passed",
@@ -97,6 +99,7 @@ class GenericWebRollbackDeployPlan(BaseModel):
     product: str
     instance: str
     artifact_id: str
+    deploy_reference: str = ""
     source_git_ref: str
     timeout_seconds: int | None = Field(default=None, ge=1)
     no_cache: bool = False
@@ -106,6 +109,7 @@ class GenericWebRollbackDeployPlan(BaseModel):
         self.product = self.product.strip()
         self.instance = self.instance.strip()
         self.artifact_id = self.artifact_id.strip()
+        self.deploy_reference = self.deploy_reference.strip()
         self.source_git_ref = self.source_git_ref.strip()
         if not self.product:
             raise ValueError("generic web rollback deploy plan requires product")
@@ -223,6 +227,7 @@ def build_generic_web_rollback_plan(
                 product=profile.product,
                 instance=lane.instance,
                 artifact_id=artifact_identity.artifact_id,
+                deploy_reference=_deploy_reference(deployment_record),
                 source_git_ref=source_git_ref,
                 timeout_seconds=request.timeout_seconds,
                 no_cache=request.no_cache,
@@ -374,11 +379,24 @@ def _validate_rollback_target(
             )
         )
         return
-    if not _immutable_artifact_id(profile=profile, deployment_record=deployment_record):
+    immutable_artifact_id = _immutable_artifact_id(
+        profile=profile,
+        deployment_record=deployment_record,
+    )
+    if not immutable_artifact_id:
         blockers.append(
             _blocker(
                 "mutable_artifact_reference",
                 "generic web rollback target must use an immutable image digest",
+            )
+        )
+    elif _deployment_target_is_application(deployment_record) and not _deploy_reference(
+        deployment_record
+    ):
+        blockers.append(
+            _blocker(
+                "missing_deploy_reference",
+                "generic web application rollback target has no immutable provider deploy reference",
             )
         )
 
@@ -425,6 +443,29 @@ def _immutable_artifact_id(
     if artifact_id.startswith(f"{image_repository}@sha256:"):
         return artifact_id
     return ""
+
+
+def _deploy_reference(deployment_record: DeploymentRecord) -> str:
+    if deployment_record.runtime_identity is None:
+        return ""
+    image_reference = deployment_record.runtime_identity.image_reference.strip()
+    if not is_non_floating_tag_reference(image_reference):
+        return ""
+    return image_reference
+
+
+def _deployment_target_is_application(deployment_record: DeploymentRecord) -> bool:
+    if deployment_record.resolved_target is not None:
+        return deployment_record.resolved_target.target_type == "application"
+    if deployment_record.deployed_target is not None:
+        return (
+            deployment_record.deployed_target.target_category == "application"
+            or deployment_record.deployed_target.provider_target_type == "application"
+        )
+    return (
+        deployment_record.deploy.target_category == "application"
+        or deployment_record.deploy.provider_target_type == "application"
+    )
 
 
 def _generic_web_rollback_plan_id(*, context: str, instance: str, deployment_record_id: str) -> str:

--- a/control_plane/contracts/product_profile_record.py
+++ b/control_plane/contracts/product_profile_record.py
@@ -364,6 +364,7 @@ class ProductPromotionWorkflowProfile(BaseModel):
     dry_run_input: str = "dry_run"
     bump_input: str = "bump"
     artifact_id_input: str = "artifact_id"
+    deploy_reference_input: str = "deploy_reference"
     source_git_ref_input: str = "source_git_ref"
     promotion_intent_input: str = "promotion_intent_id"
     default_bump: str = "patch"
@@ -380,6 +381,8 @@ class ProductPromotionWorkflowProfile(BaseModel):
             raise ValueError("product promotion workflow requires bump_input")
         if not self.artifact_id_input.strip():
             raise ValueError("product promotion workflow requires artifact_id_input")
+        if not self.deploy_reference_input.strip():
+            raise ValueError("product promotion workflow requires deploy_reference_input")
         if not self.source_git_ref_input.strip():
             raise ValueError("product promotion workflow requires source_git_ref_input")
         if not self.promotion_intent_input.strip():
@@ -388,6 +391,7 @@ class ProductPromotionWorkflowProfile(BaseModel):
             self.dry_run_input.strip(),
             self.bump_input.strip(),
             self.artifact_id_input.strip(),
+            self.deploy_reference_input.strip(),
             self.source_git_ref_input.strip(),
             self.promotion_intent_input.strip(),
         )

--- a/control_plane/contracts/ship_request.py
+++ b/control_plane/contracts/ship_request.py
@@ -5,6 +5,7 @@ from control_plane.contracts.deploy_target import (
     DeployTargetCompatibilityType,
     ensure_target_reference_matches,
 )
+from control_plane.contracts.deploy_reference import validate_provider_deploy_reference
 from control_plane.contracts.promotion_record import HealthcheckEvidence
 
 
@@ -13,6 +14,7 @@ class ShipRequest(BaseModel):
 
     schema_version: int = Field(default=1, ge=1)
     artifact_id: str
+    deploy_reference: str = ""
     context: str
     instance: str
     source_git_ref: str
@@ -36,6 +38,12 @@ class ShipRequest(BaseModel):
     def _validate_request(self) -> "ShipRequest":
         if not self.artifact_id.strip():
             raise ValueError("ship request requires artifact_id")
+        self.artifact_id = self.artifact_id.strip()
+        self.deploy_reference = validate_provider_deploy_reference(
+            artifact_id=self.artifact_id,
+            deploy_reference=self.deploy_reference,
+            label="ship request",
+        )
         if not self.context.strip():
             raise ValueError("ship request requires context")
         if not self.instance.strip():

--- a/control_plane/generic_web_promotion_http.py
+++ b/control_plane/generic_web_promotion_http.py
@@ -98,6 +98,7 @@ class GenericWebProdPromotionResponseResult(BaseModel):
     from_instance: str = ""
     to_instance: str = ""
     artifact_id: str = ""
+    deploy_reference: str = ""
     source_git_ref: str = ""
     backup_record_id: str = ""
     promotion_record_id: str = ""
@@ -319,6 +320,11 @@ def build_generic_web_promotion_workflow_outbox_delivery(
         **(
             {workflow.artifact_id_input.strip(): request.workflow.artifact_id}
             if request.workflow.artifact_id
+            else {}
+        ),
+        **(
+            {workflow.deploy_reference_input.strip(): request.workflow.deploy_reference}
+            if request.workflow.deploy_reference
             else {}
         ),
         **(

--- a/control_plane/http_routes/generic_web.py
+++ b/control_plane/http_routes/generic_web.py
@@ -198,6 +198,7 @@ class _GenericWebDeployProviderMutationAdapter:
                     profile=self._profile,
                     artifact_id=deploy.artifact_id,
                 ),
+                request_deploy_reference=deploy.deploy_reference,
                 fallback_target_name=f"{self._profile.product}-{self._lane.instance}",
             )
         return self._resolved_deploy_target
@@ -226,6 +227,7 @@ class _GenericWebDeployProviderMutationAdapter:
                     profile=self._profile,
                     artifact_id=deploy.artifact_id,
                 ),
+                request_deploy_reference=deploy.deploy_reference,
                 lane=self._lane,
             )
             self._resolved_deploy_target = resolved_target
@@ -367,6 +369,7 @@ class _GenericWebProdPromotionProviderMutationAdapter:
                     artifact_id=promotion.artifact_id,
                 ),
                 fallback_target_name=f"{self._profile.product}-{self._lane.instance}",
+                request_deploy_reference=promotion.deploy_reference,
             )
         return self._resolved_deploy_target
 
@@ -1228,7 +1231,7 @@ def build_generic_web_write_route_handlers(
                     "A generic web preview refresh is already running for the requested preview. "
                     "Retry after it completes."
                 ),
-        )
+            )
         await refresh_lock.acquire()
         try:
             cancellation: asyncio.CancelledError | None = None

--- a/control_plane/product_promotion_http.py
+++ b/control_plane/product_promotion_http.py
@@ -24,6 +24,7 @@ from control_plane.contracts.product_profile_record import (
 )
 from control_plane.contracts.promotion_record import ReleaseStatus
 from control_plane.contracts.runtime_identity import RuntimeIdentity, RuntimeIdentityStatus
+from control_plane.contracts.deploy_reference import validate_provider_deploy_reference
 from control_plane.drivers.generic_web_dispatch import (
     GenericWebProdPromotionEnvelope,
     GenericWebPromotionWorkflowEnvelope,
@@ -89,6 +90,7 @@ class ProductPromotionEvidence(BaseModel):
 
     environment: str
     artifact_id: str = ""
+    deploy_reference: str = ""
     source_git_ref: str = ""
     deployment_record_id: str = ""
     inventory_updated_at: str = ""
@@ -475,6 +477,7 @@ def product_promotion_direct_request(
         promotion=GenericWebProdPromotionRequest(
             product=profile.product,
             artifact_id=status.source.artifact_id,
+            deploy_reference=status.source.deploy_reference,
             source_git_ref=status.source.source_git_ref,
             from_instance=status.source_environment,
             to_instance=status.destination_environment,
@@ -497,6 +500,7 @@ def product_promotion_workflow_request(
             dry_run=request.dry_run,
             bump=request.bump,
             artifact_id=status.source.artifact_id,
+            deploy_reference=status.source.deploy_reference,
             source_git_ref=status.source.source_git_ref,
             evidence_fingerprint=status.evidence_fingerprint,
         ),
@@ -555,9 +559,12 @@ def product_promotion_intent_matches(
         inputs.get(workflow.promotion_intent_input.strip()) == intent_id
         and inputs.get(workflow.dry_run_input.strip()) == "false"
         and inputs.get(workflow.artifact_id_input.strip()) == status.source.artifact_id
+        and inputs.get(workflow.deploy_reference_input.strip(), "")
+        == status.source.deploy_reference
         and inputs.get(workflow.source_git_ref_input.strip()) == status.source.source_git_ref
         and request.product == profile.product
         and request.artifact_id == status.source.artifact_id
+        and request.deploy_reference == status.source.deploy_reference
         and request.source_git_ref == status.source.source_git_ref
         and request.from_instance == status.source_environment
         and request.to_instance == status.destination_environment
@@ -664,6 +671,10 @@ def _promotion_evidence(
         return ProductPromotionEvidence(environment=lane.instance)
     runtime_identity = inventory.runtime_identity
     artifact_id = _runtime_artifact_id(profile, inventory)
+    deploy_reference = _runtime_deploy_reference(
+        inventory=inventory,
+        artifact_id=artifact_id,
+    )
     source_git_ref = runtime_identity.source_git_ref.strip() if runtime_identity is not None else ""
     try:
         inventory_updated_at = _parse_timestamp(inventory.updated_at)
@@ -674,6 +685,7 @@ def _promotion_evidence(
         return ProductPromotionEvidence(
             environment=lane.instance,
             artifact_id=artifact_id,
+            deploy_reference=deploy_reference,
             source_git_ref=source_git_ref,
             deployment_record_id=(
                 runtime_identity.deployment_record_id if runtime_identity is not None else ""
@@ -698,6 +710,7 @@ def _promotion_evidence(
     return ProductPromotionEvidence(
         environment=lane.instance,
         artifact_id=artifact_id,
+        deploy_reference=deploy_reference,
         source_git_ref=source_git_ref,
         deployment_record_id=(
             runtime_identity.deployment_record_id if runtime_identity is not None else ""
@@ -727,6 +740,22 @@ def _runtime_artifact_id(
             return ""
         return artifact_id
     except (ValueError, click.ClickException):
+        return ""
+
+
+def _runtime_deploy_reference(*, inventory: EnvironmentInventory, artifact_id: str) -> str:
+    if inventory.runtime_identity is None:
+        return ""
+    image_reference = inventory.runtime_identity.image_reference.strip()
+    if not image_reference or image_reference == inventory.runtime_identity.artifact_id.strip():
+        return ""
+    try:
+        return validate_provider_deploy_reference(
+            artifact_id=artifact_id,
+            deploy_reference=image_reference,
+            label="Product promotion source evidence",
+        )
+    except ValueError:
         return ""
 
 

--- a/control_plane/workflows/dokploy_deploy.py
+++ b/control_plane/workflows/dokploy_deploy.py
@@ -6,6 +6,10 @@ from urllib.parse import urlsplit
 import click
 
 from control_plane.contracts.deployment_record import ResolvedTargetEvidence
+from control_plane.contracts.deploy_reference import (
+    is_digest_pinned_image_reference,
+    provider_image_reference,
+)
 from control_plane.contracts.runtime_identity import RuntimeIdentity, runtime_identity_env
 from control_plane.contracts.ship_request import ShipRequest
 from control_plane.dokploy import api as dokploy_api
@@ -29,6 +33,13 @@ def update_dokploy_target_artifact(
         target_id=target_id,
     )
     if target_type == "application":
+        if is_digest_pinned_image_reference(artifact_id):
+            raise click.ClickException(
+                "Dokploy application deploy requires deploy_reference when artifact_id is "
+                "digest-pinned. Use an immutable provider tag such as repo:sha-<commit>; "
+                "Dokploy cannot save repo@sha256:<digest> on application targets with a "
+                "saved Registry Swarm."
+            )
         _prepare_saved_registry_login(
             host=host,
             token=token,
@@ -198,12 +209,18 @@ def execute_dokploy_artifact_deploy(
         target_type=resolved_target.target_type,
         target_id=resolved_target.target_id,
     )
+    deploy_reference = ship_request.artifact_id
+    if resolved_target.target_type == "application":
+        deploy_reference = provider_image_reference(
+            artifact_id=ship_request.artifact_id,
+            deploy_reference=ship_request.deploy_reference,
+        )
     update_dokploy_target_artifact(
         host=host,
         token=token,
         target_type=resolved_target.target_type,
         target_id=resolved_target.target_id,
-        artifact_id=ship_request.artifact_id,
+        artifact_id=deploy_reference,
         runtime_identity=runtime_identity,
         before_provider_mutation=before_provider_mutation,
         effect_started=effect_started,

--- a/control_plane/workflows/generic_web_deploy.py
+++ b/control_plane/workflows/generic_web_deploy.py
@@ -9,6 +9,10 @@ import click
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from control_plane.contracts.deploy_target import DeployTargetCategory
+from control_plane.contracts.deploy_reference import (
+    provider_image_reference,
+    validate_provider_deploy_reference,
+)
 from control_plane.contracts.deployment_record import DeploymentRecord
 from control_plane.contracts.environment_inventory import EnvironmentInventory
 from control_plane.contracts.product_profile_record import (
@@ -53,6 +57,7 @@ class GenericWebDeployRequest(BaseModel):
     product: str
     instance: str
     artifact_id: str
+    deploy_reference: str = ""
     source_git_ref: str
     timeout_seconds: int | None = Field(default=None, ge=1)
     no_cache: bool = False
@@ -65,6 +70,7 @@ class GenericWebDeployRequest(BaseModel):
             raise ValueError("Generic web deploy requires instance.")
         if not self.artifact_id.strip():
             raise ValueError("Generic web deploy requires artifact_id.")
+        self.deploy_reference = self.deploy_reference.strip()
         if not self.source_git_ref.strip():
             raise ValueError("Generic web deploy requires source_git_ref.")
         return self
@@ -264,7 +270,10 @@ def _build_runtime_identity(
         deployment_record_id=deployment_record_id,
         artifact_id=ship_request.artifact_id,
         source_git_ref=ship_request.source_git_ref,
-        image_reference=ship_request.artifact_id,
+        image_reference=provider_image_reference(
+            artifact_id=ship_request.artifact_id,
+            deploy_reference=ship_request.deploy_reference,
+        ),
         deployed_at=deployed_at,
     )
 
@@ -333,6 +342,7 @@ def _fallback_ship_request(
     lane: ProductLaneProfile,
     deploy_provider: GenericWebDeployProvider,
     artifact_id: str = "",
+    include_deploy_reference: bool = True,
 ) -> ShipRequest:
     provider_id = deploy_provider.provider_id.strip().lower()
     if not provider_id:
@@ -342,8 +352,16 @@ def _fallback_ship_request(
         profile=profile,
         artifact_id=request.artifact_id,
     )
+    deploy_reference = ""
+    if include_deploy_reference and request.deploy_reference:
+        deploy_reference = validate_provider_deploy_reference(
+            artifact_id=resolved_artifact_id,
+            deploy_reference=request.deploy_reference,
+            label="Generic web deploy",
+        )
     return ShipRequest(
         artifact_id=resolved_artifact_id,
+        deploy_reference=deploy_reference,
         context=lane.context,
         instance=lane.instance,
         source_git_ref=request.source_git_ref,
@@ -384,6 +402,7 @@ def _resolve_deploy_target(
             profile=profile,
             artifact_id=request.artifact_id,
         ),
+        request_deploy_reference=request.deploy_reference,
         fallback_target_name=_fallback_target_name(profile=profile, lane=lane),
     )
 
@@ -439,10 +458,10 @@ def execute_generic_web_deploy(
         )
         ship_request = prepared_deploy_target.ship_request
         resolved_target = prepared_deploy_target.resolved_target
-    except click.ClickException as exc:
+    except (click.ClickException, ValueError) as exc:
         finished_at = utc_now_timestamp()
         if fallback_request is None:
-            if resolved_profile.image.repository.strip():
+            if resolved_profile.image.repository.strip() and not request.deploy_reference:
                 raise
             fallback_request = _fallback_ship_request(
                 request=request,
@@ -450,6 +469,7 @@ def execute_generic_web_deploy(
                 lane=resolved_lane,
                 deploy_provider=resolved_deploy_provider,
                 artifact_id=request.artifact_id,
+                include_deploy_reference=False,
             )
         record_store.write_deployment_record(
             build_deployment_record(

--- a/control_plane/workflows/generic_web_deploy_provider.py
+++ b/control_plane/workflows/generic_web_deploy_provider.py
@@ -17,6 +17,7 @@ from control_plane.contracts.deploy_target import (
     DeployTargetCompatibilityType,
     ProviderTargetRecord,
 )
+from control_plane.contracts.deploy_reference import validate_provider_deploy_reference
 from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
 from control_plane.contracts.dokploy_target_record import DokployTargetRecord
 from control_plane.contracts.deployment_record import ResolvedTargetEvidence
@@ -115,6 +116,7 @@ def resolve_generic_web_provider_reconciliation_target(
     request_no_cache: bool,
     normalized_artifact_id: str,
     lane: ProductLaneProfile,
+    request_deploy_reference: str = "",
 ) -> GenericWebResolvedDeployTarget:
     normalized_key = reconciliation_key.strip()
     if not normalized_key.startswith(_GENERIC_WEB_RECONCILIATION_KEY_PREFIX):
@@ -132,6 +134,11 @@ def resolve_generic_web_provider_reconciliation_target(
     del request_artifact_id
     ship_request = ShipRequest(
         artifact_id=normalized_artifact_id,
+        deploy_reference=validate_provider_deploy_reference(
+            artifact_id=normalized_artifact_id,
+            deploy_reference=request_deploy_reference,
+            label="Generic web deploy",
+        ),
         context=context_name,
         instance=instance_name,
         source_git_ref=request_source_git_ref,
@@ -232,6 +239,7 @@ class GenericWebDeployProvider(Protocol):
         lane: ProductLaneProfile,
         normalized_artifact_id: str,
         fallback_target_name: str,
+        request_deploy_reference: str = "",
     ) -> GenericWebResolvedDeployTarget: ...
 
     def execute_artifact_deploy(
@@ -271,6 +279,7 @@ class DokployGenericWebDeployProvider:
         lane: ProductLaneProfile,
         normalized_artifact_id: str,
         fallback_target_name: str,
+        request_deploy_reference: str = "",
     ) -> GenericWebResolvedDeployTarget:
         del request_artifact_id, profile
         dokploy_store = _require_dokploy_deploy_store(record_store)
@@ -324,6 +333,11 @@ class DokployGenericWebDeployProvider:
         target_name = provider_target.display_name.strip() or fallback_target_name
         ship_request = ShipRequest(
             artifact_id=normalized_artifact_id,
+            deploy_reference=validate_provider_deploy_reference(
+                artifact_id=normalized_artifact_id,
+                deploy_reference=request_deploy_reference,
+                label="Generic web deploy",
+            ),
             context=context_name,
             instance=instance_name,
             source_git_ref=request_source_git_ref,

--- a/control_plane/workflows/generic_web_promotion.py
+++ b/control_plane/workflows/generic_web_promotion.py
@@ -11,6 +11,10 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from control_plane.contracts.backup_gate_record import BackupGateRecord
 from control_plane.contracts.deploy_target import DeployTargetCategory
+from control_plane.contracts.deploy_reference import (
+    is_non_floating_tag_reference,
+    validate_provider_deploy_reference,
+)
 from control_plane.contracts.deployment_record import DeploymentRecord
 from control_plane.contracts.dokploy_target_record import DokployTargetType
 from control_plane.contracts.environment_inventory import EnvironmentInventory
@@ -75,6 +79,7 @@ class GenericWebProdPromotionRequest(BaseModel):
     schema_version: int = Field(default=1, ge=1)
     product: str
     artifact_id: str = ""
+    deploy_reference: str = ""
     source_git_ref: str = ""
     from_instance: str = "testing"
     to_instance: str = "prod"
@@ -93,6 +98,7 @@ class GenericWebProdPromotionRequest(BaseModel):
     def _validate_request(self) -> "GenericWebProdPromotionRequest":
         self.product = self.product.strip()
         self.artifact_id = self.artifact_id.strip()
+        self.deploy_reference = self.deploy_reference.strip()
         self.source_git_ref = self.source_git_ref.strip()
         self.from_instance = self.from_instance.strip().lower()
         self.to_instance = self.to_instance.strip().lower()
@@ -122,6 +128,7 @@ class GenericWebProdPromotionResult(BaseModel):
     from_instance: str
     to_instance: str
     artifact_id: str
+    deploy_reference: str = ""
     source_git_ref: str = ""
     backup_record_id: str = ""
     promotion_record_id: str
@@ -270,6 +277,7 @@ def execute_generic_web_prod_promotion(
             from_instance=source_lane.instance,
             to_instance=destination_lane.instance,
             artifact_id=request.artifact_id,
+            deploy_reference=request.deploy_reference,
             source_git_ref=request.source_git_ref,
             backup_record_id=request.backup_record_id,
             promotion_record_id=promotion_record_id,
@@ -316,6 +324,7 @@ def execute_generic_web_prod_promotion(
             product=request.product,
             instance=destination_lane.instance,
             artifact_id=request.artifact_id,
+            deploy_reference=request.deploy_reference,
             source_git_ref=request.source_git_ref,
             timeout_seconds=request.timeout_seconds,
             no_cache=request.no_cache,
@@ -540,12 +549,28 @@ def _resolve_source_inventory_inputs(
             f"request artifact={requested_artifact_id or '<default>'} "
             f"source_ref={request.source_git_ref or '<default>'}."
         )
+    deploy_reference = request.deploy_reference or _inventory_deploy_reference(source_inventory)
+    deploy_reference = validate_provider_deploy_reference(
+        artifact_id=normalized_inventory_artifact_id,
+        deploy_reference=deploy_reference,
+        label="Generic web prod promotion",
+    )
     return request.model_copy(
         update={
             "artifact_id": normalized_inventory_artifact_id,
+            "deploy_reference": deploy_reference,
             "source_git_ref": inventory_source_git_ref,
         }
     )
+
+
+def _inventory_deploy_reference(source_inventory: EnvironmentInventory) -> str:
+    if source_inventory.runtime_identity is None:
+        return ""
+    image_reference = source_inventory.runtime_identity.image_reference.strip()
+    if is_non_floating_tag_reference(image_reference):
+        return image_reference
+    return ""
 
 
 def _health_url_for_lane(*, lane: ProductLaneProfile, health_path: str) -> str:
@@ -1060,6 +1085,7 @@ def _result_from_record(
         from_instance=record.from_instance,
         to_instance=record.to_instance,
         artifact_id=record.artifact_identity.artifact_id,
+        deploy_reference=request.deploy_reference,
         source_git_ref=request.source_git_ref,
         backup_record_id=record.backup_record_id,
         promotion_record_id=record.record_id,

--- a/control_plane/workflows/generic_web_promotion_workflow.py
+++ b/control_plane/workflows/generic_web_promotion_workflow.py
@@ -30,6 +30,7 @@ class GenericWebPromotionWorkflowRequest(BaseModel):
     dry_run: bool = True
     bump: BumpLevel | None = None
     artifact_id: str = ""
+    deploy_reference: str = ""
     source_git_ref: str = ""
     evidence_fingerprint: str = ""
     observe_timeout_seconds: int = Field(default=12, ge=0, le=60)
@@ -39,6 +40,7 @@ class GenericWebPromotionWorkflowRequest(BaseModel):
         self.product = self.product.strip()
         self.context = self.context.strip()
         self.artifact_id = self.artifact_id.strip()
+        self.deploy_reference = self.deploy_reference.strip()
         self.source_git_ref = self.source_git_ref.strip()
         self.evidence_fingerprint = self.evidence_fingerprint.strip()
         if not self.product:
@@ -116,6 +118,11 @@ def dispatch_generic_web_promotion_workflow(
                 **(
                     {workflow.artifact_id_input.strip(): request.artifact_id}
                     if request.artifact_id
+                    else {}
+                ),
+                **(
+                    {workflow.deploy_reference_input.strip(): request.deploy_reference}
+                    if request.deploy_reference
                     else {}
                 ),
                 **(

--- a/control_plane/workflows/generic_web_rollback.py
+++ b/control_plane/workflows/generic_web_rollback.py
@@ -94,6 +94,7 @@ def execute_generic_web_rollback(
             product=planned_deploy.product,
             instance=planned_deploy.instance,
             artifact_id=planned_deploy.artifact_id,
+            deploy_reference=planned_deploy.deploy_reference,
             source_git_ref=planned_deploy.source_git_ref,
             timeout_seconds=planned_deploy.timeout_seconds,
             no_cache=planned_deploy.no_cache,

--- a/control_plane/workflows/verireel_prod_promotion.py
+++ b/control_plane/workflows/verireel_prod_promotion.py
@@ -55,6 +55,7 @@ class VeriReelProdPromotionRequest(BaseModel):
     from_instance: str = "testing"
     to_instance: str = "prod"
     artifact_id: str
+    deploy_reference: str = ""
     source_git_ref: str
     backup_record_id: str
     promotion_record_id: str
@@ -80,6 +81,7 @@ class VeriReelProdPromotionRequest(BaseModel):
             raise ValueError("VeriReel prod promotion requires to_instance 'prod'.")
         if not self.artifact_id.strip():
             raise ValueError("VeriReel prod promotion requires artifact_id.")
+        self.deploy_reference = self.deploy_reference.strip()
         if not self.source_git_ref.strip():
             raise ValueError("VeriReel prod promotion requires source_git_ref.")
         if not self.backup_record_id.strip():
@@ -800,6 +802,7 @@ def execute_verireel_prod_promotion(
             context=request.context,
             instance="prod",
             artifact_id=request.artifact_id,
+            deploy_reference=request.deploy_reference,
             source_git_ref=request.source_git_ref,
             expected_build_revision=request.expected_build_revision,
             expected_build_tag=request.expected_build_tag,

--- a/control_plane/workflows/verireel_stable_deploy.py
+++ b/control_plane/workflows/verireel_stable_deploy.py
@@ -8,6 +8,10 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from control_plane import runtime_environments as control_plane_runtime_environments
 from control_plane.contracts.deploy_target import DeployTargetCategory
+from control_plane.contracts.deploy_reference import (
+    provider_image_reference,
+    validate_provider_deploy_reference,
+)
 from control_plane.contracts.deployment_record import ResolvedTargetEvidence
 from control_plane.contracts.deployment_record import DeploymentRecord
 from control_plane.contracts.dokploy_target_record import DokployTargetType
@@ -45,6 +49,7 @@ class VeriReelStableDeployRequest(BaseModel):
     context: str = "verireel"
     instance: StableInstanceName = "testing"
     artifact_id: str
+    deploy_reference: str = ""
     source_git_ref: str
     expected_build_revision: str = ""
     expected_build_tag: str = ""
@@ -61,6 +66,11 @@ class VeriReelStableDeployRequest(BaseModel):
             raise ValueError("VeriReel stable deploy requires instance 'testing' or 'prod'.")
         if not self.artifact_id.strip():
             raise ValueError("VeriReel stable deploy requires artifact_id.")
+        self.deploy_reference = validate_provider_deploy_reference(
+            artifact_id=self.artifact_id,
+            deploy_reference=self.deploy_reference,
+            label="VeriReel stable deploy",
+        )
         if not self.source_git_ref.strip():
             raise ValueError("VeriReel stable deploy requires source_git_ref.")
         return self
@@ -109,6 +119,8 @@ class VeriReelStableDeployTargetResultFields(BaseModel):
 
 
 def _artifact_tag(artifact_id: str) -> str:
+    if "@" in artifact_id:
+        return ""
     artifact_name = artifact_id.rsplit("/", 1)[-1]
     if ":" not in artifact_name:
         return ""
@@ -120,7 +132,12 @@ def _expected_build_revision(request: VeriReelStableDeployRequest) -> str:
 
 
 def _expected_build_tag(request: VeriReelStableDeployRequest) -> str:
-    return request.expected_build_tag.strip() or _artifact_tag(request.artifact_id)
+    return request.expected_build_tag.strip() or _artifact_tag(
+        provider_image_reference(
+            artifact_id=request.artifact_id,
+            deploy_reference=request.deploy_reference,
+        )
+    )
 
 
 def _build_runtime_identity(
@@ -138,7 +155,10 @@ def _build_runtime_identity(
         deployment_record_id=deployment_record_id,
         artifact_id=ship_request.artifact_id,
         source_git_ref=ship_request.source_git_ref,
-        image_reference=ship_request.artifact_id,
+        image_reference=provider_image_reference(
+            artifact_id=ship_request.artifact_id,
+            deploy_reference=ship_request.deploy_reference,
+        ),
         deployed_at=deployed_at,
     )
 
@@ -159,6 +179,7 @@ def _default_target_name_for_instance(instance_name: StableInstanceName) -> str:
 def _fallback_ship_request(request: VeriReelStableDeployRequest) -> ShipRequest:
     return ShipRequest(
         artifact_id=request.artifact_id,
+        deploy_reference=request.deploy_reference,
         context=request.context,
         instance=request.instance,
         source_git_ref=request.source_git_ref,
@@ -255,6 +276,7 @@ def _resolve_ship_request(
     )
     ship_request = ShipRequest(
         artifact_id=request.artifact_id,
+        deploy_reference=request.deploy_reference,
         context=request.context,
         instance=request.instance,
         source_git_ref=request.source_git_ref,

--- a/docs/dokploy-service-deployments.md
+++ b/docs/dokploy-service-deployments.md
@@ -113,7 +113,7 @@ The product repo submits immutable image identity plus the tested source SHA;
 Launchplane resolves lane, provider target, runtime environment, managed
 secrets, and deployment records from DB-backed authority.
 
-Publish images to the profile's `image.repository` and prefer digest deployment:
+Publish images to the profile's `image.repository` and preserve digest identity:
 
 ```text
 ghcr.io/cbusillo/discord-blue@sha256:<digest>
@@ -125,12 +125,17 @@ emits a human-readable tag, the Launchplane trigger should still send the exact
 digest image reference or an artifact id that Launchplane can resolve to that
 digest.
 
-For the current generic-web application deploy path, the submitted
-`artifact_id` is the deployable immutable image reference used to update the
-Dokploy application's Docker image. Do not submit a mutable tag for service
-deploys. If a later slice adds generic artifact-manifest resolution for this
-path, the manifest must still resolve to the same `repository@sha256:digest`
-identity before Dokploy is mutated.
+For generic-web and VeriReel application targets, `artifact_id` remains the
+canonical artifact identity and should be the digest-pinned
+`repository@sha256:digest` reference. Dokploy applications with a saved Registry
+Swarm cannot save that digest reference as the Docker image because Dokploy
+re-tags application images internally. Product workflows that publish a stable
+SHA tag, such as `repository:sha-<commit>`, should pass that tag as
+`deploy_reference`. Launchplane validates that `deploy_reference` is a
+non-floating tag in the same repository, uses it only for the provider-facing
+Docker image, and records runtime identity with `artifact_id` as the digest and
+`image_reference` as the provider tag. Compose targets remain backward
+compatible with digest image references in `artifact_id`.
 
 RepairShopr Sync is the first live canary for this stable shape. The
 `cbusillo/repairshopr_api` product workflow built an immutable GHCR image,

--- a/docs/product-repo-contract.md
+++ b/docs/product-repo-contract.md
@@ -773,18 +773,24 @@ repo action instead. Raw action calls are a lower-level compatibility surface
 when a Launchplane-owned reusable workflow does not exist yet.
 
 Generic web/service repos that deploy as Dokploy applications should build and
-push their own immutable image, then submit the image digest to Launchplane's
-`generic-web` deploy route. The workflow may derive the GHCR repository from the
-current GitHub repository, publish with `docker/login-action` and
+push their own immutable image digest plus an immutable SHA tag. Submit the
+digest-pinned image reference as `artifact_id` and the SHA tag as
+`deploy_reference` to Launchplane's `generic-web` deploy route. Launchplane keeps
+`artifact_id` as the evidence and runtime artifact identity, while using
+`deploy_reference` only for the provider-facing Dokploy Docker image. This avoids
+Dokploy application saved-registry failures for `repository@sha256:digest` while
+preserving digest equality evidence. The workflow may derive the GHCR repository
+from the current GitHub repository, publish with `docker/login-action` and
 `docker/build-push-action`, then pass the product key, stable-lane intent, tested
-source SHA, and immutable image digest. While the current `generic-web/deploy`
-route still requires context or instance compatibility fields, product workflows
-may supply those values from operator-seeded GitHub variables as scoped adapter
-inputs. They are not checked-in product topology or durable lifecycle authority,
-and #1528 owns reducing that bridge behind Launchplane-owned reusable lifecycle
-contracts. The checked-in workflow must not hard-code provider targets, Dokploy
-operations, runtime domains, managed secrets, or fixed product topology;
-Launchplane resolves those from DB-backed product and target records.
+source SHA, immutable image digest, and provider SHA tag. While the current
+`generic-web/deploy` route still requires context or instance compatibility
+fields, product workflows may supply those values from operator-seeded GitHub variables
+as scoped adapter inputs. They are not checked-in product topology or
+durable lifecycle authority, and #1528 owns reducing that bridge behind
+Launchplane-owned reusable lifecycle contracts. The checked-in workflow must not
+hard-code provider targets, Dokploy operations, runtime domains, managed secrets,
+or fixed product topology; Launchplane resolves those from DB-backed product and
+target records.
 
 For this compatibility shape, `.github/workflows/launchplane-deploy.yml` is the
 supported thin connector workflow name. It should call:
@@ -801,9 +807,9 @@ supported thin connector workflow name. It should call:
 ```
 
 The payload should include the product key, stable-lane intent required by the
-current route, immutable image digest as `artifact_id`, and tested source SHA.
-Mutable image tags and checked-in image references are not durable deploy
-inputs.
+current route, immutable image digest as `artifact_id`, provider SHA tag as
+`deploy_reference`, and tested source SHA. Mutable image tags such as `latest`,
+branch names, and environment tags remain invalid deploy references.
 
 ```yaml
 - name: Request Launchplane preview refresh

--- a/frontend/generated/openapi-canonical.json
+++ b/frontend/generated/openapi-canonical.json
@@ -4450,6 +4450,11 @@
             "title": "Artifact Id",
             "type": "string"
           },
+          "deploy_reference": {
+            "default": "",
+            "title": "Deploy Reference",
+            "type": "string"
+          },
           "instance": {
             "title": "Instance",
             "type": "string"
@@ -5110,6 +5115,11 @@
             "title": "Backup Required",
             "type": "boolean"
           },
+          "deploy_reference": {
+            "default": "",
+            "title": "Deploy Reference",
+            "type": "string"
+          },
           "dry_run": {
             "default": false,
             "title": "Dry Run",
@@ -5269,6 +5279,11 @@
           "context": {
             "default": "",
             "title": "Context",
+            "type": "string"
+          },
+          "deploy_reference": {
+            "default": "",
+            "title": "Deploy Reference",
             "type": "string"
           },
           "deployment_record_id": {
@@ -5467,6 +5482,11 @@
           },
           "context": {
             "title": "Context",
+            "type": "string"
+          },
+          "deploy_reference": {
+            "default": "",
+            "title": "Deploy Reference",
             "type": "string"
           },
           "dry_run": {
@@ -15679,6 +15699,11 @@
             "title": "Context",
             "type": "string"
           },
+          "deploy_reference": {
+            "default": "",
+            "title": "Deploy Reference",
+            "type": "string"
+          },
           "deployment_record_id": {
             "default": "",
             "title": "Deployment Record Id",
@@ -15839,6 +15864,11 @@
           "artifact_id": {
             "default": "",
             "title": "Artifact Id",
+            "type": "string"
+          },
+          "deploy_reference": {
+            "default": "",
+            "title": "Deploy Reference",
             "type": "string"
           },
           "deployment_record_id": {
@@ -16508,6 +16538,11 @@
           "default_bump": {
             "default": "patch",
             "title": "Default Bump",
+            "type": "string"
+          },
+          "deploy_reference_input": {
+            "default": "deploy_reference",
+            "title": "Deploy Reference Input",
             "type": "string"
           },
           "dry_run_input": {
@@ -25513,6 +25548,11 @@
             "title": "Context",
             "type": "string"
           },
+          "deploy_reference": {
+            "default": "",
+            "title": "Deploy Reference",
+            "type": "string"
+          },
           "expected_build_revision": {
             "default": "",
             "title": "Expected Build Revision",
@@ -25755,6 +25795,11 @@
           "context": {
             "default": "verireel",
             "title": "Context",
+            "type": "string"
+          },
+          "deploy_reference": {
+            "default": "",
+            "title": "Deploy Reference",
             "type": "string"
           },
           "expected_build_revision": {
@@ -29304,6 +29349,11 @@
                         "title": "Artifact Id",
                         "type": "string"
                       },
+                      "deploy_reference": {
+                        "default": "",
+                        "title": "Deploy Reference",
+                        "type": "string"
+                      },
                       "instance": {
                         "title": "Instance",
                         "type": "string"
@@ -30454,6 +30504,11 @@
                         "title": "Backup Required",
                         "type": "boolean"
                       },
+                      "deploy_reference": {
+                        "default": "",
+                        "title": "Deploy Reference",
+                        "type": "string"
+                      },
                       "dry_run": {
                         "default": false,
                         "title": "Dry Run",
@@ -30704,6 +30759,11 @@
                       },
                       "context": {
                         "title": "Context",
+                        "type": "string"
+                      },
+                      "deploy_reference": {
+                        "default": "",
+                        "title": "Deploy Reference",
                         "type": "string"
                       },
                       "dry_run": {
@@ -39931,6 +39991,11 @@
                         "title": "Context",
                         "type": "string"
                       },
+                      "deploy_reference": {
+                        "default": "",
+                        "title": "Deploy Reference",
+                        "type": "string"
+                      },
                       "expected_build_revision": {
                         "default": "",
                         "title": "Expected Build Revision",
@@ -40145,6 +40210,11 @@
                       "context": {
                         "default": "verireel",
                         "title": "Context",
+                        "type": "string"
+                      },
+                      "deploy_reference": {
+                        "default": "",
+                        "title": "Deploy Reference",
                         "type": "string"
                       },
                       "expected_build_revision": {
@@ -40886,6 +40956,11 @@
                       "context": {
                         "default": "verireel",
                         "title": "Context",
+                        "type": "string"
+                      },
+                      "deploy_reference": {
+                        "default": "",
+                        "title": "Deploy Reference",
                         "type": "string"
                       },
                       "expected_build_revision": {
@@ -49374,6 +49449,11 @@
                       "default_bump": {
                         "default": "patch",
                         "title": "Default Bump",
+                        "type": "string"
+                      },
+                      "deploy_reference_input": {
+                        "default": "deploy_reference",
+                        "title": "Deploy Reference Input",
                         "type": "string"
                       },
                       "dry_run_input": {

--- a/frontend/generated/openapi-ui.json
+++ b/frontend/generated/openapi-ui.json
@@ -13547,6 +13547,11 @@
             "title": "Context",
             "type": "string"
           },
+          "deploy_reference": {
+            "default": "",
+            "title": "Deploy Reference",
+            "type": "string"
+          },
           "deployment_record_id": {
             "default": "",
             "title": "Deployment Record Id",
@@ -13700,6 +13705,7 @@
           "backup_status",
           "bump",
           "context",
+          "deploy_reference",
           "deployment_record_id",
           "deployment_status",
           "destination_health_status",
@@ -13732,6 +13738,11 @@
           "artifact_id": {
             "default": "",
             "title": "Artifact Id",
+            "type": "string"
+          },
+          "deploy_reference": {
+            "default": "",
+            "title": "Deploy Reference",
             "type": "string"
           },
           "deployment_record_id": {
@@ -13813,6 +13824,7 @@
         },
         "required": [
           "artifact_id",
+          "deploy_reference",
           "deployment_record_id",
           "deployment_status",
           "environment",
@@ -14447,6 +14459,11 @@
             "title": "Default Bump",
             "type": "string"
           },
+          "deploy_reference_input": {
+            "default": "deploy_reference",
+            "title": "Deploy Reference Input",
+            "type": "string"
+          },
           "dry_run_input": {
             "default": "dry_run",
             "title": "Dry Run Input",
@@ -14479,6 +14496,7 @@
           "artifact_id_input",
           "bump_input",
           "default_bump",
+          "deploy_reference_input",
           "dry_run_input",
           "promotion_intent_input",
           "ref",

--- a/frontend/src/dev-fixtures.ts
+++ b/frontend/src/dev-fixtures.ts
@@ -839,6 +839,7 @@ export function promotionStatusForFixture(
     source: {
       environment: "testing",
       artifact_id: sourceArtifact,
+      deploy_reference: `ghcr.io/example/atlas-commerce:sha-${sourceGitRef}`,
       source_git_ref: sourceGitRef,
       deployment_record_id: missingEvidence ? "" : "deployment-fixture-testing",
       inventory_updated_at: missingEvidence ? "" : OBSERVED_AT,
@@ -856,6 +857,9 @@ export function promotionStatusForFixture(
       artifact_id: missingEvidence
         ? ""
         : `ghcr.io/example/atlas-commerce@sha256:${"b".repeat(64)}`,
+      deploy_reference: missingEvidence
+        ? ""
+        : `ghcr.io/example/atlas-commerce:sha-${"2".repeat(40)}`,
       source_git_ref: missingEvidence ? "" : "2".repeat(40),
       deployment_record_id: missingEvidence ? "" : "deployment-fixture-prod",
       inventory_updated_at: missingEvidence ? "" : OBSERVED_AT,
@@ -933,6 +937,7 @@ export async function dryRunProductPromotionForFixture(
       from_instance: status.source_environment,
       to_instance: status.destination_environment,
       artifact_id: status.source.artifact_id,
+      deploy_reference: status.source.deploy_reference,
       source_git_ref: status.source.source_git_ref,
       backup_record_id: "",
       promotion_record_id: "promotion-fixture-dry-run",

--- a/frontend/src/generated/openapi.ts/types.gen.ts
+++ b/frontend/src/generated/openapi.ts/types.gen.ts
@@ -1743,6 +1743,7 @@ export type ProductPromotionDryRunResult = {
     backup_status: 'pending' | 'pass' | 'fail' | 'skipped';
     bump: 'patch' | 'minor' | 'major';
     context: string;
+    deploy_reference: string;
     deployment_record_id: string;
     deployment_status: 'pending' | 'pass' | 'fail' | 'skipped';
     destination_health_status: 'pending' | 'pass' | 'fail' | 'skipped';
@@ -1769,6 +1770,7 @@ export type ProductPromotionDryRunResult = {
 
 export type ProductPromotionEvidence = {
     artifact_id: string;
+    deploy_reference: string;
     deployment_record_id: string;
     deployment_status: 'pending' | 'pass' | 'fail' | 'skipped';
     environment: string;
@@ -1893,6 +1895,7 @@ export type ProductPromotionWorkflowProfile = {
     artifact_id_input: string;
     bump_input: string;
     default_bump: string;
+    deploy_reference_input: string;
     dry_run_input: string;
     promotion_intent_input: string;
     ref: string;

--- a/tests/test_deploy_reference.py
+++ b/tests/test_deploy_reference.py
@@ -1,0 +1,116 @@
+import unittest
+
+from pydantic import ValidationError
+
+from control_plane.contracts.deploy_reference import (
+    docker_image_digest,
+    docker_image_repository,
+    docker_image_tag,
+    validate_provider_deploy_reference,
+)
+from control_plane.contracts.ship_request import ShipRequest
+from control_plane.contracts.promotion_record import HealthcheckEvidence
+
+
+class DeployReferenceContractTests(unittest.TestCase):
+    def test_validates_digest_identity_and_non_floating_provider_tag(self) -> None:
+        deploy_reference = validate_provider_deploy_reference(
+            artifact_id="ghcr.io/every/verireel-app@sha256:"
+            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+            deploy_reference="ghcr.io/every/verireel-app:sha-abcdef1234567890abcdef1234567890abcdef12",
+            label="test deploy",
+        )
+
+        self.assertEqual(
+            deploy_reference,
+            "ghcr.io/every/verireel-app:sha-abcdef1234567890abcdef1234567890abcdef12",
+        )
+        self.assertEqual(docker_image_repository(deploy_reference), "ghcr.io/every/verireel-app")
+        self.assertEqual(
+            docker_image_tag(deploy_reference),
+            "sha-abcdef1234567890abcdef1234567890abcdef12",
+        )
+        self.assertEqual(
+            docker_image_digest(
+                "ghcr.io/every/verireel-app@sha256:"
+                "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+            ),
+            "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+        )
+
+    def test_rejects_deploy_reference_without_digest_identity(self) -> None:
+        with self.assertRaisesRegex(ValueError, "artifact_id to be a digest-pinned"):
+            validate_provider_deploy_reference(
+                artifact_id="ghcr.io/every/verireel-app:sha-abcdef",
+                deploy_reference="ghcr.io/every/verireel-app:sha-abcdef",
+                label="test deploy",
+            )
+
+    def test_rejects_digest_and_floating_deploy_references(self) -> None:
+        artifact_id = (
+            "ghcr.io/every/verireel-app@sha256:"
+            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+        )
+        for deploy_reference in (
+            artifact_id,
+            "ghcr.io/every/verireel-app:latest",
+            "ghcr.io/every/verireel-app:prod",
+        ):
+            with self.subTest(deploy_reference=deploy_reference):
+                with self.assertRaisesRegex(ValueError, "non-floating image tag"):
+                    validate_provider_deploy_reference(
+                        artifact_id=artifact_id,
+                        deploy_reference=deploy_reference,
+                        label="test deploy",
+                    )
+
+    def test_rejects_repository_mismatch(self) -> None:
+        with self.assertRaisesRegex(ValueError, "same image repository"):
+            validate_provider_deploy_reference(
+                artifact_id="ghcr.io/every/verireel-app@sha256:"
+                "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+                deploy_reference="ghcr.io/every/other-app:sha-abcdef1234567890",
+                label="test deploy",
+            )
+
+    def test_ship_request_preserves_backward_compatible_tag_only_artifact(self) -> None:
+        request = ShipRequest(
+            artifact_id="ghcr.io/every/verireel-app:sha-abcdef1234567890",
+            context="verireel",
+            instance="testing",
+            source_git_ref="abcdef1234567890",
+            target_name="ver-testing-app",
+            target_type="application",
+            provider_id="dokploy",
+            target_category="application",
+            provider_target_type="application",
+            deploy_mode="dokploy-application-api",
+            verify_health=False,
+            destination_health=HealthcheckEvidence(status="skipped"),
+        )
+
+        self.assertEqual(request.artifact_id, "ghcr.io/every/verireel-app:sha-abcdef1234567890")
+        self.assertEqual(request.deploy_reference, "")
+
+    def test_ship_request_validates_optional_deploy_reference(self) -> None:
+        with self.assertRaisesRegex(ValidationError, "same image repository"):
+            ShipRequest(
+                artifact_id="ghcr.io/every/verireel-app@sha256:"
+                "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+                deploy_reference="ghcr.io/every/other-app:sha-abcdef1234567890",
+                context="verireel",
+                instance="testing",
+                source_git_ref="abcdef1234567890",
+                target_name="ver-testing-app",
+                target_type="application",
+                provider_id="dokploy",
+                target_category="application",
+                provider_target_type="application",
+                deploy_mode="dokploy-application-api",
+                verify_health=False,
+                destination_health=HealthcheckEvidence(status="skipped"),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_deploy_reference_workflows.py
+++ b/tests/test_deploy_reference_workflows.py
@@ -1,0 +1,75 @@
+import unittest
+from pathlib import Path
+
+from tests.support.workflows import load_workflow, workflow_call_inputs
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+class DeployReferenceWorkflowContractTests(unittest.TestCase):
+    def test_stable_deploy_workflows_accept_and_forward_deploy_reference(self) -> None:
+        for workflow_name, request_step_name in (
+            (
+                "reusable-generic-web-stable-deploy.yml",
+                "Request Launchplane generic-web stable deploy",
+            ),
+            (
+                "reusable-product-driver-stable-deploy.yml",
+                "Request Launchplane stable deploy",
+            ),
+        ):
+            with self.subTest(workflow=workflow_name):
+                workflow = load_workflow(REPO_ROOT / ".github/workflows" / workflow_name)
+                self.assertIn("deploy_reference", workflow_call_inputs(workflow))
+                request_step = workflow.step_named("stable-deploy", request_step_name)
+                self.assertIsNotNone(request_step)
+                assert request_step is not None
+                payload_fields = str(request_step.with_values["payload-fields"])
+                self.assertIn(
+                    "deploy.deploy_reference=${{ inputs.deploy_reference }}",
+                    payload_fields,
+                )
+
+        generic_workflow = load_workflow(
+            REPO_ROOT / ".github/workflows/reusable-generic-web-stable-deploy.yml"
+        )
+        resolve_step = generic_workflow.step_named(
+            "stable-deploy", "Resolve Launchplane deploy request"
+        )
+        self.assertIsNotNone(resolve_step)
+        assert resolve_step is not None
+        self.assertIn('"$ARTIFACT_ID"', resolve_step.run)
+        self.assertIn('"$DEPLOY_REFERENCE"', resolve_step.run)
+
+    def test_prod_promotion_workflows_accept_and_forward_deploy_reference(self) -> None:
+        workflow = load_workflow(
+            REPO_ROOT / ".github/workflows/reusable-product-driver-prod-promotion.yml"
+        )
+        self.assertIn("deploy_reference", workflow_call_inputs(workflow))
+        request_step = workflow.step_named(
+            "prod-promotion", "Request Launchplane VeriReel prod promotion"
+        )
+        self.assertIsNotNone(request_step)
+        assert request_step is not None
+        payload_fields = str(request_step.with_values["payload-fields"])
+        self.assertIn(
+            "promotion.deploy_reference=${{ inputs.deploy_reference }}",
+            payload_fields,
+        )
+
+        generic_workflow = load_workflow(
+            REPO_ROOT / ".github/workflows/reusable-generic-web-prod-promotion.yml"
+        )
+        self.assertIn("deploy_reference", workflow_call_inputs(generic_workflow))
+        payload_step = generic_workflow.step_named(
+            "prod-promotion", "Write Launchplane generic-web promotion payload"
+        )
+        self.assertIsNotNone(payload_step)
+        assert payload_step is not None
+        self.assertIn("deploy_reference", payload_step.run)
+        self.assertIn("DEPLOY_REFERENCE", payload_step.run)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_dokploy_deploy.py
+++ b/tests/test_dokploy_deploy.py
@@ -3,9 +3,13 @@ from unittest.mock import patch
 
 import click
 
+from control_plane.contracts.deployment_record import ResolvedTargetEvidence
+from control_plane.contracts.promotion_record import HealthcheckEvidence
+from control_plane.contracts.ship_request import ShipRequest
 from control_plane.workflows.dokploy_deploy import (
     _canonical_registry_host,
     _docker_image_registry_host,
+    execute_dokploy_artifact_deploy,
     update_dokploy_target_artifact,
 )
 
@@ -292,6 +296,90 @@ class DokployDeployRegistryTests(unittest.TestCase):
             [request["path"] for request in requests],
             ["/api/application.saveDockerProvider"],
         )
+
+    def test_digest_only_application_deploy_fails_before_provider_mutation(self) -> None:
+        requests: list[dict[str, object]] = []
+
+        with (
+            patch(
+                "control_plane.workflows.dokploy_deploy.dokploy_api.fetch_dokploy_target_payload",
+                return_value={
+                    "applicationId": "app-123",
+                    "username": "every",
+                    "password": "secret-password",
+                    "registryUrl": "ghcr.io",
+                },
+            ),
+            patch(
+                "control_plane.workflows.dokploy_deploy.dokploy_api.dokploy_request",
+                side_effect=lambda **kwargs: requests.append(kwargs),
+            ),
+            patch(
+                "control_plane.workflows.dokploy_deploy.dokploy_api.update_dokploy_target_env",
+                side_effect=lambda **kwargs: requests.append(kwargs),
+            ),
+            self.assertRaisesRegex(
+                click.ClickException,
+                "requires deploy_reference.*repo:sha-<commit>",
+            ),
+        ):
+            update_dokploy_target_artifact(
+                host="https://dokploy.example.com",
+                token="secret-token",
+                target_type="application",
+                target_id="app-123",
+                artifact_id="ghcr.io/every/example@sha256:"
+                "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+            )
+
+        self.assertEqual(requests, [])
+
+    def test_compose_deploy_keeps_digest_when_deploy_reference_is_present(self) -> None:
+        artifact_id = (
+            "ghcr.io/every/example@sha256:"
+            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+        )
+        ship_request = ShipRequest(
+            artifact_id=artifact_id,
+            deploy_reference="ghcr.io/every/example:sha-abcdef1234567890",
+            context="example",
+            instance="testing",
+            source_git_ref="abcdef1234567890",
+            target_name="example-compose",
+            target_type="compose",
+            provider_id="dokploy",
+            target_category="compose",
+            provider_target_type="compose",
+            deploy_mode="dokploy-compose-api",
+            verify_health=False,
+            destination_health=HealthcheckEvidence(status="skipped"),
+        )
+        resolved_target = ResolvedTargetEvidence(
+            target_type="compose",
+            target_id="compose-123",
+            target_name="example-compose",
+        )
+
+        with (
+            patch(
+                "control_plane.workflows.dokploy_deploy.dokploy_api.latest_deployment_for_target",
+                return_value=None,
+            ),
+            patch(
+                "control_plane.workflows.dokploy_deploy.update_dokploy_target_artifact"
+            ) as update_target,
+            patch("control_plane.workflows.dokploy_deploy.dokploy_api.trigger_deployment"),
+            patch("control_plane.workflows.dokploy_deploy.dokploy_api.wait_for_target_deployment"),
+        ):
+            execute_dokploy_artifact_deploy(
+                host="https://dokploy.example.com",
+                token="secret-token",
+                ship_request=ship_request,
+                resolved_target=resolved_target,
+                deploy_timeout_seconds=60,
+            )
+
+        self.assertEqual(update_target.call_args.kwargs["artifact_id"], artifact_id)
 
 
 if __name__ == "__main__":

--- a/tests/test_generic_web_deploy.py
+++ b/tests/test_generic_web_deploy.py
@@ -401,11 +401,13 @@ class _FakeGenericWebDeployProvider:
         lane: ProductLaneProfile,
         normalized_artifact_id: str,
         fallback_target_name: str,
+        request_deploy_reference: str = "",
     ) -> GenericWebResolvedDeployTarget:
         del control_plane_root, request_artifact_id, record_store, profile, fallback_target_name
         resolved = GenericWebResolvedDeployTarget(
             ship_request=ShipRequest(
                 artifact_id=normalized_artifact_id,
+                deploy_reference=request_deploy_reference,
                 context=lane.context,
                 instance=lane.instance,
                 source_git_ref=request_source_git_ref,
@@ -727,18 +729,71 @@ class GenericWebDeployTests(unittest.TestCase):
             store.deployments[0].delegated_executor,
             "control-plane.fake-cloud",
         )
-        self.assertEqual(store.deployments[0].deploy.provider_id, "fake-cloud")
-        self.assertEqual(store.deployments[0].deploy.target_category, "service")
-        deployed_target = store.deployments[0].deployed_target
-        assert deployed_target is not None
-        self.assertEqual(deployed_target.provider_id, "fake-cloud")
-        self.assertEqual(deployed_target.target_category, "service")
-        self.assertEqual(deployed_target.provider_target_type, "managed-service")
-        self.assertEqual(len(deploy_provider.runtime_identities), 1)
-        self.assertEqual(
-            deploy_provider.runtime_identities[0].deployment_record_id,
-            store.deployments[0].record_id,
+
+    def test_execute_generic_web_deploy_uses_deploy_reference_for_runtime_image(self) -> None:
+        artifact_id = (
+            "ghcr.io/cbusillo/sellyouroutboard@sha256:"
+            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
         )
+        deploy_reference = "ghcr.io/cbusillo/sellyouroutboard:sha-abcdef1234567890"
+        store = _GenericWebDeployStore(_profile())
+        deploy_provider = _FakeGenericWebDeployProvider()
+
+        result = execute_generic_web_deploy(
+            control_plane_root=Path("."),
+            record_store=store,
+            request=GenericWebDeployRequest(
+                product="sellyouroutboard",
+                instance="testing",
+                artifact_id=artifact_id,
+                deploy_reference=deploy_reference,
+                source_git_ref="abcdef1234567890",
+            ),
+            deploy_provider=deploy_provider,
+        )
+
+        self.assertEqual(result.deploy_status, "pass")
+        artifact_identity = store.deployments[0].artifact_identity
+        self.assertIsNotNone(artifact_identity)
+        assert artifact_identity is not None
+        self.assertEqual(artifact_identity.artifact_id, artifact_id)
+        self.assertIsNotNone(store.deployments[0].runtime_identity)
+        assert store.deployments[0].runtime_identity is not None
+        self.assertEqual(store.deployments[0].runtime_identity.artifact_id, artifact_id)
+        self.assertEqual(store.deployments[0].runtime_identity.image_reference, deploy_reference)
+        self.assertEqual(deploy_provider.runtime_identities[0].artifact_id, artifact_id)
+        self.assertEqual(deploy_provider.runtime_identities[0].image_reference, deploy_reference)
+
+    def test_execute_generic_web_deploy_records_invalid_deploy_reference_before_effect(
+        self,
+    ) -> None:
+        artifact_id = (
+            "ghcr.io/cbusillo/sellyouroutboard@sha256:"
+            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+        )
+        store = _GenericWebDeployStore(_profile())
+        deploy_provider = _FakeGenericWebDeployProvider()
+
+        result = execute_generic_web_deploy(
+            control_plane_root=Path("."),
+            record_store=store,
+            request=GenericWebDeployRequest(
+                product="sellyouroutboard",
+                instance="testing",
+                artifact_id=artifact_id,
+                deploy_reference="ghcr.io/cbusillo/other:sha-abcdef1234567890",
+                source_git_ref="abcdef1234567890",
+            ),
+            deploy_provider=deploy_provider,
+        )
+
+        self.assertEqual(result.deploy_status, "fail")
+        self.assertIn("deploy_reference must use the same image repository", result.error_message)
+        self.assertFalse(result.provider_effect_attempted)
+        self.assertEqual(deploy_provider.runtime_identities, [])
+        self.assertEqual(len(store.deployments), 1)
+        self.assertEqual(store.deployments[0].deploy.status, "fail")
+        self.assertIsNone(store.deployments[0].runtime_identity)
 
     def test_execute_generic_web_deploy_records_failure_for_missing_image_profile(
         self,
@@ -1049,6 +1104,7 @@ class GenericWebDeployTests(unittest.TestCase):
                 lane: ProductLaneProfile,
                 normalized_artifact_id: str,
                 fallback_target_name: str,
+                request_deploy_reference: str = "",
             ) -> GenericWebResolvedDeployTarget:
                 del (
                     control_plane_root,
@@ -1060,6 +1116,7 @@ class GenericWebDeployTests(unittest.TestCase):
                     profile,
                     lane,
                     normalized_artifact_id,
+                    request_deploy_reference,
                     fallback_target_name,
                 )
                 raise click.ClickException("target missing")
@@ -1116,6 +1173,7 @@ class GenericWebDeployTests(unittest.TestCase):
                 ),
                 deploy_provider=_FakeGenericWebDeployProvider(),
             )
+        self.assertEqual(store.deployments, [])
 
         self.assertEqual(store.deployments, [])
 

--- a/tests/test_generic_web_http.py
+++ b/tests/test_generic_web_http.py
@@ -888,6 +888,15 @@ class GenericWebHttpTests(unittest.TestCase):
                     target_id="app-prod",
                     target_name="syo-prod-app",
                 ),
+                runtime_identity=RuntimeIdentity(
+                    product="sellyouroutboard",
+                    context="sellyouroutboard-testing",
+                    instance="prod",
+                    deployment_record_id="deployment-syo-prod-previous",
+                    artifact_id="ghcr.io/cbusillo/sellyouroutboard@sha256:abc123",
+                    source_git_ref="abc123",
+                    image_reference="ghcr.io/cbusillo/sellyouroutboard:sha-abc123",
+                ),
                 deploy=DeploymentEvidence(
                     target_name="syo-prod-app",
                     target_type="application",
@@ -1078,6 +1087,15 @@ class GenericWebHttpTests(unittest.TestCase):
                         target_type="application",
                         target_id="app-prod",
                         target_name="syo-prod-app",
+                    ),
+                    runtime_identity=RuntimeIdentity(
+                        product="sellyouroutboard",
+                        context="sellyouroutboard-testing",
+                        instance="prod",
+                        deployment_record_id="deployment-syo-prod-previous",
+                        artifact_id="ghcr.io/cbusillo/sellyouroutboard@sha256:abc123",
+                        source_git_ref="abc123",
+                        image_reference="ghcr.io/cbusillo/sellyouroutboard:sha-abc123",
                     ),
                     deploy=DeploymentEvidence(
                         target_name="syo-prod-app",
@@ -3435,11 +3453,13 @@ class GenericWebHttpTests(unittest.TestCase):
             store = FilesystemRecordStore(state_dir=state_dir)
             profile = LaunchplaneProductProfileRecord.model_validate(_product_profile_payload())
             profile = profile.model_copy(
-                update={"preview": profile.preview.model_copy(update={"slug_template": "preview-{number}"})}
+                update={
+                    "preview": profile.preview.model_copy(
+                        update={"slug_template": "preview-{number}"}
+                    )
+                }
             )
-            store.write_product_profile_record(
-                profile
-            )
+            store.write_product_profile_record(profile)
             policy = LaunchplaneAuthzPolicy.model_validate(
                 {
                     "github_actions": [
@@ -3533,7 +3553,9 @@ class GenericWebHttpTests(unittest.TestCase):
                             },
                         },
                         authorization="Bearer valid-token",
-                        headers={"Idempotency-Key": "generic-web-preview-refresh:syo:pr-42-competing"},
+                        headers={
+                            "Idempotency-Key": "generic-web-preview-refresh:syo:pr-42-competing"
+                        },
                     ),
                     timeout=0.5,
                 )

--- a/tests/test_generic_web_promotion.py
+++ b/tests/test_generic_web_promotion.py
@@ -146,17 +146,23 @@ def _request(**overrides: object) -> GenericWebProdPromotionRequest:
     return GenericWebProdPromotionRequest.model_validate(payload)
 
 
-def _deployment_record() -> DeploymentRecord:
+def _deployment_record(
+    *,
+    artifact_id: str = "ghcr.io/cbusillo/sellyouroutboard@sha256:abc123",
+    deploy_reference: str = "",
+) -> DeploymentRecord:
     runtime_identity = RuntimeIdentity(
         product="sellyouroutboard",
         context="sellyouroutboard-testing",
         instance="prod",
         deployment_record_id="deployment-syo-prod",
-        artifact_id="ghcr.io/cbusillo/sellyouroutboard@sha256:abc123",
+        artifact_id=artifact_id,
+        image_reference=deploy_reference or artifact_id,
         source_git_ref="abc123",
     )
     ship_request = ShipRequest(
-        artifact_id="ghcr.io/cbusillo/sellyouroutboard@sha256:abc123",
+        artifact_id=artifact_id,
+        deploy_reference=deploy_reference,
         context="sellyouroutboard-testing",
         instance="prod",
         source_git_ref="abc123",
@@ -581,6 +587,101 @@ class GenericWebProdPromotionTests(unittest.TestCase):
         )
         self.assertEqual(result.source_git_ref, "abc123")
         self.assertEqual(result.promotion_status, "pending")
+
+    def test_dry_run_prefers_explicit_deploy_reference_over_inventory_fallback(self) -> None:
+        store = _GenericWebPromotionStore(_profile())
+        artifact_id = f"ghcr.io/cbusillo/sellyouroutboard@sha256:{'a' * 64}"
+        inventory_reference = "ghcr.io/cbusillo/sellyouroutboard:sha-inventory"
+        request_reference = "ghcr.io/cbusillo/sellyouroutboard:sha-request"
+        store.write_environment_inventory(
+            _testing_inventory(
+                artifact_identity=ArtifactIdentityReference(artifact_id=artifact_id),
+                runtime_identity=RuntimeIdentity(
+                    product="sellyouroutboard",
+                    context="sellyouroutboard-testing",
+                    instance="testing",
+                    deployment_record_id="deployment-syo-testing",
+                    artifact_id=artifact_id,
+                    image_reference=inventory_reference,
+                    source_git_ref="abc123",
+                ),
+            )
+        )
+
+        result = execute_generic_web_prod_promotion(
+            control_plane_root=Path("."),
+            record_store=store,
+            request=_request(
+                artifact_id=artifact_id,
+                deploy_reference=request_reference,
+                dry_run=True,
+            ),
+        )
+
+        self.assertEqual(result.deploy_reference, request_reference)
+
+    def test_execute_passes_deploy_reference_to_deploy(self) -> None:
+        store = _GenericWebPromotionStore(_profile())
+        artifact_id = f"ghcr.io/cbusillo/sellyouroutboard@sha256:{'a' * 64}"
+        deploy_reference = "ghcr.io/cbusillo/sellyouroutboard:sha-request"
+        store.write_environment_inventory(
+            _testing_inventory(
+                artifact_identity=ArtifactIdentityReference(artifact_id=artifact_id),
+                runtime_identity=RuntimeIdentity(
+                    product="sellyouroutboard",
+                    context="sellyouroutboard-testing",
+                    instance="testing",
+                    deployment_record_id="deployment-syo-testing",
+                    artifact_id=artifact_id,
+                    image_reference=deploy_reference,
+                    source_git_ref="abc123",
+                ),
+            )
+        )
+
+        def fake_deploy(**kwargs: object) -> GenericWebDeployResult:
+            request = cast(GenericWebDeployRequest, kwargs["request"])
+            self.assertEqual(request.deploy_reference, deploy_reference)
+            store.write_deployment_record(
+                _deployment_record(
+                    artifact_id=artifact_id,
+                    deploy_reference=deploy_reference,
+                )
+            )
+            return _deploy_result()
+
+        with (
+            patch(
+                "control_plane.workflows.generic_web_promotion.execute_generic_web_deploy",
+                side_effect=fake_deploy,
+            ),
+            patch(
+                "control_plane.workflows.generic_web_promotion._wait_for_healthcheck",
+                return_value=None,
+            ),
+            patch(
+                "control_plane.workflows.generic_web_promotion.wait_for_runtime_identity_healthcheck_with_retry",
+                return_value=HealthcheckPass(
+                    payload={
+                        "runtime_identity": _runtime_identity_payload(
+                            artifact_id=artifact_id,
+                            image_reference=deploy_reference,
+                        )
+                    }
+                ),
+            ),
+        ):
+            result = execute_generic_web_prod_promotion(
+                control_plane_root=Path("."),
+                record_store=store,
+                request=_request(
+                    artifact_id=artifact_id,
+                    deploy_reference=deploy_reference,
+                ),
+            )
+
+        self.assertEqual(result.promotion_status, "pass")
+        self.assertEqual(result.deploy_reference, deploy_reference)
 
     def test_dry_run_rejects_release_tag_mismatch_before_mutation(self) -> None:
         store = _GenericWebPromotionStore(_profile())

--- a/tests/test_generic_web_rollback.py
+++ b/tests/test_generic_web_rollback.py
@@ -133,14 +133,17 @@ def _deployment_record(**overrides: object) -> DeploymentRecord:
     deploy_status = cast(
         Literal["pending", "pass", "fail", "skipped"], overrides.pop("deploy_status", "pass")
     )
-    runtime_identity = RuntimeIdentity(
-        product="sellyouroutboard",
-        context=context,
-        instance=instance,
-        deployment_record_id="deployment-syo-prod-previous",
-        artifact_id=artifact_id,
-        source_git_ref=source_git_ref,
-    )
+    runtime_identity = cast(RuntimeIdentity | None, overrides.pop("runtime_identity", None))
+    if runtime_identity is None:
+        runtime_identity = RuntimeIdentity(
+            product="sellyouroutboard",
+            context=context,
+            instance=instance,
+            deployment_record_id="deployment-syo-prod-previous",
+            artifact_id=artifact_id,
+            source_git_ref=source_git_ref,
+            image_reference="ghcr.io/cbusillo/sellyouroutboard:sha-abc123",
+        )
     ship_request = ShipRequest(
         artifact_id=artifact_id,
         context=context,
@@ -303,7 +306,54 @@ class GenericWebRollbackPlanTests(unittest.TestCase):
             "ghcr.io/cbusillo/sellyouroutboard@sha256:abc123",
         )
         self.assertEqual(planned_deploy.source_git_ref, "abc123")
+        self.assertEqual(
+            planned_deploy.deploy_reference,
+            "ghcr.io/cbusillo/sellyouroutboard:sha-abc123",
+        )
         self.assertEqual(plan.backup_gate.status, "skipped")
+
+    def test_plan_blocks_application_digest_without_deploy_reference(self) -> None:
+        artifact_id = "ghcr.io/cbusillo/sellyouroutboard@sha256:abc123"
+        store = _GenericWebRollbackStore(_profile())
+        store.deployments["deployment-syo-prod-previous"] = _deployment_record(
+            runtime_identity=RuntimeIdentity(
+                product="sellyouroutboard",
+                context="sellyouroutboard-testing",
+                instance="prod",
+                deployment_record_id="deployment-syo-prod-previous",
+                artifact_id=artifact_id,
+                source_git_ref="abc123",
+            )
+        )
+
+        plan = build_generic_web_rollback_plan(record_store=store, request=_request())
+
+        self.assertEqual(plan.status, "blocked")
+        self.assertIsNone(plan.planned_deploy)
+        self.assertIn("missing_deploy_reference", [blocker.code for blocker in plan.blockers])
+
+    def test_plan_preserves_provider_deploy_reference_for_digest_identity(self) -> None:
+        artifact_id = "ghcr.io/cbusillo/sellyouroutboard@sha256:abc123"
+        deploy_reference = "ghcr.io/cbusillo/sellyouroutboard:sha-abcdef1234567890"
+        store = _GenericWebRollbackStore(_profile())
+        store.deployments["deployment-syo-prod-previous"] = _deployment_record(
+            runtime_identity=RuntimeIdentity(
+                product="sellyouroutboard",
+                context="sellyouroutboard-testing",
+                instance="prod",
+                deployment_record_id="deployment-syo-prod-previous",
+                artifact_id=artifact_id,
+                source_git_ref="abc123",
+                image_reference=deploy_reference,
+            )
+        )
+
+        plan = build_generic_web_rollback_plan(record_store=store, request=_request())
+
+        self.assertIsNotNone(plan.planned_deploy)
+        assert plan.planned_deploy is not None
+        self.assertEqual(plan.planned_deploy.artifact_id, artifact_id)
+        self.assertEqual(plan.planned_deploy.deploy_reference, deploy_reference)
 
     def test_execute_writes_ready_plan_record(self) -> None:
         store = _GenericWebRollbackStore(_profile())
@@ -367,9 +417,56 @@ class GenericWebRollbackPlanTests(unittest.TestCase):
             deploy_request.artifact_id,
             "ghcr.io/cbusillo/sellyouroutboard@sha256:abc123",
         )
+        self.assertEqual(
+            deploy_request.deploy_reference,
+            "ghcr.io/cbusillo/sellyouroutboard:sha-abc123",
+        )
         self.assertEqual(deploy_request.source_git_ref, "abc123")
         self.assertEqual(deploy_request.timeout_seconds, 90)
         self.assertTrue(deploy_request.no_cache)
+
+    def test_execute_apply_passes_rollback_deploy_reference(self) -> None:
+        artifact_id = "ghcr.io/cbusillo/sellyouroutboard@sha256:abc123"
+        deploy_reference = "ghcr.io/cbusillo/sellyouroutboard:sha-abcdef1234567890"
+        store = _GenericWebRollbackStore(_profile())
+        store.deployments["deployment-syo-prod-previous"] = _deployment_record(
+            runtime_identity=RuntimeIdentity(
+                product="sellyouroutboard",
+                context="sellyouroutboard-testing",
+                instance="prod",
+                deployment_record_id="deployment-syo-prod-previous",
+                artifact_id=artifact_id,
+                source_git_ref="abc123",
+                image_reference=deploy_reference,
+            )
+        )
+
+        with patch(
+            "control_plane.workflows.generic_web_rollback.execute_generic_web_deploy",
+            return_value=GenericWebDeployResult(
+                deployment_record_id="deployment-syo-prod-rollback",
+                deploy_status="pass",
+                deploy_started_at="2026-05-25T12:00:00Z",
+                deploy_finished_at="2026-05-25T12:01:00Z",
+                product="sellyouroutboard",
+                context="sellyouroutboard-testing",
+                instance="prod",
+                target_name="syo-prod-app",
+                target_category="application",
+                provider_id="dokploy",
+                provider_target_type="application",
+                target_id="app-prod",
+            ),
+        ) as deploy:
+            execute_generic_web_rollback(
+                control_plane_root=Path("/tmp/launchplane"),
+                record_store=store,
+                request=_request(),
+            )
+
+        deploy_request = deploy.call_args.kwargs["request"]
+        self.assertEqual(deploy_request.artifact_id, artifact_id)
+        self.assertEqual(deploy_request.deploy_reference, deploy_reference)
 
     def test_execute_apply_forwards_post_deploy_extension_to_generic_deploy(self) -> None:
         store = _GenericWebRollbackStore(_profile())

--- a/tests/test_product_promotion_http.py
+++ b/tests/test_product_promotion_http.py
@@ -90,6 +90,9 @@ NOW = datetime(2026, 7, 15, 9, 0, tzinfo=UTC)
 TESTING_ARTIFACT = f"ghcr.io/example/atlas-commerce@sha256:{'a' * 64}"
 PROD_ARTIFACT = f"ghcr.io/example/atlas-commerce@sha256:{'b' * 64}"
 NEW_TESTING_ARTIFACT = f"ghcr.io/example/atlas-commerce@sha256:{'c' * 64}"
+TESTING_DEPLOY_REFERENCE = (
+    "ghcr.io/example/atlas-commerce:sha-1111111111111111111111111111111111111111"
+)
 TESTING_SOURCE_REF = "1" * 40
 PROD_SOURCE_REF = "2" * 40
 NEW_TESTING_SOURCE_REF = "3" * 40
@@ -173,6 +176,7 @@ def _inventory(
     instance: str,
     artifact_id: str,
     source_git_ref: str,
+    image_reference: str = "",
     updated_at: str = "2026-07-15T08:45:00Z",
 ) -> EnvironmentInventory:
     deployment_record_id = f"deployment-{instance}"
@@ -182,6 +186,7 @@ def _inventory(
         instance=instance,
         deployment_record_id=deployment_record_id,
         artifact_id=artifact_id,
+        image_reference=image_reference,
         source_git_ref=source_git_ref,
     )
     return EnvironmentInventory(
@@ -814,7 +819,16 @@ class ProductPromotionRequestTests(unittest.TestCase):
             )
 
     def test_workflow_request_carries_reviewed_runtime_identity(self) -> None:
-        profile, _, status = _status(_store())
+        profile, _, status = _status(
+            _store(
+                testing_inventory=_inventory(
+                    instance="testing",
+                    artifact_id=TESTING_ARTIFACT,
+                    image_reference=TESTING_DEPLOY_REFERENCE,
+                    source_git_ref=TESTING_SOURCE_REF,
+                )
+            )
+        )
         request = ProductPromotionWorkflowDispatchEnvelope(
             dry_run=False,
             reason="Ship reviewed release",
@@ -835,13 +849,24 @@ class ProductPromotionRequestTests(unittest.TestCase):
         )
 
         self.assertEqual(envelope.workflow.artifact_id, status.source.artifact_id)
+        self.assertEqual(envelope.workflow.deploy_reference, TESTING_DEPLOY_REFERENCE)
         self.assertEqual(envelope.workflow.source_git_ref, status.source.source_git_ref)
         self.assertNotIn("artifact_id", payload)
+        self.assertNotIn("deploy_reference", payload)
         self.assertNotIn("source_git_ref", payload)
         self.assertNotIn("context", payload)
 
     def test_product_promotion_intent_binds_current_target_evidence(self) -> None:
-        profile, _, status = _status(_store())
+        profile, _, status = _status(
+            _store(
+                testing_inventory=_inventory(
+                    instance="testing",
+                    artifact_id=TESTING_ARTIFACT,
+                    image_reference=TESTING_DEPLOY_REFERENCE,
+                    source_git_ref=TESTING_SOURCE_REF,
+                )
+            )
+        )
         workflow_request = ProductPromotionWorkflowDispatchEnvelope(
             dry_run=False,
             reason="Ship reviewed release",
@@ -866,6 +891,7 @@ class ProductPromotionRequestTests(unittest.TestCase):
         request = GenericWebProdPromotionRequest(
             product=profile.product,
             artifact_id=status.source.artifact_id,
+            deploy_reference=status.source.deploy_reference,
             source_git_ref=status.source.source_git_ref,
             promotion_intent_id=delivery.delivery_id,
         )

--- a/tests/test_verireel_testing_deploy.py
+++ b/tests/test_verireel_testing_deploy.py
@@ -113,6 +113,93 @@ class VeriReelTestingDeployWorkflowTests(unittest.TestCase):
             self.assertEqual(deployment.runtime_identity.source_git_ref, request.source_git_ref)
             self.assertEqual(result.rollout_status, "pass")
 
+    def test_execute_keeps_digest_identity_and_provider_deploy_reference(self) -> None:
+        artifact_id = (
+            "ghcr.io/every/verireel-app@sha256:"
+            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+        )
+        deploy_reference = "ghcr.io/every/verireel-app:sha-abcdef1234567890abcdef1234567890abcdef12"
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=root / "state")
+            request = VeriReelStableDeployRequest(
+                artifact_id=artifact_id,
+                deploy_reference=deploy_reference,
+                source_git_ref="abcdef1234567890abcdef1234567890abcdef12",
+            )
+            ship_request = ShipRequest(
+                artifact_id=artifact_id,
+                deploy_reference=deploy_reference,
+                context="verireel",
+                instance="testing",
+                source_git_ref=request.source_git_ref,
+                target_name="ver-testing-app",
+                target_type="application",
+                provider_id="dokploy",
+                target_category="application",
+                provider_target_type="application",
+                deploy_mode="dokploy-application-api",
+                wait=True,
+                verify_health=False,
+                destination_health=HealthcheckEvidence(status="skipped"),
+            )
+
+            with (
+                patch(
+                    "control_plane.workflows.verireel_stable_deploy.generate_deployment_record_id",
+                    return_value="deployment-verireel-testing-run-12345-attempt-1",
+                ),
+                patch(
+                    "control_plane.workflows.verireel_stable_deploy.utc_now_timestamp",
+                    side_effect=[
+                        "2026-04-20T18:20:00Z",
+                        "2026-04-20T18:21:15Z",
+                    ],
+                ),
+                patch(
+                    "control_plane.workflows.verireel_stable_deploy._resolve_ship_request",
+                    return_value=(
+                        ship_request,
+                        ResolvedTargetEvidence(
+                            target_type="application",
+                            target_id="testing-app-123",
+                            target_name="ver-testing-app",
+                        ),
+                        300,
+                    ),
+                ),
+                patch("control_plane.workflows.verireel_stable_deploy._execute_dokploy_deploy"),
+                patch(
+                    "control_plane.workflows.verireel_stable_deploy._verify_rollout",
+                    return_value=VeriReelRolloutVerificationResult(
+                        status="pass",
+                        base_url="https://ver-testing.shinycomputers.com",
+                        health_urls=("https://ver-testing.shinycomputers.com/api/health",),
+                    ),
+                ) as verify_rollout,
+            ):
+                execute_verireel_stable_deploy(
+                    control_plane_root=root,
+                    record_store=store,
+                    request=request,
+                )
+
+            deployment = store.read_deployment_record(
+                "deployment-verireel-testing-run-12345-attempt-1"
+            )
+            self.assertIsNotNone(deployment.artifact_identity)
+            assert deployment.artifact_identity is not None
+            self.assertEqual(deployment.artifact_identity.artifact_id, artifact_id)
+            self.assertIsNotNone(deployment.runtime_identity)
+            assert deployment.runtime_identity is not None
+            self.assertEqual(deployment.runtime_identity.artifact_id, artifact_id)
+            self.assertEqual(deployment.runtime_identity.image_reference, deploy_reference)
+            verify_rollout.assert_called_once()
+            self.assertEqual(
+                verify_rollout.call_args.kwargs["request"].expected_build_tag,
+                "",
+            )
+
     def test_execute_writes_failed_deployment_record(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)
@@ -192,7 +279,9 @@ class VeriReelTestingDeployWorkflowTests(unittest.TestCase):
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)
             ship_request = ShipRequest(
-                artifact_id="ghcr.io/every/verireel-app:sha-abcdef1234567890",
+                artifact_id="ghcr.io/every/verireel-app@sha256:"
+                "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+                deploy_reference="ghcr.io/every/verireel-app:sha-abcdef1234567890",
                 context="verireel",
                 instance="testing",
                 source_git_ref="abcdef1234567890",


### PR DESCRIPTION
## Summary
- preserve digest-pinned `artifact_id` as canonical deployment evidence
- add validated immutable `deploy_reference` for provider paths that cannot consume digests
- keep Dokploy application deploys on SHA tags while compose targets remain digest-pinned
- carry the provider reference through runtime identity, promotion, rollback, and cleanup protection
- fail legacy application rollback plans before provider mutation when no deploy reference exists

## Root cause
Dokploy Registry Swarm successfully pulled the verified `repository@sha256:digest`, then failed while re-tagging it with `refusing to create a tag with a digest reference`. Historical successful deployments used immutable `repository:sha-<gitsha>` tags.

## Validation
- focused deploy/reference/rollback suites: 44 tests passed
- full local unittest gate: 12/12 shards, 2,724 targets passed
- Ruff lint and changed-file format checks passed
- OpenAPI drift check passed
- actionlint passed on changed reusable workflows
- `git diff --check` passed
- exact-head Opus review approved; follow-up compose/idempotency/legacy-rollback findings were fixed and the full suite rerun

## Inspection
JetBrains inspection was attempted three times and remained `UNKNOWN` because the helper exceeded its proof-file capture limit. It reported zero problems but did not produce a trusted GREEN/RED verdict.

Refs cbusillo/verireel#303