### PR TITLE
Project advisory governance checks through a GitHub App

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -27,6 +27,7 @@
     "secrets": "docs/secrets.md",
     "githubActionsSecurity": "docs/github-actions-security.md",
     "dependencyHealthContract": "docs/dependency-health-contract.md",
+    "advisoryGovernanceChecks": "docs/advisory-governance-checks.md",
     "publicReadiness": "docs/public-readiness.md",
     "style": ["docs/style/python.md", "docs/style/testing.md"],
     "policies": ["docs/policies/coding-standards.md"]

--- a/control_plane/advisory_check_projection.py
+++ b/control_plane/advisory_check_projection.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from urllib.parse import quote, urlencode
+
+import click
+
+from control_plane.contracts.advisory_check_projection import (
+    AdvisoryCheckProjection,
+    AdvisoryCheckProjectionResult,
+    AdvisoryCheckProjectionStatus,
+)
+from control_plane.github_app_identity import GitHubAppInstallationToken
+from control_plane.github_payload import json_object, required_positive_int, required_string_text
+from control_plane.workflows.launchplane import github_api_request
+
+
+GitHubApiRequest = Callable[..., object]
+
+
+class AdvisoryCheckProjectionError(ValueError):
+    pass
+
+
+def write_advisory_check_projection(
+    *,
+    projection: AdvisoryCheckProjection,
+    installation_token: GitHubAppInstallationToken,
+    api_request: GitHubApiRequest = github_api_request,
+) -> AdvisoryCheckProjectionResult:
+    if installation_token.repository_id != int(projection.repository_id):
+        raise AdvisoryCheckProjectionError(
+            "GitHub App installation token does not match projection repository id."
+        )
+    if installation_token.repository.casefold() != projection.repository.casefold():
+        raise AdvisoryCheckProjectionError(
+            "GitHub App installation token does not match projection repository name."
+        )
+    owner, repo = projection.repository.split("/", 1)
+    repository_path = f"{quote(owner, safe='')}/{quote(repo, safe='')}"
+    query = urlencode(
+        {
+            "check_name": projection.name,
+            "app_id": str(installation_token.app_id),
+            "filter": "latest",
+            "per_page": "100",
+        }
+    )
+    current_payload = json_object(
+        _github_api_request(
+            api_request,
+            path=(
+                f"/repos/{repository_path}/commits/"
+                f"{quote(projection.head_sha, safe='')}/check-runs?{query}"
+            ),
+            token=installation_token.token,
+        ),
+        "GitHub advisory check runs response",
+        error_type=AdvisoryCheckProjectionError,
+    )
+    raw_check_runs = current_payload.get("check_runs")
+    if not isinstance(raw_check_runs, list):
+        raise AdvisoryCheckProjectionError(
+            "GitHub advisory check runs response must include check_runs."
+        )
+    current = next(
+        (
+            json_object(
+                item,
+                "GitHub advisory check run",
+                error_type=AdvisoryCheckProjectionError,
+            )
+            for item in raw_check_runs
+            if isinstance(item, dict)
+            and str(item.get("name") or "") == projection.name
+            and str(item.get("head_sha") or "").lower() == projection.head_sha
+            and _app_id(item.get("app")) == installation_token.app_id
+        ),
+        None,
+    )
+    if current is not None and _matches_projection(current, projection):
+        return _result(
+            status="replayed",
+            projection=projection,
+            installation_token=installation_token,
+            check_run=current,
+        )
+    body = {
+        "name": projection.name,
+        "status": "completed",
+        "conclusion": "neutral",
+        "external_id": projection.external_id,
+        "details_url": projection.details_url,
+        "output": {"title": projection.title, "summary": projection.summary},
+    }
+    status: AdvisoryCheckProjectionStatus
+    if current is None:
+        response = _github_api_request(
+            api_request,
+            path=f"/repos/{repository_path}/check-runs",
+            token=installation_token.token,
+            method="POST",
+            body={
+                "name": projection.name,
+                "head_sha": projection.head_sha,
+                **body,
+            },
+        )
+        status = "projected"
+    else:
+        check_run_id = required_positive_int(
+            current.get("id"),
+            "GitHub advisory check run requires id.",
+            error_type=AdvisoryCheckProjectionError,
+        )
+        response = _github_api_request(
+            api_request,
+            path=f"/repos/{repository_path}/check-runs/{check_run_id}",
+            token=installation_token.token,
+            method="PATCH",
+            body=body,
+        )
+        status = "updated"
+    check_run = json_object(
+        response,
+        "GitHub advisory check run response",
+        error_type=AdvisoryCheckProjectionError,
+    )
+    return _result(
+        status=status,
+        projection=projection,
+        installation_token=installation_token,
+        check_run=check_run,
+    )
+
+
+def _matches_projection(check_run: dict[str, object], projection: AdvisoryCheckProjection) -> bool:
+    output = check_run.get("output")
+    return (
+        str(check_run.get("status") or "") == "completed"
+        and str(check_run.get("conclusion") or "") == "neutral"
+        and str(check_run.get("external_id") or "") == projection.external_id
+        and str(check_run.get("details_url") or "") == projection.details_url
+        and isinstance(output, dict)
+        and str(output.get("title") or "") == projection.title
+        and str(output.get("summary") or "") == projection.summary
+    )
+
+
+def _result(
+    *,
+    status: AdvisoryCheckProjectionStatus,
+    projection: AdvisoryCheckProjection,
+    installation_token: GitHubAppInstallationToken,
+    check_run: dict[str, object],
+) -> AdvisoryCheckProjectionResult:
+    if (
+        required_string_text(
+            check_run.get("name"),
+            "GitHub advisory check run response requires name.",
+            error_type=AdvisoryCheckProjectionError,
+        )
+        != projection.name
+        or required_string_text(
+            check_run.get("head_sha"),
+            "GitHub advisory check run response requires head_sha.",
+            error_type=AdvisoryCheckProjectionError,
+        ).lower()
+        != projection.head_sha
+        or required_string_text(
+            check_run.get("external_id"),
+            "GitHub advisory check run response requires external_id.",
+            error_type=AdvisoryCheckProjectionError,
+        )
+        != projection.external_id
+        or _app_id(check_run.get("app")) != installation_token.app_id
+        or str(check_run.get("status") or "") != "completed"
+        or str(check_run.get("conclusion") or "") != "neutral"
+        or str(check_run.get("details_url") or "") != projection.details_url
+    ):
+        raise AdvisoryCheckProjectionError(
+            "GitHub advisory check run response did not match exact projection identity."
+        )
+    return AdvisoryCheckProjectionResult(
+        status=status,
+        name=projection.name,
+        head_sha=projection.head_sha,
+        external_id=projection.external_id,
+        app_id=installation_token.app_id,
+        installation_id=installation_token.installation_id,
+        check_run_id=required_positive_int(
+            check_run.get("id"),
+            "GitHub advisory check run response requires id.",
+            error_type=AdvisoryCheckProjectionError,
+        ),
+    )
+
+
+def _app_id(value: object) -> int:
+    if not isinstance(value, dict):
+        return 0
+    raw_id = value.get("id")
+    if isinstance(raw_id, int) and not isinstance(raw_id, bool) and raw_id > 0:
+        return raw_id
+    return 0
+
+
+def _github_api_request(
+    api_request: GitHubApiRequest,
+    **kwargs: object,
+) -> object:
+    try:
+        return api_request(**kwargs)
+    except click.ClickException as error:
+        raise AdvisoryCheckProjectionError(str(error)) from error

--- a/control_plane/contracts/advisory_check_projection.py
+++ b/control_plane/contracts/advisory_check_projection.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from typing import Final, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+ENGINEERING_REVIEW_CHECK_NAME: Final = "launchplane/engineering-review"
+OWNER_ACCEPTANCE_CHECK_NAME: Final = "launchplane/owner-acceptance"
+LEGACY_ENGINEERING_REVIEW_STATUS_CONTEXT: Final = "launchplane/engineering-review-shadow"
+
+LAUNCHPLANE_PROJECTED_CHECK_NAMES = frozenset(
+    {
+        ENGINEERING_REVIEW_CHECK_NAME.casefold(),
+        OWNER_ACCEPTANCE_CHECK_NAME.casefold(),
+        LEGACY_ENGINEERING_REVIEW_STATUS_CONTEXT.casefold(),
+    }
+)
+
+AdvisoryCheckProjectionStatus = Literal["projected", "updated", "replayed"]
+
+
+class AdvisoryCheckProjection(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    schema_version: int = Field(default=1, ge=1)
+    name: str
+    repository: str
+    repository_id: str = Field(pattern=r"^[1-9][0-9]*$")
+    head_sha: str = Field(pattern=r"^[0-9a-f]{40}$")
+    external_id: str = Field(pattern=r"^[0-9a-f]{64}$")
+    details_url: str
+    title: str = Field(min_length=1, max_length=255)
+    summary: str = Field(min_length=1, max_length=65535)
+
+    @model_validator(mode="after")
+    def _validate_projection(self) -> "AdvisoryCheckProjection":
+        if self.schema_version != 1:
+            raise ValueError("Unsupported advisory check projection schema version.")
+        if self.name not in {
+            ENGINEERING_REVIEW_CHECK_NAME,
+            OWNER_ACCEPTANCE_CHECK_NAME,
+        }:
+            raise ValueError("Advisory check projection uses an unreserved check name.")
+        if self.repository.strip() != self.repository or self.repository.count("/") != 1:
+            raise ValueError("Advisory check projection repository must use owner/name.")
+        if not all(part.strip() for part in self.repository.split("/", 1)):
+            raise ValueError("Advisory check projection repository must use owner/name.")
+        if self.details_url.strip() != self.details_url or not self.details_url:
+            raise ValueError("Advisory check projection requires a canonical details URL.")
+        if self.title.strip() != self.title or self.summary.strip() != self.summary:
+            raise ValueError("Advisory check projection text must be canonical.")
+        return self
+
+
+class AdvisoryCheckProjectionResult(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    schema_version: int = Field(default=1, ge=1)
+    status: AdvisoryCheckProjectionStatus
+    name: str
+    head_sha: str = Field(pattern=r"^[0-9a-f]{40}$")
+    external_id: str = Field(pattern=r"^[0-9a-f]{64}$")
+    app_id: int = Field(ge=1)
+    installation_id: int = Field(ge=1)
+    check_run_id: int = Field(ge=1)
+    conclusion: Literal["neutral"] = "neutral"
+
+
+def is_launchplane_projected_check(name: str) -> bool:
+    return name.strip().casefold() in LAUNCHPLANE_PROJECTED_CHECK_NAMES

--- a/control_plane/contracts/engineering_review_decision.py
+++ b/control_plane/contracts/engineering_review_decision.py
@@ -7,6 +7,9 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from control_plane.contracts.advisory_check_projection import (
+    ENGINEERING_REVIEW_CHECK_NAME,
+)
 from control_plane.contracts.change_impact import (
     ChangeImpactDecisionStatus,
     ChangeImpactReviewTier,
@@ -22,7 +25,7 @@ EngineeringReviewDecisionStatus = Literal[
 ENGINEERING_REVIEW_DECISION_CREATE_ACTION = "engineering_review_decision.create"
 ENGINEERING_REVIEW_DECISION_READ_ACTION = "engineering_review_decision.read"
 ENGINEERING_REVIEW_DECISION_PROJECT_ACTION = "engineering_review_decision.project"
-ENGINEERING_REVIEW_STATUS_CONTEXT = "launchplane/engineering-review-shadow"
+ENGINEERING_REVIEW_STATUS_CONTEXT = ENGINEERING_REVIEW_CHECK_NAME
 
 _SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
 
@@ -116,12 +119,15 @@ class EngineeringReviewDecisionProjectionResult(BaseModel):
     model_config = ConfigDict(extra="forbid", frozen=True)
 
     schema_version: int = Field(default=1, ge=1)
-    status: Literal["projected", "replayed"]
-    context: Literal["launchplane/engineering-review-shadow"] = (
-        "launchplane/engineering-review-shadow"
-    )
+    status: Literal["projected", "updated", "replayed"]
+    context: Literal["launchplane/engineering-review"] = "launchplane/engineering-review"
     state: Literal["pending", "success", "failure", "error"]
     head_sha: str
+    external_id: str = Field(pattern=r"^[0-9a-f]{64}$")
+    app_id: int = Field(ge=1)
+    installation_id: int = Field(ge=1)
+    check_run_id: int = Field(ge=1)
+    conclusion: Literal["neutral"] = "neutral"
 
 
 def build_engineering_review_decision_binding(

--- a/control_plane/contracts/owner_acceptance.py
+++ b/control_plane/contracts/owner_acceptance.py
@@ -51,6 +51,7 @@ OwnerAcceptanceReasonCode = Literal[
 ]
 OwnerAcceptanceEventWriteStatus = Literal["written", "replayed"]
 OwnerAcceptanceSourceEventKind = Literal["browser_api", "system"]
+OWNER_ACCEPTANCE_PROJECT_ACTION = "owner_acceptance.project"
 
 OWNER_ACCEPTANCE_STATUS_PRECEDENCE: tuple[OwnerAcceptanceDecisionStatus, ...] = (
     "unavailable",

--- a/control_plane/engineering_review_decision_projection.py
+++ b/control_plane/engineering_review_decision_projection.py
@@ -2,14 +2,15 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from typing import Literal
-from urllib.parse import quote
 
+from control_plane.advisory_check_projection import write_advisory_check_projection
+from control_plane.contracts.advisory_check_projection import AdvisoryCheckProjection
 from control_plane.contracts.engineering_review_decision import (
     ENGINEERING_REVIEW_STATUS_CONTEXT,
     EngineeringReviewDecisionProjectionResult,
     EngineeringReviewDecisionRecord,
 )
-from control_plane.github_payload import json_object, required_string_text
+from control_plane.github_app_identity import GitHubAppInstallationToken
 from control_plane.workflows.launchplane import github_api_request
 
 
@@ -24,88 +25,47 @@ class EngineeringReviewDecisionProjectionError(ValueError):
 def project_engineering_review_decision(
     *,
     record: EngineeringReviewDecisionRecord,
-    token: str,
+    installation_token: GitHubAppInstallationToken,
     api_request: GitHubApiRequest = github_api_request,
 ) -> EngineeringReviewDecisionProjectionResult:
     state, description = _projection_state(record)
-    owner, repo = record.target.repository.split("/", 1)
-    encoded_owner = quote(owner, safe="")
-    encoded_repo = quote(repo, safe="")
-    encoded_sha = quote(record.target.head_sha, safe="")
     target_url = (
-        f"https://github.com/{record.target.repository}/pull/"
-        f"{record.target.pull_request_number}"
+        f"https://github.com/{record.target.repository}/pull/{record.target.pull_request_number}"
     )
-    current_payload = json_object(
-        api_request(
-            path=f"/repos/{encoded_owner}/{encoded_repo}/commits/{encoded_sha}/status",
-            token=token,
-        ),
-        "GitHub combined status response",
-        error_type=EngineeringReviewDecisionProjectionError,
-    )
-    statuses = current_payload.get("statuses")
-    if not isinstance(statuses, list):
-        raise EngineeringReviewDecisionProjectionError(
-            "GitHub combined status response must include statuses."
-        )
-    current = next(
+    summary = "\n".join(
         (
-            item
-            for item in statuses
-            if isinstance(item, dict)
-            and str(item.get("context") or "") == ENGINEERING_REVIEW_STATUS_CONTEXT
-        ),
-        None,
+            "Launchplane advisory projection; mode=shadow, authoritative=false, "
+            "enforcement_effect=none.",
+            "",
+            description,
+            f"Decision binding: `{record.decision_binding_sha256}`",
+        )
     )
-    if current is not None and (
-        str(current.get("state") or "") == state
-        and str(current.get("description") or "") == description
-        and str(current.get("target_url") or "") == target_url
-    ):
-        return EngineeringReviewDecisionProjectionResult(
-            status="replayed", state=state, head_sha=record.target.head_sha
+    try:
+        result = write_advisory_check_projection(
+            projection=AdvisoryCheckProjection(
+                name=ENGINEERING_REVIEW_STATUS_CONTEXT,
+                repository=record.target.repository,
+                repository_id=record.target.repository_id,
+                head_sha=record.target.head_sha,
+                external_id=record.decision_binding_sha256,
+                details_url=target_url,
+                title=f"Engineering review: {record.status.replace('_', ' ')}",
+                summary=summary,
+            ),
+            installation_token=installation_token,
+            api_request=api_request,
         )
-    response = json_object(
-        api_request(
-            path=f"/repos/{encoded_owner}/{encoded_repo}/statuses/{encoded_sha}",
-            token=token,
-            method="POST",
-            body={
-                "state": state,
-                "target_url": target_url,
-                "description": description,
-                "context": ENGINEERING_REVIEW_STATUS_CONTEXT,
-            },
-        ),
-        "GitHub engineering review status response",
-        error_type=EngineeringReviewDecisionProjectionError,
-    )
-    if (
-        required_string_text(
-            response.get("context"),
-            "GitHub engineering review status response requires context.",
-            error_type=EngineeringReviewDecisionProjectionError,
-        )
-        != ENGINEERING_REVIEW_STATUS_CONTEXT
-        or required_string_text(
-            response.get("state"),
-            "GitHub engineering review status response requires state.",
-            error_type=EngineeringReviewDecisionProjectionError,
-        )
-        != state
-        or required_string_text(
-            response.get("sha"),
-            "GitHub engineering review status response requires sha.",
-            error_type=EngineeringReviewDecisionProjectionError,
-        ).lower()
-        != record.target.head_sha
-    ):
-        raise EngineeringReviewDecisionProjectionError(
-            "GitHub engineering review status response did not match the decision."
-        )
+    except ValueError as error:
+        raise EngineeringReviewDecisionProjectionError(str(error)) from error
     return EngineeringReviewDecisionProjectionResult(
-        status="projected", state=state, head_sha=record.target.head_sha
+        status=result.status,
+        state=state,
+        head_sha=result.head_sha,
+        external_id=result.external_id,
+        app_id=result.app_id,
+        installation_id=result.installation_id,
+        check_run_id=result.check_run_id,
     )
 
 

--- a/control_plane/github_app_identity.py
+++ b/control_plane/github_app_identity.py
@@ -1,0 +1,256 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from urllib.parse import quote
+
+import jwt
+import click
+
+from control_plane import runtime_environments
+from control_plane.github_payload import json_object, required_positive_int, required_string_text
+from control_plane.workflows.launchplane import github_api_request
+
+
+ADVISORY_GITHUB_APP_ID_ENV_KEY = "LAUNCHPLANE_ADVISORY_GITHUB_APP_ID"
+ADVISORY_GITHUB_APP_PRIVATE_KEY_ENV_KEY = "LAUNCHPLANE_ADVISORY_GITHUB_APP_PRIVATE_KEY"
+_LAUNCHPLANE_SERVICE_CONTEXT = "launchplane"
+_ALLOWED_INSTALLATION_PERMISSIONS = {"checks": "write", "metadata": "read"}
+
+GitHubApiRequest = Callable[..., object]
+
+
+class GitHubAppIdentityError(ValueError):
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class GitHubAppIdentity:
+    app_id: int
+    private_key: str = field(repr=False)
+
+
+@dataclass(frozen=True, slots=True)
+class GitHubAppInstallationToken:
+    token: str = field(repr=False)
+    app_id: int
+    installation_id: int
+    repository_id: int
+    repository: str
+    expires_at: str
+
+
+def resolve_advisory_github_app_identity(*, control_plane_root: Path) -> GitHubAppIdentity:
+    try:
+        values = runtime_environments.resolve_runtime_context_values(
+            control_plane_root=control_plane_root,
+            context_name=_LAUNCHPLANE_SERVICE_CONTEXT,
+        )
+    except click.ClickException as error:
+        raise GitHubAppIdentityError(
+            "Launchplane advisory GitHub App identity is unavailable."
+        ) from error
+    raw_app_id = values.get(ADVISORY_GITHUB_APP_ID_ENV_KEY, "").strip()
+    private_key = (
+        values.get(ADVISORY_GITHUB_APP_PRIVATE_KEY_ENV_KEY, "").strip().replace("\\n", "\n")
+    )
+    if not raw_app_id.isdecimal() or int(raw_app_id) < 1 or not private_key:
+        raise GitHubAppIdentityError("Launchplane advisory GitHub App identity is unavailable.")
+    return GitHubAppIdentity(app_id=int(raw_app_id), private_key=private_key)
+
+
+def mint_repository_installation_token(
+    *,
+    identity: GitHubAppIdentity,
+    repository: str,
+    repository_id: str,
+    api_request: GitHubApiRequest = github_api_request,
+    now: datetime | None = None,
+) -> GitHubAppInstallationToken:
+    normalized_repository = repository.strip()
+    if normalized_repository.count("/") != 1:
+        raise GitHubAppIdentityError("GitHub App repository must use owner/name.")
+    owner, repo = normalized_repository.split("/", 1)
+    if not owner or not repo or not repository_id.isdecimal() or int(repository_id) < 1:
+        raise GitHubAppIdentityError("GitHub App repository identity is invalid.")
+    issued_at = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    try:
+        app_jwt = jwt.encode(
+            {
+                "iat": int((issued_at - timedelta(seconds=60)).timestamp()),
+                "exp": int((issued_at + timedelta(minutes=8)).timestamp()),
+                "iss": str(identity.app_id),
+            },
+            identity.private_key,
+            algorithm="RS256",
+        )
+    except jwt.PyJWTError as error:
+        raise GitHubAppIdentityError(
+            "Launchplane advisory GitHub App private key is invalid."
+        ) from error
+    app_payload = json_object(
+        _github_api_request(api_request, path="/app", token=app_jwt),
+        "GitHub App identity response",
+        error_type=GitHubAppIdentityError,
+    )
+    if (
+        required_positive_int(
+            app_payload.get("id"),
+            "GitHub App identity response requires id.",
+            error_type=GitHubAppIdentityError,
+        )
+        != identity.app_id
+    ):
+        raise GitHubAppIdentityError("GitHub App identity does not match configured app id.")
+    installation_payload = json_object(
+        _github_api_request(
+            api_request,
+            path=f"/repos/{quote(owner, safe='')}/{quote(repo, safe='')}/installation",
+            token=app_jwt,
+        ),
+        "GitHub App installation response",
+        error_type=GitHubAppIdentityError,
+    )
+    installation_id = required_positive_int(
+        installation_payload.get("id"),
+        "GitHub App installation response requires id.",
+        error_type=GitHubAppIdentityError,
+    )
+    if (
+        required_positive_int(
+            installation_payload.get("app_id"),
+            "GitHub App installation response requires app_id.",
+            error_type=GitHubAppIdentityError,
+        )
+        != identity.app_id
+    ):
+        raise GitHubAppIdentityError("GitHub App installation belongs to another app.")
+    _validate_permissions(installation_payload.get("permissions"), label="installation")
+    token_payload = json_object(
+        _github_api_request(
+            api_request,
+            path=f"/app/installations/{installation_id}/access_tokens",
+            token=app_jwt,
+            method="POST",
+            body={
+                "repository_ids": [int(repository_id)],
+                "permissions": {"checks": "write"},
+            },
+        ),
+        "GitHub App installation token response",
+        error_type=GitHubAppIdentityError,
+    )
+    token = required_string_text(
+        token_payload.get("token"),
+        "GitHub App installation token response requires token.",
+        error_type=GitHubAppIdentityError,
+    )
+    expires_at = required_string_text(
+        token_payload.get("expires_at"),
+        "GitHub App installation token response requires expires_at.",
+        error_type=GitHubAppIdentityError,
+    )
+    if _parse_github_timestamp(expires_at) <= issued_at + timedelta(minutes=1):
+        raise GitHubAppIdentityError(
+            "GitHub App installation token expiry is not safely in the future."
+        )
+    _validate_permissions(token_payload.get("permissions"), label="installation token")
+    repositories = token_payload.get("repositories")
+    if not isinstance(repositories, list) or len(repositories) != 1:
+        raise GitHubAppIdentityError(
+            "GitHub App installation token must be scoped to exactly one repository."
+        )
+    repository_payload = json_object(
+        repositories[0],
+        "GitHub App installation token repository",
+        error_type=GitHubAppIdentityError,
+    )
+    observed_repository_id = required_positive_int(
+        repository_payload.get("id"),
+        "GitHub App installation token repository requires id.",
+        error_type=GitHubAppIdentityError,
+    )
+    if observed_repository_id != int(repository_id):
+        raise GitHubAppIdentityError(
+            "GitHub App installation token repository does not match exact repository id."
+        )
+    if (
+        required_string_text(
+            repository_payload.get("full_name"),
+            "GitHub App installation token repository requires full_name.",
+            error_type=GitHubAppIdentityError,
+        ).casefold()
+        != normalized_repository.casefold()
+    ):
+        raise GitHubAppIdentityError(
+            "GitHub App installation token repository does not match exact repository name."
+        )
+    return GitHubAppInstallationToken(
+        token=token,
+        app_id=identity.app_id,
+        installation_id=installation_id,
+        repository_id=observed_repository_id,
+        repository=normalized_repository,
+        expires_at=expires_at,
+    )
+
+
+def revoke_installation_token(
+    *,
+    installation_token: GitHubAppInstallationToken,
+    api_request: GitHubApiRequest = github_api_request,
+) -> None:
+    response = _github_api_request(
+        api_request,
+        path="/installation/token",
+        token=installation_token.token,
+        method="DELETE",
+    )
+    if response is not None:
+        raise GitHubAppIdentityError(
+            "GitHub App installation token revocation response must be empty."
+        )
+
+
+def _validate_permissions(value: object, *, label: str) -> None:
+    if not isinstance(value, Mapping):
+        raise GitHubAppIdentityError(f"GitHub App {label} permissions are malformed.")
+    observed = {str(key): str(permission) for key, permission in value.items()}
+    if observed.get("checks") != "write":
+        raise GitHubAppIdentityError(f"GitHub App {label} lacks checks write permission.")
+    unexpected = {
+        key: permission
+        for key, permission in observed.items()
+        if key not in _ALLOWED_INSTALLATION_PERMISSIONS
+        or _ALLOWED_INSTALLATION_PERMISSIONS[key] != permission
+    }
+    if unexpected:
+        raise GitHubAppIdentityError(
+            f"GitHub App {label} grants permissions beyond advisory check projection."
+        )
+
+
+def _parse_github_timestamp(value: str) -> datetime:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise GitHubAppIdentityError(
+            "GitHub App installation token expiry is malformed."
+        ) from error
+    if parsed.tzinfo is None:
+        raise GitHubAppIdentityError(
+            "GitHub App installation token expiry must include a timezone."
+        )
+    return parsed.astimezone(timezone.utc)
+
+
+def _github_api_request(
+    api_request: GitHubApiRequest,
+    **kwargs: object,
+) -> object:
+    try:
+        return api_request(**kwargs)
+    except click.ClickException as error:
+        raise GitHubAppIdentityError(str(error)) from error

--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -69,6 +69,10 @@ from control_plane.engineering_review_service import (
     resolve_engineering_review_pull_request_target,
 )
 from control_plane.every_code_worker import EVERY_CODE_GITHUB_TOKEN_ENV_KEY
+from control_plane.github_app_identity import (
+    mint_repository_installation_token,
+    resolve_advisory_github_app_identity,
+)
 from control_plane.http_routes import (
     AcceptedEvidenceResponse as AcceptedEvidenceResponse,
     BackupGateEvidenceRequest as BackupGateEvidenceRequest,
@@ -85,6 +89,7 @@ from control_plane.http_routes import (
     CHANGE_IMPACT_EVALUATION_ROUTE,
     CHANGE_IMPACT_POLICY_APPLY_ROUTE,
     OWNER_ACCEPTANCE_EVENTS_ROUTE,
+    OWNER_ACCEPTANCE_PROJECT_ROUTE,
     PRODUCT_OWNER_POLICY_APPLY_ROUTE,
     PRODUCT_OWNER_REQUIREMENT_APPLY_ROUTE,
     PRODUCT_OWNER_ROUTING_APPLY_ROUTE,
@@ -860,6 +865,12 @@ _BOUNDED_REQUEST_BODY_CONTRACTS: dict[str, tuple[str, int, bool, bool]] = {
     ),
     OWNER_ACCEPTANCE_EVENTS_ROUTE: (
         "Owner acceptance event",
+        _OWNER_ACCEPTANCE_MAX_BODY_BYTES,
+        True,
+        True,
+    ),
+    OWNER_ACCEPTANCE_PROJECT_ROUTE: (
+        "Owner acceptance projection",
         _OWNER_ACCEPTANCE_MAX_BODY_BYTES,
         True,
         True,
@@ -4121,9 +4132,7 @@ def create_launchplane_fastapi_app(
         assert bearer_identity_config is not None
         try:
             return EngineeringReviewWorkerIdentity(
-                worker_runtime_id=(
-                    bearer_identity_config.engineering_review_worker_runtime_id
-                ),
+                worker_runtime_id=(bearer_identity_config.engineering_review_worker_runtime_id),
                 worker_host=bearer_identity_config.engineering_review_worker_host,
             )
         except ValueError as error:
@@ -4322,27 +4331,25 @@ def create_launchplane_fastapi_app(
         http_error=_launchplane_http_error,
         error_response_model=LaunchplaneErrorResponse,
         target_resolver=resolved_engineering_review_target_resolver,
-        repository_evidence_provider=(
-            resolved_change_impact_repository_evidence_provider
-        ),
+        repository_evidence_provider=(resolved_change_impact_repository_evidence_provider),
     )
-    engineering_review_decision_route_dependencies = (
-        EngineeringReviewDecisionRouteDependencies(
-            read_write_identity=read_write_identity,
-            get_record_store=get_record_store,
-            next_trace_id=next_trace_id,
-            authorization_allows=resolved_authz_policy_runtime.allows,
-            http_error=_launchplane_http_error,
-            error_response_model=LaunchplaneErrorResponse,
-            repository_evidence_provider=(
-                resolved_change_impact_repository_evidence_provider
+    engineering_review_decision_route_dependencies = EngineeringReviewDecisionRouteDependencies(
+        read_write_identity=read_write_identity,
+        get_record_store=get_record_store,
+        next_trace_id=next_trace_id,
+        authorization_allows=resolved_authz_policy_runtime.allows,
+        http_error=_launchplane_http_error,
+        error_response_model=LaunchplaneErrorResponse,
+        repository_evidence_provider=(resolved_change_impact_repository_evidence_provider),
+        github_app_token=lambda repository, repository_id: mint_repository_installation_token(
+            identity=resolve_advisory_github_app_identity(
+                control_plane_root=resolved_control_plane_root
             ),
-            github_token=lambda: resolve_launchplane_github_token(
-                control_plane_root=resolved_control_plane_root,
-                context_name=_LAUNCHPLANE_SERVICE_CONTEXT,
-            ),
-            github_api=github_api_request,
-        )
+            repository=repository,
+            repository_id=repository_id,
+            api_request=github_api_request,
+        ),
+        github_api=github_api_request,
     )
     evidence_write_route_dependencies = EvidenceWriteRouteDependencies(
         read_write_identity=read_write_identity,
@@ -19987,19 +19994,25 @@ def create_launchplane_fastapi_app(
         dependencies=ChangeImpactReadRouteDependencies(
             common=read_route_dependencies,
             read_evaluation_identity=read_bearer_identity,
-            repository_evidence_provider=(
-                resolved_change_impact_repository_evidence_provider
-            ),
+            repository_evidence_provider=(resolved_change_impact_repository_evidence_provider),
         ),
     )
     register_owner_acceptance_routes(
         app,
         dependencies=OwnerAcceptanceRouteDependencies(
             common=read_route_dependencies,
+            read_write_identity=read_write_identity,
             read_browser_mutation_identity=read_browser_mutation_identity,
-            repository_evidence_provider=(
-                resolved_change_impact_repository_evidence_provider
+            repository_evidence_provider=(resolved_change_impact_repository_evidence_provider),
+            github_app_token=lambda repository, repository_id: mint_repository_installation_token(
+                identity=resolve_advisory_github_app_identity(
+                    control_plane_root=resolved_control_plane_root
+                ),
+                repository=repository,
+                repository_id=repository_id,
+                api_request=github_api_request,
             ),
+            github_api=github_api_request,
         ),
     )
 

--- a/control_plane/http_routes/__init__.py
+++ b/control_plane/http_routes/__init__.py
@@ -81,6 +81,7 @@ from control_plane.http_routes.owner_acceptance import (
     OWNER_ACCEPTANCE_EVALUATION_ROUTE,
     OWNER_ACCEPTANCE_EVENT_ROUTE,
     OWNER_ACCEPTANCE_EVENTS_ROUTE,
+    OWNER_ACCEPTANCE_PROJECT_ROUTE,
     OwnerAcceptanceRouteDependencies,
     register_owner_acceptance_routes,
 )
@@ -138,6 +139,7 @@ __all__ = (
     "OWNER_ACCEPTANCE_EVALUATION_ROUTE",
     "OWNER_ACCEPTANCE_EVENT_ROUTE",
     "OWNER_ACCEPTANCE_EVENTS_ROUTE",
+    "OWNER_ACCEPTANCE_PROJECT_ROUTE",
     "OwnerAcceptanceRouteDependencies",
     "PromotionEvidenceRequest",
     "PRODUCT_OWNER_POLICY_APPLY_ROUTE",

--- a/control_plane/http_routes/engineering_review_decision.py
+++ b/control_plane/http_routes/engineering_review_decision.py
@@ -18,7 +18,6 @@ from control_plane.contracts.engineering_review_decision import (
 )
 from control_plane.engineering_review_decision_projection import (
     EngineeringReviewDecisionProjectionError,
-    GitHubApiRequest,
     project_engineering_review_decision,
 )
 from control_plane.engineering_review_decision_service import (
@@ -27,6 +26,11 @@ from control_plane.engineering_review_decision_service import (
     require_engineering_review_decision_store,
 )
 from control_plane.http_routes.support import ApiRouteRegistrar, ReadRouteDependencies
+from control_plane.github_app_identity import (
+    GitHubAppIdentityError,
+    GitHubAppInstallationToken,
+    revoke_installation_token,
+)
 from control_plane.service_auth import LaunchplaneIdentity
 
 
@@ -54,8 +58,8 @@ class EngineeringReviewDecisionRouteDependencies:
     http_error: Callable[..., Exception]
     error_response_model: type[BaseModel]
     repository_evidence_provider: ChangeImpactRepositoryEvidenceProvider
-    github_token: Callable[[], str]
-    github_api: GitHubApiRequest
+    github_app_token: Callable[[str, str], GitHubAppInstallationToken]
+    github_api: Callable[..., object]
 
 
 def register_engineering_review_decision_routes(
@@ -80,9 +84,7 @@ def register_engineering_review_decision_routes(
 
     async def evaluate(
         request: EngineeringReviewDecisionRequest,
-        identity: Annotated[
-            LaunchplaneIdentity, Depends(write_dependencies.read_write_identity)
-        ],
+        identity: Annotated[LaunchplaneIdentity, Depends(write_dependencies.read_write_identity)],
         record_store: Annotated[object, Depends(write_dependencies.get_record_store)],
     ) -> EngineeringReviewDecisionResponse:
         trace_id = write_dependencies.next_trace_id()
@@ -91,9 +93,7 @@ def register_engineering_review_decision_routes(
             decision, created = evaluate_engineering_review_decision(
                 store=require_engineering_review_decision_store(record_store),
                 request=request,
-                repository_evidence_provider=(
-                    write_dependencies.repository_evidence_provider
-                ),
+                repository_evidence_provider=(write_dependencies.repository_evidence_provider),
             )
         except FileNotFoundError as error:
             raise write_dependencies.http_error(
@@ -153,18 +153,14 @@ def register_engineering_review_decision_routes(
 
     async def project(
         request: EngineeringReviewDecisionProjectionRequest,
-        identity: Annotated[
-            LaunchplaneIdentity, Depends(write_dependencies.read_write_identity)
-        ],
+        identity: Annotated[LaunchplaneIdentity, Depends(write_dependencies.read_write_identity)],
         record_store: Annotated[object, Depends(write_dependencies.get_record_store)],
     ) -> EngineeringReviewDecisionProjectionResponse:
         trace_id = write_dependencies.next_trace_id()
         authorize(identity, ENGINEERING_REVIEW_DECISION_PROJECT_ACTION, trace_id)
         try:
             decision_store = require_engineering_review_decision_store(record_store)
-            decision = decision_store.read_engineering_review_decision_record(
-                request.decision_id
-            )
+            decision = decision_store.read_engineering_review_decision_record(request.decision_id)
             latest = decision_store.list_engineering_review_decision_records(
                 repository=decision.target.repository,
                 pull_request_number=decision.target.pull_request_number,
@@ -186,16 +182,21 @@ def register_engineering_review_decision_routes(
                 raise EngineeringReviewDecisionProjectionError(
                     "Engineering review projection target is stale."
                 )
-            token = write_dependencies.github_token().strip()
-            if not token:
-                raise EngineeringReviewDecisionProjectionError(
-                    "Engineering review projection token is unavailable."
-                )
-            result = project_engineering_review_decision(
-                record=decision,
-                token=token,
-                api_request=write_dependencies.github_api,
+            installation_token = write_dependencies.github_app_token(
+                decision.target.repository,
+                decision.target.repository_id,
             )
+            try:
+                result = project_engineering_review_decision(
+                    record=decision,
+                    installation_token=installation_token,
+                    api_request=write_dependencies.github_api,
+                )
+            finally:
+                revoke_installation_token(
+                    installation_token=installation_token,
+                    api_request=write_dependencies.github_api,
+                )
         except FileNotFoundError as error:
             raise write_dependencies.http_error(
                 status_code=404,
@@ -203,7 +204,7 @@ def register_engineering_review_decision_routes(
                 code="not_found",
                 message=str(error),
             ) from error
-        except EngineeringReviewDecisionProjectionError as error:
+        except (EngineeringReviewDecisionProjectionError, GitHubAppIdentityError) as error:
             raise write_dependencies.http_error(
                 status_code=503,
                 trace_id=trace_id,

--- a/control_plane/http_routes/owner_acceptance.py
+++ b/control_plane/http_routes/owner_acceptance.py
@@ -7,12 +7,18 @@ from fastapi import Depends, Header, Path, Query
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from control_plane.change_impact_service import ChangeImpactRepositoryEvidenceProvider
-from control_plane.contracts.change_impact import ChangeImpactTargetReference
+from control_plane.contracts.change_impact import ChangeImpactTarget, ChangeImpactTargetReference
+from control_plane.contracts.advisory_check_projection import AdvisoryCheckProjectionResult
 from control_plane.contracts.owner_acceptance import (
     OWNER_ACCEPTANCE_EVENT_WRITE_ACTION,
+    OWNER_ACCEPTANCE_PROJECT_ACTION,
     OWNER_ACCEPTANCE_READ_ACTION,
     OwnerAcceptanceDecision,
     OwnerAcceptanceEventRecord,
+)
+from control_plane.github_app_identity import (
+    GitHubAppInstallationToken,
+    revoke_installation_token,
 )
 from control_plane.http_routes.support import (
     ApiRouteRegistrar,
@@ -32,13 +38,16 @@ from control_plane.owner_acceptance_queue import (
     OwnerAcceptanceQueueEntry,
     build_owner_acceptance_queue,
 )
+from control_plane.owner_acceptance_projection import project_owner_acceptance_decision
 from control_plane.service_auth import AuthorizationTarget, GitHubHumanIdentity, LaunchplaneIdentity
+from control_plane.workflows.launchplane import github_api_request
 
 
 OWNER_ACCEPTANCE_EVALUATION_ROUTE = "/v1/owner-acceptance/evaluation"
 OWNER_ACCEPTANCE_EVENTS_ROUTE = "/v1/owner-acceptance/events"
 OWNER_ACCEPTANCE_EVENT_ROUTE = "/v1/owner-acceptance/events/{event_id}"
 OWNER_ACCEPTANCE_QUEUE_ROUTE = "/v1/owner-acceptance/queue"
+OWNER_ACCEPTANCE_PROJECT_ROUTE = "/v1/owner-acceptance/project"
 
 
 @dataclass(frozen=True, slots=True)
@@ -46,6 +55,9 @@ class OwnerAcceptanceRouteDependencies:
     common: ReadRouteDependencies
     read_browser_mutation_identity: Callable[..., LaunchplaneIdentity]
     repository_evidence_provider: ChangeImpactRepositoryEvidenceProvider
+    read_write_identity: Callable[..., LaunchplaneIdentity] | None = None
+    github_app_token: Callable[[str, str], GitHubAppInstallationToken] | None = None
+    github_api: Callable[..., object] = github_api_request
 
 
 class OwnerAcceptanceEventEnvelope(BaseModel):
@@ -110,12 +122,56 @@ class OwnerAcceptanceQueueResponse(BaseModel):
     entries: tuple[OwnerAcceptanceQueueEntry, ...]
 
 
+class OwnerAcceptanceProjectionRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    schema_version: int = Field(default=1, ge=1)
+    target: ChangeImpactTargetReference
+
+    @model_validator(mode="after")
+    def _validate_request(self) -> "OwnerAcceptanceProjectionRequest":
+        if self.schema_version != 1:
+            raise ValueError("Unsupported Owner acceptance projection schema version.")
+        return self
+
+
+class OwnerAcceptanceProjectionResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["ok"] = "ok"
+    trace_id: str
+    decision: OwnerAcceptanceDecision
+    result: AdvisoryCheckProjectionResult
+
+
+def _validate_projection_target(
+    decision: OwnerAcceptanceDecision,
+    target: ChangeImpactTarget,
+) -> None:
+    bindings = tuple(
+        product.binding for product in decision.products if product.binding is not None
+    )
+    if decision.binding is not None:
+        bindings = (decision.binding, *bindings)
+    for binding in bindings:
+        if (
+            binding.repository.casefold() != target.repository.casefold()
+            or binding.repository_id != target.repository_id
+            or binding.repository_owner_id != target.repository_owner_id
+            or binding.pull_request_number != target.pull_request_number
+            or binding.head_sha != target.head_sha
+            or binding.tree_sha != target.tree_sha
+        ):
+            raise ValueError("Owner acceptance projection target changed during evaluation.")
+
+
 def register_owner_acceptance_routes(
     app: ApiRouteRegistrar,
     *,
     dependencies: OwnerAcceptanceRouteDependencies,
 ) -> None:
     common = dependencies.common
+    projection_identity = dependencies.read_write_identity or common.read_identity
 
     def evaluate(
         repository: Annotated[
@@ -330,9 +386,7 @@ def register_owner_acceptance_routes(
                 message=str(error),
             ) from error
         generated_at = (
-            datetime.now(timezone.utc)
-            .isoformat(timespec="microseconds")
-            .replace("+00:00", "Z")
+            datetime.now(timezone.utc).isoformat(timespec="microseconds").replace("+00:00", "Z")
         )
         return OwnerAcceptanceQueueResponse(
             trace_id=trace_id,
@@ -343,6 +397,67 @@ def register_owner_acceptance_routes(
             has_more=result.has_more,
             entry_count=len(result.entries),
             entries=result.entries,
+        )
+
+    async def project(
+        request: OwnerAcceptanceProjectionRequest,
+        identity: Annotated[LaunchplaneIdentity, Depends(projection_identity)],
+        record_store: Annotated[object, Depends(common.get_record_store)],
+    ) -> OwnerAcceptanceProjectionResponse:
+        trace_id = common.next_trace_id()
+        if not common.authorization_allows(
+            identity=identity,
+            action=OWNER_ACCEPTANCE_PROJECT_ACTION,
+            product="launchplane",
+            context="owner-acceptance",
+            target=AuthorizationTarget(scope="context"),
+        ):
+            raise common.http_error(
+                status_code=403,
+                trace_id=trace_id,
+                code="authorization_denied",
+                message="Caller cannot project Owner acceptance decisions.",
+            )
+        try:
+            if dependencies.github_app_token is None:
+                raise ValueError("Owner acceptance projection identity is unavailable.")
+            initial_evidence = dependencies.repository_evidence_provider.resolve(request.target)
+            decision = evaluate_owner_acceptance(
+                store=record_store,
+                target=request.target,
+                repository_evidence_provider=dependencies.repository_evidence_provider,
+            )
+            evidence = dependencies.repository_evidence_provider.resolve(request.target)
+            if initial_evidence.target != evidence.target:
+                raise ValueError("Owner acceptance projection target changed during evaluation.")
+            _validate_projection_target(decision, evidence.target)
+            installation_token = dependencies.github_app_token(
+                evidence.target.repository,
+                evidence.target.repository_id,
+            )
+            try:
+                result = project_owner_acceptance_decision(
+                    decision=decision,
+                    target=evidence.target,
+                    installation_token=installation_token,
+                    api_request=dependencies.github_api,
+                )
+            finally:
+                revoke_installation_token(
+                    installation_token=installation_token,
+                    api_request=dependencies.github_api,
+                )
+        except (OwnerAcceptanceEvaluationUnavailableError, TypeError, ValueError) as error:
+            raise common.http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="owner_acceptance_projection_unavailable",
+                message=str(error),
+            ) from error
+        return OwnerAcceptanceProjectionResponse(
+            trace_id=trace_id,
+            decision=decision,
+            result=result,
         )
 
     errors = {
@@ -361,6 +476,17 @@ def register_owner_acceptance_routes(
         tags=["owner-acceptance"],
         operation_id="evaluate_owner_acceptance",
         responses=errors,
+    )
+    app.add_api_route(
+        OWNER_ACCEPTANCE_PROJECT_ROUTE,
+        project,
+        methods=["POST"],
+        response_model=OwnerAcceptanceProjectionResponse,
+        operation_id="project_owner_acceptance_decision",
+        tags=["owner-acceptance"],
+        responses={
+            status: {"model": common.error_response_model} for status in (400, 401, 403, 503)
+        },
     )
     app.add_api_route(
         OWNER_ACCEPTANCE_EVENTS_ROUTE,

--- a/control_plane/merge_train_github.py
+++ b/control_plane/merge_train_github.py
@@ -6,6 +6,7 @@ from urllib.request import Request, urlopen
 
 from pydantic import BaseModel, ConfigDict, model_validator
 
+from control_plane.contracts.advisory_check_projection import is_launchplane_projected_check
 from control_plane.contracts.merge_train_batch import MergeTrainBatchCandidate
 from control_plane.contracts.merge_train_batch import MergeTrainBatchEntry
 from control_plane.contracts.merge_train_batch import MergeTrainBatchLandingEntry
@@ -1114,7 +1115,11 @@ def _check_runs_status(payload: dict[str, object]) -> MergeTrainCheckStatus:
     statuses: list[MergeTrainCheckStatus] = []
     for item in check_runs:
         check_run = _json_object(item, "GitHub check run")
+        if is_launchplane_projected_check(str(check_run.get("name") or "")):
+            continue
         statuses.append(_check_run_status(check_run))
+    if not statuses:
+        return "unknown"
     return _combine_check_statuses(*statuses)
 
 

--- a/control_plane/owner_acceptance_projection.py
+++ b/control_plane/owner_acceptance_projection.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+import hashlib
+import json
+
+from control_plane.advisory_check_projection import write_advisory_check_projection
+from control_plane.contracts.advisory_check_projection import (
+    AdvisoryCheckProjection,
+    AdvisoryCheckProjectionResult,
+    OWNER_ACCEPTANCE_CHECK_NAME,
+)
+from control_plane.contracts.change_impact import ChangeImpactTarget
+from control_plane.contracts.owner_acceptance import OwnerAcceptanceDecision
+from control_plane.github_app_identity import GitHubAppInstallationToken
+from control_plane.workflows.launchplane import github_api_request
+
+
+GitHubApiRequest = Callable[..., object]
+
+
+def project_owner_acceptance_decision(
+    *,
+    decision: OwnerAcceptanceDecision,
+    target: ChangeImpactTarget,
+    installation_token: GitHubAppInstallationToken,
+    api_request: GitHubApiRequest = github_api_request,
+) -> AdvisoryCheckProjectionResult:
+    external_id = owner_acceptance_projection_sha256(decision)
+    details_url = f"https://github.com/{target.repository}/pull/{target.pull_request_number}"
+    return write_advisory_check_projection(
+        projection=AdvisoryCheckProjection(
+            name=OWNER_ACCEPTANCE_CHECK_NAME,
+            repository=target.repository,
+            repository_id=target.repository_id,
+            head_sha=target.head_sha,
+            external_id=external_id,
+            details_url=details_url,
+            title=f"Owner acceptance: {decision.status.replace('_', ' ')}",
+            summary=_summary(decision),
+        ),
+        installation_token=installation_token,
+        api_request=api_request,
+    )
+
+
+def owner_acceptance_projection_sha256(decision: OwnerAcceptanceDecision) -> str:
+    payload = decision.model_dump(
+        mode="json",
+        exclude={"evaluated_at"},
+        exclude_none=True,
+    )
+    return hashlib.sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+
+
+def _summary(decision: OwnerAcceptanceDecision) -> str:
+    lines = [
+        "Launchplane advisory projection; mode=shadow, authoritative=false, "
+        "enforcement_effect=none.",
+        "",
+        f"Aggregate decision: **{decision.status.replace('_', ' ')}**",
+        f"Reason code: `{decision.reason_code}`",
+    ]
+    if decision.products:
+        lines.extend(("", "Per-product decisions:"))
+        for product in decision.products:
+            binding = (
+                product.binding.binding_sha256 if product.binding is not None else "unavailable"
+            )
+            lines.append(
+                f"- `{product.product}`: **{product.status.replace('_', ' ')}** "
+                f"(`{product.reason_code}`; binding `{binding}`)"
+            )
+    else:
+        lines.extend(("", "No product-specific Owner decision is currently required."))
+    return "\n".join(lines)

--- a/control_plane/tenant_admission_controller.py
+++ b/control_plane/tenant_admission_controller.py
@@ -8,6 +8,12 @@ from urllib.parse import quote, urlencode
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from control_plane.contracts.advisory_check_projection import (
+    ENGINEERING_REVIEW_CHECK_NAME,
+    LEGACY_ENGINEERING_REVIEW_STATUS_CONTEXT,
+    OWNER_ACCEPTANCE_CHECK_NAME,
+    is_launchplane_projected_check,
+)
 from control_plane.contracts.manager_preview_approval_projection import (
     MANAGER_PREVIEW_APPROVAL_CHECK_NAME,
 )
@@ -168,6 +174,9 @@ class TenantAdmissionTechnicalChecks(BaseModel):
     excluded_contexts: tuple[str, ...] = (
         MANAGER_PREVIEW_APPROVAL_CHECK_NAME,
         TENANT_ADMISSION_STATUS_CONTEXT,
+        ENGINEERING_REVIEW_CHECK_NAME,
+        OWNER_ACCEPTANCE_CHECK_NAME,
+        LEGACY_ENGINEERING_REVIEW_STATUS_CONTEXT,
     )
     evaluated_at: str
     binding_sha256: str = ""
@@ -1030,10 +1039,7 @@ def _technical_status_signals(
             error_type=TenantAdmissionControllerError,
         )
         normalized_context = context.casefold()
-        if (
-            normalized_context in _EXCLUDED_TECHNICAL_CONTEXTS
-            or normalized_context in seen_contexts
-        ):
+        if _is_excluded_technical_context(context) or normalized_context in seen_contexts:
             continue
         seen_contexts.add(normalized_context)
         signals.append(
@@ -1083,7 +1089,7 @@ def _technical_check_run_signals(
             "GitHub check run app requires a positive id.",
             error_type=TenantAdmissionControllerError,
         )
-        if name.casefold() in _EXCLUDED_TECHNICAL_CONTEXTS:
+        if _is_excluded_technical_context(name):
             continue
         signals.append(
             TenantAdmissionTechnicalCheckSignal(
@@ -1124,7 +1130,7 @@ def _required_technical_checks(
             error_type=TenantAdmissionControllerError,
         )
         normalized_context = context.casefold()
-        if normalized_context in _EXCLUDED_TECHNICAL_CONTEXTS:
+        if _is_excluded_technical_context(context):
             continue
         raw_app_id = check.get("app_id")
         if raw_app_id is None:
@@ -1147,10 +1153,7 @@ def _required_technical_checks(
             error_type=TenantAdmissionControllerError,
         )
         normalized_context = context.casefold()
-        if (
-            normalized_context in _EXCLUDED_TECHNICAL_CONTEXTS
-            or normalized_context in detailed_contexts
-        ):
+        if _is_excluded_technical_context(context) or normalized_context in detailed_contexts:
             continue
         required_checks[(normalized_context, None)] = TenantAdmissionRequiredTechnicalCheck(
             name=context,
@@ -1176,6 +1179,13 @@ def _optional_github_app_id(payload: dict[str, object]) -> int | None:
         app.get("id"),
         "GitHub commit status app requires a positive id.",
         error_type=TenantAdmissionControllerError,
+    )
+
+
+def _is_excluded_technical_context(name: str) -> bool:
+    return (
+        name.strip().casefold() in _EXCLUDED_TECHNICAL_CONTEXTS
+        or is_launchplane_projected_check(name)
     )
 
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -59,6 +59,9 @@ Use these docs as the source of truth for `launchplane`.
   supply-chain pinning, source classification, provenance, and update policy.
 - [dependency-health-contract.md](dependency-health-contract.md) — causal
   pull-request dependency comparisons and absolute health evidence.
+- [advisory-governance-checks.md](advisory-governance-checks.md) — dedicated
+  GitHub App identity, stable advisory engineering/Owner check runs, replay,
+  drift, and authority self-exclusion.
 - [style/python.md](style/python.md) — Python conventions.
 - [style/testing.md](style/testing.md) — testing conventions.
 - [policies/coding-standards.md](policies/coding-standards.md) — naming and

--- a/docs/advisory-governance-checks.md
+++ b/docs/advisory-governance-checks.md
@@ -1,0 +1,71 @@
+---
+title: Advisory Governance Check Projection
+---
+
+## Purpose
+
+Launchplane projects its server-owned engineering review and Owner acceptance
+decisions into GitHub as advisory check runs. GitHub is a visibility surface,
+not an authority source. The projection cannot authorize merge, tenant
+admission, promotion, or production deployment.
+
+The two stable check names are:
+
+- `launchplane/engineering-review`
+- `launchplane/owner-acceptance`
+
+Both check runs complete with GitHub conclusion `neutral`. Their title and
+summary expose the current Launchplane decision, exact binding digest, and the
+fixed `mode=shadow`, `authoritative=false`, `enforcement_effect=none` contract.
+Owner projection uses one stable aggregate check and lists each affected
+product decision in the output instead of creating product-derived check names.
+
+## GitHub App Identity
+
+Projection uses a dedicated GitHub App installation identity. The App may have
+only repository Checks write and GitHub's mandatory Metadata read permission.
+Launchplane verifies the configured numeric App id, repository installation,
+permission set, exact numeric repository id, and repository full name before it
+uses a short-lived installation token.
+
+The App id is the non-secret runtime-environment value
+`LAUNCHPLANE_ADVISORY_GITHUB_APP_ID`. The private key is the managed-secret
+value `LAUNCHPLANE_ADVISORY_GITHUB_APP_PRIVATE_KEY`. Both belong to the
+Launchplane service context in DB-backed runtime records; they are not checked
+in, persisted in projection records, or accepted from callers. Installation
+tokens are minted for one exact repository with only Checks write permission
+and are revoked after the projection attempt. They are never logged or
+persisted.
+
+Registering and installing the live App is an operator authorization step. The
+code and dry-run contracts remain testable before that authorization exists;
+missing identity or installation state fails the projection route closed.
+
+## Projection Routes
+
+`POST /v1/engineering-review-decisions/project` projects the latest persisted
+engineering decision only after Launchplane re-resolves the exact repository,
+pull request, head, and tree evidence.
+
+`POST /v1/owner-acceptance/project` accepts only a repository and pull-request
+reference. Launchplane evaluates current Owner acceptance from server-owned
+evidence, re-resolves the exact target, and rejects any mid-flight head, tree,
+repository-id, or owner-id drift before writing GitHub.
+
+Each check run stores the Launchplane decision digest as `external_id`.
+Identical state replays without a write. Changed binding or decision state on
+the same head updates the App-owned check run. A changed head receives its own
+new check run and cannot reuse evidence from the prior head.
+
+## No Feedback Loop
+
+Launchplane-owned governance check names are excluded from merge-train check-run
+aggregation and from tenant-admission commit-status, check-run, and required-
+check inputs. The legacy `launchplane/engineering-review-shadow` status is also
+excluded from tenant admission during cutover. Tests prove that merge and
+admission results are unchanged when advisory checks are present, pending, or
+failed.
+
+GitHub rulesets must not make these advisory names required while the contracts
+remain shadow-only. Ruleset and CODEOWNERS drift detection and reconciliation
+belong to the downstream projection workstream.

--- a/docs/merge-train-policy.md
+++ b/docs/merge-train-policy.md
@@ -41,6 +41,10 @@ Tenant merge eligibility (`evaluate_tenant_merge_eligibility`) and repository cl
 - Unified tenant admission is recomputed from DB records. The GitHub `tenant-admission` commit status is a public projection, not merge authority.
 - The tenant admission controller is a separate exact-PR landing path. It re-fetches current GitHub identity/head/mergeability facts, recomputes admission, reads the live required-status-check policy, filters admission projection contexts out of that policy, enforces strict base freshness when configured, and rechecks all three immediately before an expected-SHA merge. Missing or malformed required-check policy or evidence fails closed. It does not enqueue work or reuse scheduler ordering, labels, batch candidates, stack collapse, or failure policy.
 - The tenant controller and merge train share the repository/base controller-state row only as a mutual-exclusion and crash-reconciliation fence. Acquisition writes a controller-specific initial action atomically and adoption is action-aware, so one controller cannot rewrite another controller's unfinished recovery state even before its first checkpoint. The row cannot make a tenant admission decision and a green GitHub status is never merge authority.
+- Advisory `launchplane/engineering-review` and
+  `launchplane/owner-acceptance` check runs are visibility projections and are
+  excluded from merge-train and tenant-admission technical-check inputs. Their
+  presence, state, or provider replay cannot change a Launchplane verdict.
 - Engineering repositories remain on their existing flow; invoking the tenant controller for an engineering classification returns not-applicable without merging.
 
 ## Controller Lease And Resume State

--- a/docs/owner-acceptance.md
+++ b/docs/owner-acceptance.md
@@ -207,10 +207,22 @@ same idempotency key, and `409 owner_acceptance_binding_changed` refreshes the
 Current evaluation without auto-resubmitting. Every receipt remains shadow,
 non-authoritative, and has no merge or production enforcement effect.
 
+## Advisory GitHub Projection
+
+`POST /v1/owner-acceptance/project` projects the current aggregate decision as
+the stable `launchplane/owner-acceptance` GitHub App check run. The caller
+supplies only repository and pull-request reference. Launchplane derives every
+product decision and exact binding, rechecks the current target before the
+provider write, and uses the decision digest as the check-run `external_id`.
+
+The completed check conclusion is always `neutral`; the output lists the
+aggregate state plus each affected product and binding. The check remains
+shadow-only, is excluded from Launchplane merge/admission technical inputs, and
+cannot become Owner authority.
+
 ## Out Of Scope
 
 - production authorization and promotion consumers
-- GitHub status projection
 - tenant-admission cutover
 - manager/delegate cleanup
 - break-glass acceptance

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -59,6 +59,16 @@ title: Secrets
   uses the short-lived token only for repository metadata lookup, and does not
   persist the token or private key in plan/apply artifacts. Do not use a PAT or
   the Launchplane service GitHub App as a fallback.
+- Advisory engineering and Owner check-run projection uses its own dedicated
+  GitHub App. Store its numeric id as the DB-backed Launchplane service-context
+  runtime value `LAUNCHPLANE_ADVISORY_GITHUB_APP_ID` and its private key as the
+  managed-secret value `LAUNCHPLANE_ADVISORY_GITHUB_APP_PRIVATE_KEY`. Install
+  it only on repositories that receive advisory governance checks and grant
+  only Checks write plus mandatory Metadata read. Launchplane mints a
+  repository-scoped installation token, verifies exact App, installation,
+  repository, and permission identity, revokes the token after use, and never
+  persists or logs the token.
+  Do not reuse onboarding, runner-host-hygiene, PAT, or ordinary service tokens.
 - The protected
   `LAUNCHPLANE_AUTHZ_GENERIC_WEB_ONBOARDING_MANAGED_SET_JSON` secret contains
   the permanent exact Launchplane workflow grants for onboarding and preview

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -3176,6 +3176,17 @@ files, repository names, branches, titles, labels, or commit text. Preview
 refresh, verification, destroy, and cleanup remain independent from admission,
 projection delivery, and merge-controller results.
 
+`POST /v1/engineering-review-decisions/project` and
+`POST /v1/owner-acceptance/project` write the stable
+`launchplane/engineering-review` and `launchplane/owner-acceptance` check runs
+through a dedicated least-privilege GitHub App. Launchplane verifies exact App,
+installation, repository, and permission identity, mints a one-repository
+Checks-write token, rechecks current server-owned evidence, and uses the exact
+decision digest as `external_id`. Replays avoid duplicate writes and same-head
+binding changes update only the App-owned run. Both checks complete `neutral`,
+remain shadow/non-authoritative, and are excluded from merge-train and tenant-
+admission technical inputs.
+
 The CM tenant preview workflow uses tenant-product scope for both artifact
 publish input/evidence and preview lifecycle requests. Artifact publish still
 uses Odoo driver routes, but source-ref build metadata resolves through the

--- a/frontend/generated/openapi-canonical.json
+++ b/frontend/generated/openapi-canonical.json
@@ -61,6 +61,72 @@
         "title": "AcceptedEvidenceResponse",
         "type": "object"
       },
+      "AdvisoryCheckProjectionResult": {
+        "additionalProperties": false,
+        "properties": {
+          "app_id": {
+            "minimum": 1.0,
+            "title": "App Id",
+            "type": "integer"
+          },
+          "check_run_id": {
+            "minimum": 1.0,
+            "title": "Check Run Id",
+            "type": "integer"
+          },
+          "conclusion": {
+            "const": "neutral",
+            "default": "neutral",
+            "title": "Conclusion",
+            "type": "string"
+          },
+          "external_id": {
+            "pattern": "^[0-9a-f]{64}$",
+            "title": "External Id",
+            "type": "string"
+          },
+          "head_sha": {
+            "pattern": "^[0-9a-f]{40}$",
+            "title": "Head Sha",
+            "type": "string"
+          },
+          "installation_id": {
+            "minimum": 1.0,
+            "title": "Installation Id",
+            "type": "integer"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "schema_version": {
+            "default": 1,
+            "minimum": 1.0,
+            "title": "Schema Version",
+            "type": "integer"
+          },
+          "status": {
+            "enum": [
+              "projected",
+              "updated",
+              "replayed"
+            ],
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "status",
+          "name",
+          "head_sha",
+          "external_id",
+          "app_id",
+          "installation_id",
+          "check_run_id"
+        ],
+        "title": "AdvisoryCheckProjectionResult",
+        "type": "object"
+      },
       "AgentContextEvidence": {
         "additionalProperties": false,
         "properties": {
@@ -4141,15 +4207,41 @@
       "EngineeringReviewDecisionProjectionResult": {
         "additionalProperties": false,
         "properties": {
+          "app_id": {
+            "minimum": 1.0,
+            "title": "App Id",
+            "type": "integer"
+          },
+          "check_run_id": {
+            "minimum": 1.0,
+            "title": "Check Run Id",
+            "type": "integer"
+          },
+          "conclusion": {
+            "const": "neutral",
+            "default": "neutral",
+            "title": "Conclusion",
+            "type": "string"
+          },
           "context": {
-            "const": "launchplane/engineering-review-shadow",
-            "default": "launchplane/engineering-review-shadow",
+            "const": "launchplane/engineering-review",
+            "default": "launchplane/engineering-review",
             "title": "Context",
+            "type": "string"
+          },
+          "external_id": {
+            "pattern": "^[0-9a-f]{64}$",
+            "title": "External Id",
             "type": "string"
           },
           "head_sha": {
             "title": "Head Sha",
             "type": "string"
+          },
+          "installation_id": {
+            "minimum": 1.0,
+            "title": "Installation Id",
+            "type": "integer"
           },
           "schema_version": {
             "default": 1,
@@ -4170,6 +4262,7 @@
           "status": {
             "enum": [
               "projected",
+              "updated",
               "replayed"
             ],
             "title": "Status",
@@ -4179,7 +4272,11 @@
         "required": [
           "status",
           "state",
-          "head_sha"
+          "head_sha",
+          "external_id",
+          "app_id",
+          "installation_id",
+          "check_run_id"
         ],
         "title": "EngineeringReviewDecisionProjectionResult",
         "type": "object"
@@ -11953,6 +12050,53 @@
           "reason_code"
         ],
         "title": "OwnerAcceptanceProductDecision",
+        "type": "object"
+      },
+      "OwnerAcceptanceProjectionRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "schema_version": {
+            "default": 1,
+            "minimum": 1.0,
+            "title": "Schema Version",
+            "type": "integer"
+          },
+          "target": {
+            "$ref": "#/components/schemas/ChangeImpactTargetReference"
+          }
+        },
+        "required": [
+          "target"
+        ],
+        "title": "OwnerAcceptanceProjectionRequest",
+        "type": "object"
+      },
+      "OwnerAcceptanceProjectionResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "decision": {
+            "$ref": "#/components/schemas/OwnerAcceptanceDecision"
+          },
+          "result": {
+            "$ref": "#/components/schemas/AdvisoryCheckProjectionResult"
+          },
+          "status": {
+            "const": "ok",
+            "default": "ok",
+            "title": "Status",
+            "type": "string"
+          },
+          "trace_id": {
+            "title": "Trace Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "trace_id",
+          "decision",
+          "result"
+        ],
+        "title": "OwnerAcceptanceProjectionResponse",
         "type": "object"
       },
       "OwnerAcceptanceQueueEntry": {
@@ -26971,7 +27115,10 @@
           "excluded_contexts": {
             "default": [
               "manager-preview-approval",
-              "tenant-admission"
+              "tenant-admission",
+              "launchplane/engineering-review",
+              "launchplane/owner-acceptance",
+              "launchplane/engineering-review-shadow"
             ],
             "items": {
               "type": "string"
@@ -52365,6 +52512,99 @@
           }
         },
         "summary": "Read Event",
+        "tags": [
+          "owner-acceptance"
+        ]
+      }
+    },
+    "/v1/owner-acceptance/project": {
+      "post": {
+        "operationId": "project_owner_acceptance_decision",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Authorization",
+            "required": false,
+            "schema": {
+              "default": "",
+              "title": "Authorization",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OwnerAcceptanceProjectionRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OwnerAcceptanceProjectionResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "summary": "Project",
         "tags": [
           "owner-acceptance"
         ]

--- a/frontend/generated/openapi-ui.json
+++ b/frontend/generated/openapi-ui.json
@@ -18220,7 +18220,10 @@
           "excluded_contexts": {
             "default": [
               "manager-preview-approval",
-              "tenant-admission"
+              "tenant-admission",
+              "launchplane/engineering-review",
+              "launchplane/owner-acceptance",
+              "launchplane/engineering-review-shadow"
             ],
             "items": {
               "type": "string"

--- a/tests/test_advisory_check_projection.py
+++ b/tests/test_advisory_check_projection.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import unittest
+
+from control_plane.advisory_check_projection import (
+    AdvisoryCheckProjectionError,
+    write_advisory_check_projection,
+)
+from control_plane.contracts.advisory_check_projection import (
+    AdvisoryCheckProjection,
+    OWNER_ACCEPTANCE_CHECK_NAME,
+)
+from control_plane.github_app_identity import GitHubAppInstallationToken
+
+
+HEAD_SHA = "a" * 40
+EXTERNAL_ID = "b" * 64
+
+
+def _projection() -> AdvisoryCheckProjection:
+    return AdvisoryCheckProjection(
+        name=OWNER_ACCEPTANCE_CHECK_NAME,
+        repository="example/repo",
+        repository_id="123",
+        head_sha=HEAD_SHA,
+        external_id=EXTERNAL_ID,
+        details_url="https://github.com/example/repo/pull/7",
+        title="Owner acceptance: pending",
+        summary="Launchplane advisory projection.",
+    )
+
+
+def _token() -> GitHubAppInstallationToken:
+    return GitHubAppInstallationToken(
+        token="secret-token",
+        app_id=42,
+        installation_id=77,
+        repository_id=123,
+        repository="example/repo",
+        expires_at="2026-08-07T15:00:00Z",
+    )
+
+
+def _check_run(*, external_id: str = EXTERNAL_ID, app_id: int = 42) -> dict[str, object]:
+    projection = _projection()
+    return {
+        "id": 91,
+        "name": projection.name,
+        "head_sha": projection.head_sha,
+        "status": "completed",
+        "conclusion": "neutral",
+        "external_id": external_id,
+        "details_url": projection.details_url,
+        "output": {"title": projection.title, "summary": projection.summary},
+        "app": {"id": app_id},
+    }
+
+
+class AdvisoryCheckProjectionTests(unittest.TestCase):
+    def test_replays_identical_exact_projection_without_write(self) -> None:
+        calls: list[dict[str, object]] = []
+
+        def api_request(**kwargs):  # type: ignore[no-untyped-def]
+            calls.append(kwargs)
+            return {"check_runs": [_check_run()]}
+
+        result = write_advisory_check_projection(
+            projection=_projection(),
+            installation_token=_token(),
+            api_request=api_request,
+        )
+
+        self.assertEqual(result.status, "replayed")
+        self.assertEqual(len(calls), 1)
+        self.assertIn("check_name=launchplane%2Fowner-acceptance", str(calls[0]["path"]))
+
+    def test_updates_same_head_when_binding_changes(self) -> None:
+        calls: list[dict[str, object]] = []
+
+        def api_request(**kwargs):  # type: ignore[no-untyped-def]
+            calls.append(kwargs)
+            if kwargs.get("method") == "PATCH":
+                updated = _check_run()
+                updated["external_id"] = kwargs["body"]["external_id"]
+                return updated
+            return {"check_runs": [_check_run(external_id="c" * 64)]}
+
+        result = write_advisory_check_projection(
+            projection=_projection(),
+            installation_token=_token(),
+            api_request=api_request,
+        )
+
+        self.assertEqual(result.status, "updated")
+        self.assertEqual(calls[-1]["method"], "PATCH")
+        self.assertEqual(calls[-1]["path"], "/repos/example/repo/check-runs/91")
+
+    def test_rejects_check_run_written_by_another_app(self) -> None:
+        def api_request(**kwargs):  # type: ignore[no-untyped-def]
+            if kwargs.get("method") == "POST":
+                return _check_run(app_id=99)
+            return {"check_runs": []}
+
+        with self.assertRaisesRegex(AdvisoryCheckProjectionError, "exact projection identity"):
+            write_advisory_check_projection(
+                projection=_projection(),
+                installation_token=_token(),
+                api_request=api_request,
+            )
+
+    def test_rejects_token_scoped_to_another_repository_name(self) -> None:
+        token = GitHubAppInstallationToken(
+            token="secret-token",
+            app_id=42,
+            installation_id=77,
+            repository_id=123,
+            repository="example/other",
+            expires_at="2026-08-07T15:00:00Z",
+        )
+
+        with self.assertRaisesRegex(AdvisoryCheckProjectionError, "repository name"):
+            write_advisory_check_projection(
+                projection=_projection(),
+                installation_token=token,
+                api_request=lambda **_: {},
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_engineering_review_decision.py
+++ b/tests/test_engineering_review_decision.py
@@ -18,6 +18,7 @@ from control_plane.contracts.every_code_work_request import EveryCodeWorkRequest
 from control_plane.engineering_review_decision_projection import (
     project_engineering_review_decision,
 )
+from control_plane.github_app_identity import GitHubAppInstallationToken
 from control_plane.engineering_review_decision_service import (
     evaluate_engineering_review_decision,
 )
@@ -45,9 +46,7 @@ def _shared_authority() -> EngineeringReviewAuthorityRecord:
     base_authority = _authority()
     return EngineeringReviewAuthorityRecord.model_validate(
         {
-            **base_authority.model_dump(
-                mode="json", exclude={"authority_id", "authority_digest"}
-            ),
+            **base_authority.model_dump(mode="json", exclude={"authority_id", "authority_digest"}),
             "repository": REPOSITORY,
         }
     )
@@ -246,9 +245,7 @@ class EngineeringReviewDecisionTests(unittest.TestCase):
         self.assertEqual(approved.qualifying_model_families, ("anthropic", "openai"))
 
     def test_blocking_result_wins_and_stale_run_is_ignored(self) -> None:
-        stale = _completed_run(slot=1, family="openai").model_copy(
-            update={"head_sha": "c" * 40}
-        )
+        stale = _completed_run(slot=1, family="openai").model_copy(update={"head_sha": "c" * 40})
         blocked = _completed_run(slot=2, family="anthropic", decision="blocked")
         store = _Store((stale, blocked))
 
@@ -279,7 +276,7 @@ class EngineeringReviewDecisionTests(unittest.TestCase):
         self.assertFalse(second_created)
         self.assertEqual(first.decision_id, second.decision_id)
 
-    def test_projection_is_idempotent_and_shadow_named(self) -> None:
+    def test_projection_is_idempotent_and_advisory_named(self) -> None:
         store = _Store((_completed_run(slot=1, family="openai"),))
         record, _created = evaluate_engineering_review_decision(
             store=store,
@@ -292,14 +289,34 @@ class EngineeringReviewDecisionTests(unittest.TestCase):
             calls.append(kwargs)
             if kwargs.get("method") == "POST":
                 body = kwargs["body"]
-                return {"context": body["context"], "state": body["state"], "sha": HEAD_SHA}
-            return {"statuses": []}
+                return {
+                    "id": 91,
+                    "name": body["name"],
+                    "head_sha": body["head_sha"],
+                    "status": body["status"],
+                    "conclusion": body["conclusion"],
+                    "external_id": body["external_id"],
+                    "details_url": body["details_url"],
+                    "output": body["output"],
+                    "app": {"id": 42},
+                }
+            return {"check_runs": []}
 
         result = project_engineering_review_decision(
-            record=record, token="token", api_request=api_request
+            record=record,
+            installation_token=GitHubAppInstallationToken(
+                token="token",
+                app_id=42,
+                installation_id=43,
+                repository_id=int(record.target.repository_id),
+                repository=record.target.repository,
+                expires_at="2026-08-07T15:00:00Z",
+            ),
+            api_request=api_request,
         )
         self.assertEqual(result.status, "projected")
-        self.assertEqual(calls[-1]["body"]["context"], "launchplane/engineering-review-shadow")
+        self.assertEqual(calls[-1]["body"]["name"], "launchplane/engineering-review")
+        self.assertEqual(calls[-1]["body"]["conclusion"], "neutral")
 
 
 if __name__ == "__main__":

--- a/tests/test_github_app_identity.py
+++ b/tests/test_github_app_identity.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import unittest
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+import jwt
+
+from control_plane.github_app_identity import (
+    GitHubAppIdentity,
+    GitHubAppIdentityError,
+    GitHubAppInstallationToken,
+    mint_repository_installation_token,
+    revoke_installation_token,
+)
+
+
+class GitHubAppIdentityTests(unittest.TestCase):
+    private_key: str
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        cls.private_key = private_key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        ).decode()
+
+    def test_mints_exact_repository_scoped_checks_token(self) -> None:
+        observed_jwts: list[str] = []
+
+        def api_request(**kwargs):  # type: ignore[no-untyped-def]
+            token = kwargs["token"]
+            if kwargs["path"] != "/app/installations/77/access_tokens":
+                observed_jwts.append(token)
+            if kwargs["path"] == "/app":
+                return {"id": 42}
+            if kwargs["path"] == "/repos/example/repo/installation":
+                return {
+                    "id": 77,
+                    "app_id": 42,
+                    "permissions": {"checks": "write", "metadata": "read"},
+                }
+            self.assertEqual(
+                kwargs["body"],
+                {"repository_ids": [123], "permissions": {"checks": "write"}},
+            )
+            return {
+                "token": "installation-token-secret",
+                "expires_at": "2026-08-07T15:00:00Z",
+                "permissions": {"checks": "write", "metadata": "read"},
+                "repositories": [{"id": 123, "full_name": "example/repo"}],
+            }
+
+        result = mint_repository_installation_token(
+            identity=GitHubAppIdentity(app_id=42, private_key=self.private_key),
+            repository="example/repo",
+            repository_id="123",
+            api_request=api_request,
+            now=datetime(2026, 8, 7, 14, 0, tzinfo=timezone.utc),
+        )
+
+        self.assertEqual(result.app_id, 42)
+        self.assertEqual(result.installation_id, 77)
+        self.assertEqual(result.repository_id, 123)
+        self.assertNotIn("installation-token-secret", repr(result))
+        claims = jwt.decode(observed_jwts[0], options={"verify_signature": False})
+        self.assertEqual(claims["iss"], "42")
+        self.assertEqual(claims["exp"] - claims["iat"], 540)
+
+    def test_revokes_installation_token_without_exposing_secret(self) -> None:
+        calls: list[dict[str, object]] = []
+        token = GitHubAppInstallationToken(
+            token="installation-token-secret",
+            app_id=42,
+            installation_id=77,
+            repository_id=123,
+            repository="example/repo",
+            expires_at="2026-08-07T15:00:00Z",
+        )
+
+        def api_request(**kwargs):  # type: ignore[no-untyped-def]
+            calls.append(kwargs)
+            return None
+
+        revoke_installation_token(
+            installation_token=token,
+            api_request=api_request,
+        )
+
+        self.assertEqual(calls[0]["path"], "/installation/token")
+        self.assertEqual(calls[0]["method"], "DELETE")
+        self.assertNotIn("installation-token-secret", repr(token))
+
+    def test_rejects_installation_from_another_app(self) -> None:
+        def api_request(**kwargs):  # type: ignore[no-untyped-def]
+            if kwargs["path"] == "/app":
+                return {"id": 42}
+            return {
+                "id": 77,
+                "app_id": 99,
+                "permissions": {"checks": "write"},
+            }
+
+        with self.assertRaisesRegex(GitHubAppIdentityError, "another app"):
+            mint_repository_installation_token(
+                identity=GitHubAppIdentity(app_id=42, private_key=self.private_key),
+                repository="example/repo",
+                repository_id="123",
+                api_request=api_request,
+            )
+
+    def test_rejects_invalid_private_key_without_api_call(self) -> None:
+        calls: list[dict[str, object]] = []
+
+        with self.assertRaisesRegex(GitHubAppIdentityError, "private key is invalid"):
+            mint_repository_installation_token(
+                identity=GitHubAppIdentity(app_id=42, private_key="not-a-private-key"),
+                repository="example/repo",
+                repository_id="123",
+                api_request=lambda **kwargs: calls.append(kwargs),
+            )
+
+        self.assertEqual(calls, [])
+
+    def test_rejects_surplus_installation_permissions(self) -> None:
+        def api_request(**kwargs):  # type: ignore[no-untyped-def]
+            if kwargs["path"] == "/app":
+                return {"id": 42}
+            return {
+                "id": 77,
+                "app_id": 42,
+                "permissions": {"checks": "write", "contents": "read"},
+            }
+
+        with self.assertRaisesRegex(GitHubAppIdentityError, "beyond"):
+            mint_repository_installation_token(
+                identity=GitHubAppIdentity(app_id=42, private_key=self.private_key),
+                repository="example/repo",
+                repository_id="123",
+                api_request=api_request,
+            )
+
+    def test_rejects_expired_installation_token(self) -> None:
+        def api_request(**kwargs):  # type: ignore[no-untyped-def]
+            if kwargs["path"] == "/app":
+                return {"id": 42}
+            if kwargs["path"] == "/repos/example/repo/installation":
+                return {
+                    "id": 77,
+                    "app_id": 42,
+                    "permissions": {"checks": "write"},
+                }
+            return {
+                "token": "expired-token",
+                "expires_at": "2026-08-07T14:00:30Z",
+                "permissions": {"checks": "write"},
+                "repositories": [{"id": 123, "full_name": "example/repo"}],
+            }
+
+        with self.assertRaisesRegex(GitHubAppIdentityError, "safely in the future"):
+            mint_repository_installation_token(
+                identity=GitHubAppIdentity(app_id=42, private_key=self.private_key),
+                repository="example/repo",
+                repository_id="123",
+                api_request=api_request,
+                now=datetime(2026, 8, 7, 14, 0, tzinfo=timezone.utc),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_merge_train_github.py
+++ b/tests/test_merge_train_github.py
@@ -572,6 +572,44 @@ class GitHubMergeTrainClientTests(unittest.TestCase):
         self.assertEqual(observed_candidate.status, "ready_for_checks")
         self.assertEqual(observed_candidate.required_checks_status, "pending")
 
+    def test_observe_batch_candidate_checks_excludes_launchplane_advisory_runs(self) -> None:
+        candidate = _batch_candidate().model_copy(
+            update={"candidate_sha": "candidate-sha", "status": "ready_for_checks"}
+        )
+        baseline_transport = RecordingMergeTrainGitHubTransport(
+            responses=(
+                {"state": "success"},
+                {"check_runs": [{"name": "ci-gate", **_check_run("completed", "success")}]},
+            )
+        )
+        transport = RecordingMergeTrainGitHubTransport(
+            responses=(
+                {"state": "success"},
+                {
+                    "check_runs": [
+                        {"name": "ci-gate", **_check_run("completed", "success")},
+                        {
+                            "name": "launchplane/engineering-review",
+                            **_check_run("queued", None),
+                        },
+                        {
+                            "name": "launchplane/owner-acceptance",
+                            **_check_run("completed", "failure"),
+                        },
+                    ]
+                },
+            )
+        )
+
+        observed_candidate = GitHubMergeTrainClient(
+            transport=transport
+        ).observe_batch_candidate_checks(candidate=candidate)
+        baseline_candidate = GitHubMergeTrainClient(
+            transport=baseline_transport
+        ).observe_batch_candidate_checks(candidate=candidate)
+
+        self.assertEqual(observed_candidate, baseline_candidate)
+
     def test_land_batch_candidate_merges_original_prs_in_order(self) -> None:
         landing_plan = _landing_plan()
         checkpoints: list[tuple[str, int, int]] = []

--- a/tests/test_owner_acceptance_http.py
+++ b/tests/test_owner_acceptance_http.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import cast
+from typing import Any, Callable, cast
 import unittest
 
 from fastapi import FastAPI, HTTPException
@@ -12,9 +12,11 @@ from control_plane.http_routes.owner_acceptance import (
     OWNER_ACCEPTANCE_EVALUATION_ROUTE,
     OWNER_ACCEPTANCE_EVENT_ROUTE,
     OWNER_ACCEPTANCE_EVENTS_ROUTE,
+    OWNER_ACCEPTANCE_PROJECT_ROUTE,
     OwnerAcceptanceRouteDependencies,
     register_owner_acceptance_routes,
 )
+from control_plane.github_app_identity import GitHubAppInstallationToken
 from control_plane.http_routes.support import ApiRouteRegistrar, ReadRouteDependencies
 from control_plane.service_auth import (
     GitHubHumanIdentity,
@@ -27,6 +29,7 @@ from tests.test_owner_acceptance import (
     REPOSITORY,
     SECOND_PRODUCT,
     _EvidenceProvider,
+    REPOSITORY_ID,
     _human,
     _repository_evidence,
     _store,
@@ -44,6 +47,8 @@ def _app(
     identity: LaunchplaneIdentity | None = None,
     browser_identity: LaunchplaneIdentity | None = None,
     repository_evidence_provider: _EvidenceProvider | None = None,
+    github_app_token: Callable[[str, str], GitHubAppInstallationToken] | None = None,
+    github_api: Callable[..., object] | None = None,
 ) -> FastAPI:
     resolved_identity = identity or _human()
     resolved_browser_identity = browser_identity or resolved_identity
@@ -60,16 +65,118 @@ def _app(
         cast(ApiRouteRegistrar, app),
         dependencies=OwnerAcceptanceRouteDependencies(
             common=common,
+            read_write_identity=lambda: resolved_identity,
             read_browser_mutation_identity=lambda: resolved_browser_identity,
             repository_evidence_provider=(
                 repository_evidence_provider or _EvidenceProvider(_repository_evidence())
             ),
+            github_app_token=github_app_token,
+            **({"github_api": github_api} if github_api is not None else {}),
         ),
     )
     return app
 
 
 class OwnerAcceptanceHttpTests(unittest.IsolatedAsyncioTestCase):
+    async def test_projects_current_owner_decision_as_neutral_github_app_check(self) -> None:
+        with TemporaryDirectory() as directory:
+            store = _store(Path(directory))
+            calls: list[dict[str, Any]] = []
+
+            def github_api(**kwargs):  # type: ignore[no-untyped-def]
+                calls.append(kwargs)
+                if kwargs.get("method") == "DELETE":
+                    return None
+                if kwargs.get("method") == "POST":
+                    body = kwargs["body"]
+                    return {
+                        "id": 91,
+                        "name": body["name"],
+                        "head_sha": body["head_sha"],
+                        "status": body["status"],
+                        "conclusion": body["conclusion"],
+                        "external_id": body["external_id"],
+                        "details_url": body["details_url"],
+                        "output": body["output"],
+                        "app": {"id": 42},
+                    }
+                return {"check_runs": []}
+
+            app = _app(
+                store=store,
+                github_app_token=lambda _repository, _repository_id: GitHubAppInstallationToken(
+                    token="installation-token",
+                    app_id=42,
+                    installation_id=77,
+                    repository_id=int(REPOSITORY_ID),
+                    repository=REPOSITORY,
+                    expires_at="2026-08-07T15:00:00Z",
+                ),
+                github_api=github_api,
+            )
+
+            async with lifespan_client(app) as client:
+                response = await client.post(
+                    OWNER_ACCEPTANCE_PROJECT_ROUTE,
+                    json={
+                        "target": {
+                            "repository": REPOSITORY,
+                            "pull_request_number": 2022,
+                        }
+                    },
+                )
+
+        self.assertEqual(response.status_code, 200, response.text)
+        payload = response.json()
+        self.assertEqual(payload["decision"]["status"], "pending")
+        self.assertEqual(payload["result"]["name"], "launchplane/owner-acceptance")
+        self.assertEqual(payload["result"]["conclusion"], "neutral")
+        self.assertEqual(calls[-2]["body"]["conclusion"], "neutral")
+        self.assertEqual(calls[-1]["method"], "DELETE")
+
+    async def test_projection_rejects_head_drift_before_github_write(self) -> None:
+        class _DriftingProvider(_EvidenceProvider):
+            def __init__(self) -> None:
+                super().__init__(_repository_evidence())
+                self.calls = 0
+
+            def resolve(self, target):  # type: ignore[no-untyped-def]
+                self.calls += 1
+                if self.calls >= 3:
+                    return _repository_evidence(head="c" * 40)
+                return super().resolve(target)
+
+        with TemporaryDirectory() as directory:
+            store = _store(Path(directory))
+            github_calls: list[dict[str, Any]] = []
+            app = _app(
+                store=store,
+                repository_evidence_provider=_DriftingProvider(),
+                github_app_token=lambda _repository, _repository_id: GitHubAppInstallationToken(
+                    token="installation-token",
+                    app_id=42,
+                    installation_id=77,
+                    repository_id=int(REPOSITORY_ID),
+                    repository=REPOSITORY,
+                    expires_at="2026-08-07T15:00:00Z",
+                ),
+                github_api=lambda **kwargs: github_calls.append(kwargs),
+            )
+
+            async with lifespan_client(app) as client:
+                response = await client.post(
+                    OWNER_ACCEPTANCE_PROJECT_ROUTE,
+                    json={
+                        "target": {
+                            "repository": REPOSITORY,
+                            "pull_request_number": 2022,
+                        }
+                    },
+                )
+
+        self.assertEqual(response.status_code, 503, response.text)
+        self.assertEqual(github_calls, [])
+
     async def test_evaluate_and_human_event_use_server_derived_binding(self) -> None:
         with TemporaryDirectory() as directory:
             store = _store(Path(directory))

--- a/tests/test_tenant_admission_controller.py
+++ b/tests/test_tenant_admission_controller.py
@@ -75,6 +75,44 @@ class TenantAdmissionControllerTests(unittest.TestCase):
                 self.assertEqual(checks.status, "pass")
                 self.assertFalse(transport.merge_called)
 
+    def test_launchplane_advisory_checks_are_excluded_from_technical_inputs(self) -> None:
+        admission = _status_with_path_states(
+            trusted_state="pending",
+            waiver_state="pending",
+            manager_state="satisfied",
+        )
+        with TemporaryDirectory() as temporary_name, TemporaryDirectory() as baseline_name:
+            transport = _TenantControllerTransport(include_launchplane_projection_signals=True)
+            baseline_transport = _TenantControllerTransport()
+            with (
+                patch(
+                    "control_plane.tenant_admission_controller.get_tenant_admission_status",
+                    return_value=admission,
+                ),
+                patch(
+                    "control_plane.tenant_admission_controller.utc_now_timestamp",
+                    return_value=EVALUATED_AT,
+                ),
+            ):
+                result = execute_tenant_admission_controller_run_once(
+                    request=_request(mutate=False),
+                    store=FilesystemRecordStore(state_dir=Path(temporary_name)),
+                    token="token",
+                    trace_id="trace-advisory-exclusion",
+                    transport_factory=lambda _token: transport,
+                )
+                baseline = execute_tenant_admission_controller_run_once(
+                    request=_request(mutate=False),
+                    store=FilesystemRecordStore(state_dir=Path(baseline_name)),
+                    token="token",
+                    trace_id="trace-advisory-baseline",
+                    transport_factory=lambda _token: baseline_transport,
+                )
+
+        self.assertEqual(result.outcome, baseline.outcome)
+        assert result.technical_checks is not None
+        self.assertEqual(result.technical_checks, baseline.technical_checks)
+
     def test_mutate_merges_exact_head_and_excludes_admission_statuses(self) -> None:
         with TemporaryDirectory() as temporary_name:
             store = FilesystemRecordStore(state_dir=Path(temporary_name))
@@ -921,6 +959,7 @@ class _TenantControllerTransport:
         required_check_app_ids: tuple[int, ...] = (),
         strict_required_checks: object = True,
         head_contains_base: bool = True,
+        include_launchplane_projection_signals: bool = False,
     ) -> None:
         self.technical_state = technical_state
         self.include_technical_signals = include_technical_signals
@@ -938,6 +977,7 @@ class _TenantControllerTransport:
         self.required_check_app_ids = list(required_check_app_ids)
         self.strict_required_checks = strict_required_checks
         self.head_contains_base = head_contains_base
+        self.include_launchplane_projection_signals = include_launchplane_projection_signals
         self.merge_called = False
         self.technical_checks_read = False
         self.requests: list[tuple[str, str, dict[str, object] | None]] = []
@@ -961,17 +1001,27 @@ class _TenantControllerTransport:
             required_check_app_id = (
                 self.required_check_app_ids.pop(0) if self.required_check_app_ids else 15368
             )
+            contexts = ["ci/build", "unit-tests"]
+            checks = [
+                {"context": "ci/build", "app_id": None},
+                {"context": "unit-tests", "app_id": required_check_app_id},
+            ]
+            if self.include_launchplane_projection_signals:
+                contexts.extend(["launchplane/engineering-review", "launchplane/owner-acceptance"])
+                checks.extend(
+                    [
+                        {"context": "launchplane/engineering-review", "app_id": 42},
+                        {"context": "launchplane/owner-acceptance", "app_id": 42},
+                    ]
+                )
             return {
                 **(
                     {"strict": self.strict_required_checks}
                     if self.strict_required_checks is not None
                     else {}
                 ),
-                "contexts": ["ci/build", "unit-tests"],
-                "checks": [
-                    {"context": "ci/build", "app_id": None},
-                    {"context": "unit-tests", "app_id": required_check_app_id},
-                ],
+                "contexts": contexts,
+                "checks": checks,
             }
         if method == "GET" and path.endswith("/status"):
             self.technical_checks_read = True
@@ -989,6 +1039,16 @@ class _TenantControllerTransport:
                         "app": None,
                     }
                 )
+            if self.include_launchplane_projection_signals:
+                statuses.extend(
+                    [
+                        {
+                            "context": "launchplane/engineering-review-shadow",
+                            "state": "failure",
+                        },
+                        {"context": "launchplane/owner-acceptance", "state": "failure"},
+                    ]
+                )
             return {
                 "sha": self.status_response_sha or _candidate().head_sha,
                 "total_count": len(statuses),
@@ -996,7 +1056,7 @@ class _TenantControllerTransport:
             }
         if method == "GET" and "/check-runs?" in path:
             self.technical_checks_read = True
-            check_runs = (
+            check_runs: list[dict[str, object]] = (
                 [
                     {
                         "name": "unit-tests",
@@ -1009,6 +1069,25 @@ class _TenantControllerTransport:
                 if self.include_technical_signals
                 else []
             )
+            if self.include_launchplane_projection_signals:
+                check_runs.extend(
+                    [
+                        {
+                            "name": "launchplane/engineering-review",
+                            "head_sha": _candidate().head_sha,
+                            "app": {"id": 42},
+                            "status": "completed",
+                            "conclusion": "failure",
+                        },
+                        {
+                            "name": "launchplane/owner-acceptance",
+                            "head_sha": _candidate().head_sha,
+                            "app": {"id": 42},
+                            "status": "queued",
+                            "conclusion": None,
+                        },
+                    ]
+                )
             return {"total_count": len(check_runs), "check_runs": check_runs}
         if method == "PUT" and path.endswith("/merge"):
             self.merge_called = True


### PR DESCRIPTION
## Summary

- mint exact repository-scoped GitHub App installation tokens with only Checks write permission and revoke them after projection attempts
- project stable neutral `launchplane/engineering-review` and `launchplane/owner-acceptance` check runs from server-owned exact evidence
- exclude Launchplane governance projections from merge-train and tenant-admission technical-check authority, with byte-identical verdict tests
- document the runtime configuration, secret, replay, drift, and authority boundaries and regenerate OpenAPI artifacts

## Validation

- `uv run --extra dev launchplane ci unittest-shard local --jobs 4`
- `uv run --extra dev mypy control_plane tests`
- changed-file `ruff check --no-fix` and `ruff format --check`
- `pnpm --dir frontend validate`
- `uv run launchplane service audit-config-authority --control-plane-root .`
- 123 focused projection, Owner, merge-train, and tenant-admission tests
- Opus and Gemini final review; actionable identity, error-translation, exact-repository, response-validation, and token-revocation findings resolved
- JetBrains inspection attempted but inconclusive due `execution_not_proven` / `proof_file_limit_exceeded`; zero problems were extracted, but no trustworthy IDE verdict was established

## Remaining Live Authorization

The code and dry-run contracts are complete. Canary projection still requires an Owner/operator to register and install the dedicated GitHub App with only Checks write plus mandatory Metadata read, then write the App id/private key into Launchplane-managed runtime/secret records. No product-repository implementation is included.

Refs #2030
Parent #2004
