### PR TITLE
Persist exact preview runtime evidence

### DIFF
--- a/control_plane/drivers/generic_web_preview_extensions.py
+++ b/control_plane/drivers/generic_web_preview_extensions.py
@@ -20,8 +20,13 @@ from control_plane.verireel_read_http import (
 from control_plane.workflows.generic_web_preview import (
     GenericWebPreviewDestroyRequest,
     GenericWebPreviewDestroyResult,
+    GenericWebPreviewReadinessCheck,
+    GenericWebPreviewReadinessResult,
     GenericWebPreviewRefreshRequest,
     GenericWebPreviewRefreshResult,
+    GenericWebPreviewSmokeCheck,
+    GenericWebPreviewSmokeResult,
+    GenericWebPreviewTransportSummary,
     preview_pr_number_from_slug,
     resolve_generic_web_preview_slug,
 )
@@ -29,6 +34,62 @@ from control_plane.workflows.verireel_preview_driver import (
     VeriReelPreviewDestroyRequest,
     VeriReelPreviewRefreshRequest,
 )
+
+
+def _successful_driver_refresh_evidence(
+    *,
+    profile: LaunchplaneProductProfileRecord,
+    request: GenericWebPreviewRefreshRequest,
+    result: dict[str, object],
+) -> tuple[GenericWebPreviewReadinessResult, GenericWebPreviewSmokeResult] | None:
+    if result.get("refresh_status") != "pass":
+        return None
+    template_instance = profile.preview.template_instance.strip()
+    template_lane = next(
+        (lane for lane in profile.lanes if lane.instance == template_instance),
+        None,
+    )
+    checked_at = str(result.get("refresh_finished_at") or result.get("refresh_started_at") or "")
+    readiness = GenericWebPreviewReadinessResult(
+        readiness_status="pass",
+        checked_at=checked_at,
+        product=profile.product,
+        context=profile.preview.context,
+        template_context=template_lane.context if template_lane is not None else "",
+        template_instance=template_instance,
+        source=request.source,
+        missing_template_env_keys=(),
+        missing_provider_fields=(),
+        transport=GenericWebPreviewTransportSummary(
+            data_transport_mode=profile.preview.data_transport_mode,
+            copied_env_keys=profile.preview.copied_env_keys,
+            omitted_env_keys=profile.preview.omitted_env_keys,
+            override_env_keys=tuple(profile.preview.override_env),
+            preview_url_env_keys=profile.preview.preview_url_env_keys,
+            preview_domain_env_keys=profile.preview.preview_domain_env_keys,
+            migration_command_configured=bool(profile.preview.migration_command.strip()),
+            seed_command_configured=bool(profile.preview.seed_command.strip()),
+        ),
+        checks=(
+            GenericWebPreviewReadinessCheck(
+                check_id="driver_refresh",
+                status="pass",
+                message="Driver-owned preview provisioning prerequisites passed.",
+            ),
+        ),
+    )
+    smoke = GenericWebPreviewSmokeResult(
+        smoke_status="pass",
+        checked_at=checked_at,
+        checks=(
+            GenericWebPreviewSmokeCheck(
+                check_id="driver_preview_health",
+                status="pass",
+                message="Driver-owned preview health check passed before product verification.",
+            ),
+        ),
+    )
+    return readiness, smoke
 
 
 def apply_generic_web_preview_driver_refresh(
@@ -55,27 +116,33 @@ def apply_generic_web_preview_driver_refresh(
         anchor_pr_number=anchor_pr_number,
         label="Generic web preview refresh",
     )
+    verireel_refresh_request = VeriReelPreviewRefreshRequest(
+        context=profile.preview.context,
+        anchor_repo=_generic_web_preview_anchor_repo(profile),
+        anchor_pr_number=anchor_pr_number,
+        anchor_pr_url=_generic_web_preview_anchor_pr_url(
+            request=request,
+            profile=profile,
+            anchor_pr_number=anchor_pr_number,
+        ),
+        anchor_head_sha=_generic_web_preview_anchor_head_sha(request),
+        preview_slug=preview_slug,
+        preview_url=request.preview_url,
+        image_reference=request.image_reference,
+        timeout_seconds=request.timeout_seconds,
+    )
     records, result = apply_verireel_preview_refresh_result(
         control_plane_root=control_plane_root,
         record_store=record_store,
         request=VeriReelPreviewRefreshEnvelope(
             product=profile.product,
-            refresh=VeriReelPreviewRefreshRequest(
-                context=profile.preview.context,
-                anchor_repo=_generic_web_preview_anchor_repo(profile),
-                anchor_pr_number=anchor_pr_number,
-                anchor_pr_url=_generic_web_preview_anchor_pr_url(
-                    request=request,
-                    profile=profile,
-                    anchor_pr_number=anchor_pr_number,
-                ),
-                anchor_head_sha=_generic_web_preview_anchor_head_sha(request),
-                preview_slug=preview_slug,
-                preview_url=request.preview_url,
-                image_reference=request.image_reference,
-                timeout_seconds=request.timeout_seconds,
-            ),
+            refresh=verireel_refresh_request,
         ),
+    )
+    driver_evidence = _successful_driver_refresh_evidence(
+        profile=profile,
+        request=request,
+        result=result,
     )
     generic_result = GenericWebPreviewRefreshResult.model_validate(
         {
@@ -83,6 +150,8 @@ def apply_generic_web_preview_driver_refresh(
             "product": profile.product,
             "context": profile.preview.context,
             "preview_slug": preview_slug,
+            "readiness": driver_evidence[0] if driver_evidence is not None else None,
+            "smoke": driver_evidence[1] if driver_evidence is not None else None,
         }
     )
     return records, generic_result.model_dump(mode="json")

--- a/control_plane/verireel_read_http.py
+++ b/control_plane/verireel_read_http.py
@@ -523,6 +523,7 @@ def apply_verireel_preview_refresh_records(
         overall_health_status="pending" if refresh_passed else "fail",
         failure_stage="" if refresh_passed else "provision",
         failure_summary="" if refresh_passed else failure_summary,
+        runtime_identity=driver_result.runtime_identity,
     )
     return apply_launchplane_generation_evidence(
         control_plane_root_path=control_plane_root,

--- a/control_plane/workflows/verireel_preview_driver.py
+++ b/control_plane/workflows/verireel_preview_driver.py
@@ -16,7 +16,11 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from control_plane import runtime_environments as control_plane_runtime_environments
 from control_plane import secrets as control_plane_secrets
-from control_plane.contracts.runtime_identity import RuntimeIdentity, runtime_identity_env
+from control_plane.contracts.runtime_identity import (
+    RuntimeIdentity,
+    health_payload_runtime_identity_status,
+    runtime_identity_env,
+)
 from control_plane.contracts.runtime_key_safety_policy import RuntimeKeySafetyTarget
 from control_plane.contracts.secret_record import SecretBinding
 from control_plane.runtime_key_safety import (
@@ -39,6 +43,7 @@ DEFAULT_PREVIEW_TIMEOUT_SECONDS = 300
 PREVIEW_APP_PREFIX = "ver-preview"
 PREVIEW_DATABASE_PREFIX = "verireel_preview_"
 PREVIEW_BASE_URL_ENV_KEY = "LAUNCHPLANE_PREVIEW_BASE_URL"
+_HARD_RUNTIME_IDENTITY_FIELDS = frozenset({"product", "context", "instance", "environment_kind"})
 _PREVIEW_REFRESH_GENERATED_ENV_KEYS = frozenset(
     {
         "BETTER_AUTH_SECRET",
@@ -150,6 +155,7 @@ class VeriReelPreviewRefreshResult(BaseModel):
     application_name: str
     application_id: str
     preview_url: str
+    runtime_identity: RuntimeIdentity | None = None
     error_message: str = ""
 
 
@@ -1135,9 +1141,14 @@ def _build_preview_database_command(
     )
 
 
-def _wait_for_preview_health(*, preview_url: str, timeout_seconds: int) -> None:
+def _wait_for_preview_health(
+    *,
+    preview_url: str,
+    timeout_seconds: int,
+    expected_runtime_identity: RuntimeIdentity,
+) -> RuntimeIdentity:
     health_url = f"{preview_url.rstrip('/')}/api/health"
-    deadline = timeout_seconds
+    started_at = time.monotonic()
     request = Request(
         health_url,
         headers={
@@ -1145,18 +1156,48 @@ def _wait_for_preview_health(*, preview_url: str, timeout_seconds: int) -> None:
             "Cache-Control": "no-store",
         },
     )
-    while deadline > 0:
+    last_detail = "health endpoint did not return matching runtime identity"
+    while time.monotonic() - started_at <= timeout_seconds:
+        remaining_seconds = max(1, timeout_seconds - int(time.monotonic() - started_at))
         try:
-            with urlopen(request, timeout=min(15, deadline)) as response:
+            with urlopen(request, timeout=min(15, remaining_seconds)) as response:
                 payload = json.loads(response.read().decode("utf-8"))
-            if payload.get("ok") is True:
-                return
+            if not isinstance(payload, dict):
+                last_detail = "health endpoint returned non-object JSON"
+            elif payload.get("ok") is not True:
+                last_detail = "health endpoint did not report ok=true"
+            else:
+                status, detail, observed = health_payload_runtime_identity_status(
+                    expected=expected_runtime_identity,
+                    payload=payload,
+                    json_parse_failed=False,
+                )
+                if status == "match" and observed is not None:
+                    return observed
+                if status == "mismatch" and _runtime_identity_mismatch_is_hard(detail):
+                    raise click.ClickException(
+                        "Preview runtime identity did not match the expected deployment identity: "
+                        f"{detail}."
+                    )
+                last_detail = detail
         except (HTTPError, URLError, TimeoutError, json.JSONDecodeError, ValueError):
-            pass
-        sleep_seconds = min(5, deadline)
+            last_detail = "health endpoint request failed or returned invalid JSON"
+        elapsed_seconds = time.monotonic() - started_at
+        if elapsed_seconds >= timeout_seconds:
+            break
+        sleep_seconds = min(5, timeout_seconds - elapsed_seconds)
         time.sleep(sleep_seconds)
-        deadline -= sleep_seconds
-    raise click.ClickException(f"Timed out waiting for {health_url} to report ok=true.")
+    raise click.ClickException(
+        f"Timed out waiting for {health_url} to report the expected runtime identity: {last_detail}."
+    )
+
+
+def _runtime_identity_mismatch_is_hard(detail: str) -> bool:
+    prefix = "Runtime identity mismatched fields: "
+    if not detail.startswith(prefix):
+        return False
+    fields = {field.strip() for field in detail.removeprefix(prefix).split(",") if field.strip()}
+    return bool(fields & _HARD_RUNTIME_IDENTITY_FIELDS)
 
 
 def _resolve_existing_preview_database(
@@ -1260,6 +1301,7 @@ def execute_verireel_preview_refresh(
             ),
             timeout_seconds=request.timeout_seconds,
         )
+        expected_runtime_identity = _build_preview_runtime_identity(request=request)
         env_text = dokploy_api.render_dokploy_env_text_with_overrides(
             str(template_application.get("env") or ""),
             updates={
@@ -1298,7 +1340,7 @@ def execute_verireel_preview_refresh(
                     generate=_random_urlsafe_secret,
                     template_env_map=template_env_map,
                 ),
-                **runtime_identity_env(_build_preview_runtime_identity(request=request)),
+                **runtime_identity_env(expected_runtime_identity),
             },
         )
         application = _ensure_application(
@@ -1364,7 +1406,11 @@ def execute_verireel_preview_refresh(
             command="node prisma/seed.mjs",
             timeout_seconds=request.timeout_seconds,
         )
-        _wait_for_preview_health(preview_url=preview_url, timeout_seconds=request.timeout_seconds)
+        observed_runtime_identity = _wait_for_preview_health(
+            preview_url=preview_url,
+            timeout_seconds=request.timeout_seconds,
+            expected_runtime_identity=expected_runtime_identity,
+        )
         for stale_domain_id in stale_domain_ids:
             _delete_domain(host=host, token=token, domain_id=stale_domain_id)
     except click.ClickException as exc:
@@ -1432,6 +1478,7 @@ def execute_verireel_preview_refresh(
         application_name=application_name,
         application_id=str((resolved_application or {}).get("applicationId") or "").strip(),
         preview_url=preview_url,
+        runtime_identity=observed_runtime_identity,
     )
 
 

--- a/docs/preview-workflow-contract.md
+++ b/docs/preview-workflow-contract.md
@@ -140,6 +140,11 @@ behavior. Dokploy schedule failures remain failed refreshes. Launchplane attache
 bounded redacted deployment output when the provider exposes it, and retries only
 typed transient failures that occur before schedule execution; deterministic
 remote exits and ambiguous post-trigger failures are not executed again.
+After a driver-owned refresh passes its provisioning and health boundary, the
+generic response records successful readiness and smoke evidence and persists the
+same exact runtime identity injected into the serving application. Later product
+verification may advance that generation from verifying to ready, but it must not
+replace or fabricate the serving artifact or source revision.
 
 Preview comment updates that are not part of the lifecycle workflow use
 `cbusillo/launchplane/.github/workflows/reusable-preview-pr-feedback.yml@<launchplane-sha>`.

--- a/tests/test_generic_web_preview_extensions.py
+++ b/tests/test_generic_web_preview_extensions.py
@@ -72,6 +72,17 @@ class GenericWebPreviewExtensionTests(unittest.TestCase):
                 "application_name": "ver-preview-pr-42",
                 "application_id": "app-pr-42",
                 "preview_url": "https://pr-42.preview.example.test",
+                "runtime_identity": {
+                    "product": "verireel",
+                    "context": "verireel-testing",
+                    "instance": "pr-42",
+                    "environment_kind": "preview",
+                    "deployment_record_id": "deployment-verireel-testing-pr-42",
+                    "artifact_id": "ghcr.io/cbusillo/verireel-app:pr-42-a1b2c3d4",
+                    "source_git_ref": "a1b2c3d4",
+                    "image_reference": "ghcr.io/cbusillo/verireel-app:pr-42-a1b2c3d4",
+                    "preview_id": "pr-42",
+                },
                 "error_message": "",
             },
         )
@@ -98,6 +109,18 @@ class GenericWebPreviewExtensionTests(unittest.TestCase):
         self.assertEqual(result["product"], "verireel")
         self.assertEqual(result["context"], "verireel-testing")
         self.assertEqual(result["preview_slug"], "pr-42")
+        readiness = result["readiness"]
+        smoke = result["smoke"]
+        runtime_identity = result["runtime_identity"]
+        self.assertIsInstance(readiness, dict)
+        self.assertIsInstance(smoke, dict)
+        self.assertIsInstance(runtime_identity, dict)
+        assert isinstance(readiness, dict)
+        assert isinstance(smoke, dict)
+        assert isinstance(runtime_identity, dict)
+        self.assertEqual(readiness["readiness_status"], "pass")
+        self.assertEqual(smoke["smoke_status"], "pass")
+        self.assertEqual(runtime_identity["source_git_ref"], "a1b2c3d4")
         delegated = apply_refresh.call_args.kwargs["request"].refresh
         self.assertEqual(delegated.context, "verireel-testing")
         self.assertEqual(delegated.anchor_repo, "verireel")

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -63,6 +63,7 @@ from control_plane.contracts.runtime_key_safety_policy import (
     RuntimeKeySafetyPolicyRecord,
     RuntimeSecretSafetyRule,
 )
+from control_plane.contracts.runtime_identity import RuntimeIdentity
 from control_plane.contracts.runner_host_hygiene import (
     RunnerHostHygieneApplyAuditRecord,
     RunnerHostHygieneApplyPolicy,
@@ -10031,6 +10032,17 @@ class LaunchplaneServiceTests(unittest.TestCase):
                     application_name="ver-preview-pr-123-app",
                     application_id="preview-app-123",
                     preview_url="https://pr-123.ver-preview.shinycomputers.com",
+                    runtime_identity=RuntimeIdentity(
+                        product="verireel",
+                        context="verireel-testing",
+                        instance="pr-123",
+                        environment_kind="preview",
+                        deployment_record_id="deployment-verireel-testing-pr-123",
+                        artifact_id="ghcr.io/every/verireel-app:pr-123-sha-6b3c9d7",
+                        source_git_ref="6b3c9d7e8f901234567890abcdef1234567890ab",
+                        image_reference="ghcr.io/every/verireel-app:pr-123-sha-6b3c9d7",
+                        preview_id="pr-123",
+                    ),
                 ),
             ) as execute_mock:
                 refresh_payload = {
@@ -10087,6 +10099,12 @@ class LaunchplaneServiceTests(unittest.TestCase):
             self.assertEqual(generation.state, "verifying")
             self.assertEqual(generation.deploy_status, "pass")
             self.assertEqual(generation.verify_status, "pending")
+            self.assertIsNotNone(generation.runtime_identity)
+            assert generation.runtime_identity is not None
+            self.assertEqual(
+                generation.runtime_identity.source_git_ref,
+                "6b3c9d7e8f901234567890abcdef1234567890ab",
+            )
             self.assertEqual(
                 generation.resolved_manifest_fingerprint,
                 "verireel-preview-manifest-pr-123-6b3c9d7",

--- a/tests/test_verireel_preview_driver.py
+++ b/tests/test_verireel_preview_driver.py
@@ -1,9 +1,10 @@
 import base64
+import json
 import subprocess
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import click
 
@@ -19,6 +20,7 @@ from control_plane.dokploy import DokployTargetDefinition
 from control_plane.workflows.verireel_preview_driver import VeriReelPreviewDestroyRequest
 from control_plane.workflows.verireel_preview_driver import VeriReelPreviewRefreshRequest
 from control_plane.workflows.verireel_preview_driver import VeriReelPreviewRefreshTransportError
+from control_plane.workflows.verireel_preview_driver import _build_preview_runtime_identity
 from control_plane.workflows.verireel_preview_driver import _build_preview_database_command
 from control_plane.workflows.verireel_preview_driver import (
     _enforce_verireel_preview_runtime_key_safety,
@@ -29,6 +31,7 @@ from control_plane.workflows.verireel_preview_driver import _resolve_preview_sec
 from control_plane.workflows.verireel_preview_driver import _resolve_preview_url
 from control_plane.workflows.verireel_preview_driver import _run_application_command
 from control_plane.workflows.verireel_preview_driver import _run_application_command_with_retries
+from control_plane.workflows.verireel_preview_driver import _wait_for_preview_health
 from control_plane.workflows.verireel_preview_driver import _verireel_template_runtime_secret_keys
 from control_plane.workflows.verireel_preview_driver import execute_verireel_preview_refresh
 
@@ -687,7 +690,10 @@ class VeriReelPreviewDriverTests(unittest.TestCase):
             patch(
                 "control_plane.workflows.verireel_preview_driver._run_application_command_with_retries"
             ),
-            patch("control_plane.workflows.verireel_preview_driver._wait_for_preview_health"),
+            patch(
+                "control_plane.workflows.verireel_preview_driver._wait_for_preview_health",
+                side_effect=lambda **kwargs: kwargs["expected_runtime_identity"],
+            ),
         ):
             result = execute_verireel_preview_refresh(
                 control_plane_root=Path(temporary_directory_name),
@@ -775,7 +781,10 @@ class VeriReelPreviewDriverTests(unittest.TestCase):
             patch(
                 "control_plane.workflows.verireel_preview_driver._run_application_command_with_retries"
             ) as run_command_with_retries,
-            patch("control_plane.workflows.verireel_preview_driver._wait_for_preview_health"),
+            patch(
+                "control_plane.workflows.verireel_preview_driver._wait_for_preview_health",
+                side_effect=lambda **kwargs: kwargs["expected_runtime_identity"],
+            ),
         ):
             result = execute_verireel_preview_refresh(
                 control_plane_root=Path(temporary_directory_name),
@@ -784,6 +793,9 @@ class VeriReelPreviewDriverTests(unittest.TestCase):
             )
 
         self.assertEqual(result.refresh_status, "pass")
+        self.assertEqual(
+            result.runtime_identity, _build_preview_runtime_identity(request=_refresh_request())
+        )
         self.assertEqual(captured_env["BETTER_AUTH_SECRET"], "existing-auth-secret")
         self.assertEqual(captured_env["VERIREEL_CRON_SECRET"], "existing-cron-secret")
         self.assertEqual(
@@ -802,6 +814,85 @@ class VeriReelPreviewDriverTests(unittest.TestCase):
             run_command_with_retries.call_args_list[1].kwargs["command"],
             "node prisma/seed.mjs",
         )
+
+    def test_wait_for_preview_health_returns_matching_runtime_identity(self) -> None:
+        expected = _build_preview_runtime_identity(request=_refresh_request())
+        response = MagicMock()
+        response.read.return_value = json.dumps(
+            {
+                "ok": True,
+                "runtime_identity": expected.model_dump(mode="json"),
+            }
+        ).encode("utf-8")
+        response.__enter__.return_value = response
+        with patch(
+            "control_plane.workflows.verireel_preview_driver.urlopen", return_value=response
+        ):
+            observed = _wait_for_preview_health(
+                preview_url="https://pr-71.preview.example.test",
+                timeout_seconds=30,
+                expected_runtime_identity=expected,
+            )
+
+        self.assertEqual(observed, expected)
+
+    def test_wait_for_preview_health_rejects_runtime_identity_mismatch(self) -> None:
+        expected = _build_preview_runtime_identity(request=_refresh_request())
+        mismatched = expected.model_copy(update={"source_git_ref": "a" * 40})
+        response = MagicMock()
+        response.read.return_value = json.dumps(
+            {
+                "ok": True,
+                "runtime_identity": mismatched.model_dump(mode="json"),
+            }
+        ).encode("utf-8")
+        response.__enter__.return_value = response
+        with (
+            patch("control_plane.workflows.verireel_preview_driver.urlopen", return_value=response),
+            patch(
+                "control_plane.workflows.verireel_preview_driver.time.monotonic",
+                side_effect=(0.0, 0.0, 0.0, 2.0),
+            ),
+            patch("control_plane.workflows.verireel_preview_driver.time.sleep") as sleep,
+        ):
+            with self.assertRaisesRegex(click.ClickException, "source_git_ref"):
+                _wait_for_preview_health(
+                    preview_url="https://pr-71.preview.example.test",
+                    timeout_seconds=1,
+                    expected_runtime_identity=expected,
+                )
+
+        sleep.assert_not_called()
+
+    def test_wait_for_preview_health_fails_immediately_on_hard_identity_mismatch(
+        self,
+    ) -> None:
+        expected = _build_preview_runtime_identity(request=_refresh_request())
+        mismatched = expected.model_copy(update={"product": "different-product"})
+        response = MagicMock()
+        response.read.return_value = json.dumps(
+            {
+                "ok": True,
+                "runtime_identity": mismatched.model_dump(mode="json"),
+            }
+        ).encode("utf-8")
+        response.__enter__.return_value = response
+        with (
+            patch("control_plane.workflows.verireel_preview_driver.urlopen", return_value=response),
+            patch(
+                "control_plane.workflows.verireel_preview_driver.time.monotonic",
+                side_effect=(0.0, 0.0, 0.0),
+            ),
+            patch("control_plane.workflows.verireel_preview_driver.time.sleep") as sleep,
+        ):
+            with self.assertRaisesRegex(click.ClickException, "product"):
+                _wait_for_preview_health(
+                    preview_url="https://pr-71.preview.example.test",
+                    timeout_seconds=30,
+                    expected_runtime_identity=expected,
+                )
+
+        sleep.assert_not_called()
 
     def test_preview_destroy_request_requires_pr_scoped_preview_slug(self) -> None:
         with self.assertRaisesRegex(ValueError, "preview_slug to match anchor_pr_number"):


### PR DESCRIPTION
## Summary

- require the VeriReel driver health endpoint to return the exact runtime identity injected into the preview application before refresh succeeds
- persist the observed runtime identity on the preview generation rather than reconstructing or fabricating serving evidence
- report driver-owned readiness and health smoke separately while leaving product verification pending until the dedicated verification route passes
- fail immediately for wrong product/context/instance/environment identity and allow deploy/source identity convergence only until the bounded timeout

Refs #2039
Follow-up to #2040

## Why

After #2040 deployed, VeriReel PR #310 provisioned and product verification passed, but the generic refresh response still exposed null readiness, smoke, and runtime identity. The live `/api/health` endpoint already reported the exact expected head and digest; this change makes Launchplane verify and durably retain that evidence before reporting refresh success.

## Validation

- `uv run --extra dev python -m unittest tests.test_verireel_preview_driver tests.test_generic_web_preview_extensions tests.test_service.LaunchplaneServiceTests.test_verireel_preview_refresh_driver_executes_for_authorized_workflow`
- `uv run --extra dev ruff check control_plane/drivers/generic_web_preview_extensions.py control_plane/verireel_read_http.py control_plane/workflows/verireel_preview_driver.py tests/test_generic_web_preview_extensions.py tests/test_service.py tests/test_verireel_preview_driver.py`
- `uv run --extra dev ruff format --check control_plane/drivers/generic_web_preview_extensions.py control_plane/verireel_read_http.py control_plane/workflows/verireel_preview_driver.py tests/test_generic_web_preview_extensions.py tests/test_service.py tests/test_verireel_preview_driver.py`
- `uv run --extra dev mypy control_plane tests`
- `pnpm --dir frontend check:openapi-drift`
- `uv run launchplane service audit-config-authority --control-plane-root .`

JetBrains changed-file inspection was attempted repeatedly, but the local inspection API remained unavailable/inconclusive; no GREEN or RED claim is made from IDE evidence.

## Review Focus

- exact expected-versus-observed runtime identity comparison
- hard mismatch versus bounded convergence behavior
- preserving `verifying` / `verify_status=pending` until product verification
- readiness/smoke wording that does not impersonate the later product E2E gate
