### PR TITLE
Add exact-head engineering review shadow canary

### DIFF
--- a/docs/canaries/engineering-review-shadow.md
+++ b/docs/canaries/engineering-review-shadow.md
@@ -1,0 +1,8 @@
+---
+title: Engineering Review Shadow Canary
+---
+
+This branch and its pull request are a non-production, non-authoritative
+routine shadow canary for Launchplane's exact-head engineering-review flow.
+They do not change runtime behavior, workflows, dependencies, policy, or
+release authority.

--- a/docs/canaries/engineering-review-shadow.md
+++ b/docs/canaries/engineering-review-shadow.md
@@ -6,3 +6,6 @@ This branch and its pull request are a non-production, non-authoritative
 routine shadow canary for Launchplane's exact-head engineering-review flow.
 They do not change runtime behavior, workflows, dependencies, policy, or
 release authority.
+
+The canary head may advance between rehearsals so each run proves fresh,
+exact-head evidence rather than replaying an earlier assignment.


### PR DESCRIPTION
## Summary

- add the temporary routine engineering-review shadow canary note
- explicitly keep the canary non-production and non-authoritative
- leave runtime code, workflows, dependencies, policy, and release authority unchanged

## Validation

- `git diff --check`
- changed-file Markdown lint and formatting validation passed

## Current status

- exact canary head: `c2b1801941518b4e8a2d632fd99bc57f13e00ca9`
- implementer work is complete and the branch is clean
- independent Launchplane review and shadow status are pending terminal request completion

## Canary handling

Leave this PR open and do not merge it. Launchplane will run exact-head shadow review canaries against this PR and close it after proof.

Refs #2015
Related: #2001