### PR TITLE
Fix NPMplus null locations response handling

### DIFF
--- a/control_plane/npmplus.py
+++ b/control_plane/npmplus.py
@@ -118,6 +118,11 @@ class NpmplusProxyHost(NpmplusProxyHostPayload):
     id: int = Field(ge=1)
     locations: tuple[NpmplusLocation, ...] = ()
 
+    @field_validator("locations", mode="before")
+    @classmethod
+    def _normalize_null_locations(cls, value: object) -> object:
+        return () if value is None else value
+
 
 @dataclass(frozen=True)
 class NpmplusCredentials:

--- a/tests/test_npmplus.py
+++ b/tests/test_npmplus.py
@@ -266,6 +266,15 @@ class NpmplusClientTests(unittest.TestCase):
         with self.assertRaises(click.ClickException):
             client.list_proxy_hosts()
 
+    def test_list_proxy_hosts_normalizes_null_locations(self) -> None:
+        opener = _Opener()
+        opener.proxy_hosts_payload = [{**_proxy_host_payload(id=78), "locations": None}]
+        client = NpmplusClient(credentials=_credentials(), opener=opener)
+
+        proxy_hosts = client.list_proxy_hosts()
+
+        self.assertEqual(proxy_hosts[0].locations, ())
+
     def test_credentials_fail_closed_for_missing_secret(self) -> None:
         with self.assertRaises(ValueError):
             NpmplusCredentials(base_url="https://npmplus.example.test", identity="user", secret="")


### PR DESCRIPTION
## Summary
- normalize `locations: null` from NPMplus proxy-host responses to an empty tuple
- keep operator-authored proxy-host payloads strict
- add client-level regression coverage

## Validation
- `uv run --extra dev python -m unittest tests.test_npmplus tests.test_npmplus_ingress_workflow`
- `uv run --extra dev launchplane ci unittest-shard local`
- `uv run --extra dev ruff check control_plane/npmplus.py tests/test_npmplus.py`
- `uv run --extra dev ruff format --check control_plane/npmplus.py tests/test_npmplus.py`
- `uv run --extra dev mypy control_plane/npmplus.py tests/test_npmplus.py`

Supports the issue #1986 preview ingress proof.