### PR TITLE
Allow context secrets to use instance safety targets

### DIFF
--- a/control_plane/product_config.py
+++ b/control_plane/product_config.py
@@ -416,8 +416,6 @@ def _product_config_secret_inputs(
             raise ProductConfigError(f"Product config secret #{index} requires name.")
         if not isinstance(plaintext_value, str) or not plaintext_value.strip():
             raise ProductConfigError(f"Product config secret #{index} requires a non-empty value.")
-        secret_context = str(raw_secret.get("context", context_name) or "").strip()
-        secret_instance = str(raw_secret.get("instance", instance_name) or "").strip()
         expected_scope = _default_secret_scope(
             context_name=context_name, instance_name=instance_name
         )
@@ -428,23 +426,36 @@ def _product_config_secret_inputs(
             )
             or ""
         ).strip()
+        default_context = "" if scope == "global" else context_name
+        default_instance = instance_name if scope == "context_instance" else ""
+        secret_context = str(raw_secret.get("context", default_context) or "").strip()
+        secret_instance = str(raw_secret.get("instance", default_instance) or "").strip()
         validated_scope = _validate_product_config_secret_scope_route(
             scope=scope,
             context_name=secret_context,
             instance_name=secret_instance,
             index=index,
         )
-        if validated_scope != expected_scope:
+        context_scope_uses_instance_safety_target = (
+            validated_scope == "context" and expected_scope == "context_instance"
+        )
+        if validated_scope != expected_scope and not context_scope_uses_instance_safety_target:
             raise ProductConfigError(
                 f"Product config secret #{index} scope must match the top-level target."
             )
-        _validate_product_config_target_alignment(
-            target_kind=f"secret #{index}",
-            context_name=secret_context,
-            instance_name=secret_instance,
-            expected_context=context_name,
-            expected_instance=instance_name,
-        )
+        if context_scope_uses_instance_safety_target:
+            if secret_context != context_name:
+                raise ProductConfigError(
+                    f"Product config secret #{index} target must match the top-level target."
+                )
+        else:
+            _validate_product_config_target_alignment(
+                target_kind=f"secret #{index}",
+                context_name=secret_context,
+                instance_name=secret_instance,
+                expected_context=context_name,
+                expected_instance=instance_name,
+            )
         integration = str(
             raw_secret.get(
                 "integration",

--- a/tests/test_http_app_policy_apply.py
+++ b/tests/test_http_app_policy_apply.py
@@ -1794,6 +1794,77 @@ class FastApiProductConfigApplyTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(secret_records[0].name, "SMTP_PASSWORD")
         self.assertEqual(secret_binding.binding_key, "SMTP_PASSWORD")
 
+    async def test_product_config_apply_writes_context_secret_for_instance_safety_target(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            _write_runtime_key_safety_policy(
+                database_url=database_url,
+                context_name="launchplane",
+                instance_name="prod",
+                rules=(
+                    RuntimeSecretSafetyRule(
+                        binding_key="GITHUB_TOKEN",
+                        secret_class="prod_only",
+                        allowed_contexts=("launchplane",),
+                        allowed_instances=("prod",),
+                    ),
+                ),
+            )
+            app_store = PostgresRecordStore(database_url=database_url)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_product_config_policy(
+                    action="product_config.apply",
+                    product="launchplane",
+                    context="launchplane",
+                ),
+                record_store_factory=lambda: app_store,
+            )
+            request_payload = {
+                "schema_version": 1,
+                "mode": "apply",
+                "product": "launchplane",
+                "context": "launchplane",
+                "instance": "prod",
+                "source_label": "issue-2018-test",
+                "runtime_env": {
+                    "scope": "instance",
+                    "env": {"GITHUB_API_URL": "https://api.github.com"},
+                },
+                "secrets": [
+                    {
+                        "scope": "context",
+                        "name": "GITHUB_TOKEN",
+                        "binding_key": "GITHUB_TOKEN",
+                        "value": "github-token-value",
+                        "description": "Launchplane GitHub evidence token.",
+                    }
+                ],
+            }
+
+            with patch.dict(
+                os.environ,
+                {control_plane_secrets.LAUNCHPLANE_SECRET_MASTER_KEY_ENV_VAR: "test-master-key"},
+                clear=True,
+            ):
+                response = await _post_product_config_apply(
+                    app,
+                    request_payload,
+                    idempotency_key="context-secret-instance-safety-target",
+                )
+                self.assertEqual(response.status_code, 202, response.text)
+                secret_record = app_store.list_secret_records()[0]
+            app_store.close()
+
+        self.assertEqual(response.json()["result"]["runtime_key_safety"]["status"], "pass")
+        self.assertNotIn("github-token-value", response.text)
+        self.assertEqual(secret_record.scope, "context")
+        self.assertEqual(secret_record.context, "launchplane")
+        self.assertEqual(secret_record.instance, "")
+
     async def test_product_config_apply_reports_live_target_runtime_next_action(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)

--- a/tests/test_runtime_environments.py
+++ b/tests/test_runtime_environments.py
@@ -2175,6 +2175,94 @@ ODOO_DB_PASSWORD = "file-secret"
             finally:
                 store.close()
 
+    def test_product_config_context_secret_uses_instance_safety_target(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            control_plane_root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(control_plane_root / "launchplane.sqlite3")
+            input_file = control_plane_root / "product-config.json"
+            _write_runtime_key_safety_policy(
+                database_url=database_url,
+                binding_key="GITHUB_TOKEN",
+                context_name="launchplane",
+                instance_name="prod",
+            )
+            input_file.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "product": "launchplane",
+                        "context": "launchplane",
+                        "instance": "prod",
+                        "runtime_env": {
+                            "scope": "instance",
+                            "env": {"GITHUB_API_URL": "https://api.github.com"},
+                        },
+                        "secrets": [
+                            {
+                                "scope": "context",
+                                "name": "GITHUB_TOKEN",
+                                "binding_key": "GITHUB_TOKEN",
+                                "value": "github-token-value",
+                                "description": "Launchplane GitHub evidence token.",
+                            }
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            with patch.dict(
+                os.environ,
+                {
+                    "LAUNCHPLANE_DATABASE_URL": database_url,
+                    "LAUNCHPLANE_SECRET_KEYS_JSON": json.dumps(
+                        {
+                            "active_key_id": "test-key",
+                            "keys": {"test-key": Fernet.generate_key().decode()},
+                        }
+                    ),
+                },
+                clear=True,
+            ):
+                result = CliRunner().invoke(
+                    main,
+                    [
+                        "product-config",
+                        "apply",
+                        "--input-file",
+                        str(input_file),
+                        "--actor",
+                        "operator@example.com",
+                        "--source-label",
+                        "issue-2018-test",
+                        "--apply",
+                        "--allow-direct-db-mutation",
+                    ],
+                )
+                context_values = (
+                    control_plane_runtime_environments.resolve_runtime_context_values(
+                        control_plane_root=control_plane_root,
+                        context_name="launchplane",
+                    )
+                )
+
+            self.assertEqual(result.exit_code, 0, result.output)
+            self.assertNotIn("github-token-value", result.output)
+            self.assertEqual(context_values["GITHUB_TOKEN"], "github-token-value")
+
+            store = PostgresRecordStore(database_url=database_url)
+            try:
+                secret_record = next(
+                    record
+                    for record in store.list_secret_records()
+                    if record.name == "GITHUB_TOKEN"
+                )
+                self.assertEqual(secret_record.scope, "context")
+                self.assertEqual(secret_record.context, "launchplane")
+                self.assertEqual(secret_record.instance, "")
+            finally:
+                store.close()
+
     def test_product_config_apply_requires_direct_db_acknowledgement(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             control_plane_root = Path(temporary_directory_name)


### PR DESCRIPTION
## Summary

- allow a context-scoped managed secret to use a same-context top-level instance solely for runtime key-safety evaluation
- persist the secret without an instance so context-only runtime resolution can consume it
- keep global and context-instance target alignment fail-closed
- cover direct product-config and HTTP apply paths

## Validation

- `uv run python -m unittest tests.test_runtime_environments` (51 tests)
- `uv run python -m unittest tests.test_http_app_policy_apply.FastApiProductConfigApplyTests` (39 tests)
- `git diff --check`

Closes #2018
Related: #2001
Related: #2015