### PR TITLE
Bind Owner acceptance to verified preview runtime

### DIFF
--- a/control_plane/contracts/owner_acceptance.py
+++ b/control_plane/contracts/owner_acceptance.py
@@ -5,8 +5,15 @@ import hashlib
 import json
 import re
 from typing import Literal
+from urllib.parse import urlsplit
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from control_plane.contracts.artifact_dependency_provenance import (
+    normalize_artifact_sha256_digest,
+)
+from control_plane.contracts.deploy_reference import docker_image_digest
+from control_plane.contracts.runtime_identity import RuntimeIdentity
 
 OWNER_ACCEPTANCE_READ_ACTION = "owner_acceptance.read"
 OWNER_ACCEPTANCE_EVENT_WRITE_ACTION = "owner_acceptance_event.write"
@@ -39,6 +46,8 @@ OwnerAcceptanceReasonCode = Literal[
     "multi_product_unsupported",
     "owner_authority_unavailable",
     "owner_authority_denied",
+    "preview_evidence_unavailable",
+    "preview_evidence_stale",
 ]
 OwnerAcceptanceEventWriteStatus = Literal["written", "replayed"]
 OwnerAcceptanceSourceEventKind = Literal["browser_api", "system"]
@@ -97,6 +106,14 @@ def _normalize_timestamp(value: str, field_name: str) -> str:
     return parsed.astimezone(timezone.utc).isoformat(timespec="microseconds").replace("+00:00", "Z")
 
 
+def _normalize_http_url(value: str, field_name: str) -> str:
+    normalized = _required_token(value, field_name)
+    parsed = urlsplit(normalized)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise ValueError(f"{field_name} must be an absolute HTTP(S) URL")
+    return normalized
+
+
 def _canonical_sha256(payload: object) -> str:
     encoded = json.dumps(
         payload,
@@ -105,6 +122,135 @@ def _canonical_sha256(payload: object) -> str:
         ensure_ascii=True,
     ).encode("utf-8")
     return hashlib.sha256(encoded).hexdigest()
+
+
+class OwnerAcceptanceRuntimeIdentityBinding(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    schema_version: int = Field(default=1, ge=1)
+    product: str
+    context: str
+    instance: str
+    environment_kind: str
+    deployment_record_id: str
+    artifact_id: str
+    source_git_ref: str
+    image_reference: str
+    release_tuple_id: str = ""
+    preview_id: str
+    preview_generation_id: str
+    runtime_identity_sha256: str = ""
+
+    @model_validator(mode="after")
+    def _validate_runtime_identity(self) -> "OwnerAcceptanceRuntimeIdentityBinding":
+        if self.schema_version != 1:
+            raise ValueError("Unsupported Owner acceptance runtime identity schema version.")
+        for field_name in (
+            "product",
+            "context",
+            "instance",
+            "environment_kind",
+            "deployment_record_id",
+            "artifact_id",
+            "preview_id",
+            "preview_generation_id",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _required_token(str(getattr(self, field_name)), field_name),
+            )
+        object.__setattr__(
+            self,
+            "source_git_ref",
+            _normalize_git_sha(self.source_git_ref, "source_git_ref"),
+        )
+        object.__setattr__(
+            self,
+            "image_reference",
+            _required_token(self.image_reference, "image_reference"),
+        )
+        object.__setattr__(self, "release_tuple_id", self.release_tuple_id.strip())
+        computed_digest = owner_acceptance_runtime_identity_sha256(self)
+        if self.runtime_identity_sha256:
+            normalized_digest = _normalize_sha256(
+                self.runtime_identity_sha256,
+                "runtime_identity_sha256",
+            )
+            if normalized_digest != computed_digest:
+                raise ValueError("Owner acceptance runtime identity digest does not match payload")
+            object.__setattr__(self, "runtime_identity_sha256", normalized_digest)
+        else:
+            object.__setattr__(self, "runtime_identity_sha256", computed_digest)
+        return self
+
+
+class OwnerAcceptancePreviewBinding(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    schema_version: int = Field(default=1, ge=1)
+    context: str
+    preview_id: str
+    serving_generation_id: str
+    artifact_id: str
+    artifact_image_digest: str
+    manifest_fingerprint: str
+    preview_url: str
+    runtime_identity: OwnerAcceptanceRuntimeIdentityBinding
+
+    @model_validator(mode="after")
+    def _validate_preview(self) -> "OwnerAcceptancePreviewBinding":
+        if self.schema_version != 1:
+            raise ValueError("Unsupported Owner acceptance preview binding schema version.")
+        for field_name in (
+            "context",
+            "preview_id",
+            "serving_generation_id",
+            "artifact_id",
+            "manifest_fingerprint",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _required_token(str(getattr(self, field_name)), field_name),
+            )
+        object.__setattr__(
+            self,
+            "artifact_image_digest",
+            _required_token(self.artifact_image_digest, "artifact_image_digest").lower(),
+        )
+        object.__setattr__(
+            self,
+            "preview_url",
+            _normalize_http_url(self.preview_url, "preview_url"),
+        )
+        runtime = self.runtime_identity
+        mismatches = []
+        if runtime.context.casefold() != self.context.casefold():
+            mismatches.append("context")
+        if runtime.artifact_id.casefold() != self.artifact_id.casefold():
+            mismatches.append("artifact_id")
+        if runtime.preview_id != self.preview_id:
+            mismatches.append("preview_id")
+        if runtime.preview_generation_id != self.serving_generation_id:
+            mismatches.append("preview_generation_id")
+        if runtime.environment_kind.casefold() != "preview":
+            mismatches.append("environment_kind")
+        image_digest = docker_image_digest(runtime.image_reference)
+        if not image_digest or normalize_artifact_sha256_digest(
+            image_digest,
+            label="Owner acceptance preview runtime image digest",
+        ) != normalize_artifact_sha256_digest(
+            self.artifact_image_digest,
+            label="Owner acceptance preview artifact image digest",
+        ):
+            mismatches.append("artifact_image_digest")
+        if mismatches:
+            raise ValueError(
+                "Owner acceptance preview runtime identity mismatched fields: "
+                + ", ".join(mismatches)
+            )
+        return self
 
 
 class OwnerAcceptanceBinding(BaseModel):
@@ -130,6 +276,7 @@ class OwnerAcceptanceBinding(BaseModel):
     owner_requirement_record_id: str
     owner_requirement_revision: int = Field(ge=1)
     owner_requirement_digest: str
+    preview: OwnerAcceptancePreviewBinding | None = None
     binding_sha256: str = ""
 
     @model_validator(mode="after")
@@ -169,6 +316,16 @@ class OwnerAcceptanceBinding(BaseModel):
                 field_name,
                 _normalize_sha256(str(getattr(self, field_name)), field_name),
             )
+        if self.preview is not None:
+            mismatches = []
+            if self.preview.runtime_identity.product.casefold() != self.product.casefold():
+                mismatches.append("product")
+            if self.preview.runtime_identity.source_git_ref != self.head_sha:
+                mismatches.append("head_sha")
+            if mismatches:
+                raise ValueError(
+                    "Owner acceptance preview binding mismatched fields: " + ", ".join(mismatches)
+                )
         computed_binding = owner_acceptance_binding_sha256(self)
         if self.binding_sha256:
             normalized_binding = _normalize_sha256(self.binding_sha256, "binding_sha256")
@@ -358,6 +515,44 @@ def owner_acceptance_binding_sha256(binding: OwnerAcceptanceBinding) -> str:
             exclude={"binding_sha256"},
             exclude_none=True,
         )
+    )
+
+
+def owner_acceptance_runtime_identity_sha256(
+    identity: OwnerAcceptanceRuntimeIdentityBinding | RuntimeIdentity,
+) -> str:
+    payload = {
+        "schema_version": 1,
+        "product": identity.product,
+        "context": identity.context,
+        "instance": identity.instance,
+        "environment_kind": identity.environment_kind,
+        "deployment_record_id": identity.deployment_record_id,
+        "artifact_id": identity.artifact_id,
+        "source_git_ref": identity.source_git_ref,
+        "image_reference": identity.image_reference,
+        "release_tuple_id": identity.release_tuple_id,
+        "preview_id": identity.preview_id,
+        "preview_generation_id": identity.preview_generation_id,
+    }
+    return _canonical_sha256(payload)
+
+
+def owner_acceptance_runtime_identity_binding(
+    identity: RuntimeIdentity,
+) -> OwnerAcceptanceRuntimeIdentityBinding:
+    return OwnerAcceptanceRuntimeIdentityBinding(
+        product=identity.product,
+        context=identity.context,
+        instance=identity.instance,
+        environment_kind=identity.environment_kind,
+        deployment_record_id=identity.deployment_record_id,
+        artifact_id=identity.artifact_id,
+        source_git_ref=identity.source_git_ref,
+        image_reference=identity.image_reference,
+        release_tuple_id=identity.release_tuple_id,
+        preview_id=identity.preview_id,
+        preview_generation_id=identity.preview_generation_id,
     )
 
 

--- a/control_plane/manager_preview_approval.py
+++ b/control_plane/manager_preview_approval.py
@@ -14,7 +14,6 @@ from control_plane.contracts.manager_preview_approval import (
     ManagerPreviewApprovalEventRecord,
     ManagerPreviewApprovalEventWriteStatus,
     ManagerPreviewApprovalReasonCode,
-    immutable_image_digest,
 )
 from control_plane.contracts.repository_human_admission import (
     RepositoryHumanRolePolicyRecord,
@@ -25,6 +24,10 @@ from control_plane.repository_human_admission import (
     RepositoryHumanRolePolicyError,
     manager_authority_current,
     manager_role_policy_provenance,
+)
+from control_plane.preview_serving_evidence import (
+    PreviewServingEvidenceError,
+    verify_serving_preview,
 )
 from control_plane.service_auth import AuthorizationTarget, GitHubHumanIdentity
 from control_plane.service_auth import matching_github_human_policy_rules
@@ -97,78 +100,32 @@ def build_current_manager_preview_approval_binding(
     preview: PreviewRecord,
     generation: PreviewGenerationRecord,
 ) -> ManagerPreviewApprovalBinding:
-    if preview.state != "active":
-        raise ManagerPreviewApprovalEvidenceError(
-            code="preview_inactive",
-            message="The preview is not active.",
-        )
-    if not preview.serving_generation_id:
-        raise ManagerPreviewApprovalEvidenceError(
-            code="serving_generation_missing",
-            message="The preview does not have a serving generation.",
-        )
-    if (
-        generation.preview_id != preview.preview_id
-        or generation.generation_id != preview.serving_generation_id
-    ):
-        raise ManagerPreviewApprovalEvidenceError(
-            code="serving_generation_mismatch",
-            message="The supplied generation is not the preview's serving generation.",
-        )
-    if generation.state != "ready":
-        raise ManagerPreviewApprovalEvidenceError(
-            code="generation_not_ready",
-            message="The serving preview generation is not ready.",
-        )
-    if any(
-        status != "pass"
-        for status in (
-            generation.deploy_status,
-            generation.verify_status,
-            generation.overall_health_status,
-        )
-    ):
-        raise ManagerPreviewApprovalEvidenceError(
-            code="generation_verification_failed",
-            message="The serving preview generation has not passed deployment and verification.",
-        )
-    if (
-        generation.anchor_summary.repo.lower() != preview.anchor_repo.lower()
-        or generation.anchor_summary.pr_number != preview.anchor_pr_number
-        or generation.anchor_summary.pr_url != preview.anchor_pr_url
-        or preview.latest_manifest_fingerprint != generation.resolved_manifest_fingerprint
-    ):
-        raise ManagerPreviewApprovalEvidenceError(
-            code="preview_identity_mismatch",
-            message="The preview and serving generation identity do not match.",
-        )
-    if not generation.artifact_id:
-        raise ManagerPreviewApprovalEvidenceError(
-            code="artifact_identity_missing",
-            message="The serving preview generation does not have immutable artifact identity.",
-        )
-    if generation.runtime_identity is None:
-        raise ManagerPreviewApprovalEvidenceError(
-            code="runtime_identity_missing",
-            message="The serving preview generation does not have verified runtime identity.",
-        )
     try:
-        artifact_image_digest = immutable_image_digest(generation.runtime_identity.image_reference)
+        evidence = verify_serving_preview(
+            product=product,
+            preview=preview,
+            generation=generation,
+        )
         return ManagerPreviewApprovalBinding(
             product=product,
-            context=preview.context,
-            repository=preview.anchor_repo,
-            pr_number=preview.anchor_pr_number,
-            pr_url=preview.anchor_pr_url,
-            head_sha=generation.anchor_summary.head_sha,
-            preview_id=preview.preview_id,
-            serving_generation_id=generation.generation_id,
-            artifact_id=generation.artifact_id,
-            artifact_image_digest=artifact_image_digest,
-            manifest_fingerprint=generation.resolved_manifest_fingerprint,
-            preview_url=preview.canonical_url,
-            runtime_identity=generation.runtime_identity,
+            context=evidence.context,
+            repository=evidence.anchor_repo,
+            pr_number=evidence.anchor_pr_number,
+            pr_url=evidence.anchor_pr_url,
+            head_sha=evidence.head_sha,
+            preview_id=evidence.preview_id,
+            serving_generation_id=evidence.serving_generation_id,
+            artifact_id=evidence.artifact_id,
+            artifact_image_digest=evidence.artifact_image_digest,
+            manifest_fingerprint=evidence.manifest_fingerprint,
+            preview_url=evidence.preview_url,
+            runtime_identity=evidence.runtime_identity,
         )
+    except PreviewServingEvidenceError as error:
+        raise ManagerPreviewApprovalEvidenceError(
+            code=error.code,
+            message=str(error),
+        ) from error
     except ValueError as error:
         raise ManagerPreviewApprovalEvidenceError(
             code="runtime_identity_mismatch",

--- a/control_plane/owner_acceptance.py
+++ b/control_plane/owner_acceptance.py
@@ -21,9 +21,14 @@ from control_plane.contracts.owner_acceptance import (
     OwnerAcceptanceDecisionStatus,
     OwnerAcceptanceEventRecord,
     OwnerAcceptanceEventWriteStatus,
+    OwnerAcceptancePreviewBinding,
     OwnerAcceptanceReasonCode,
     OwnerAcceptanceSourceEventKind,
+    owner_acceptance_runtime_identity_binding,
 )
+from control_plane.contracts.preview_generation_record import PreviewGenerationRecord
+from control_plane.contracts.preview_record import PreviewRecord
+from control_plane.contracts.product_profile_record import LaunchplaneProductProfileRecord
 from control_plane.contracts.product_owner import (
     ProductOwnerActionContext,
     ProductOwnerActorIdentity,
@@ -34,6 +39,9 @@ from control_plane.product_owner_service import (
     require_product_owner_requirement_read_store,
 )
 from control_plane.service_auth import GitHubHumanIdentity, LaunchplaneIdentity
+from control_plane.preview_serving_evidence import (
+    verify_serving_preview,
+)
 
 
 class OwnerAcceptanceEventConflictError(RuntimeError):
@@ -75,6 +83,21 @@ class OwnerAcceptanceEventStore(Protocol):
         self,
         event_id: str,
     ) -> OwnerAcceptanceEventRecord: ...
+
+
+class OwnerAcceptancePreviewReadStore(Protocol):
+    def read_product_profile_record(self, product: str) -> LaunchplaneProductProfileRecord: ...
+
+    def list_preview_records(
+        self,
+        *,
+        context_name: str = "",
+        anchor_repo: str = "",
+        anchor_pr_number: int | None = None,
+        limit: int | None = None,
+    ) -> tuple[PreviewRecord, ...]: ...
+
+    def read_preview_generation_record(self, generation_id: str) -> PreviewGenerationRecord: ...
 
 
 class OwnerAcceptanceWriteResult(NamedTuple):
@@ -125,28 +148,78 @@ def evaluate_owner_acceptance(
             reason_code="multi_product_unsupported",
             evaluated_at=normalized_evaluated_at,
         )
-    binding = _binding_from_impact(
-        impact=impact,
-        product_index=0,
-        store=store,
-        actor=None,
-        evaluated_at=normalized_evaluated_at,
-    )
+    try:
+        binding = _binding_from_impact(
+            impact=impact,
+            product_index=0,
+            store=store,
+            actor=None,
+            evaluated_at=normalized_evaluated_at,
+        )
+    except OwnerAcceptanceEvaluationUnavailableError:
+        affected_product = impact.affected_products[0]
+        preview_events = tuple(
+            event
+            for event in require_owner_acceptance_event_store(
+                store
+            ).list_owner_acceptance_event_records(
+                repository_id=impact.target.repository_id,
+                pull_request_number=impact.target.pull_request_number,
+                product=affected_product.product,
+                system=affected_product.system,
+                action=affected_product.owner_action,
+            )
+            if event.binding.preview is not None and event.occurred_at <= normalized_evaluated_at
+        )
+        if preview_events:
+            current_event = max(
+                preview_events,
+                key=lambda event: (event.occurred_at, event.event_id),
+            )
+            return _decision(
+                status="stale",
+                reason_code="preview_evidence_stale",
+                binding=current_event.binding,
+                event=current_event,
+                evaluated_at=normalized_evaluated_at,
+            )
+        return _decision(
+            status="unavailable",
+            reason_code="preview_evidence_unavailable",
+            evaluated_at=normalized_evaluated_at,
+        )
     if binding is None:
         return _decision(
             status="unavailable",
             reason_code="owner_authority_unavailable",
             evaluated_at=normalized_evaluated_at,
         )
+    events = require_owner_acceptance_event_store(store).list_owner_acceptance_event_records(
+        repository_id=binding.repository_id,
+        pull_request_number=binding.pull_request_number,
+        product=binding.product,
+        system=binding.system,
+        action=binding.action,
+    )
+    effective_preview_events = tuple(
+        event
+        for event in events
+        if event.binding.preview is not None and event.occurred_at <= normalized_evaluated_at
+    )
+    if binding.preview is None and effective_preview_events:
+        return _decision(
+            status="stale",
+            reason_code="preview_evidence_stale",
+            binding=binding,
+            event=max(
+                effective_preview_events,
+                key=lambda event: (event.occurred_at, event.event_id),
+            ),
+            evaluated_at=normalized_evaluated_at,
+        )
     return evaluate_owner_acceptance_for_binding(
         binding=binding,
-        events=require_owner_acceptance_event_store(store).list_owner_acceptance_event_records(
-            repository_id=binding.repository_id,
-            pull_request_number=binding.pull_request_number,
-            product=binding.product,
-            system=binding.system,
-            action=binding.action,
-        ),
+        events=events,
         evaluated_at=normalized_evaluated_at,
     )
 
@@ -229,6 +302,17 @@ def record_owner_acceptance_event(
         authorization=authorization,
     )
     event_store = require_owner_acceptance_event_store(store)
+    prior_events = event_store.list_owner_acceptance_event_records(
+        repository_id=binding.repository_id,
+        pull_request_number=binding.pull_request_number,
+        product=binding.product,
+        system=binding.system,
+        action=binding.action,
+    )
+    if binding.preview is None and any(event.binding.preview is not None for event in prior_events):
+        raise OwnerAcceptanceEvaluationUnavailableError(
+            "Preview-bound Owner acceptance cannot downgrade to an exact-change-only binding."
+        )
     write_status = event_store.write_owner_acceptance_event_record(record)
     if write_status == "replayed":
         record = event_store.read_owner_acceptance_event_record(record.event_id)
@@ -349,6 +433,17 @@ def require_owner_acceptance_event_store(store: object) -> OwnerAcceptanceEventS
     return cast(OwnerAcceptanceEventStore, store)
 
 
+def require_owner_acceptance_preview_read_store(store: object) -> OwnerAcceptancePreviewReadStore:
+    for method_name in (
+        "read_product_profile_record",
+        "list_preview_records",
+        "read_preview_generation_record",
+    ):
+        if not callable(getattr(store, method_name, None)):
+            raise TypeError("Owner acceptance preview evidence storage is unavailable.")
+    return cast(OwnerAcceptancePreviewReadStore, store)
+
+
 def _evaluate_change_impact_for_target(
     *,
     store: object,
@@ -460,6 +555,13 @@ def _binding_from_impact(
         or not authority.requirement_digest
     ):
         return None
+    preview = _resolve_owner_acceptance_preview_binding(
+        store=store,
+        product=context.product,
+        repository=impact.target.repository,
+        pull_request_number=impact.target.pull_request_number,
+        head_sha=impact.target.head_sha,
+    )
     binding = OwnerAcceptanceBinding(
         repository_id=impact.target.repository_id,
         repository_owner_id=impact.target.repository_owner_id,
@@ -480,6 +582,7 @@ def _binding_from_impact(
         owner_requirement_record_id=authority.requirement_record_id,
         owner_requirement_revision=authority.requirement_revision,
         owner_requirement_digest=authority.requirement_digest,
+        preview=preview,
     )
     if (
         expected_binding_sha256
@@ -504,6 +607,80 @@ def _binding_from_impact(
         if actor_authority.decision != "authorized":
             raise OwnerAcceptanceAuthorizationError("Caller is not a current product Owner.")
     return binding
+
+
+def _resolve_owner_acceptance_preview_binding(
+    *,
+    store: object,
+    product: str,
+    repository: str,
+    pull_request_number: int,
+    head_sha: str,
+) -> OwnerAcceptancePreviewBinding | None:
+    preview_store = require_owner_acceptance_preview_read_store(store)
+    try:
+        profile = preview_store.read_product_profile_record(product)
+    except (FileNotFoundError, LookupError):
+        return None
+    except ValueError as error:
+        raise OwnerAcceptanceEvaluationUnavailableError(
+            "Owner acceptance product profile is unavailable or invalid."
+        ) from error
+    if not profile.preview.enabled:
+        return None
+    if profile.repository.strip().casefold() != repository.strip().casefold():
+        raise OwnerAcceptanceEvaluationUnavailableError(
+            "Preview product profile does not match the exact-change repository."
+        )
+    repository_name = repository.split("/", 1)[-1].casefold()
+    previews = tuple(
+        preview
+        for preview in preview_store.list_preview_records(
+            context_name=profile.preview.context,
+            anchor_pr_number=pull_request_number,
+        )
+        if preview.anchor_repo.strip().casefold() in {repository.casefold(), repository_name}
+        and preview.state == "active"
+    )
+    if not previews:
+        raise OwnerAcceptanceEvaluationUnavailableError(
+            "Owner acceptance requires an active serving preview for this product."
+        )
+    if len(previews) != 1:
+        raise OwnerAcceptanceEvaluationUnavailableError(
+            "Owner acceptance requires exactly one unambiguous serving preview."
+        )
+    preview = previews[0]
+    if not preview.serving_generation_id.strip():
+        raise OwnerAcceptanceEvaluationUnavailableError(
+            "Owner acceptance preview does not have a serving generation."
+        )
+    try:
+        generation = preview_store.read_preview_generation_record(preview.serving_generation_id)
+        evidence = verify_serving_preview(
+            product=product,
+            preview=preview,
+            generation=generation,
+            require_runtime_generation_id=True,
+        )
+        if evidence.head_sha.strip().lower() != head_sha.strip().lower():
+            raise OwnerAcceptanceEvaluationUnavailableError(
+                "Owner acceptance preview does not serve the current pull request head."
+            )
+        return OwnerAcceptancePreviewBinding(
+            context=evidence.context,
+            preview_id=evidence.preview_id,
+            serving_generation_id=evidence.serving_generation_id,
+            artifact_id=evidence.artifact_id,
+            artifact_image_digest=evidence.artifact_image_digest,
+            manifest_fingerprint=evidence.manifest_fingerprint,
+            preview_url=evidence.preview_url,
+            runtime_identity=owner_acceptance_runtime_identity_binding(evidence.runtime_identity),
+        )
+    except (FileNotFoundError, LookupError, ValueError) as error:
+        raise OwnerAcceptanceEvaluationUnavailableError(
+            "Owner acceptance preview evidence is unavailable or invalid."
+        ) from error
 
 
 def _decision(

--- a/control_plane/preview_serving_evidence.py
+++ b/control_plane/preview_serving_evidence.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from control_plane.contracts.artifact_dependency_provenance import (
+    normalize_artifact_sha256_digest,
+)
+from control_plane.contracts.preview_generation_record import PreviewGenerationRecord
+from control_plane.contracts.preview_record import PreviewRecord
+from control_plane.contracts.runtime_identity import RuntimeIdentity
+
+
+PreviewServingEvidenceCode = Literal[
+    "preview_inactive",
+    "serving_generation_missing",
+    "serving_generation_mismatch",
+    "generation_not_ready",
+    "generation_verification_failed",
+    "preview_identity_mismatch",
+    "artifact_identity_missing",
+    "runtime_identity_missing",
+    "runtime_identity_mismatch",
+]
+
+
+class PreviewServingEvidenceError(ValueError):
+    def __init__(self, *, code: PreviewServingEvidenceCode, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+@dataclass(frozen=True, slots=True)
+class VerifiedServingPreview:
+    product: str
+    context: str
+    anchor_repo: str
+    anchor_pr_number: int
+    anchor_pr_url: str
+    head_sha: str
+    preview_id: str
+    serving_generation_id: str
+    artifact_id: str
+    artifact_image_digest: str
+    manifest_fingerprint: str
+    preview_url: str
+    runtime_identity: RuntimeIdentity
+
+
+def immutable_image_digest(image_reference: str, *, label: str) -> str:
+    normalized = image_reference.strip()
+    _, separator, digest = normalized.rpartition("@")
+    if not separator:
+        raise ValueError(f"{label} requires an immutable image reference")
+    return normalize_artifact_sha256_digest(digest, label=f"{label} image digest")
+
+
+def verify_serving_preview(
+    *,
+    product: str,
+    preview: PreviewRecord,
+    generation: PreviewGenerationRecord,
+    require_runtime_generation_id: bool = False,
+) -> VerifiedServingPreview:
+    normalized_product = product.strip().lower()
+    if preview.state != "active":
+        raise PreviewServingEvidenceError(
+            code="preview_inactive",
+            message="The preview is not active.",
+        )
+    if not preview.serving_generation_id:
+        raise PreviewServingEvidenceError(
+            code="serving_generation_missing",
+            message="The preview does not have a serving generation.",
+        )
+    if (
+        generation.preview_id != preview.preview_id
+        or generation.generation_id != preview.serving_generation_id
+    ):
+        raise PreviewServingEvidenceError(
+            code="serving_generation_mismatch",
+            message="The supplied generation is not the preview's serving generation.",
+        )
+    if generation.state != "ready":
+        raise PreviewServingEvidenceError(
+            code="generation_not_ready",
+            message="The serving preview generation is not ready.",
+        )
+    if any(
+        status != "pass"
+        for status in (
+            generation.deploy_status,
+            generation.verify_status,
+            generation.overall_health_status,
+        )
+    ):
+        raise PreviewServingEvidenceError(
+            code="generation_verification_failed",
+            message="The serving preview generation has not passed deployment and verification.",
+        )
+    if (
+        generation.anchor_summary.repo.lower() != preview.anchor_repo.lower()
+        or generation.anchor_summary.pr_number != preview.anchor_pr_number
+        or generation.anchor_summary.pr_url != preview.anchor_pr_url
+        or preview.latest_manifest_fingerprint != generation.resolved_manifest_fingerprint
+    ):
+        raise PreviewServingEvidenceError(
+            code="preview_identity_mismatch",
+            message="The preview and serving generation identity do not match.",
+        )
+    if not generation.artifact_id:
+        raise PreviewServingEvidenceError(
+            code="artifact_identity_missing",
+            message="The serving preview generation does not have immutable artifact identity.",
+        )
+    if generation.runtime_identity is None:
+        raise PreviewServingEvidenceError(
+            code="runtime_identity_missing",
+            message="The serving preview generation does not have verified runtime identity.",
+        )
+    runtime_identity = generation.runtime_identity
+    expected_runtime_values = {
+        "product": normalized_product,
+        "context": preview.context.strip().lower(),
+        "artifact_id": generation.artifact_id,
+        "source_git_ref": generation.anchor_summary.head_sha.strip().lower(),
+    }
+    mismatches = [
+        field_name
+        for field_name, expected_value in expected_runtime_values.items()
+        if str(getattr(runtime_identity, field_name)).strip().lower() != expected_value.lower()
+    ]
+    if runtime_identity.environment_kind.strip().lower() != "preview":
+        mismatches.append("environment_kind")
+    if runtime_identity.preview_id.strip() != preview.preview_id:
+        mismatches.append("preview_id")
+    runtime_generation_id = runtime_identity.preview_generation_id.strip()
+    if (require_runtime_generation_id and runtime_generation_id != generation.generation_id) or (
+        not require_runtime_generation_id
+        and runtime_generation_id
+        and runtime_generation_id != generation.generation_id
+    ):
+        mismatches.append("preview_generation_id")
+    try:
+        artifact_image_digest = immutable_image_digest(
+            runtime_identity.image_reference,
+            label="preview serving runtime identity",
+        )
+    except ValueError as error:
+        raise PreviewServingEvidenceError(
+            code="runtime_identity_mismatch",
+            message="The serving preview runtime identity is incomplete or inconsistent.",
+        ) from error
+    if mismatches:
+        raise PreviewServingEvidenceError(
+            code="runtime_identity_mismatch",
+            message="The serving preview runtime identity is incomplete or inconsistent.",
+        )
+    return VerifiedServingPreview(
+        product=normalized_product,
+        context=preview.context,
+        anchor_repo=preview.anchor_repo,
+        anchor_pr_number=preview.anchor_pr_number,
+        anchor_pr_url=preview.anchor_pr_url,
+        head_sha=generation.anchor_summary.head_sha,
+        preview_id=preview.preview_id,
+        serving_generation_id=generation.generation_id,
+        artifact_id=generation.artifact_id,
+        artifact_image_digest=artifact_image_digest,
+        manifest_fingerprint=generation.resolved_manifest_fingerprint,
+        preview_url=preview.canonical_url,
+        runtime_identity=runtime_identity,
+    )

--- a/docs/owner-acceptance.md
+++ b/docs/owner-acceptance.md
@@ -22,16 +22,22 @@ change:
 - active change-impact policy record ID, revision, and digest;
 - affected product, system, Owner action, and environment from change-impact;
 - active product Owner policy and requirement record IDs, revisions, and
-  digests.
+  digests;
+- when an enabled product preview has one active serving record, its context,
+  preview and generation IDs, artifact ID and immutable image digest, manifest
+  fingerprint, canonical URL, and an explicit verified-runtime identity
+  projection.
 
 Preferred Owner routing affects notification order only; it does not grant or
 deny Owner authority and is intentionally excluded from the acceptance
 binding.
 
-The first HTTP slice intentionally does not accept caller-supplied head, tree,
-policy, or Owner provenance. Verified preview/runtime binding is deliberately
-deferred to the next Owner-acceptance slice rather than accepting caller-owned
-runtime assertions.
+The API does not accept caller-supplied head, tree, policy, Owner, preview,
+artifact, manifest, or runtime provenance. Launchplane resolves all of it from
+service-owned GitHub, product-profile, preview, generation, and runtime records.
+The runtime projection deliberately excludes deployment time, so redeploying
+the same verified identity does not stale acceptance, while any identity field
+used to prove the serving artifact remains bound.
 
 ## Evaluation
 
@@ -45,9 +51,13 @@ Engineering-only changes return `not_required` and write no event. Product
 changes with incomplete change-impact evidence, unavailable Owner policy, or
 missing Owner requirement fail closed to `unavailable`. Once any event exists
 for an older exact binding, a changed head, tree, policy, requirement,
-or membership evaluates as `stale` for the new binding. Multi-product changes
-also fail closed until evaluation can require and aggregate one acceptance per
-affected product.
+membership, serving generation, artifact, manifest, preview URL, or verified
+runtime identity evaluates as `stale` for the new binding. An enabled preview
+with ambiguous, incomplete, non-serving, or failed verification evidence is
+`unavailable`. If a preview-bound acceptance already exists, preview teardown
+evaluates as `preview_evidence_stale` and cannot be replaced by a weaker
+exact-change-only acceptance. Multi-product changes also fail closed until
+evaluation can require and aggregate one acceptance per affected product.
 
 ## Event Authoring
 
@@ -62,9 +72,9 @@ The binding digest is a compare-only precondition, not caller-owned evidence.
 Launchplane re-resolves all exact-change and authority evidence at write time
 and returns `409 owner_acceptance_binding_changed` without writing an event if
 the current binding differs from the one the Owner reviewed. This prevents a
-force-push, policy revision, requirement revision, or Owner-scope change
-between evaluation and event authoring from silently changing what the human
-accepts.
+force-push, policy revision, requirement revision, Owner-scope change, or
+serving-preview/runtime change between evaluation and event authoring from
+silently changing what the human accepts.
 
 Human actions are:
 
@@ -87,7 +97,9 @@ PostgreSQL stores the append-only ledger in
 `launchplane_owner_acceptance_events` with an event-id primary key, subject,
 binding, and acceptance indexes, and JSONB payload storage. Replaying an
 identical event is deterministic; replaying the same event ID with a changed
-payload is a conflict.
+payload is a conflict. Optional preview evidence lives inside the existing JSONB
+payload; non-preview bindings omit the field and preserve the original binding,
+acceptance, event, and replay digests byte-for-byte.
 
 Migration `f3a5c7e9b1d4` creates the empty table and indexes only. It performs
 no backfill from GitHub comments, manager-preview approvals, technical waivers,
@@ -100,6 +112,5 @@ or tenant-admission evidence.
 - frontend Owner workbench
 - tenant-admission cutover
 - multi-product aggregation
-- verified preview/runtime evidence
 - manager/delegate cleanup
 - break-glass acceptance

--- a/docs/records.md
+++ b/docs/records.md
@@ -263,16 +263,23 @@ identities cannot author or impersonate Owner events.
 
 Each event binding includes exact numeric GitHub repository identity, PR, head,
 tree, active change-impact policy provenance, product/system/action/environment,
-and active Owner policy plus requirement provenance. Changed head, tree, policy,
-requirement, or membership stales earlier acceptance for the new exact binding.
-Multi-product aggregation and verified preview/runtime binding remain deferred
-and fail closed rather than accepting partial or caller-owned evidence.
+and active Owner policy plus requirement provenance. When an enabled product
+preview has one active serving record, the binding also embeds preview and
+generation IDs, immutable artifact image digest, manifest fingerprint,
+canonical URL, and an explicit verified-runtime identity projection. Changed
+head, tree, policy, requirement, membership, preview generation, artifact,
+manifest, URL, or runtime identity stales earlier acceptance for the new exact
+binding. Multi-product aggregation remains deferred and fails closed rather
+than accepting partial evidence.
 
 Filesystem rehearsal records live under `launchplane_owner_acceptance_events/`.
 PostgreSQL stores the ledger in `launchplane_owner_acceptance_events` with an
 event-id primary key and subject, binding, and acceptance indexes. Migration
 `f3a5c7e9b1d4` creates the empty table and indexes without backfilling from
 GitHub comments, manager-preview approvals, or tenant admission evidence.
+Optional preview evidence lives inside the existing JSONB payload, so this
+additive slice requires no new schema migration. Non-preview payloads omit the
+field and preserve the original #2022 binding and replay digests.
 
 ## Change Impact Policy Records
 

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -3518,6 +3518,15 @@ inventory. Engineering-only changes return `not_required` and write no event.
 Incomplete change-impact or Owner authority evidence fails closed.
 Preferred Owner routing remains notification-only, does not participate in the
 authority decision, and is not part of the exact acceptance binding.
+When an enabled product preview has an active record for the exact repository
+and pull request, Launchplane requires one unambiguous ready serving generation
+whose deploy, verification, and health evidence passed. The binding then adds
+the preview/generation IDs, immutable artifact image digest, manifest
+fingerprint, canonical preview URL, and an explicit verified-runtime identity
+projection. Preview, artifact, manifest, and runtime evidence remains entirely
+server-derived. Ambiguous or incomplete evidence fails closed, and a prior
+preview-bound event prevents later downgrade to a non-preview binding after
+teardown.
 
 `POST /v1/owner-acceptance/events` uses the browser mutation identity path and
 requires a browser-authenticated GitHub human plus a bounded `Idempotency-Key`.

--- a/frontend/generated/openapi-canonical.json
+++ b/frontend/generated/openapi-canonical.json
@@ -11438,6 +11438,16 @@
             "title": "Owner Requirement Revision",
             "type": "integer"
           },
+          "preview": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/OwnerAcceptancePreviewBinding"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "product": {
             "title": "Product",
             "type": "string"
@@ -11555,7 +11565,9 @@
               "change_impact_stale",
               "multi_product_unsupported",
               "owner_authority_unavailable",
-              "owner_authority_denied"
+              "owner_authority_denied",
+              "preview_evidence_unavailable",
+              "preview_evidence_stale"
             ],
             "title": "Reason Code",
             "type": "string"
@@ -11790,6 +11802,135 @@
           "decision"
         ],
         "title": "OwnerAcceptanceEventResponse",
+        "type": "object"
+      },
+      "OwnerAcceptancePreviewBinding": {
+        "additionalProperties": false,
+        "properties": {
+          "artifact_id": {
+            "title": "Artifact Id",
+            "type": "string"
+          },
+          "artifact_image_digest": {
+            "title": "Artifact Image Digest",
+            "type": "string"
+          },
+          "context": {
+            "title": "Context",
+            "type": "string"
+          },
+          "manifest_fingerprint": {
+            "title": "Manifest Fingerprint",
+            "type": "string"
+          },
+          "preview_id": {
+            "title": "Preview Id",
+            "type": "string"
+          },
+          "preview_url": {
+            "title": "Preview Url",
+            "type": "string"
+          },
+          "runtime_identity": {
+            "$ref": "#/components/schemas/OwnerAcceptanceRuntimeIdentityBinding"
+          },
+          "schema_version": {
+            "default": 1,
+            "minimum": 1.0,
+            "title": "Schema Version",
+            "type": "integer"
+          },
+          "serving_generation_id": {
+            "title": "Serving Generation Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "context",
+          "preview_id",
+          "serving_generation_id",
+          "artifact_id",
+          "artifact_image_digest",
+          "manifest_fingerprint",
+          "preview_url",
+          "runtime_identity"
+        ],
+        "title": "OwnerAcceptancePreviewBinding",
+        "type": "object"
+      },
+      "OwnerAcceptanceRuntimeIdentityBinding": {
+        "additionalProperties": false,
+        "properties": {
+          "artifact_id": {
+            "title": "Artifact Id",
+            "type": "string"
+          },
+          "context": {
+            "title": "Context",
+            "type": "string"
+          },
+          "deployment_record_id": {
+            "title": "Deployment Record Id",
+            "type": "string"
+          },
+          "environment_kind": {
+            "title": "Environment Kind",
+            "type": "string"
+          },
+          "image_reference": {
+            "title": "Image Reference",
+            "type": "string"
+          },
+          "instance": {
+            "title": "Instance",
+            "type": "string"
+          },
+          "preview_generation_id": {
+            "title": "Preview Generation Id",
+            "type": "string"
+          },
+          "preview_id": {
+            "title": "Preview Id",
+            "type": "string"
+          },
+          "product": {
+            "title": "Product",
+            "type": "string"
+          },
+          "release_tuple_id": {
+            "default": "",
+            "title": "Release Tuple Id",
+            "type": "string"
+          },
+          "runtime_identity_sha256": {
+            "default": "",
+            "title": "Runtime Identity Sha256",
+            "type": "string"
+          },
+          "schema_version": {
+            "default": 1,
+            "minimum": 1.0,
+            "title": "Schema Version",
+            "type": "integer"
+          },
+          "source_git_ref": {
+            "title": "Source Git Ref",
+            "type": "string"
+          }
+        },
+        "required": [
+          "product",
+          "context",
+          "instance",
+          "environment_kind",
+          "deployment_record_id",
+          "artifact_id",
+          "source_git_ref",
+          "image_reference",
+          "preview_id",
+          "preview_generation_id"
+        ],
+        "title": "OwnerAcceptanceRuntimeIdentityBinding",
         "type": "object"
       },
       "PostDeployUpdateEvidence": {

--- a/tests/test_manager_preview_approval.py
+++ b/tests/test_manager_preview_approval.py
@@ -53,6 +53,28 @@ OCCURRED_AT = "2026-07-30T12:00:00Z"
 
 
 class ManagerPreviewApprovalTests(unittest.TestCase):
+    def test_verified_binding_digest_remains_compatible_after_evidence_extraction(self) -> None:
+        binding = build_current_manager_preview_approval_binding(
+            product=PRODUCT,
+            preview=_preview(),
+            generation=_generation(),
+        )
+
+        self.assertEqual(
+            binding.binding_sha256,
+            "4484dd9b84b4cd956a23cbfcc335d1ad72fecf0fdd20de9e3097646ea82fa60c",
+        )
+
+    def test_legacy_binding_allows_blank_runtime_generation_identity(self) -> None:
+        binding = build_current_manager_preview_approval_binding(
+            product=PRODUCT,
+            preview=_preview(),
+            generation=_generation(runtime_identity=_runtime_identity(preview_generation_id="")),
+        )
+
+        self.assertEqual(binding.serving_generation_id, "generation-17")
+        self.assertEqual(binding.runtime_identity.preview_generation_id, "")
+
     def test_records_approval_only_after_exact_manager_authorization(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             store = FilesystemRecordStore(state_dir=Path(temporary_directory_name))

--- a/tests/test_owner_acceptance.py
+++ b/tests/test_owner_acceptance.py
@@ -16,6 +16,17 @@ from control_plane.contracts.change_impact import (
     ChangeImpactTargetReference,
 )
 from control_plane.contracts.owner_acceptance import OwnerAcceptanceEventRecord
+from control_plane.contracts.preview_generation_record import (
+    PreviewGenerationRecord,
+    PreviewPullRequestSummary,
+)
+from control_plane.contracts.preview_record import PreviewRecord
+from control_plane.contracts.product_profile_record import (
+    LaunchplaneProductProfileRecord,
+    ProductImageProfile,
+    ProductLaneProfile,
+    ProductPreviewProfile,
+)
 from control_plane.contracts.product_owner import (
     ProductOwnerGrant,
     ProductOwnerIdentity,
@@ -26,11 +37,13 @@ from control_plane.contracts.product_owner import (
 from control_plane.owner_acceptance import (
     OwnerAcceptanceAuthorizationError,
     OwnerAcceptanceBindingConflictError,
+    OwnerAcceptanceEvaluationUnavailableError,
     OwnerAcceptanceEventConflictError,
     evaluate_owner_acceptance,
     record_owner_acceptance_event,
 )
 from control_plane.service_auth import GitHubHumanIdentity, TerminalAgentIdentity
+from control_plane.contracts.runtime_identity import RuntimeIdentity
 from control_plane.storage.filesystem import FilesystemRecordStore
 
 
@@ -40,6 +53,7 @@ REPOSITORY = "example/web"
 PRODUCT = "generic-web-a"
 SECOND_PRODUCT = "generic-web-b"
 SYSTEM = "web"
+PREVIEW_CONTEXT = "generic-web-a-preview"
 OWNER_GITHUB_ID = 3001
 HEAD_SHA = "a" * 40
 TREE_SHA = "b" * 40
@@ -179,8 +193,14 @@ def _store(
     *,
     include_dependency_evidence: bool = True,
     shared_dependency_evidence: bool = False,
+    invalid_product_profile: bool = False,
 ) -> FilesystemRecordStore:
     class _OwnerAcceptanceStore(FilesystemRecordStore):
+        def read_product_profile_record(self, product: str) -> LaunchplaneProductProfileRecord:
+            if invalid_product_profile:
+                raise ValueError("invalid product profile")
+            return super().read_product_profile_record(product)
+
         def list_change_impact_stored_evidence(
             self,
             *,
@@ -223,6 +243,105 @@ def _store(
     return store
 
 
+def _preview_profile() -> LaunchplaneProductProfileRecord:
+    return LaunchplaneProductProfileRecord(
+        product=PRODUCT,
+        display_name="Generic Web A",
+        repository=REPOSITORY,
+        driver_id="generic-web",
+        image=ProductImageProfile(repository="ghcr.io/example/web"),
+        runtime_port=3000,
+        health_path="/health",
+        lanes=(
+            ProductLaneProfile(
+                instance="testing",
+                context="generic-web-a-testing",
+                base_url="https://testing.example.test",
+                health_url="https://testing.example.test/health",
+            ),
+        ),
+        preview=ProductPreviewProfile(
+            enabled=True,
+            context=PREVIEW_CONTEXT,
+            slug_template="pr-{number}",
+            app_name_prefix="generic-web-a-preview",
+        ),
+        updated_at="2026-08-07T00:00:00Z",
+        source="test",
+    )
+
+
+def _write_preview_evidence(
+    store: FilesystemRecordStore,
+    *,
+    head_sha: str = HEAD_SHA,
+    preview_id: str = "preview-generic-web-a-pr-2022",
+    generation_id: str = "preview-generic-web-a-pr-2022-generation-0001",
+    runtime_generation_id: str | None = None,
+    artifact_id: str = "artifact-generic-web-a-pr-2022",
+    image_digest: str = "a" * 64,
+    preview_state: str = "active",
+    generation_state: str = "ready",
+    verify_status: str = "pass",
+) -> None:
+    preview = PreviewRecord(
+        preview_id=preview_id,
+        context=PREVIEW_CONTEXT,
+        anchor_repo="web",
+        anchor_pr_number=2022,
+        anchor_pr_url="https://github.com/example/web/pull/2022",
+        preview_label="preview",
+        canonical_url="https://pr-2022.example.test",
+        state=preview_state,  # type: ignore[arg-type]
+        created_at="2026-08-07T00:00:00Z",
+        updated_at="2026-08-07T01:00:00Z",
+        eligible_at="2026-08-07T00:00:00Z",
+        active_generation_id=generation_id,
+        serving_generation_id=generation_id,
+        latest_generation_id=generation_id,
+        latest_manifest_fingerprint=f"manifest-{generation_id}",
+    )
+    runtime_identity = RuntimeIdentity(
+        product=PRODUCT,
+        context=PREVIEW_CONTEXT,
+        instance="preview-pr-2022",
+        environment_kind="preview",
+        deployment_record_id=f"deployment-{generation_id}",
+        artifact_id=artifact_id,
+        source_git_ref=head_sha,
+        image_reference=f"ghcr.io/example/web@sha256:{image_digest}",
+        preview_id=preview.preview_id,
+        preview_generation_id=(
+            generation_id if runtime_generation_id is None else runtime_generation_id
+        ),
+    )
+    generation = PreviewGenerationRecord(
+        generation_id=generation_id,
+        preview_id=preview.preview_id,
+        sequence=1,
+        state=generation_state,  # type: ignore[arg-type]
+        requested_reason="Owner acceptance preview evidence.",
+        requested_at="2026-08-07T00:00:00Z",
+        ready_at="2026-08-07T01:00:00Z",
+        resolved_manifest_fingerprint=preview.latest_manifest_fingerprint,
+        artifact_id=artifact_id,
+        source_map=(),
+        anchor_summary=PreviewPullRequestSummary(
+            repo="web",
+            pr_number=2022,
+            head_sha=head_sha,
+            pr_url=preview.anchor_pr_url,
+        ),
+        deploy_status="pass",
+        verify_status=verify_status,  # type: ignore[arg-type]
+        overall_health_status="pass",
+        runtime_identity=runtime_identity,
+    )
+    store.write_product_profile_record(_preview_profile())
+    store.write_preview_generation_record(generation)
+    store.write_preview_record(preview)
+
+
 def _expected_binding_sha256(
     *,
     store: object,
@@ -243,6 +362,264 @@ def _expected_binding_sha256(
 
 
 class OwnerAcceptanceTests(unittest.TestCase):
+    def test_non_preview_binding_digest_remains_backward_compatible(self) -> None:
+        with TemporaryDirectory() as directory:
+            store = _store(Path(directory))
+
+            self.assertEqual(
+                _expected_binding_sha256(
+                    store=store,
+                    provider=_EvidenceProvider(_repository_evidence()),
+                ),
+                "6f61c0b708961a549242c3ae7c97b599149648955c8bebd8fb540567c409c04a",
+            )
+
+    def test_preview_backed_acceptance_binds_verified_serving_runtime(self) -> None:
+        with TemporaryDirectory() as directory:
+            store = _store(Path(directory))
+            _write_preview_evidence(store)
+            provider = _EvidenceProvider(_repository_evidence())
+            target = ChangeImpactTargetReference(repository=REPOSITORY, pull_request_number=2022)
+
+            decision = evaluate_owner_acceptance(
+                store=store,
+                repository_evidence_provider=provider,
+                target=target,
+                evaluated_at="2026-08-07T12:00:00Z",
+            )
+
+            self.assertEqual(decision.status, "pending")
+            self.assertIsNotNone(decision.binding)
+            assert decision.binding is not None
+            self.assertIsNotNone(decision.binding.preview)
+            assert decision.binding.preview is not None
+            self.assertEqual(decision.binding.preview.context, PREVIEW_CONTEXT)
+            self.assertEqual(
+                decision.binding.preview.artifact_image_digest,
+                f"sha256:{'a' * 64}",
+            )
+            result = record_owner_acceptance_event(
+                store=store,
+                repository_evidence_provider=provider,
+                target=target,
+                identity=_human(),
+                action="accepted",
+                expected_binding_sha256=decision.binding.binding_sha256,
+                source_event_kind="browser_api",
+                source_event_id="accept-preview",
+                occurred_at="2026-08-07T12:00:00Z",
+            )
+            self.assertEqual(result.decision.status, "accepted")
+            self.assertIsNotNone(result.record.binding.preview)
+
+    def test_preview_drift_conflicts_without_writing(self) -> None:
+        with TemporaryDirectory() as directory:
+            store = _store(Path(directory))
+            _write_preview_evidence(store)
+            provider = _EvidenceProvider(_repository_evidence())
+            expected_binding_sha256 = _expected_binding_sha256(store=store, provider=provider)
+            _write_preview_evidence(
+                store,
+                generation_id="preview-generic-web-a-pr-2022-generation-0002",
+                artifact_id="artifact-generic-web-a-pr-2022-v2",
+                image_digest="b" * 64,
+            )
+
+            with self.assertRaises(OwnerAcceptanceBindingConflictError):
+                record_owner_acceptance_event(
+                    store=store,
+                    repository_evidence_provider=provider,
+                    target=ChangeImpactTargetReference(
+                        repository=REPOSITORY,
+                        pull_request_number=2022,
+                    ),
+                    identity=_human(),
+                    action="accepted",
+                    expected_binding_sha256=expected_binding_sha256,
+                    source_event_kind="browser_api",
+                    source_event_id="accept-preview-drift",
+                    occurred_at="2026-08-07T12:00:00Z",
+                )
+
+            self.assertEqual(store.list_owner_acceptance_event_records(), ())
+
+    def test_incomplete_preview_fails_closed(self) -> None:
+        with TemporaryDirectory() as directory:
+            store = _store(Path(directory))
+            _write_preview_evidence(store, verify_status="fail")
+
+            decision = evaluate_owner_acceptance(
+                store=store,
+                repository_evidence_provider=_EvidenceProvider(_repository_evidence()),
+                target=ChangeImpactTargetReference(
+                    repository=REPOSITORY,
+                    pull_request_number=2022,
+                ),
+                evaluated_at="2026-08-07T12:00:00Z",
+            )
+
+            self.assertEqual(decision.status, "unavailable")
+            self.assertEqual(decision.reason_code, "preview_evidence_unavailable")
+            self.assertEqual(store.list_owner_acceptance_event_records(), ())
+
+    def test_enabled_preview_without_active_evidence_fails_closed(self) -> None:
+        with TemporaryDirectory() as directory:
+            store = _store(Path(directory))
+            store.write_product_profile_record(_preview_profile())
+
+            decision = evaluate_owner_acceptance(
+                store=store,
+                repository_evidence_provider=_EvidenceProvider(_repository_evidence()),
+                target=ChangeImpactTargetReference(
+                    repository=REPOSITORY,
+                    pull_request_number=2022,
+                ),
+                evaluated_at="2026-08-07T12:00:00Z",
+            )
+
+            self.assertEqual(decision.status, "unavailable")
+            self.assertEqual(decision.reason_code, "preview_evidence_unavailable")
+            self.assertEqual(store.list_owner_acceptance_event_records(), ())
+
+    def test_malformed_preview_profile_fails_closed(self) -> None:
+        with TemporaryDirectory() as directory:
+            store = _store(Path(directory), invalid_product_profile=True)
+            with self.assertRaisesRegex(ValueError, "invalid product profile"):
+                store.read_product_profile_record(PRODUCT)
+
+            decision = evaluate_owner_acceptance(
+                store=store,
+                repository_evidence_provider=_EvidenceProvider(_repository_evidence()),
+                target=ChangeImpactTargetReference(
+                    repository=REPOSITORY,
+                    pull_request_number=2022,
+                ),
+                evaluated_at="2026-08-07T12:00:00Z",
+            )
+
+            self.assertEqual(decision.status, "unavailable")
+            self.assertEqual(decision.reason_code, "preview_evidence_unavailable")
+            self.assertEqual(store.list_owner_acceptance_event_records(), ())
+
+    def test_owner_binding_requires_runtime_generation_identity(self) -> None:
+        with TemporaryDirectory() as directory:
+            store = _store(Path(directory))
+            _write_preview_evidence(store, runtime_generation_id="")
+
+            decision = evaluate_owner_acceptance(
+                store=store,
+                repository_evidence_provider=_EvidenceProvider(_repository_evidence()),
+                target=ChangeImpactTargetReference(
+                    repository=REPOSITORY,
+                    pull_request_number=2022,
+                ),
+                evaluated_at="2026-08-07T12:00:00Z",
+            )
+
+            self.assertEqual(decision.status, "unavailable")
+            self.assertEqual(decision.reason_code, "preview_evidence_unavailable")
+            self.assertEqual(store.list_owner_acceptance_event_records(), ())
+
+    def test_ambiguous_serving_previews_fail_closed(self) -> None:
+        with TemporaryDirectory() as directory:
+            store = _store(Path(directory))
+            _write_preview_evidence(store)
+            _write_preview_evidence(
+                store,
+                preview_id="preview-generic-web-a-pr-2022-duplicate",
+                generation_id="preview-generic-web-a-pr-2022-generation-duplicate",
+                artifact_id="artifact-generic-web-a-pr-2022-duplicate",
+                image_digest="b" * 64,
+            )
+
+            decision = evaluate_owner_acceptance(
+                store=store,
+                repository_evidence_provider=_EvidenceProvider(_repository_evidence()),
+                target=ChangeImpactTargetReference(
+                    repository=REPOSITORY,
+                    pull_request_number=2022,
+                ),
+                evaluated_at="2026-08-07T12:00:00Z",
+            )
+
+            self.assertEqual(decision.status, "unavailable")
+            self.assertEqual(decision.reason_code, "preview_evidence_unavailable")
+            self.assertEqual(store.list_owner_acceptance_event_records(), ())
+
+    def test_destroyed_preview_cannot_downgrade_prior_acceptance(self) -> None:
+        with TemporaryDirectory() as directory:
+            store = _store(Path(directory))
+            _write_preview_evidence(store)
+            provider = _EvidenceProvider(_repository_evidence())
+            target = ChangeImpactTargetReference(repository=REPOSITORY, pull_request_number=2022)
+            expected_binding_sha256 = _expected_binding_sha256(store=store, provider=provider)
+            record_owner_acceptance_event(
+                store=store,
+                repository_evidence_provider=provider,
+                target=target,
+                identity=_human(),
+                action="accepted",
+                expected_binding_sha256=expected_binding_sha256,
+                source_event_kind="browser_api",
+                source_event_id="accept-preview",
+                occurred_at="2026-08-07T12:00:00Z",
+            )
+            _write_preview_evidence(store, preview_state="destroyed")
+
+            decision = evaluate_owner_acceptance(
+                store=store,
+                repository_evidence_provider=provider,
+                target=target,
+                evaluated_at="2026-08-07T12:30:00Z",
+            )
+
+            self.assertEqual(decision.status, "stale")
+            self.assertEqual(decision.reason_code, "preview_evidence_stale")
+            self.assertIsNotNone(decision.binding)
+            assert decision.binding is not None
+            with self.assertRaises(OwnerAcceptanceEvaluationUnavailableError):
+                record_owner_acceptance_event(
+                    store=store,
+                    repository_evidence_provider=provider,
+                    target=target,
+                    identity=_human(),
+                    action="accepted",
+                    expected_binding_sha256=decision.binding.binding_sha256,
+                    source_event_kind="browser_api",
+                    source_event_id="accept-preview-downgrade",
+                    occurred_at="2026-08-07T12:30:00Z",
+                )
+
+    def test_future_preview_acceptance_is_not_effective_after_teardown(self) -> None:
+        with TemporaryDirectory() as directory:
+            store = _store(Path(directory))
+            _write_preview_evidence(store)
+            provider = _EvidenceProvider(_repository_evidence())
+            target = ChangeImpactTargetReference(repository=REPOSITORY, pull_request_number=2022)
+            record_owner_acceptance_event(
+                store=store,
+                repository_evidence_provider=provider,
+                target=target,
+                identity=_human(),
+                action="accepted",
+                expected_binding_sha256=_expected_binding_sha256(store=store, provider=provider),
+                source_event_kind="browser_api",
+                source_event_id="future-preview-acceptance",
+                occurred_at="2026-08-07T13:00:00Z",
+            )
+            _write_preview_evidence(store, preview_state="destroyed")
+
+            decision = evaluate_owner_acceptance(
+                store=store,
+                repository_evidence_provider=provider,
+                target=target,
+                evaluated_at="2026-08-07T12:00:00Z",
+            )
+
+            self.assertEqual(decision.status, "unavailable")
+            self.assertEqual(decision.reason_code, "preview_evidence_unavailable")
+            self.assertIsNone(decision.current_event)
+
     def test_acceptance_records_and_replays_for_exact_binding(self) -> None:
         with TemporaryDirectory() as directory:
             store = _store(Path(directory))

--- a/tests/test_owner_acceptance_http.py
+++ b/tests/test_owner_acceptance_http.py
@@ -28,6 +28,7 @@ from tests.test_owner_acceptance import (
     _human,
     _repository_evidence,
     _store,
+    _write_preview_evidence,
 )
 
 
@@ -304,6 +305,49 @@ class OwnerAcceptanceHttpTests(unittest.IsolatedAsyncioTestCase):
                         "expected_binding_sha256": expected_binding_sha256,
                     },
                     headers={"Idempotency-Key": "accept-stale-binding"},
+                )
+
+            self.assertEqual(response.status_code, 409, response.text)
+            self.assertEqual(response.json()["detail"]["code"], "owner_acceptance_binding_changed")
+            self.assertEqual(store.list_owner_acceptance_event_records(), ())
+
+    async def test_event_route_rejects_serving_preview_drift(self) -> None:
+        with TemporaryDirectory() as directory:
+            store = _store(Path(directory))
+            _write_preview_evidence(store)
+            provider = _EvidenceProvider(_repository_evidence())
+            app = _app(store=store, repository_evidence_provider=provider)
+            target: dict[str, str | int] = {
+                "repository": REPOSITORY,
+                "pull_request_number": 2022,
+            }
+            async with lifespan_client(app) as client:
+                evaluated = await client.get(
+                    OWNER_ACCEPTANCE_EVALUATION_ROUTE,
+                    params=target,
+                )
+                self.assertEqual(evaluated.status_code, 200, evaluated.text)
+                preview = evaluated.json()["decision"]["binding"]["preview"]
+                self.assertEqual(
+                    preview["serving_generation_id"],
+                    "preview-generic-web-a-pr-2022-generation-0001",
+                )
+                expected_binding_sha256 = evaluated.json()["decision"]["binding"]["binding_sha256"]
+                _write_preview_evidence(
+                    store,
+                    generation_id="preview-generic-web-a-pr-2022-generation-0002",
+                    artifact_id="artifact-generic-web-a-pr-2022-v2",
+                    image_digest="b" * 64,
+                )
+
+                response = await client.post(
+                    OWNER_ACCEPTANCE_EVENTS_ROUTE,
+                    json={
+                        "target": target,
+                        "action": "accepted",
+                        "expected_binding_sha256": expected_binding_sha256,
+                    },
+                    headers={"Idempotency-Key": "accept-preview-drift"},
                 )
 
             self.assertEqual(response.status_code, 409, response.text)

--- a/tests/test_postgres_integration.py
+++ b/tests/test_postgres_integration.py
@@ -42,6 +42,8 @@ from control_plane.contracts.owner_acceptance import (
     OwnerAcceptanceAuthorization,
     OwnerAcceptanceBinding,
     OwnerAcceptanceEventRecord,
+    OwnerAcceptancePreviewBinding,
+    owner_acceptance_runtime_identity_binding,
 )
 from control_plane.contracts.merge_train_controller_state import (
     MergeTrainControllerAdoptionRejectedError,
@@ -864,6 +866,29 @@ def _owner_acceptance_event() -> OwnerAcceptanceEventRecord:
         owner_requirement_record_id="product-owner-requirement-example-site-r1",
         owner_requirement_revision=1,
         owner_requirement_digest="c" * 64,
+        preview=OwnerAcceptancePreviewBinding(
+            context="example-site-preview",
+            preview_id="preview-example-site-pr-17",
+            serving_generation_id="preview-example-site-pr-17-generation-0001",
+            artifact_id="artifact-example-site-pr-17",
+            artifact_image_digest=f"sha256:{'d' * 64}",
+            manifest_fingerprint="manifest-example-site-pr-17",
+            preview_url="https://pr-17.example.test",
+            runtime_identity=owner_acceptance_runtime_identity_binding(
+                RuntimeIdentity(
+                    product="example-site",
+                    context="example-site-preview",
+                    instance="preview-pr-17",
+                    environment_kind="preview",
+                    deployment_record_id="deployment-example-site-pr-17",
+                    artifact_id="artifact-example-site-pr-17",
+                    source_git_ref="1" * 40,
+                    image_reference=f"ghcr.io/example/example-site@sha256:{'d' * 64}",
+                    preview_id="preview-example-site-pr-17",
+                    preview_generation_id="preview-example-site-pr-17-generation-0001",
+                )
+            ),
+        ),
     )
     return OwnerAcceptanceEventRecord(
         binding=binding,


### PR DESCRIPTION
## Summary
- bind shadow Owner acceptance to the exact active serving preview, generation, artifact digest, manifest, and verified runtime identity
- fail closed on missing, ambiguous, malformed, stale, unhealthy, or head-mismatched preview evidence
- preserve byte-identical non-preview and legacy manager binding behavior
- document the contract and add filesystem, HTTP, manager-compatibility, and PostgreSQL integration coverage

## Validation
- `uv run --extra dev launchplane ci unittest-shard local` (2,755 targets)
- `uv run --extra dev python -m unittest tests.test_owner_acceptance tests.test_owner_acceptance_http tests.test_manager_preview_approval`
- `uv run --extra dev mypy control_plane tests`
- changed-file Ruff lint and format checks
- `pnpm --dir frontend check:openapi-drift`
- `uv run alembic heads` (`f3a5c7e9b1d4`)
- independent Opus and Gemini reviews: MERGE

Closes #2023
