### PR TITLE
Fix NPMplus access-list API payload mapping

### DIFF
--- a/control_plane/npmplus.py
+++ b/control_plane/npmplus.py
@@ -109,7 +109,18 @@ class NpmplusProxyHostPayload(BaseModel):
         return self
 
     def to_api_payload(self) -> JsonObject:
-        return self.model_dump(mode="json", exclude={"locations": {"__all__": {"id"}}})
+        payload = self.model_dump(
+            mode="json",
+            exclude={
+                "access_list_id": True,
+                "locations": {"__all__": {"id"}},
+            },
+        )
+        payload["npmplus_access_list_ids"] = (
+            [] if self.access_list_id == 0 else [self.access_list_id]
+        )
+        payload["npmplus_access_list_type"] = "public" if self.access_list_id == 0 else "custom"
+        return payload
 
 
 class NpmplusProxyHost(NpmplusProxyHostPayload):
@@ -117,6 +128,38 @@ class NpmplusProxyHost(NpmplusProxyHostPayload):
 
     id: int = Field(ge=1)
     locations: tuple[NpmplusLocation, ...] = ()
+
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize_access_list_fields(cls, value: object) -> object:
+        if not isinstance(value, dict):
+            return value
+        access_list_ids = value.get("npmplus_access_list_ids")
+        access_list_type = value.get("npmplus_access_list_type")
+        if access_list_ids is None and access_list_type is None:
+            return value
+        if access_list_ids is None or access_list_type is None:
+            raise ValueError("NPMplus proxy host access-list fields must be provided together")
+        if not isinstance(access_list_ids, list) or any(
+            isinstance(access_list_id, bool)
+            or not isinstance(access_list_id, int)
+            or access_list_id < 1
+            for access_list_id in access_list_ids
+        ):
+            raise ValueError("NPMplus proxy host access-list ids must be positive integers")
+        if access_list_type == "public":
+            if access_list_ids:
+                raise ValueError("Public NPMplus proxy hosts cannot reference access-list ids")
+            normalized_access_list_id = 0
+        elif access_list_type == "custom":
+            if len(access_list_ids) != 1:
+                raise ValueError(
+                    "Launchplane requires exactly one access-list id for custom NPMplus hosts"
+                )
+            normalized_access_list_id = access_list_ids[0]
+        else:
+            raise ValueError("Unsupported NPMplus proxy host access-list type")
+        return {**value, "access_list_id": normalized_access_list_id}
 
     @field_validator("locations", mode="before")
     @classmethod

--- a/tests/test_npmplus.py
+++ b/tests/test_npmplus.py
@@ -133,6 +133,47 @@ class NpmplusProxyHostPayloadTests(unittest.TestCase):
         self.assertEqual(host.id, 78)
         self.assertEqual(host.domain_names, ("ingress-canary.example.test",))
 
+    def test_proxy_host_response_maps_public_access_list_fields(self) -> None:
+        host = NpmplusProxyHost.model_validate(
+            {
+                **_proxy_host_payload(id=78),
+                "npmplus_access_list_ids": [],
+                "npmplus_access_list_type": "public",
+            }
+        )
+
+        self.assertEqual(host.access_list_id, 0)
+
+    def test_proxy_host_response_maps_single_custom_access_list(self) -> None:
+        host = NpmplusProxyHost.model_validate(
+            {
+                **_proxy_host_payload(id=78),
+                "npmplus_access_list_ids": [42],
+                "npmplus_access_list_type": "custom",
+            }
+        )
+
+        self.assertEqual(host.access_list_id, 42)
+
+    def test_proxy_host_response_rejects_incomplete_access_list_fields(self) -> None:
+        with self.assertRaises(ValidationError):
+            NpmplusProxyHost.model_validate(
+                {
+                    **_proxy_host_payload(id=78),
+                    "npmplus_access_list_ids": [],
+                }
+            )
+
+    def test_proxy_host_response_rejects_multiple_custom_access_lists(self) -> None:
+        with self.assertRaises(ValidationError):
+            NpmplusProxyHost.model_validate(
+                {
+                    **_proxy_host_payload(id=78),
+                    "npmplus_access_list_ids": [42, 43],
+                    "npmplus_access_list_type": "custom",
+                }
+            )
+
     def test_location_payload_rejects_unknown_request_fields(self) -> None:
         with self.assertRaises(ValidationError):
             NpmplusLocationPayload.model_validate(
@@ -180,6 +221,21 @@ class NpmplusProxyHostPayloadTests(unittest.TestCase):
         assert isinstance(locations, list)
         location = cast(dict[str, object], locations[0])
         self.assertNotIn("id", location)
+
+    def test_proxy_host_api_payload_maps_access_list_fields(self) -> None:
+        public_payload = NpmplusProxyHostPayload.model_validate(_proxy_host_payload())
+        restricted_payload = NpmplusProxyHostPayload.model_validate(
+            {**_proxy_host_payload(), "access_list_id": 42}
+        )
+
+        public_api_payload = public_payload.to_api_payload()
+        restricted_api_payload = restricted_payload.to_api_payload()
+
+        self.assertNotIn("access_list_id", public_api_payload)
+        self.assertEqual(public_api_payload["npmplus_access_list_ids"], [])
+        self.assertEqual(public_api_payload["npmplus_access_list_type"], "public")
+        self.assertEqual(restricted_api_payload["npmplus_access_list_ids"], [42])
+        self.assertEqual(restricted_api_payload["npmplus_access_list_type"], "custom")
 
 
 class NpmplusClientTests(unittest.TestCase):


### PR DESCRIPTION
## Summary
- translate Launchplane's single `access_list_id` contract to NPMplus's native access-list fields on writes
- normalize native public and single-custom access-list responses on reads
- fail closed for incomplete, invalid, or multi-list provider state that Launchplane cannot represent

## Validation
- `uv run --extra dev python -m unittest tests.test_npmplus tests.test_npmplus_ingress_workflow`
- `uv run --extra dev launchplane ci unittest-shard local`
- `uv run --extra dev ruff check control_plane/npmplus.py tests/test_npmplus.py`
- `uv run --extra dev ruff format --check control_plane/npmplus.py tests/test_npmplus.py`
- `uv run --extra dev mypy control_plane/npmplus.py tests/test_npmplus.py`

Supports the guarded preview ingress proof for issue #1986.