### PR TITLE
Trust policy-declared change impact

### DIFF
--- a/control_plane/change_impact_service.py
+++ b/control_plane/change_impact_service.py
@@ -226,12 +226,11 @@ def evaluate_change_impact(
                 sensitive = True
 
     dependency_components = {
-        evidence.component for evidence in stored_evidence if evidence.kind == "dependency"
+        evidence.component
+        for evidence in stored_evidence
+        if evidence.kind == "dependency" and evidence.confidence == "known"
     }
     matched_components = {evidence.component for evidence in matched if evidence.component}
-    for component in matched_components - dependency_components:
-        if rules_by_component[component].affected_products:
-            unknown.append(f"missing trusted dependency evidence for component {component}")
 
     for evidence in stored_evidence:
         if evidence.confidence != "known":
@@ -246,6 +245,15 @@ def evaluate_change_impact(
             )
             continue
         rule = rules_by_component[evidence.component]
+        if (
+            evidence.kind == "reviewer"
+            and evidence.affected_products
+            and evidence.component not in dependency_components
+        ):
+            unknown.append(
+                f"reviewer evidence lacks trusted dependency evidence for {evidence.component}"
+            )
+            continue
         affected_products.update(evidence.affected_products)
         affected_products.update(rule.affected_products)
         matched.append(_stored_evidence_match(evidence=evidence, rule=rule))
@@ -333,11 +341,15 @@ def _validate_policy_append(
     expected_current_record_id: str,
     expected_current_policy_digest: str,
 ) -> bool:
-    matching = tuple(existing for existing in records if existing.repository_id == record.repository_id)
+    matching = tuple(
+        existing for existing in records if existing.repository_id == record.repository_id
+    )
     same_id = tuple(existing for existing in matching if existing.record_id == record.record_id)
     if same_id:
         if len(same_id) != 1 or same_id[0].policy_digest != record.policy_digest:
-            raise ChangeImpactPolicyConflictError("change-impact policy record id conflicts with history")
+            raise ChangeImpactPolicyConflictError(
+                "change-impact policy record id conflicts with history"
+            )
         if same_id[0].status != record.status:
             raise ChangeImpactPolicyConflictError(
                 "change-impact policy replay status conflicts with history"
@@ -345,10 +357,14 @@ def _validate_policy_append(
         return True
     current_records = tuple(existing for existing in matching if existing.status == "active")
     if len(current_records) > 1:
-        raise ChangeImpactPolicySequenceError("change-impact policy history has multiple active revisions")
+        raise ChangeImpactPolicySequenceError(
+            "change-impact policy history has multiple active revisions"
+        )
     current = current_records[0] if current_records else None
     if record.status != "active":
-        raise ChangeImpactPolicySequenceError("incoming change-impact policy revision must be active")
+        raise ChangeImpactPolicySequenceError(
+            "incoming change-impact policy revision must be active"
+        )
     if record.effective_at > _evaluation_timestamp(""):
         raise ChangeImpactPolicySequenceError(
             "incoming change-impact policy effective_at cannot be in the future"
@@ -357,7 +373,9 @@ def _validate_policy_append(
         if record.policy_revision != 1:
             raise ChangeImpactPolicySequenceError("initial change-impact policy revision must be 1")
         if expected_current_record_id.strip() or expected_current_policy_digest.strip():
-            raise ChangeImpactPolicyConflictError("initial change-impact policy expected tip must be absent")
+            raise ChangeImpactPolicyConflictError(
+                "initial change-impact policy expected tip must be absent"
+            )
         return False
     if (
         expected_current_record_id.strip() != current.record_id
@@ -367,7 +385,9 @@ def _validate_policy_append(
     if record.policy_revision != current.policy_revision + 1:
         raise ChangeImpactPolicySequenceError("next change-impact policy revision is not linear")
     if record.supersedes_record_id != current.record_id:
-        raise ChangeImpactPolicySequenceError("next change-impact policy must supersede current record")
+        raise ChangeImpactPolicySequenceError(
+            "next change-impact policy must supersede current record"
+        )
     if record.effective_at < current.effective_at:
         raise ChangeImpactPolicySequenceError(
             "next change-impact policy effective_at cannot precede current revision"
@@ -551,14 +571,24 @@ def _binding_matches_target(
 
 def _evaluation_timestamp(value: str) -> str:
     if not value.strip():
-        return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace(
-            "+00:00",
-            "Z",
+        return (
+            datetime.now(timezone.utc)
+            .replace(microsecond=0)
+            .isoformat()
+            .replace(
+                "+00:00",
+                "Z",
+            )
         )
     parsed = datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
     if parsed.tzinfo is None:
         raise ValueError("evaluated_at must include a timezone")
-    return parsed.astimezone(timezone.utc).replace(microsecond=0).isoformat().replace(
-        "+00:00",
-        "Z",
+    return (
+        parsed.astimezone(timezone.utc)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace(
+            "+00:00",
+            "Z",
+        )
     )

--- a/docs/change-impact-policy.md
+++ b/docs/change-impact-policy.md
@@ -38,20 +38,22 @@ Launchplane resolves evaluation evidence through two server-owned boundaries:
   the current pull-request head and tree, and the complete changed-file set. A
   second pull-request read rejects a head that changes during collection, and
   renamed files preserve both old and new paths for policy matching.
-- Launchplane storage is the only dependency or reviewer evidence source.
-  Stored reviewer evidence may add affected products but cannot downgrade a
-  deterministic sensitive match.
+- The active DB-backed component policy is authoritative for the affected
+  products it declares directly. Launchplane storage is the only source for
+  additional dependency or reviewer evidence. Stored reviewer evidence may add
+  affected products only when trusted dependency evidence exists for the same
+  matched component, and it cannot downgrade a deterministic sensitive match.
 
 GitHub Actions callers are additionally bound to the OIDC repository ID, owner
 ID, repository name, and workflow `sha`. A repository or head mismatch is a
 non-success result. Human and operator callers still receive current provider
 facts rather than caller assertions.
 
-Until the dependency and independent-review records tracked by #2011 and #2001
-exist, product-impacting components without stored dependency evidence return
-`unknown` with the sensitive/two-review fallback. Provider unavailability and
-incomplete pagination fail closed; no caller-controlled evidence fallback is
-available.
+Missing dependency records do not invalidate a product scope declared directly
+by the active component policy. They are required only when stored evidence is
+used to extend that declared scope. Reviewer-only product claims remain
+insufficient and return `unknown`. Provider unavailability and incomplete
+pagination fail closed; no caller-controlled evidence fallback is available.
 
 ## Output
 

--- a/docs/records.md
+++ b/docs/records.md
@@ -298,10 +298,11 @@ They bind the exact repository, pull request number, head SHA, tree SHA, policy
 revision, and policy digest. Unknown paths, missing dependency evidence,
 ambiguous stored evidence, stale provider or OIDC head binding, provider
 failure, or invalid policy history fail closed to non-success output with the
-stricter two-review engineering requirement. Dependency and reviewer evidence
-is read only from exact-target Launchplane records; those record families remain
-future work under #2011 and #2001, so missing evidence cannot be replaced by a
-caller assertion.
+stricter two-review engineering requirement. The active component policy may
+declare affected products directly. Additional dependency and reviewer evidence
+is read only from exact-target Launchplane records, and reviewer product claims
+require trusted same-component dependency evidence; missing extension evidence
+cannot be replaced by a caller assertion.
 
 Filesystem rehearsal records live under `launchplane_change_impact_policies/`.
 PostgreSQL uses `launchplane_change_impact_policies` with one active policy per

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -3568,10 +3568,12 @@ production authorization, and legacy manager cleanup remain out of scope. See
 target reference plus optional non-authoritative metadata. Launchplane uses its
 managed GitHub credential to resolve immutable repository identity, current
 head/tree, and changed files; GitHub Actions callers must also match the OIDC
-repository IDs/name and workflow `sha`. Dependency and reviewer evidence is
-read only from Launchplane storage. Missing records, stale heads, incomplete
-provider evidence, and provider failures cannot fall back to caller input and
-therefore fail closed.
+repository IDs/name and workflow `sha`. The active DB-backed component policy
+may declare affected products directly. Additional dependency and reviewer
+evidence is read only from Launchplane storage, and reviewer product claims
+require trusted same-component dependency evidence. Missing extension records,
+stale heads, incomplete provider evidence, and provider failures cannot fall
+back to caller input and therefore fail closed.
 
 The response remains shadow-only with exact policy revision/digest and
 repository/PR/head/tree binding. See `docs/change-impact-policy.md` for the

--- a/tests/test_change_impact.py
+++ b/tests/test_change_impact.py
@@ -125,16 +125,17 @@ def _stored_evidence(
 
 
 class ChangeImpactEvaluationTests(unittest.TestCase):
-    def test_routine_product_change_requires_stored_dependency_evidence(self) -> None:
+    def test_policy_declared_product_scope_is_authoritative_and_storage_can_extend_it(self) -> None:
         policy = _policy()
         without_storage = evaluate_change_impact(
             repository_evidence=_repository_evidence("src/runtime/app.py"),
             policies=(policy,),
             evaluated_at="2026-08-06T01:00:00Z",
         )
-        self.assertEqual(without_storage.status, "unknown")
-        self.assertEqual(without_storage.engineering_review_tier, "sensitive")
-        self.assertEqual(without_storage.required_engineering_review_count, 2)
+        self.assertEqual(without_storage.status, "success")
+        self.assertEqual(without_storage.engineering_review_tier, "routine")
+        self.assertEqual(without_storage.required_engineering_review_count, 1)
+        self.assertEqual(without_storage.owner_impact, "required")
 
         evaluation = evaluate_change_impact(
             repository_evidence=_repository_evidence("src/runtime/app.py"),
@@ -151,7 +152,9 @@ class ChangeImpactEvaluationTests(unittest.TestCase):
         self.assertEqual(evaluation.engineering_review_tier, "routine")
         self.assertEqual(evaluation.required_engineering_review_count, 1)
         self.assertEqual(evaluation.owner_impact, "required")
-        self.assertEqual(tuple(item.product for item in evaluation.affected_products), ("generic-web-a",))
+        self.assertEqual(
+            tuple(item.product for item in evaluation.affected_products), ("generic-web-a",)
+        )
         self.assertEqual(evaluation.policy_revision, policy.policy_revision)
         self.assertEqual(evaluation.policy_digest, policy.policy_digest)
 
@@ -215,7 +218,9 @@ class ChangeImpactEvaluationTests(unittest.TestCase):
         self.assertEqual(evaluation.status, "unknown")
         self.assertEqual(evaluation.engineering_review_tier, "sensitive")
         self.assertEqual(evaluation.required_engineering_review_count, 2)
-        self.assertIn("missing trusted dependency evidence", evaluation.unknown_evidence[0])
+        self.assertIn(
+            "reviewer evidence lacks trusted dependency evidence", evaluation.unknown_evidence[0]
+        )
 
     def test_unknown_path_and_ambiguous_storage_fail_closed(self) -> None:
         policy = _policy()
@@ -230,9 +235,7 @@ class ChangeImpactEvaluationTests(unittest.TestCase):
         ambiguous = evaluate_change_impact(
             repository_evidence=_repository_evidence("src/runtime/app.py"),
             policies=(policy,),
-            stored_evidence=(
-                _stored_evidence("generic-web-runtime", confidence="ambiguous"),
-            ),
+            stored_evidence=(_stored_evidence("generic-web-runtime", confidence="ambiguous"),),
             evaluated_at="2026-08-06T01:00:00Z",
         )
         self.assertEqual(ambiguous.status, "unknown")
@@ -336,8 +339,11 @@ class ChangeImpactEvaluationTests(unittest.TestCase):
 
     def test_dry_run_rejects_future_effective_policy(self) -> None:
         future_effective_at = (
-            datetime.now(timezone.utc) + timedelta(days=1)
-        ).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+            (datetime.now(timezone.utc) + timedelta(days=1))
+            .replace(microsecond=0)
+            .isoformat()
+            .replace("+00:00", "Z")
+        )
         with TemporaryDirectory() as directory:
             store = FilesystemRecordStore(Path(directory))
             with self.assertRaises(ChangeImpactPolicySequenceError):


### PR DESCRIPTION
## Summary

- treat affected products declared by the active DB-backed component policy as authoritative without requiring a redundant stored dependency record
- keep reviewer-supplied product extensions fail-closed unless trusted same-component dependency evidence exists
- align change-impact records, service-boundary, and policy documentation with the runtime authority model

This unblocks a runtime VeriReel change-impact policy so PR #310 can be enumerated and classified by the automatic Owner Acceptance Current-items feed.

## Validation

- `uv run --extra dev launchplane ci unittest-shard local`
- `uv run --extra dev mypy control_plane tests`
- focused change-impact and Owner acceptance tests
- changed-file Ruff lint and format checks
- independent Claude and GPT policy-boundary review

Refs #2044
