### PR TITLE
Aggregate Owner acceptance across affected products

### DIFF
--- a/control_plane/contracts/owner_acceptance.py
+++ b/control_plane/contracts/owner_acceptance.py
@@ -52,6 +52,16 @@ OwnerAcceptanceReasonCode = Literal[
 OwnerAcceptanceEventWriteStatus = Literal["written", "replayed"]
 OwnerAcceptanceSourceEventKind = Literal["browser_api", "system"]
 
+OWNER_ACCEPTANCE_STATUS_PRECEDENCE: tuple[OwnerAcceptanceDecisionStatus, ...] = (
+    "unavailable",
+    "stale",
+    "revoked",
+    "changes_requested",
+    "pending",
+    "accepted",
+    "not_required",
+)
+
 _GIT_SHA_PATTERN = re.compile(r"^[0-9a-f]{40}(?:[0-9a-f]{24})?$")
 _SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
 _REPOSITORY_PATTERN = re.compile(r"^[^/\s]+/[^/\s]+$")
@@ -483,6 +493,46 @@ class OwnerAcceptanceEventRecord(BaseModel):
         return self
 
 
+class OwnerAcceptanceProductDecision(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    schema_version: int = Field(default=1, ge=1)
+    product: str
+    system: str
+    action: str
+    environment: str
+    status: OwnerAcceptanceDecisionStatus
+    reason_code: OwnerAcceptanceReasonCode
+    binding: OwnerAcceptanceBinding | None = None
+    current_event: OwnerAcceptanceEventRecord | None = None
+
+    @model_validator(mode="after")
+    def _validate_product_decision(self) -> "OwnerAcceptanceProductDecision":
+        if self.schema_version != 1:
+            raise ValueError("Unsupported Owner acceptance product decision schema version.")
+        for field_name in ("product", "system", "action", "environment"):
+            object.__setattr__(
+                self,
+                field_name,
+                _required_token(str(getattr(self, field_name)), field_name),
+            )
+        if self.binding is not None:
+            for field_name in ("product", "system", "action", "environment"):
+                if getattr(self.binding, field_name) != getattr(self, field_name):
+                    raise ValueError(
+                        f"Owner acceptance product decision {field_name} does not match binding"
+                    )
+        if self.current_event is not None:
+            if self.binding is None:
+                raise ValueError("Owner acceptance product decision event requires a binding")
+            for field_name in ("product", "system", "action", "environment"):
+                if getattr(self.current_event.binding, field_name) != getattr(self, field_name):
+                    raise ValueError(
+                        f"Owner acceptance product decision event {field_name} does not match subject"
+                    )
+        return self
+
+
 class OwnerAcceptanceDecision(BaseModel):
     model_config = ConfigDict(extra="forbid", frozen=True)
 
@@ -494,6 +544,7 @@ class OwnerAcceptanceDecision(BaseModel):
     reason_code: OwnerAcceptanceReasonCode
     binding: OwnerAcceptanceBinding | None = None
     current_event: OwnerAcceptanceEventRecord | None = None
+    products: tuple[OwnerAcceptanceProductDecision, ...] = ()
     evaluated_at: str
 
     @model_validator(mode="after")

--- a/control_plane/owner_acceptance.py
+++ b/control_plane/owner_acceptance.py
@@ -10,10 +10,12 @@ from control_plane.change_impact_service import (
     require_change_impact_policy_read_store,
 )
 from control_plane.contracts.change_impact import (
+    ChangeImpactAffectedProduct,
     ChangeImpactEvaluation,
     ChangeImpactTargetReference,
 )
 from control_plane.contracts.owner_acceptance import (
+    OWNER_ACCEPTANCE_STATUS_PRECEDENCE,
     OwnerAcceptanceAction,
     OwnerAcceptanceAuthorization,
     OwnerAcceptanceBinding,
@@ -22,6 +24,7 @@ from control_plane.contracts.owner_acceptance import (
     OwnerAcceptanceEventRecord,
     OwnerAcceptanceEventWriteStatus,
     OwnerAcceptancePreviewBinding,
+    OwnerAcceptanceProductDecision,
     OwnerAcceptanceReasonCode,
     OwnerAcceptanceSourceEventKind,
     owner_acceptance_runtime_identity_binding,
@@ -142,84 +145,9 @@ def evaluate_owner_acceptance(
             reason_code="change_impact_unavailable",
             evaluated_at=normalized_evaluated_at,
         )
-    if len(impact.affected_products) != 1:
-        return _decision(
-            status="unavailable",
-            reason_code="multi_product_unsupported",
-            evaluated_at=normalized_evaluated_at,
-        )
-    try:
-        binding = _binding_from_impact(
-            impact=impact,
-            product_index=0,
-            store=store,
-            actor=None,
-            evaluated_at=normalized_evaluated_at,
-        )
-    except OwnerAcceptanceEvaluationUnavailableError:
-        affected_product = impact.affected_products[0]
-        preview_events = tuple(
-            event
-            for event in require_owner_acceptance_event_store(
-                store
-            ).list_owner_acceptance_event_records(
-                repository_id=impact.target.repository_id,
-                pull_request_number=impact.target.pull_request_number,
-                product=affected_product.product,
-                system=affected_product.system,
-                action=affected_product.owner_action,
-            )
-            if event.binding.preview is not None and event.occurred_at <= normalized_evaluated_at
-        )
-        if preview_events:
-            current_event = max(
-                preview_events,
-                key=lambda event: (event.occurred_at, event.event_id),
-            )
-            return _decision(
-                status="stale",
-                reason_code="preview_evidence_stale",
-                binding=current_event.binding,
-                event=current_event,
-                evaluated_at=normalized_evaluated_at,
-            )
-        return _decision(
-            status="unavailable",
-            reason_code="preview_evidence_unavailable",
-            evaluated_at=normalized_evaluated_at,
-        )
-    if binding is None:
-        return _decision(
-            status="unavailable",
-            reason_code="owner_authority_unavailable",
-            evaluated_at=normalized_evaluated_at,
-        )
-    events = require_owner_acceptance_event_store(store).list_owner_acceptance_event_records(
-        repository_id=binding.repository_id,
-        pull_request_number=binding.pull_request_number,
-        product=binding.product,
-        system=binding.system,
-        action=binding.action,
-    )
-    effective_preview_events = tuple(
-        event
-        for event in events
-        if event.binding.preview is not None and event.occurred_at <= normalized_evaluated_at
-    )
-    if binding.preview is None and effective_preview_events:
-        return _decision(
-            status="stale",
-            reason_code="preview_evidence_stale",
-            binding=binding,
-            event=max(
-                effective_preview_events,
-                key=lambda event: (event.occurred_at, event.event_id),
-            ),
-            evaluated_at=normalized_evaluated_at,
-        )
-    return evaluate_owner_acceptance_for_binding(
-        binding=binding,
-        events=events,
+    return _evaluate_owner_acceptance_for_impact(
+        impact=impact,
+        store=store,
         evaluated_at=normalized_evaluated_at,
     )
 
@@ -260,7 +188,50 @@ def record_owner_acceptance_event(
         raise OwnerAcceptanceBindingConflictError(
             "Owner acceptance binding changed; evaluate the exact change again before recording."
         )
-    if len(impact.affected_products) != 1:
+    event_store = require_owner_acceptance_event_store(store)
+    target_events = event_store.list_owner_acceptance_event_records(
+        repository_id=impact.target.repository_id,
+        pull_request_number=impact.target.pull_request_number,
+    )
+    prewrite_decision = _evaluate_owner_acceptance_for_impact(
+        impact=impact,
+        store=store,
+        evaluated_at=normalized_occurred_at,
+        events=target_events,
+    )
+    normalized_expected_binding_sha256 = expected_binding_sha256.strip().lower()
+    current_matches = tuple(
+        product_index
+        for product_index, product_decision in enumerate(prewrite_decision.products)
+        if product_decision.binding is not None
+        and product_decision.binding.binding_sha256 == normalized_expected_binding_sha256
+    )
+    selected_product_index = current_matches[0] if len(current_matches) == 1 else None
+    if selected_product_index is None:
+        historical_subjects = {
+            (
+                event.binding.product,
+                event.binding.system,
+                event.binding.action,
+                event.binding.environment,
+            )
+            for event in target_events
+            if event.binding.binding_sha256 == normalized_expected_binding_sha256
+        }
+        historical_matches = tuple(
+            product_index
+            for product_index, affected_product in enumerate(impact.affected_products)
+            if (
+                affected_product.product,
+                affected_product.system,
+                affected_product.owner_action,
+                affected_product.owner_environment,
+            )
+            in historical_subjects
+        )
+        if len(historical_matches) == 1:
+            selected_product_index = historical_matches[0]
+    if selected_product_index is None:
         raise OwnerAcceptanceBindingConflictError(
             "Owner acceptance binding changed; evaluate the exact change again before recording."
         )
@@ -270,7 +241,7 @@ def record_owner_acceptance_event(
     )
     binding = _binding_from_impact(
         impact=impact,
-        product_index=0,
+        product_index=selected_product_index,
         store=store,
         actor=actor,
         evaluated_at=normalized_occurred_at,
@@ -301,13 +272,16 @@ def record_owner_acceptance_event(
         reason=reason,
         authorization=authorization,
     )
-    event_store = require_owner_acceptance_event_store(store)
-    prior_events = event_store.list_owner_acceptance_event_records(
-        repository_id=binding.repository_id,
-        pull_request_number=binding.pull_request_number,
-        product=binding.product,
-        system=binding.system,
-        action=binding.action,
+    prior_events = tuple(
+        event
+        for event in event_store.list_owner_acceptance_event_records(
+            repository_id=binding.repository_id,
+            pull_request_number=binding.pull_request_number,
+            product=binding.product,
+            system=binding.system,
+            action=binding.action,
+        )
+        if event.binding.environment == binding.environment
     )
     if binding.preview is None and any(event.binding.preview is not None for event in prior_events):
         raise OwnerAcceptanceEvaluationUnavailableError(
@@ -316,15 +290,18 @@ def record_owner_acceptance_event(
     write_status = event_store.write_owner_acceptance_event_record(record)
     if write_status == "replayed":
         record = event_store.read_owner_acceptance_event_record(record.event_id)
-    decision = evaluate_owner_acceptance_for_binding(
+    selected_decision = evaluate_owner_acceptance_for_binding(
         binding=binding,
-        events=event_store.list_owner_acceptance_event_records(
-            repository_id=binding.repository_id,
-            pull_request_number=binding.pull_request_number,
-            product=binding.product,
-            system=binding.system,
-            action=binding.action,
-        ),
+        events=(*prior_events, record),
+        evaluated_at=normalized_occurred_at,
+    )
+    product_decisions = list(prewrite_decision.products)
+    product_decisions[selected_product_index] = _product_decision(
+        affected_product=impact.affected_products[selected_product_index],
+        decision=selected_decision,
+    )
+    decision = aggregate_owner_acceptance_decision(
+        products=tuple(product_decisions),
         evaluated_at=normalized_occurred_at,
     )
     return OwnerAcceptanceWriteResult(
@@ -420,6 +397,158 @@ def evaluate_owner_acceptance_for_binding(
         binding=binding,
         event=latest,
         evaluated_at=normalized_evaluated_at,
+    )
+
+
+def aggregate_owner_acceptance_decision(
+    *,
+    products: tuple[OwnerAcceptanceProductDecision, ...],
+    evaluated_at: str,
+) -> OwnerAcceptanceDecision:
+    if not products:
+        raise ValueError("Owner acceptance aggregate requires at least one product decision.")
+    precedence = {status: index for index, status in enumerate(OWNER_ACCEPTANCE_STATUS_PRECEDENCE)}
+    _, governing = min(
+        enumerate(products),
+        key=lambda item: (precedence[item[1].status], item[0]),
+    )
+    return _decision(
+        status=governing.status,
+        reason_code=governing.reason_code,
+        binding=governing.binding,
+        event=governing.current_event,
+        products=products,
+        evaluated_at=evaluated_at,
+    )
+
+
+def _evaluate_owner_acceptance_for_impact(
+    *,
+    impact: ChangeImpactEvaluation,
+    store: object,
+    evaluated_at: str,
+    events: tuple[OwnerAcceptanceEventRecord, ...] | None = None,
+) -> OwnerAcceptanceDecision:
+    resolved_events = events
+    if resolved_events is None:
+        resolved_events = require_owner_acceptance_event_store(
+            store
+        ).list_owner_acceptance_event_records(
+            repository_id=impact.target.repository_id,
+            pull_request_number=impact.target.pull_request_number,
+        )
+    products = tuple(
+        _evaluate_owner_acceptance_product(
+            impact=impact,
+            affected_product=affected_product,
+            product_index=product_index,
+            store=store,
+            events=resolved_events,
+            evaluated_at=evaluated_at,
+        )
+        for product_index, affected_product in enumerate(impact.affected_products)
+    )
+    return aggregate_owner_acceptance_decision(products=products, evaluated_at=evaluated_at)
+
+
+def _evaluate_owner_acceptance_product(
+    *,
+    impact: ChangeImpactEvaluation,
+    affected_product: ChangeImpactAffectedProduct,
+    product_index: int,
+    store: object,
+    events: tuple[OwnerAcceptanceEventRecord, ...],
+    evaluated_at: str,
+) -> OwnerAcceptanceProductDecision:
+    product_events = tuple(
+        event
+        for event in events
+        if event.binding.product == affected_product.product
+        and event.binding.system == affected_product.system
+        and event.binding.action == affected_product.owner_action
+        and event.binding.environment == affected_product.owner_environment
+    )
+    try:
+        binding = _binding_from_impact(
+            impact=impact,
+            product_index=product_index,
+            store=store,
+            actor=None,
+            evaluated_at=evaluated_at,
+        )
+    except OwnerAcceptanceEvaluationUnavailableError:
+        preview_events = tuple(
+            event
+            for event in product_events
+            if event.binding.preview is not None and event.occurred_at <= evaluated_at
+        )
+        if preview_events:
+            current_event = max(
+                preview_events,
+                key=lambda event: (event.occurred_at, event.event_id),
+            )
+            decision = _decision(
+                status="stale",
+                reason_code="preview_evidence_stale",
+                binding=current_event.binding,
+                event=current_event,
+                evaluated_at=evaluated_at,
+            )
+        else:
+            decision = _decision(
+                status="unavailable",
+                reason_code="preview_evidence_unavailable",
+                evaluated_at=evaluated_at,
+            )
+        return _product_decision(affected_product=affected_product, decision=decision)
+    if binding is None:
+        return _product_decision(
+            affected_product=affected_product,
+            decision=_decision(
+                status="unavailable",
+                reason_code="owner_authority_unavailable",
+                evaluated_at=evaluated_at,
+            ),
+        )
+    effective_preview_events = tuple(
+        event
+        for event in product_events
+        if event.binding.preview is not None and event.occurred_at <= evaluated_at
+    )
+    if binding.preview is None and effective_preview_events:
+        decision = _decision(
+            status="stale",
+            reason_code="preview_evidence_stale",
+            binding=binding,
+            event=max(
+                effective_preview_events,
+                key=lambda event: (event.occurred_at, event.event_id),
+            ),
+            evaluated_at=evaluated_at,
+        )
+    else:
+        decision = evaluate_owner_acceptance_for_binding(
+            binding=binding,
+            events=product_events,
+            evaluated_at=evaluated_at,
+        )
+    return _product_decision(affected_product=affected_product, decision=decision)
+
+
+def _product_decision(
+    *,
+    affected_product: ChangeImpactAffectedProduct,
+    decision: OwnerAcceptanceDecision,
+) -> OwnerAcceptanceProductDecision:
+    return OwnerAcceptanceProductDecision(
+        product=affected_product.product,
+        system=affected_product.system,
+        action=affected_product.owner_action,
+        environment=affected_product.owner_environment,
+        status=decision.status,
+        reason_code=decision.reason_code,
+        binding=decision.binding,
+        current_event=decision.current_event,
     )
 
 
@@ -690,12 +819,14 @@ def _decision(
     evaluated_at: str,
     binding: OwnerAcceptanceBinding | None = None,
     event: OwnerAcceptanceEventRecord | None = None,
+    products: tuple[OwnerAcceptanceProductDecision, ...] = (),
 ) -> OwnerAcceptanceDecision:
     return OwnerAcceptanceDecision(
         status=status,
         reason_code=reason_code,
         binding=binding,
         current_event=event,
+        products=products,
         evaluated_at=evaluated_at,
     )
 

--- a/control_plane/storage/filesystem.py
+++ b/control_plane/storage/filesystem.py
@@ -1397,7 +1397,11 @@ class FilesystemRecordStore:
                     f"Incoming active {step_label.replace('_', ' ')} revision cannot take effect "
                     "in the future."
                 )
-            records = self._list_models_locked(model_type, record_type)
+            records = tuple(
+                existing
+                for existing in self._list_models_locked(model_type, record_type)
+                if existing.product == record.product and existing.system == record.system
+            )
             same_id = tuple(
                 existing for existing in records if existing.record_id == record.record_id
             )

--- a/docs/owner-acceptance.md
+++ b/docs/owner-acceptance.md
@@ -5,8 +5,9 @@ title: Owner Acceptance
 ## Purpose
 
 Owner acceptance is a shadow-only exact-change ledger for product/system Owner
-review of pull requests. It does not authorize production, merge trains,
-tenant admission, promotion, GitHub required checks, or manager-preview flows.
+review of pull requests. Every affected product receives an independent binding
+and decision. It does not authorize production, merge trains, tenant admission,
+promotion, GitHub required checks, or manager-preview flows.
 
 Launchplane is the only authority. GitHub comments, reviews, checked-in files,
 workflow inputs, local operator bearer tokens, agents, and workers cannot create
@@ -56,8 +57,23 @@ runtime identity evaluates as `stale` for the new binding. An enabled preview
 with ambiguous, incomplete, non-serving, or failed verification evidence is
 `unavailable`. If a preview-bound acceptance already exists, preview teardown
 evaluates as `preview_evidence_stale` and cannot be replaced by a weaker
-exact-change-only acceptance. Multi-product changes also fail closed until
-evaluation can require and aggregate one acceptance per affected product.
+exact-change-only acceptance.
+
+For every successfully impact-resolved product change, the response includes a
+deterministic `products` entry for each affected product in change-impact order;
+single-product changes therefore contain one entry. Early engineering-only,
+stale-impact, and unavailable-impact results contain no product entries. Each
+entry carries its own status, reason, binding, and current event. The top-level
+status is the worst current product status using this precedence: `unavailable`, `stale`,
+`revoked`, `changes_requested`, `pending`, `accepted`, `not_required`. Ties use
+the existing product order. The singular top-level binding and event mirror
+that governing product for compatibility. Aggregate acceptance is therefore
+`accepted` only when every affected product is currently accepted.
+
+Products removed from later current change-impact evidence stop governing the
+read result; evaluation does not write synthetic ledger events. Products added
+by a later exact head or policy/evidence revision receive their own current
+binding, while changed evidence continues to stale prior bindings normally.
 
 ## Event Authoring
 
@@ -75,6 +91,18 @@ the current binding differs from the one the Owner reviewed. This prevents a
 force-push, policy revision, requirement revision, Owner-scope change, or
 serving-preview/runtime change between evaluation and event authoring from
 silently changing what the human accepts.
+
+For a multi-product change, `expected_binding_sha256` also selects exactly one
+of the current server-derived product bindings. The request still cannot name a
+product. A digest that matches no current affected-product binding returns the
+same conflict without writing. One request writes at most one product event;
+the response returns the recomputed aggregate decision so remaining product
+acceptances stay visible.
+
+The `Idempotency-Key` is scoped by the exact binding because the immutable event
+ID includes both values. Reusing one key for different product-binding digests
+creates distinct product events; replaying it for the same binding remains
+idempotent.
 
 Human actions are:
 
@@ -101,6 +129,10 @@ payload is a conflict. Optional preview evidence lives inside the existing JSONB
 payload; non-preview bindings omit the field and preserve the original binding,
 acceptance, event, and replay digests byte-for-byte.
 
+Multi-product aggregation uses the existing subject indexes and one PR-scoped
+event read followed by in-memory product grouping. It adds no table, column,
+index, backfill, or migration revision.
+
 Migration `f3a5c7e9b1d4` creates the empty table and indexes only. It performs
 no backfill from GitHub comments, manager-preview approvals, technical waivers,
 or tenant-admission evidence.
@@ -111,6 +143,5 @@ or tenant-admission evidence.
 - GitHub status projection
 - frontend Owner workbench
 - tenant-admission cutover
-- multi-product aggregation
 - manager/delegate cleanup
 - break-glass acceptance

--- a/docs/records.md
+++ b/docs/records.md
@@ -269,8 +269,12 @@ generation IDs, immutable artifact image digest, manifest fingerprint,
 canonical URL, and an explicit verified-runtime identity projection. Changed
 head, tree, policy, requirement, membership, preview generation, artifact,
 manifest, URL, or runtime identity stales earlier acceptance for the new exact
-binding. Multi-product aggregation remains deferred and fails closed rather
-than accepting partial evidence.
+binding. Multi-product evaluation returns one independently authorized decision
+per affected product and accepts only when every current product decision is
+accepted. The top-level status and singular binding mirror the deterministic
+worst current product decision for compatibility. Event writes use the reviewed
+binding digest to select one server-derived product binding and never accept a
+caller-supplied product.
 
 Filesystem rehearsal records live under `launchplane_owner_acceptance_events/`.
 PostgreSQL stores the ledger in `launchplane_owner_acceptance_events` with an

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -3532,9 +3532,10 @@ teardown.
 requires a browser-authenticated GitHub human plus a bounded `Idempotency-Key`.
 It also requires the `expected_binding_sha256` returned by evaluation. The
 digest is a compare-only precondition: Launchplane re-resolves all evidence and
-returns a conflict without writing when the exact binding changed. The service
-then verifies that
-the immutable GitHub user ID is a current Owner for the affected exact scope
+returns a conflict without writing when the exact binding changed. For
+multi-product changes, that digest selects exactly one current server-derived
+product binding; callers cannot name or inject a product. The service then
+verifies that the immutable GitHub user ID is a current Owner for the affected exact scope
 before writing `accepted`, `changes_requested`, or `revoked`. Agents, workers,
 GitHub Actions, local operators, and other bearer identities cannot satisfy this
 route. Caller-owned head, tree, policy, Owner, or membership evidence is
@@ -3544,9 +3545,10 @@ through the same Owner-acceptance read authority.
 
 The ledger is append-only and shadow-only. Changed bound evidence or changed
 Owner policy/requirement/membership makes prior acceptance stale for the new
-binding. GitHub projection, frontend workbench, tenant-admission consumers,
-multi-product aggregation, verified preview/runtime binding, production
-authorization, and legacy manager cleanup remain out of scope. See
+binding. Evaluation returns one decision per affected product and is accepted
+only when all are current; dropped products stop governing without a read-side
+write. GitHub projection, frontend workbench, tenant-admission consumers,
+production authorization, and legacy manager cleanup remain out of scope. See
 `docs/owner-acceptance.md` for the full record and migration boundary.
 
 ## Change Impact Shadow API

--- a/frontend/generated/openapi-canonical.json
+++ b/frontend/generated/openapi-canonical.json
@@ -11553,6 +11553,14 @@
             "title": "Mode",
             "type": "string"
           },
+          "products": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/OwnerAcceptanceProductDecision"
+            },
+            "title": "Products",
+            "type": "array"
+          },
           "reason_code": {
             "enum": [
               "engineering_only",
@@ -11856,6 +11864,95 @@
           "runtime_identity"
         ],
         "title": "OwnerAcceptancePreviewBinding",
+        "type": "object"
+      },
+      "OwnerAcceptanceProductDecision": {
+        "additionalProperties": false,
+        "properties": {
+          "action": {
+            "title": "Action",
+            "type": "string"
+          },
+          "binding": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/OwnerAcceptanceBinding"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "current_event": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/OwnerAcceptanceEventRecord"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "environment": {
+            "title": "Environment",
+            "type": "string"
+          },
+          "product": {
+            "title": "Product",
+            "type": "string"
+          },
+          "reason_code": {
+            "enum": [
+              "engineering_only",
+              "acceptance_missing",
+              "acceptance_valid",
+              "changes_requested",
+              "acceptance_revoked",
+              "acceptance_stale",
+              "change_impact_unavailable",
+              "change_impact_stale",
+              "multi_product_unsupported",
+              "owner_authority_unavailable",
+              "owner_authority_denied",
+              "preview_evidence_unavailable",
+              "preview_evidence_stale"
+            ],
+            "title": "Reason Code",
+            "type": "string"
+          },
+          "schema_version": {
+            "default": 1,
+            "minimum": 1.0,
+            "title": "Schema Version",
+            "type": "integer"
+          },
+          "status": {
+            "enum": [
+              "not_required",
+              "pending",
+              "accepted",
+              "changes_requested",
+              "revoked",
+              "stale",
+              "unavailable"
+            ],
+            "title": "Status",
+            "type": "string"
+          },
+          "system": {
+            "title": "System",
+            "type": "string"
+          }
+        },
+        "required": [
+          "product",
+          "system",
+          "action",
+          "environment",
+          "status",
+          "reason_code"
+        ],
+        "title": "OwnerAcceptanceProductDecision",
         "type": "object"
       },
       "OwnerAcceptanceRuntimeIdentityBinding": {

--- a/tests/test_owner_acceptance.py
+++ b/tests/test_owner_acceptance.py
@@ -39,6 +39,7 @@ from control_plane.owner_acceptance import (
     OwnerAcceptanceBindingConflictError,
     OwnerAcceptanceEvaluationUnavailableError,
     OwnerAcceptanceEventConflictError,
+    aggregate_owner_acceptance_decision,
     evaluate_owner_acceptance,
     record_owner_acceptance_event,
 )
@@ -140,12 +141,13 @@ def _impact_policy(
 
 def _owner_policy(
     *,
+    product: str = PRODUCT,
     revision: int = 1,
     supersedes_record_id: str | None = None,
     owners: tuple[ProductOwnerGrant, ...] | None = None,
 ) -> ProductOwnerPolicyRecord:
     return ProductOwnerPolicyRecord(
-        product=PRODUCT,
+        product=product,
         system=SYSTEM,
         policy_revision=revision,
         owners=owners
@@ -167,11 +169,12 @@ def _owner_policy(
 
 def _owner_requirement(
     *,
+    product: str = PRODUCT,
     revision: int = 1,
     supersedes_record_id: str | None = None,
 ) -> ProductOwnerRequirementRecord:
     return ProductOwnerRequirementRecord(
-        product=PRODUCT,
+        product=product,
         system=SYSTEM,
         requirement_revision=revision,
         requirements=(
@@ -192,13 +195,23 @@ def _store(
     root: Path,
     *,
     include_dependency_evidence: bool = True,
-    shared_dependency_evidence: bool = False,
+    shared_dependency_evidence: bool | list[bool] = False,
+    include_second_product_authority: bool | None = None,
     invalid_product_profile: bool = False,
+    product_profile_read_limit: int | None = None,
 ) -> FilesystemRecordStore:
     class _OwnerAcceptanceStore(FilesystemRecordStore):
+        product_profile_read_count = 0
+
         def read_product_profile_record(self, product: str) -> LaunchplaneProductProfileRecord:
+            self.product_profile_read_count += 1
             if invalid_product_profile:
                 raise ValueError("invalid product profile")
+            if (
+                product_profile_read_limit is not None
+                and self.product_profile_read_count > product_profile_read_limit
+            ):
+                raise ValueError("product profile read limit exceeded")
             return super().read_product_profile_record(product)
 
         def list_change_impact_stored_evidence(
@@ -211,7 +224,12 @@ def _store(
         ) -> tuple[ChangeImpactStoredEvidence, ...]:
             if not include_dependency_evidence:
                 return ()
-            if shared_dependency_evidence:
+            shared_evidence_enabled = (
+                shared_dependency_evidence[0]
+                if isinstance(shared_dependency_evidence, list)
+                else shared_dependency_evidence
+            )
+            if shared_evidence_enabled:
                 return (
                     ChangeImpactStoredEvidence(
                         record_id="dependency-shared",
@@ -240,6 +258,13 @@ def _store(
     store.write_change_impact_policy_record(_impact_policy())
     store.write_product_owner_policy_record(_owner_policy())
     store.write_product_owner_requirement_record(_owner_requirement())
+    if (
+        bool(shared_dependency_evidence)
+        if include_second_product_authority is None
+        else include_second_product_authority
+    ):
+        store.write_product_owner_policy_record(_owner_policy(product=SECOND_PRODUCT))
+        store.write_product_owner_requirement_record(_owner_requirement(product=SECOND_PRODUCT))
     return store
 
 
@@ -934,7 +959,7 @@ class OwnerAcceptanceTests(unittest.TestCase):
             assert binding is not None
             self.assertEqual(binding.owner_policy_revision, 2)
 
-    def test_multi_product_change_fails_closed(self) -> None:
+    def test_multi_product_change_requires_acceptance_per_product(self) -> None:
         with TemporaryDirectory() as directory:
             store = _store(Path(directory), shared_dependency_evidence=True)
             decision = evaluate_owner_acceptance(
@@ -949,9 +974,244 @@ class OwnerAcceptanceTests(unittest.TestCase):
                 evaluated_at="2026-08-07T12:00:00Z",
             )
 
-            self.assertEqual(decision.status, "unavailable")
-            self.assertEqual(decision.reason_code, "multi_product_unsupported")
+            self.assertEqual(decision.status, "pending")
+            self.assertEqual(decision.reason_code, "acceptance_missing")
+            self.assertEqual(
+                tuple(product.product for product in decision.products),
+                (PRODUCT, SECOND_PRODUCT),
+            )
+            self.assertEqual(
+                tuple(product.status for product in decision.products),
+                ("pending", "pending"),
+            )
+            self.assertIsNotNone(decision.binding)
+            assert decision.binding is not None
+            self.assertEqual(decision.binding.product, PRODUCT)
             self.assertEqual(store.list_owner_acceptance_event_records(), ())
+
+    def test_multi_product_write_selects_each_server_derived_binding(self) -> None:
+        with TemporaryDirectory() as directory:
+            store = _store(Path(directory), shared_dependency_evidence=True)
+            provider = _EvidenceProvider(_repository_evidence(path="src/shared/app.py"))
+            target = ChangeImpactTargetReference(repository=REPOSITORY, pull_request_number=2022)
+            initial = evaluate_owner_acceptance(
+                store=store,
+                repository_evidence_provider=provider,
+                target=target,
+                evaluated_at="2026-08-07T12:00:00Z",
+            )
+            bindings = {product.product: product.binding for product in initial.products}
+            self.assertTrue(all(binding is not None for binding in bindings.values()))
+
+            second = bindings[SECOND_PRODUCT]
+            assert second is not None
+            accepted_second = record_owner_acceptance_event(
+                store=store,
+                repository_evidence_provider=provider,
+                target=target,
+                identity=_human(),
+                action="accepted",
+                expected_binding_sha256=second.binding_sha256,
+                source_event_kind="browser_api",
+                source_event_id="accept-both-products",
+                occurred_at="2026-08-07T12:05:00Z",
+            )
+            self.assertEqual(accepted_second.record.binding.product, SECOND_PRODUCT)
+            self.assertEqual(accepted_second.decision.status, "pending")
+            self.assertEqual(
+                tuple(product.status for product in accepted_second.decision.products),
+                ("pending", "accepted"),
+            )
+
+            first = bindings[PRODUCT]
+            assert first is not None
+            accepted_first = record_owner_acceptance_event(
+                store=store,
+                repository_evidence_provider=provider,
+                target=target,
+                identity=_human(),
+                action="accepted",
+                expected_binding_sha256=first.binding_sha256,
+                source_event_kind="browser_api",
+                source_event_id="accept-both-products",
+                occurred_at="2026-08-07T12:10:00Z",
+            )
+            self.assertEqual(accepted_first.record.binding.product, PRODUCT)
+            self.assertEqual(accepted_first.decision.status, "accepted")
+            self.assertEqual(
+                tuple(product.status for product in accepted_first.decision.products),
+                ("accepted", "accepted"),
+            )
+            events = store.list_owner_acceptance_event_records()
+            self.assertEqual(len(events), 2)
+            self.assertEqual(len({event.event_id for event in events}), 2)
+
+    def test_write_does_not_re_resolve_aggregate_after_persisting(self) -> None:
+        with TemporaryDirectory() as directory:
+            store = _store(Path(directory), product_profile_read_limit=3)
+            provider = _EvidenceProvider(_repository_evidence())
+            target = ChangeImpactTargetReference(repository=REPOSITORY, pull_request_number=2022)
+            evaluated = evaluate_owner_acceptance(
+                store=store,
+                repository_evidence_provider=provider,
+                target=target,
+                evaluated_at="2026-08-07T12:00:00Z",
+            )
+            assert evaluated.binding is not None
+
+            result = record_owner_acceptance_event(
+                store=store,
+                repository_evidence_provider=provider,
+                target=target,
+                identity=_human(),
+                action="accepted",
+                expected_binding_sha256=evaluated.binding.binding_sha256,
+                source_event_kind="browser_api",
+                source_event_id="accept-with-bounded-evidence-reads",
+                occurred_at="2026-08-07T12:05:00Z",
+            )
+
+            self.assertEqual(result.status, "written")
+            self.assertEqual(result.decision.status, "accepted")
+            self.assertEqual(getattr(store, "product_profile_read_count"), 3)
+
+    def test_multi_product_aggregate_fails_closed_for_missing_authority(self) -> None:
+        with TemporaryDirectory() as directory:
+            store = _store(
+                Path(directory),
+                shared_dependency_evidence=True,
+                include_second_product_authority=False,
+            )
+            decision = evaluate_owner_acceptance(
+                store=store,
+                repository_evidence_provider=_EvidenceProvider(
+                    _repository_evidence(path="src/shared/app.py")
+                ),
+                target=ChangeImpactTargetReference(
+                    repository=REPOSITORY,
+                    pull_request_number=2022,
+                ),
+                evaluated_at="2026-08-07T12:00:00Z",
+            )
+
+            self.assertEqual(decision.status, "unavailable")
+            self.assertEqual(decision.reason_code, "owner_authority_unavailable")
+            self.assertEqual(
+                tuple(product.status for product in decision.products),
+                ("pending", "unavailable"),
+            )
+            self.assertIsNone(decision.binding)
+
+    def test_aggregate_status_precedence_and_tie_break_are_deterministic(self) -> None:
+        with TemporaryDirectory() as directory:
+            store = _store(Path(directory), shared_dependency_evidence=True)
+            initial = evaluate_owner_acceptance(
+                store=store,
+                repository_evidence_provider=_EvidenceProvider(
+                    _repository_evidence(path="src/shared/app.py")
+                ),
+                target=ChangeImpactTargetReference(
+                    repository=REPOSITORY,
+                    pull_request_number=2022,
+                ),
+                evaluated_at="2026-08-07T12:00:00Z",
+            )
+            first, second = initial.products
+            cases = (
+                ("unavailable", "owner_authority_unavailable", "accepted", "acceptance_valid"),
+                ("stale", "acceptance_stale", "revoked", "acceptance_revoked"),
+                ("revoked", "acceptance_revoked", "changes_requested", "changes_requested"),
+                ("changes_requested", "changes_requested", "pending", "acceptance_missing"),
+                ("pending", "acceptance_missing", "accepted", "acceptance_valid"),
+                ("accepted", "acceptance_valid", "not_required", "engineering_only"),
+            )
+            for first_status, first_reason, second_status, second_reason in cases:
+                with self.subTest(first_status=first_status, second_status=second_status):
+                    aggregate = aggregate_owner_acceptance_decision(
+                        products=(
+                            first.model_copy(
+                                update={"status": first_status, "reason_code": first_reason}
+                            ),
+                            second.model_copy(
+                                update={"status": second_status, "reason_code": second_reason}
+                            ),
+                        ),
+                        evaluated_at="2026-08-07T12:00:00Z",
+                    )
+                    self.assertEqual(aggregate.status, first_status)
+                    self.assertEqual(aggregate.reason_code, first_reason)
+
+            tied = aggregate_owner_acceptance_decision(
+                products=(first, second),
+                evaluated_at="2026-08-07T12:00:00Z",
+            )
+            self.assertIsNotNone(tied.binding)
+            assert tied.binding is not None
+            self.assertEqual(tied.binding.product, PRODUCT)
+
+    def test_product_set_drift_is_deterministic_and_read_only(self) -> None:
+        with TemporaryDirectory() as directory:
+            shared_evidence_enabled = [False]
+            store = _store(
+                Path(directory),
+                shared_dependency_evidence=shared_evidence_enabled,
+                include_second_product_authority=True,
+            )
+            target = ChangeImpactTargetReference(repository=REPOSITORY, pull_request_number=2022)
+            single_provider = _EvidenceProvider(_repository_evidence(path="src/runtime/app.py"))
+            single = evaluate_owner_acceptance(
+                store=store,
+                repository_evidence_provider=single_provider,
+                target=target,
+                evaluated_at="2026-08-07T12:00:00Z",
+            )
+            assert single.binding is not None
+            accepted = record_owner_acceptance_event(
+                store=store,
+                repository_evidence_provider=single_provider,
+                target=target,
+                identity=_human(),
+                action="accepted",
+                expected_binding_sha256=single.binding.binding_sha256,
+                source_event_kind="browser_api",
+                source_event_id="accept-before-product-set-drift",
+                occurred_at="2026-08-07T12:05:00Z",
+            )
+
+            shared_evidence_enabled[0] = True
+            expanded_provider = _EvidenceProvider(
+                _repository_evidence(path="src/shared/app.py", head="c" * 40)
+            )
+            expanded = evaluate_owner_acceptance(
+                store=store,
+                repository_evidence_provider=expanded_provider,
+                target=target,
+                evaluated_at="2026-08-07T12:10:00Z",
+            )
+            self.assertEqual(
+                tuple(product.status for product in expanded.products),
+                ("stale", "pending"),
+            )
+            self.assertNotEqual(
+                expanded.products[0].binding.binding_sha256
+                if expanded.products[0].binding is not None
+                else "",
+                accepted.record.binding.binding_sha256,
+            )
+
+            shared_evidence_enabled[0] = False
+            contracted_provider = _EvidenceProvider(
+                _repository_evidence(path="src/runtime/app.py", head="c" * 40)
+            )
+            contracted = evaluate_owner_acceptance(
+                store=store,
+                repository_evidence_provider=contracted_provider,
+                target=target,
+                evaluated_at="2026-08-07T12:15:00Z",
+            )
+            self.assertEqual(contracted.status, "stale")
+            self.assertEqual(tuple(product.product for product in contracted.products), (PRODUCT,))
+            self.assertEqual(len(store.list_owner_acceptance_event_records()), 1)
 
 
 if __name__ == "__main__":

--- a/tests/test_owner_acceptance_http.py
+++ b/tests/test_owner_acceptance_http.py
@@ -23,7 +23,9 @@ from control_plane.service_auth import (
 )
 from tests.support.http import lifespan_client
 from tests.test_owner_acceptance import (
+    PRODUCT,
     REPOSITORY,
+    SECOND_PRODUCT,
     _EvidenceProvider,
     _human,
     _repository_evidence,
@@ -136,6 +138,75 @@ class OwnerAcceptanceHttpTests(unittest.IsolatedAsyncioTestCase):
                 )
                 self.assertEqual(read.status_code, 200, read.text)
                 self.assertEqual(read.json()["record"], payload["record"])
+
+    async def test_multi_product_flow_uses_digest_selection_without_product_input(self) -> None:
+        with TemporaryDirectory() as directory:
+            store = _store(Path(directory), shared_dependency_evidence=True)
+            provider = _EvidenceProvider(_repository_evidence(path="src/shared/app.py"))
+            app = _app(store=store, repository_evidence_provider=provider)
+            target: dict[str, str | int] = {
+                "repository": REPOSITORY,
+                "pull_request_number": 2022,
+            }
+
+            async with lifespan_client(app) as client:
+                evaluated = await client.get(OWNER_ACCEPTANCE_EVALUATION_ROUTE, params=target)
+                self.assertEqual(evaluated.status_code, 200, evaluated.text)
+                decision = evaluated.json()["decision"]
+                self.assertEqual(
+                    [product["product"] for product in decision["products"]],
+                    [PRODUCT, SECOND_PRODUCT],
+                )
+                bindings = {
+                    product["product"]: product["binding"]["binding_sha256"]
+                    for product in decision["products"]
+                }
+
+                injected = await client.post(
+                    OWNER_ACCEPTANCE_EVENTS_ROUTE,
+                    json={
+                        "target": target,
+                        "action": "accepted",
+                        "expected_binding_sha256": bindings[SECOND_PRODUCT],
+                        "product": SECOND_PRODUCT,
+                    },
+                    headers={"Idempotency-Key": "accept-multi-product"},
+                )
+                self.assertEqual(injected.status_code, 422, injected.text)
+                self.assertEqual(store.list_owner_acceptance_event_records(), ())
+
+                accepted_second = await client.post(
+                    OWNER_ACCEPTANCE_EVENTS_ROUTE,
+                    json={
+                        "target": target,
+                        "action": "accepted",
+                        "expected_binding_sha256": bindings[SECOND_PRODUCT],
+                    },
+                    headers={"Idempotency-Key": "accept-multi-product"},
+                )
+                self.assertEqual(accepted_second.status_code, 202, accepted_second.text)
+                second_payload = accepted_second.json()
+                self.assertEqual(second_payload["record"]["binding"]["product"], SECOND_PRODUCT)
+                self.assertEqual(second_payload["decision"]["status"], "pending")
+
+                accepted_first = await client.post(
+                    OWNER_ACCEPTANCE_EVENTS_ROUTE,
+                    json={
+                        "target": target,
+                        "action": "accepted",
+                        "expected_binding_sha256": bindings[PRODUCT],
+                    },
+                    headers={"Idempotency-Key": "accept-multi-product"},
+                )
+                self.assertEqual(accepted_first.status_code, 202, accepted_first.text)
+                first_payload = accepted_first.json()
+                self.assertEqual(first_payload["record"]["binding"]["product"], PRODUCT)
+                self.assertEqual(first_payload["decision"]["status"], "accepted")
+                self.assertEqual(
+                    [product["status"] for product in first_payload["decision"]["products"]],
+                    ["accepted", "accepted"],
+                )
+                self.assertEqual(len(store.list_owner_acceptance_event_records()), 2)
 
     async def test_changes_requested_and_revoked_require_reasons_and_evaluate(self) -> None:
         target: dict[str, str | int] = {

--- a/tests/test_postgres_integration.py
+++ b/tests/test_postgres_integration.py
@@ -844,7 +844,7 @@ def _manager_preview_approval_event() -> ManagerPreviewApprovalEventRecord:
     )
 
 
-def _owner_acceptance_event() -> OwnerAcceptanceEventRecord:
+def _owner_acceptance_event(*, product: str = "example-site") -> OwnerAcceptanceEventRecord:
     occurred_at = "2026-08-07T12:00:00Z"
     binding = OwnerAcceptanceBinding(
         repository_id="1001",
@@ -856,36 +856,36 @@ def _owner_acceptance_event() -> OwnerAcceptanceEventRecord:
         change_impact_policy_record_id="change-impact-policy-1001-r1",
         change_impact_policy_revision=1,
         change_impact_policy_digest="a" * 64,
-        product="example-site",
+        product=product,
         system="web",
         action="pull_request.owner_acceptance",
         environment="pull_request",
-        owner_policy_record_id="product-owner-policy-example-site-r1",
+        owner_policy_record_id=f"product-owner-policy-{product}-r1",
         owner_policy_revision=1,
         owner_policy_digest="b" * 64,
-        owner_requirement_record_id="product-owner-requirement-example-site-r1",
+        owner_requirement_record_id=f"product-owner-requirement-{product}-r1",
         owner_requirement_revision=1,
         owner_requirement_digest="c" * 64,
         preview=OwnerAcceptancePreviewBinding(
-            context="example-site-preview",
-            preview_id="preview-example-site-pr-17",
-            serving_generation_id="preview-example-site-pr-17-generation-0001",
-            artifact_id="artifact-example-site-pr-17",
+            context=f"{product}-preview",
+            preview_id=f"preview-{product}-pr-17",
+            serving_generation_id=f"preview-{product}-pr-17-generation-0001",
+            artifact_id=f"artifact-{product}-pr-17",
             artifact_image_digest=f"sha256:{'d' * 64}",
-            manifest_fingerprint="manifest-example-site-pr-17",
-            preview_url="https://pr-17.example.test",
+            manifest_fingerprint=f"manifest-{product}-pr-17",
+            preview_url=f"https://pr-17.{product}.example.test",
             runtime_identity=owner_acceptance_runtime_identity_binding(
                 RuntimeIdentity(
-                    product="example-site",
-                    context="example-site-preview",
+                    product=product,
+                    context=f"{product}-preview",
                     instance="preview-pr-17",
                     environment_kind="preview",
-                    deployment_record_id="deployment-example-site-pr-17",
-                    artifact_id="artifact-example-site-pr-17",
+                    deployment_record_id=f"deployment-{product}-pr-17",
+                    artifact_id=f"artifact-{product}-pr-17",
                     source_git_ref="1" * 40,
-                    image_reference=f"ghcr.io/example/example-site@sha256:{'d' * 64}",
-                    preview_id="preview-example-site-pr-17",
-                    preview_generation_id="preview-example-site-pr-17-generation-0001",
+                    image_reference=f"ghcr.io/example/{product}@sha256:{'d' * 64}",
+                    preview_id=f"preview-{product}-pr-17",
+                    preview_generation_id=f"preview-{product}-pr-17-generation-0001",
                 )
             ),
         ),
@@ -895,9 +895,9 @@ def _owner_acceptance_event() -> OwnerAcceptanceEventRecord:
         action="accepted",
         occurred_at=occurred_at,
         source_event_kind="browser_api",
-        source_event_id="acceptance-101",
+        source_event_id=f"acceptance-{product}-101",
         authorization=OwnerAcceptanceAuthorization(
-            owner_identity_id="owner-identity-github-example",
+            owner_identity_id=f"owner-identity-github-{product}",
             owner_github_id=101,
             owner_login="owner",
             owner_policy_record_id=binding.owner_policy_record_id,
@@ -969,8 +969,10 @@ class RealPostgresSchemaIntegrationTests(unittest.TestCase):
     def test_owner_acceptance_events_persist_append_only(self) -> None:
         with _store_for_fresh_head_database() as store:
             event = _owner_acceptance_event()
+            second_event = _owner_acceptance_event(product="example-admin")
 
             self.assertEqual(store.write_owner_acceptance_event_record(event), "written")
+            self.assertEqual(store.write_owner_acceptance_event_record(second_event), "written")
             replay_payload = event.model_dump(mode="json")
             replay_payload["occurred_at"] = "2026-08-07T12:01:00Z"
             replay_payload["authorization"]["authorized_at"] = "2026-08-07T12:01:00Z"
@@ -987,6 +989,15 @@ class RealPostgresSchemaIntegrationTests(unittest.TestCase):
                     action="pull_request.owner_acceptance",
                 ),
                 (event,),
+            )
+            all_product_events = store.list_owner_acceptance_event_records(
+                repository_id="1001",
+                pull_request_number=17,
+            )
+            self.assertEqual(len(all_product_events), 2)
+            self.assertEqual(
+                {record.binding.product for record in all_product_events},
+                {"example-site", "example-admin"},
             )
 
             conflicting = OwnerAcceptanceEventRecord.model_validate(

--- a/tests/test_product_owner_policy.py
+++ b/tests/test_product_owner_policy.py
@@ -55,17 +55,18 @@ def _grant(subject_id: str) -> ProductOwnerGrant:
 
 def _policy(
     *,
+    product: str = PRODUCT,
     revision: int = 1,
     subjects: tuple[str, ...] = ("1001", "1002"),
     supersedes_record_id: str | None = None,
 ) -> ProductOwnerPolicyRecord:
     return ProductOwnerPolicyRecord(
         record_id=build_product_owner_policy_record_id(
-            product=PRODUCT,
+            product=product,
             system=SYSTEM,
             policy_revision=revision,
         ),
-        product=PRODUCT,
+        product=product,
         system=SYSTEM,
         policy_revision=revision,
         owners=tuple(_grant(subject) for subject in subjects),
@@ -106,6 +107,40 @@ def _context() -> ProductOwnerActionContext:
 
 
 class ProductOwnerPolicyTests(unittest.TestCase):
+    def test_filesystem_storage_keeps_product_revision_streams_independent(self) -> None:
+        with TemporaryDirectory() as directory:
+            store = FilesystemRecordStore(Path(directory))
+            second_product = "product-beta"
+
+            self.assertEqual(store.write_product_owner_policy_record(_policy()), "written")
+            self.assertEqual(
+                store.write_product_owner_policy_record(_policy(product=second_product)),
+                "written",
+            )
+            self.assertEqual(
+                store.write_product_owner_requirement_record(_requirement()),
+                "written",
+            )
+            self.assertEqual(
+                store.write_product_owner_requirement_record(_requirement(product=second_product)),
+                "written",
+            )
+
+            self.assertEqual(
+                {
+                    record.product
+                    for record in store.list_product_owner_policy_records(status="active")
+                },
+                {PRODUCT, second_product},
+            )
+            self.assertEqual(
+                {
+                    record.product
+                    for record in store.list_product_owner_requirement_records(status="active")
+                },
+                {PRODUCT, second_product},
+            )
+
     def test_policy_requires_human_immutable_identity_and_quorum_one(self) -> None:
         policy = _policy()
         self.assertEqual(policy.quorum, 1)


### PR DESCRIPTION
## Summary
- return one deterministic Owner-acceptance decision per affected product and fail closed until every product is accepted
- select exactly one server-derived product binding for each write using the reviewed binding digest, without accepting caller-owned product evidence
- preserve per-product preview/runtime stale behavior, authorization, replay, and single-product binding digests
- align filesystem product-owner revision streams with PostgreSQL `(product, system)` scoping
- document aggregate precedence, product-set drift, and binding-scoped idempotency

## Validation
- `uv run --extra dev launchplane ci unittest-shard local` (2,778 targets)
- focused Owner acceptance/HTTP/product-owner tests (45 tests)
- real PostgreSQL integration gate (80 tests)
- `uv run --extra dev mypy control_plane tests`
- changed-file Ruff lint and format checks
- `pnpm --dir frontend check:openapi-drift`
- `uv run alembic heads` (`f3a5c7e9b1d4`)
- independent Opus review: MERGE; Gemini concerns independently checked and shown blocked by the authoritative digest comparison and existing guards

Closes #2025
