### PR TITLE
Fix macOS tmux no-server detection

### DIFF
--- a/control_plane/every_code_worker.py
+++ b/control_plane/every_code_worker.py
@@ -869,7 +869,13 @@ def _every_code_tmux_session_names(
     if result.returncode != 0:
         detail = f"{result.stdout}\n{result.stderr}".lower()
         if any(
-            marker in detail for marker in ("no server running", "failed to connect", "no sessions")
+            marker in detail
+            for marker in (
+                "no server running",
+                "failed to connect",
+                "error connecting to",
+                "no sessions",
+            )
         ):
             return ()
         return None

--- a/tests/test_every_code_worker.py
+++ b/tests/test_every_code_worker.py
@@ -25,6 +25,7 @@ from control_plane.contracts.product_profile_record import LaunchplaneProductPro
 from control_plane.contracts.product_profile_record import ProductImageProfile
 from control_plane.contracts.product_profile_record import ProductPreviewProfile
 from control_plane.every_code_worker import (
+    _every_code_tmux_session_names,
     EveryCodeWorkerApiError,
     EveryCodeWorkerApiStore,
     apply_every_code_pr_feedback_for_host,
@@ -1121,6 +1122,27 @@ class EveryCodeWorkerTests(unittest.TestCase):
 
         self.assertEqual(session_name, "every-code-every-code-cbusillo-code-123")
         self.assertEqual(fenced_session_name, "every-code-every-code-cbusillo-code-123-f2")
+
+    def test_tmux_missing_server_on_macos_is_an_empty_session_set(self) -> None:
+        def runner(
+            args: Sequence[str], env: Mapping[str, str] | None = None
+        ) -> subprocess.CompletedProcess[str]:
+            del env
+            return subprocess.CompletedProcess(
+                args,
+                1,
+                "",
+                "error connecting to /private/tmp/tmux-501/default (No such file or directory)",
+            )
+
+        self.assertEqual(
+            _every_code_tmux_session_names(
+                tmux_binary="tmux",
+                request_id="every-code-cbusillo-launchplane-2015-test",
+                runner=runner,
+            ),
+            (),
+        )
 
     def test_long_session_names_keep_a_stable_fenced_prefix(self) -> None:
         request_id = "every-code-" + ("very-long-request-" * 10)


### PR DESCRIPTION
## Summary

- treat macOS tmux's `error connecting to ...` response as an empty session set
- keep unexpected tmux failures fail-closed
- add a regression test for the exact macOS response observed by the #2001 live canary

## Validation

- `uv run python -m unittest tests.test_every_code_worker` (102 tests)

Related: #2001
Related: #2015