### PR TITLE
Add scoped preview ingress authorization

### DIFF
--- a/.github/workflows/generic-web-preview-authorization.yml
+++ b/.github/workflows/generic-web-preview-authorization.yml
@@ -33,6 +33,17 @@ name: Generic Web Preview Authorization
         required: false
         default: ""
         type: string
+      launchplane_sha:
+        description: >-
+          Reviewed Launchplane reusable-workflow SHA; defaults to this workflow revision.
+        required: false
+        default: ""
+        type: string
+      include_ingress_operator:
+        description: Temporarily include scoped preview-ingress plan/apply rules.
+        required: false
+        default: false
+        type: boolean
       confirmation:
         description: Type APPLY GENERIC WEB PREVIEW AUTHORIZATION when mode=apply.
         required: false
@@ -68,6 +79,8 @@ jobs:
       PRODUCT: ${{ inputs.product }}
       REPOSITORY: ${{ inputs.repository }}
       PREVIEW_CONTEXT: ${{ inputs.preview_context }}
+      LAUNCHPLANE_SHA: ${{ inputs.launchplane_sha }}
+      INCLUDE_INGRESS_OPERATOR: ${{ inputs.include_ingress_operator }}
       CONFIRMATION: ${{ inputs.confirmation }}
       REASON: ${{ inputs.reason }}
       RELATED_ISSUE: ${{ inputs.related_issue }}
@@ -113,6 +126,12 @@ jobs:
           if repository_match is None:
               raise SystemExit("repository must use owner/name form.")
           preview_context = optional("PREVIEW_CONTEXT") or f"{product}-preview"
+          launchplane_sha = (optional("LAUNCHPLANE_SHA", 40) or os.environ["GITHUB_SHA"]).lower()
+          if re.fullmatch(r"[0-9a-f]{40}", launchplane_sha) is None:
+              raise SystemExit("launchplane_sha must be a full commit SHA when provided.")
+          include_ingress_operator = required("INCLUDE_INGRESS_OPERATOR", 5).lower()
+          if include_ingress_operator not in {"true", "false"}:
+              raise SystemExit("include_ingress_operator must be true or false.")
           required("REASON")
           required("RELATED_ISSUE")
           with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as handle:
@@ -120,6 +139,7 @@ jobs:
               handle.write(f"repository_owner={repository_match.group(1)}\n")
               handle.write(f"repository_name={repository_match.group(2)}\n")
               handle.write(f"preview_context={preview_context}\n")
+              handle.write(f"launchplane_sha={launchplane_sha}\n")
           PY
 
       - name: Mint repository metadata token
@@ -163,6 +183,7 @@ jobs:
           DEFAULT_BRANCH: ${{ steps.repository.outputs.default_branch }}
           NORMALIZED_PRODUCT: ${{ steps.inputs.outputs.product }}
           NORMALIZED_PREVIEW_CONTEXT: ${{ steps.inputs.outputs.preview_context }}
+          NORMALIZED_LAUNCHPLANE_SHA: ${{ steps.inputs.outputs.launchplane_sha }}
           REPOSITORY_ID: ${{ steps.repository.outputs.repository_id }}
           REPOSITORY_OWNER_ID: ${{ steps.repository.outputs.repository_owner_id }}
         run: |
@@ -175,14 +196,16 @@ jobs:
             --arg repository_owner_id "$REPOSITORY_OWNER_ID" \
             --arg default_branch "$DEFAULT_BRANCH" \
             --arg preview_context "$NORMALIZED_PREVIEW_CONTEXT" \
-            --arg launchplane_sha "$GITHUB_SHA" \
+            --arg launchplane_sha "$NORMALIZED_LAUNCHPLANE_SHA" \
+            --argjson include_ingress_operator "$INCLUDE_INGRESS_OPERATOR" \
             --arg reason "$REASON" \
             --arg related_issue "$RELATED_ISSUE" \
             '{schema_version:1, product:"launchplane", operation:$operation,
               target_product:$target_product, repository:$repository,
               repository_id:$repository_id, repository_owner_id:$repository_owner_id,
               default_branch:$default_branch, preview_context:$preview_context,
-              launchplane_sha:$launchplane_sha, reason:$reason,
+              launchplane_sha:$launchplane_sha,
+              include_ingress_operator:$include_ingress_operator, reason:$reason,
               related_issue:$related_issue}' \
             > authz-plan-request.json
 
@@ -202,6 +225,7 @@ jobs:
         shell: bash
         env:
           NORMALIZED_PRODUCT: ${{ steps.inputs.outputs.product }}
+          NORMALIZED_LAUNCHPLANE_SHA: ${{ steps.inputs.outputs.launchplane_sha }}
         run: |
           set -euo pipefail
           plan_sha256="$(jq -r '.result.plan_sha256 // empty' authz-plan.json)"
@@ -216,7 +240,8 @@ jobs:
             echo
             echo "- Product: $NORMALIZED_PRODUCT"
             echo "- Operation: $OPERATION"
-            echo "- Launchplane worker SHA: \`$GITHUB_SHA\`"
+            echo "- Launchplane worker SHA: \`$NORMALIZED_LAUNCHPLANE_SHA\`"
+            echo "- Include ingress operator: $INCLUDE_INGRESS_OPERATOR"
             echo "- Plan: \`$plan_sha256\`"
             echo "- Rules added: $(jq -r '.result.diff.added_rule_count' authz-plan.json)"
             echo "- Rules removed: $(jq -r '.result.diff.removed_rule_count' authz-plan.json)"

--- a/control_plane/generic_web_preview_authz.py
+++ b/control_plane/generic_web_preview_authz.py
@@ -12,6 +12,13 @@ from control_plane.service_auth import GitHubActionsPolicyRule, LaunchplaneAuthz
 GENERIC_WEB_PREVIEW_MANAGED_SET_ID = "operator.generic-web-preview"
 GENERIC_WEB_PREVIEW_CALLER_WORKFLOW_PATH = ".github/workflows/launchplane-preview.yml"
 GENERIC_WEB_PREVIEW_NOTICE_WORKFLOW_PATH = ".github/workflows/launchplane-preview-notice.yml"
+_LAUNCHPLANE_REPOSITORY = "cbusillo/launchplane"
+_INGRESS_PLAN_WORKFLOW_REF = (
+    f"{_LAUNCHPLANE_REPOSITORY}/.github/workflows/ingress-route-dry-run.yml@refs/heads/main"
+)
+_INGRESS_APPLY_WORKFLOW_REF = (
+    f"{_LAUNCHPLANE_REPOSITORY}/.github/workflows/ingress-route-apply.yml@refs/heads/main"
+)
 _PRODUCT_PATTERN = re.compile(r"^[a-z0-9][a-z0-9-]{0,62}$")
 _REPOSITORY_PATTERN = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
 _COMMIT_SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
@@ -32,6 +39,7 @@ class GenericWebPreviewAuthzPlanRequest(BaseModel):
     default_branch: str = "main"
     preview_context: str = ""
     launchplane_sha: str
+    include_ingress_operator: bool = False
     reason: str
     related_issue: str
 
@@ -118,7 +126,10 @@ def build_generic_web_preview_authz_reconcile_request(
         rule for rule in retained_github_rules if request.target_product in rule.products
     )
     if request.operation == "onboard" and current_target_rules:
-        generated_rules = generic_web_preview_rules(request)
+        generated_rules = _desired_generic_web_preview_rules(
+            current_policy=current_policy,
+            request=request,
+        )
         if _rules_by_managed_id(current_target_rules) != _rules_by_managed_id(generated_rules):
             raise ValueError(
                 "generic-web preview authz onboarding found different current managed preview "
@@ -135,7 +146,10 @@ def build_generic_web_preview_authz_reconcile_request(
         or request.target_product not in rule.products
     )
     if request.operation != "retire":
-        generated_rules = generic_web_preview_rules(request)
+        generated_rules = _desired_generic_web_preview_rules(
+            current_policy=current_policy,
+            request=request,
+        )
         existing_ids = {
             rule.managed_rule_id for rule in desired_github_rules if rule.managed_rule_id
         }
@@ -159,6 +173,97 @@ def build_generic_web_preview_authz_reconcile_request(
         related_issue=request.related_issue,
         desired_policy=desired_policy,
     )
+
+
+def _desired_generic_web_preview_rules(
+    *,
+    current_policy: LaunchplaneAuthzPolicy,
+    request: GenericWebPreviewAuthzPlanRequest,
+) -> tuple[GitHubActionsPolicyRule, ...]:
+    preview_rules = generic_web_preview_rules(request)
+    if not request.include_ingress_operator:
+        return preview_rules
+    return (
+        *preview_rules,
+        *generic_web_preview_ingress_operator_rules(
+            current_policy=current_policy,
+            request=request,
+        ),
+    )
+
+
+def generic_web_preview_ingress_operator_rules(
+    *,
+    current_policy: LaunchplaneAuthzPolicy,
+    request: GenericWebPreviewAuthzPlanRequest,
+) -> tuple[GitHubActionsPolicyRule, ...]:
+    generation = request.launchplane_sha[:7]
+    plan_template = _ingress_operator_rule_template(
+        current_policy=current_policy,
+        action="ingress_route.plan",
+        workflow_ref=_INGRESS_PLAN_WORKFLOW_REF,
+    )
+    apply_template = _ingress_operator_rule_template(
+        current_policy=current_policy,
+        action="ingress_route.apply",
+        workflow_ref=_INGRESS_APPLY_WORKFLOW_REF,
+    )
+
+    def rule(
+        *, slot: str, action: str, template: GitHubActionsPolicyRule
+    ) -> GitHubActionsPolicyRule:
+        return template.model_copy(
+            update={
+                "managed_set_id": GENERIC_WEB_PREVIEW_MANAGED_SET_ID,
+                "managed_rule_id": (
+                    f"generic-web-preview.{request.target_product}.{generation}.{slot}"
+                ),
+                "products": (request.target_product,),
+                "contexts": (request.preview_context,),
+                "instances": (),
+                "actions": (action,),
+            }
+        )
+
+    return (
+        rule(slot="ingress-plan", action="ingress_route.plan", template=plan_template),
+        rule(slot="ingress-apply", action="ingress_route.apply", template=apply_template),
+    )
+
+
+def _ingress_operator_rule_template(
+    *,
+    current_policy: LaunchplaneAuthzPolicy,
+    action: str,
+    workflow_ref: str,
+) -> GitHubActionsPolicyRule:
+    candidates = tuple(
+        rule
+        for rule in current_policy.github_actions
+        if rule.repository == _LAUNCHPLANE_REPOSITORY
+        and rule.workflow_refs == (workflow_ref,)
+        and rule.actions == (action,)
+        and rule.job_workflow_refs
+    )
+    templates = {
+        (
+            rule.repository,
+            rule.repository_id,
+            rule.repository_owner_id,
+            rule.workflow_refs,
+            rule.job_workflow_refs,
+            rule.event_names,
+            rule.refs,
+            rule.environments,
+        ): rule
+        for rule in candidates
+    }
+    if len(templates) != 1:
+        raise ValueError(
+            "generic-web preview ingress authorization requires one unambiguous pinned "
+            f"{action} workflow template in the active policy"
+        )
+    return next(iter(templates.values()))
 
 
 def generic_web_preview_rules(
@@ -194,7 +299,7 @@ def generic_web_preview_rules(
     ) -> GitHubActionsPolicyRule:
         return GitHubActionsPolicyRule(
             managed_set_id=GENERIC_WEB_PREVIEW_MANAGED_SET_ID,
-            managed_rule_id=(f"generic-web-preview.{request.target_product}.{generation}.{slot}"),
+            managed_rule_id=f"generic-web-preview.{request.target_product}.{generation}.{slot}",
             repository=request.repository,
             repository_id=request.repository_id,
             repository_owner_id=request.repository_owner_id,

--- a/docs/new-product-repo.md
+++ b/docs/new-product-repo.md
@@ -78,6 +78,16 @@ an operator-owned manifest that cannot use the conventional path. Direct local
 CLI mutation remains break-glass bootstrap or repair behavior and requires
 `--allow-direct-db-mutation`; it is not an onboarding alternative.
 
+If live proof finds that an existing preview wildcard ingress route needs a
+Launchplane-managed repair, `Generic Web Preview Authorization` can temporarily
+include the scoped `Ingress Route Dry Run` and `Ingress Route Apply` workflow
+rules. Expand with `include_ingress_operator=true` and the exact reviewed
+reusable-workflow SHA, perform the route dry-run/apply, then contract with the
+same SHA and `include_ingress_operator=false`. The planner copies the pinned
+ingress workflow identity from the active policy and fails closed when no single
+template exists; operators do not hand-author authz JSON or edit a per-product
+policy secret.
+
 The conventional product-repo caller files are
 `.github/workflows/launchplane-preview.yml` for pull-request refresh,
 verification, and feedback, and

--- a/frontend/generated/openapi-canonical.json
+++ b/frontend/generated/openapi-canonical.json
@@ -4508,6 +4508,11 @@
             "title": "Default Branch",
             "type": "string"
           },
+          "include_ingress_operator": {
+            "default": false,
+            "title": "Include Ingress Operator",
+            "type": "boolean"
+          },
           "launchplane_sha": {
             "title": "Launchplane Sha",
             "type": "string"

--- a/tests/test_generic_web_preview_authz.py
+++ b/tests/test_generic_web_preview_authz.py
@@ -28,36 +28,37 @@ def _request(**overrides: object) -> GenericWebPreviewAuthzPlanRequest:
 
 
 def _ingress_templates() -> tuple[GitHubActionsPolicyRule, ...]:
-    common = {
-        "repository": "cbusillo/launchplane",
-        "repository_id": "999",
-        "repository_owner_id": "456",
-        "job_workflow_refs": (
-            "cbusillo/launchplane/.github/workflows/reusable-ingress-route-dry-run.yml@" + "b" * 40,
-        ),
-        "event_names": ("workflow_dispatch",),
-        "products": ("template",),
-        "contexts": ("template",),
-    }
     return (
         GitHubActionsPolicyRule(
-            **common,
+            repository="cbusillo/launchplane",
+            repository_id="999",
+            repository_owner_id="456",
             workflow_refs=(
                 "cbusillo/launchplane/.github/workflows/ingress-route-dry-run.yml@refs/heads/main",
             ),
+            job_workflow_refs=(
+                "cbusillo/launchplane/.github/workflows/reusable-ingress-route-dry-run.yml@"
+                + "b" * 40,
+            ),
+            event_names=("workflow_dispatch",),
+            products=("template",),
+            contexts=("template",),
             actions=("ingress_route.plan",),
         ),
         GitHubActionsPolicyRule(
-            **{
-                **common,
-                "job_workflow_refs": (
-                    "cbusillo/launchplane/.github/workflows/"
-                    "reusable-ingress-route-apply.yml@" + "c" * 40,
-                ),
-            },
+            repository="cbusillo/launchplane",
+            repository_id="999",
+            repository_owner_id="456",
             workflow_refs=(
                 "cbusillo/launchplane/.github/workflows/ingress-route-apply.yml@refs/heads/main",
             ),
+            job_workflow_refs=(
+                "cbusillo/launchplane/.github/workflows/reusable-ingress-route-apply.yml@"
+                + "c" * 40,
+            ),
+            event_names=("workflow_dispatch",),
+            products=("template",),
+            contexts=("template",),
             actions=("ingress_route.apply",),
         ),
     )

--- a/tests/test_generic_web_preview_authz.py
+++ b/tests/test_generic_web_preview_authz.py
@@ -1,16 +1,18 @@
 import unittest
+from pathlib import Path
 
 from control_plane.generic_web_preview_authz import (
     GENERIC_WEB_PREVIEW_MANAGED_SET_ID,
     GenericWebPreviewAuthzPlanRequest,
     build_generic_web_preview_authz_reconcile_request,
+    generic_web_preview_ingress_operator_rules,
     generic_web_preview_rules,
 )
-from control_plane.service_auth import LaunchplaneAuthzPolicy
+from control_plane.service_auth import GitHubActionsPolicyRule, LaunchplaneAuthzPolicy
 
 
-def _request(**overrides: str) -> GenericWebPreviewAuthzPlanRequest:
-    values = {
+def _request(**overrides: object) -> GenericWebPreviewAuthzPlanRequest:
+    values: dict[str, object] = {
         "target_product": "demo-web",
         "repository": "example/demo-web",
         "repository_id": "123",
@@ -25,7 +27,51 @@ def _request(**overrides: str) -> GenericWebPreviewAuthzPlanRequest:
     return GenericWebPreviewAuthzPlanRequest.model_validate(values)
 
 
+def _ingress_templates() -> tuple[GitHubActionsPolicyRule, ...]:
+    common = {
+        "repository": "cbusillo/launchplane",
+        "repository_id": "999",
+        "repository_owner_id": "456",
+        "job_workflow_refs": (
+            "cbusillo/launchplane/.github/workflows/reusable-ingress-route-dry-run.yml@" + "b" * 40,
+        ),
+        "event_names": ("workflow_dispatch",),
+        "products": ("template",),
+        "contexts": ("template",),
+    }
+    return (
+        GitHubActionsPolicyRule(
+            **common,
+            workflow_refs=(
+                "cbusillo/launchplane/.github/workflows/ingress-route-dry-run.yml@refs/heads/main",
+            ),
+            actions=("ingress_route.plan",),
+        ),
+        GitHubActionsPolicyRule(
+            **{
+                **common,
+                "job_workflow_refs": (
+                    "cbusillo/launchplane/.github/workflows/"
+                    "reusable-ingress-route-apply.yml@" + "c" * 40,
+                ),
+            },
+            workflow_refs=(
+                "cbusillo/launchplane/.github/workflows/ingress-route-apply.yml@refs/heads/main",
+            ),
+            actions=("ingress_route.apply",),
+        ),
+    )
+
+
 class GenericWebPreviewAuthzTests(unittest.TestCase):
+    def test_operator_workflow_exposes_scoped_ingress_expansion(self) -> None:
+        workflow_text = Path(".github/workflows/generic-web-preview-authorization.yml").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn("include_ingress_operator", workflow_text)
+        self.assertIn("launchplane_sha", workflow_text)
+
     def test_onboarding_generates_exact_six_rule_contract(self) -> None:
         rules = generic_web_preview_rules(_request())
 
@@ -139,6 +185,59 @@ class GenericWebPreviewAuthzTests(unittest.TestCase):
                 for rule in contracted.desired_policy.github_actions
             )
         )
+
+    def test_expand_and_contract_support_temporary_ingress_operator_rules(self) -> None:
+        request = _request()
+        current_policy = LaunchplaneAuthzPolicy(
+            schema_version=2,
+            github_actions=(*generic_web_preview_rules(request), *_ingress_templates()),
+        )
+
+        ingress_rules = generic_web_preview_ingress_operator_rules(
+            current_policy=current_policy,
+            request=_request(include_ingress_operator=True),
+        )
+        self.assertEqual(len(ingress_rules), 2)
+        self.assertEqual(
+            {rule.actions[0] for rule in ingress_rules},
+            {"ingress_route.apply", "ingress_route.plan"},
+        )
+        for rule in ingress_rules:
+            self.assertEqual(rule.repository, "cbusillo/launchplane")
+            self.assertEqual(rule.repository_id, "999")
+            self.assertEqual(rule.repository_owner_id, "456")
+            self.assertEqual(rule.products, ("demo-web",))
+            self.assertEqual(rule.contexts, ("demo-web-preview",))
+            self.assertEqual(rule.event_names, ("workflow_dispatch",))
+            self.assertTrue(rule.job_workflow_refs)
+
+        expanded = build_generic_web_preview_authz_reconcile_request(
+            current_policy=current_policy,
+            request=_request(operation="expand", include_ingress_operator=True),
+        )
+        self.assertEqual(len(expanded.desired_policy.github_actions), 8)
+
+        contracted = build_generic_web_preview_authz_reconcile_request(
+            current_policy=expanded.desired_policy,
+            request=_request(operation="contract"),
+        )
+        self.assertEqual(len(contracted.desired_policy.github_actions), 6)
+        self.assertFalse(
+            any(
+                rule.actions[0].startswith("ingress_route.")
+                for rule in contracted.desired_policy.github_actions
+            )
+        )
+
+    def test_ingress_operator_expansion_requires_pinned_templates(self) -> None:
+        with self.assertRaisesRegex(ValueError, "requires one unambiguous pinned"):
+            build_generic_web_preview_authz_reconcile_request(
+                current_policy=LaunchplaneAuthzPolicy(
+                    schema_version=2,
+                    github_actions=generic_web_preview_rules(_request()),
+                ),
+                request=_request(operation="expand", include_ingress_operator=True),
+            )
 
     def test_retire_removes_only_target_product(self) -> None:
         target = _request()


### PR DESCRIPTION
## Summary
- allow the typed generic-web preview authz planner to temporarily include pinned ingress plan/apply rules
- copy immutable operator workflow identity from the active policy and fail closed on ambiguity
- support contracting back to the normal six preview rules without hand-authored policy JSON

## Validation
- `uv run --extra dev python -m unittest tests.test_generic_web_preview_authz tests.test_product_onboarding`
- `uv run --extra dev ruff check control_plane/generic_web_preview_authz.py tests/test_generic_web_preview_authz.py`
- `uv run --extra dev ruff format --check control_plane/generic_web_preview_authz.py tests/test_generic_web_preview_authz.py`
- `actionlint -no-color .github/workflows/generic-web-preview-authorization.yml`

Closes no issue; supports #1986.