### PR TITLE
Authorize Owner acceptance humans safely

### DIFF
--- a/.github/workflows/authz-policy-reconcile.yml
+++ b/.github/workflows/authz-policy-reconcile.yml
@@ -22,6 +22,7 @@ name: Manage Launchplane Authorization
           - authz-policy-reconcile
           - generic-web-onboarding
           - manager-preview-approval
+          - owner-acceptance
           - product-health-monitoring
           - odoo-route-binding
           - odoo-external-route-binding
@@ -85,6 +86,18 @@ jobs:
       related_issue: ${{ inputs.related_issue }}
     secrets:
       managed_set_json: ${{ secrets.LAUNCHPLANE_AUTHZ_MANAGER_PREVIEW_APPROVAL_MANAGED_SET_JSON }}
+
+  reconcile-owner-acceptance:
+    if: ${{ inputs.managed_set == 'owner-acceptance' }}
+    uses: cbusillo/launchplane/.github/workflows/reusable-authz-policy-reconcile.yml@39aecc250d6dee91204e24673725bd1ea1ca6bda # main
+    with:
+      mode: ${{ inputs.mode }}
+      expected_managed_set_id: operator.owner-acceptance
+      reviewed_plan_sha256: ${{ inputs.reviewed_plan_sha256 }}
+      reason: ${{ inputs.reason }}
+      related_issue: ${{ inputs.related_issue }}
+    secrets:
+      managed_set_json: ${{ secrets.LAUNCHPLANE_AUTHZ_OWNER_ACCEPTANCE_MANAGED_SET_JSON }}
 
   reconcile-generic-web-onboarding:
     if: ${{ inputs.managed_set == 'generic-web-onboarding' }}

--- a/control_plane/authz_grant_service.py
+++ b/control_plane/authz_grant_service.py
@@ -19,6 +19,10 @@ from control_plane.contracts.authz_policy_record import (
     authz_policy_sha256,
     build_authz_policy_record_id,
 )
+from control_plane.contracts.owner_acceptance import (
+    OWNER_ACCEPTANCE_EVENT_WRITE_ACTION,
+    OWNER_ACCEPTANCE_READ_ACTION,
+)
 from control_plane.service_auth import (
     AuthzInstanceSelectors,
     GitHubActionsIdentity,
@@ -161,8 +165,40 @@ _IMMUTABLE_WORKFLOW_ACTION_SAFETIES = frozenset(
 )
 _MANAGED_AUTHZ_RECONCILE_SOURCE = "service:authz-managed-rule-set-reconcile"
 _AUTHZ_POLICY_ADMIN_ACTION = "authz_policy_grant.write"
+_OWNER_ACCEPTANCE_MANAGED_SET_ID = "operator.owner-acceptance"
+_OWNER_ACCEPTANCE_ACTIONS = frozenset(
+    {OWNER_ACCEPTANCE_READ_ACTION, OWNER_ACCEPTANCE_EVENT_WRITE_ACTION}
+)
 AuthzSchemaMigrationMode = Literal["reject", "migrate_v1_to_v2"]
 AuthzUnmanagedAdoptionMode = Literal["reject", "adopt_matching"]
+
+
+def _validate_owner_acceptance_managed_set(policy: LaunchplaneAuthzPolicy) -> None:
+    if any(
+        rules
+        for principal_type, rules in _authz_policy_rule_collections(policy)
+        if principal_type != "github_humans"
+    ):
+        raise ValueError("Owner Acceptance managed authz may contain only GitHub human rules.")
+    for rule in policy.github_humans:
+        if not rule.github_ids or rule.logins or rule.organizations or rule.teams:
+            raise ValueError(
+                "Owner Acceptance managed authz rules require only immutable GitHub IDs."
+            )
+        if rule.roles != ("read_only",):
+            raise ValueError("Owner Acceptance managed authz rules require the read_only role.")
+        if rule.products != ("launchplane",) or rule.contexts != ("owner-acceptance",):
+            raise ValueError(
+                "Owner Acceptance managed authz rules require the exact Launchplane workbench scope."
+            )
+        if rule.instances:
+            raise ValueError(
+                "Owner Acceptance managed authz rules cannot declare instance selectors."
+            )
+        if frozenset(rule.actions) != _OWNER_ACCEPTANCE_ACTIONS:
+            raise ValueError(
+                "Owner Acceptance managed authz rules require only the read and event-write actions."
+            )
 
 
 class AuthzManagedPolicyReconcileEnvelope(BaseModel):
@@ -206,6 +242,8 @@ class AuthzManagedPolicyReconcileEnvelope(BaseModel):
         if self.desired_policy.schema_version != 2:
             raise ValueError("Managed authz desired policy must use schema version 2.")
         self.desired_policy = _normalize_desired_authz_policy(self.desired_policy)
+        if self.managed_set_id == _OWNER_ACCEPTANCE_MANAGED_SET_ID:
+            _validate_owner_acceptance_managed_set(self.desired_policy)
         for principal_type, rules in _authz_policy_rule_collections(self.desired_policy):
             for rule in rules:
                 if rule.managed_set_id != self.managed_set_id or not rule.managed_rule_id:

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -432,8 +432,15 @@ policy-admin worker rules for the standalone authz wrapper and must declare the
 `operator.authz-policy-reconcile` managed-set identity;
 `LAUNCHPLANE_AUTHZ_MANAGER_PREVIEW_APPROVAL_MANAGED_SET_JSON` owns the generic
 GitHub-human manager preview approval writer set and must declare the exact
-`operator.manager-preview-approval` managed-set identity. Generic-web preview
-caller grants are no longer sourced from a per-product repository secret. The
+`operator.manager-preview-approval` managed-set identity;
+`LAUNCHPLANE_AUTHZ_OWNER_ACCEPTANCE_MANAGED_SET_JSON` owns only the dedicated
+GitHub-human Owner Acceptance workbench grants and must declare the exact
+`operator.owner-acceptance` managed-set identity. Bind its rules to immutable
+numeric GitHub user IDs with the minimum `read_only` role and only
+`owner_acceptance.read` plus `owner_acceptance_event.write` for product
+`launchplane` and context `owner-acceptance`. Product Owner membership remains
+a separate server-side requirement for event writes. Generic-web preview caller
+grants are no longer sourced from a per-product repository secret. The
 typed product-onboarding planner derives repository identity, caller workflow
 refs, immutable Launchplane worker refs, products, contexts, events, and actions
 and submits the complete `operator.generic-web-preview` desired set through the

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -77,6 +77,13 @@ title: Secrets
   generated preview caller rules in it. Product rules are planned from typed
   runtime input and persisted in the DB-backed `operator.generic-web-preview`
   managed set.
+- The protected `LAUNCHPLANE_AUTHZ_OWNER_ACCEPTANCE_MANAGED_SET_JSON` secret
+  contains the complete `operator.owner-acceptance` GitHub-human desired set.
+  Bind every rule to immutable numeric GitHub user IDs and grant only the
+  `read_only` role, `launchplane` product, `owner-acceptance` context,
+  `owner_acceptance.read`, and `owner_acceptance_event.write`. Keep product
+  Owner membership in the independently managed Owner policy; this secret
+  grants workbench access but cannot satisfy Owner authority.
 
 ## DB-Backed Secret Resolution
 

--- a/tests/test_authz_grant_service.py
+++ b/tests/test_authz_grant_service.py
@@ -561,6 +561,70 @@ class AuthzManagedPolicyServiceTests(unittest.TestCase):
                 }
             )
 
+    def test_owner_acceptance_managed_set_enforces_minimum_human_boundary(self) -> None:
+        valid_rule = {
+            "managed_set_id": "operator.owner-acceptance",
+            "managed_rule_id": "owner.current",
+            "github_ids": [1001],
+            "roles": ["read_only"],
+            "products": ["launchplane"],
+            "contexts": ["owner-acceptance"],
+            "actions": ["owner_acceptance.read", "owner_acceptance_event.write"],
+        }
+        request_payload = {
+            "schema_version": 2,
+            "product": "launchplane",
+            "mode": "dry_run",
+            "managed_set_id": "operator.owner-acceptance",
+            "desired_policy": {
+                "schema_version": 2,
+                "github_humans": [valid_rule],
+            },
+        }
+
+        AuthzManagedPolicyReconcileEnvelope.model_validate(request_payload)
+
+        invalid_rules = (
+            ({**valid_rule, "github_ids": [], "logins": ["owner"]}, "immutable GitHub IDs"),
+            ({**valid_rule, "roles": ["admin"]}, "read_only role"),
+            ({**valid_rule, "products": ["other"]}, "exact Launchplane workbench scope"),
+            (
+                {**valid_rule, "actions": [*valid_rule["actions"], "product_config.apply"]},
+                "only the read and event-write actions",
+            ),
+        )
+        for invalid_rule, message in invalid_rules:
+            with self.subTest(message=message), self.assertRaisesRegex(ValidationError, message):
+                AuthzManagedPolicyReconcileEnvelope.model_validate(
+                    {
+                        **request_payload,
+                        "desired_policy": {
+                            "schema_version": 2,
+                            "github_humans": [invalid_rule],
+                        },
+                    }
+                )
+
+        with self.assertRaisesRegex(ValidationError, "only GitHub human rules"):
+            AuthzManagedPolicyReconcileEnvelope.model_validate(
+                {
+                    **request_payload,
+                    "desired_policy": {
+                        "schema_version": 2,
+                        "github_actions": [
+                            {
+                                "managed_set_id": "operator.owner-acceptance",
+                                "managed_rule_id": "worker.invalid",
+                                "repository": "cbusillo/launchplane",
+                                "repository_id": "1001",
+                                "repository_owner_id": "2001",
+                                "actions": ["owner_acceptance.read"],
+                            }
+                        ],
+                    },
+                }
+            )
+
     def test_managed_reconcile_requires_explicit_migration_and_adoption(self) -> None:
         current_record = _active_record()
         desired_policy = {

--- a/tests/test_authz_operator_workflow.py
+++ b/tests/test_authz_operator_workflow.py
@@ -34,6 +34,7 @@ class AuthzOperatorWorkflowTests(unittest.TestCase):
                 "authz-policy-reconcile",
                 "generic-web-onboarding",
                 "manager-preview-approval",
+                "owner-acceptance",
                 "product-health-monitoring",
                 "odoo-route-binding",
                 "odoo-external-route-binding",
@@ -59,6 +60,10 @@ class AuthzOperatorWorkflowTests(unittest.TestCase):
             "reconcile-manager-preview-approval": (
                 "${{ inputs.managed_set == 'manager-preview-approval' }}",
                 "${{ secrets.LAUNCHPLANE_AUTHZ_MANAGER_PREVIEW_APPROVAL_MANAGED_SET_JSON }}",
+            ),
+            "reconcile-owner-acceptance": (
+                "${{ inputs.managed_set == 'owner-acceptance' }}",
+                "${{ secrets.LAUNCHPLANE_AUTHZ_OWNER_ACCEPTANCE_MANAGED_SET_JSON }}",
             ),
             "reconcile-generic-web-onboarding": (
                 "${{ inputs.managed_set == 'generic-web-onboarding' }}",
@@ -130,6 +135,7 @@ class AuthzOperatorWorkflowTests(unittest.TestCase):
                     "reconcile-authz-policy-reconcile": "operator.authz-policy-reconcile",
                     "reconcile-generic-web-onboarding": "operator.generic-web-onboarding",
                     "reconcile-manager-preview-approval": "operator.manager-preview-approval",
+                    "reconcile-owner-acceptance": "operator.owner-acceptance",
                 }
                 if job_name in expected_managed_set_ids:
                     self.assertEqual(

--- a/tests/test_service_auth.py
+++ b/tests/test_service_auth.py
@@ -286,10 +286,12 @@ class LaunchplaneAuthzPolicyBoundaryTests(unittest.TestCase):
     def test_action_safety_classifies_privileged_action_families(self) -> None:
         cases = {
             "authz_diagnostic.evaluate": "read",
+            "owner_acceptance.read": "read",
             "product_environment.read": "read",
             "work_graph.rank": "read",
             "preview_pr_feedback_notification_attempt.read": "read",
             "preview_pr_feedback.write": "safe_write",
+            "owner_acceptance_event.write": "safe_write",
             "every_code_work_request.rerun": "safe_write",
             "product_config.apply": "mutation",
             "product_config.apply.secret": "secret_backed",
@@ -310,6 +312,7 @@ class LaunchplaneAuthzPolicyBoundaryTests(unittest.TestCase):
         allowed_actions = (
             "product_environment.read",
             "work_graph.rank",
+            "owner_acceptance_event.write",
             "preview_pr_feedback.write",
         )
         denied_actions = (


### PR DESCRIPTION
## Summary

- add a dedicated protected `owner-acceptance` authorization managed-set path
- enforce immutable GitHub-ID-only, `read_only`, exact workbench action/scope rules service-side
- document the distinct secret/managed-set boundary and preserve separate product Owner authorization

## Validation

- `uv run --extra dev launchplane ci unittest-shard local`
- `uv run --extra dev mypy control_plane tests`
- `uv run --extra dev ruff check` on changed Python files
- `uv run --extra dev ruff format --check` on changed Python files
- `uv run launchplane service audit-config-authority --control-plane-root .`
- `actionlint .github/workflows/authz-policy-reconcile.yml`
- independent focused security review: no findings

PyCharm changed-file inspection executed but reported broad existing diagnostics in the two large touched Python files; none mapped to the new validator or tests.

Refs #2044