### PR TITLE
Add protected Product Owner policy administration

### DIFF
--- a/.github/workflows/authz-policy-reconcile.yml
+++ b/.github/workflows/authz-policy-reconcile.yml
@@ -23,6 +23,7 @@ name: Manage Launchplane Authorization
           - generic-web-onboarding
           - manager-preview-approval
           - owner-acceptance
+          - product-owner-policy-admin
           - product-health-monitoring
           - odoo-route-binding
           - odoo-external-route-binding
@@ -98,6 +99,18 @@ jobs:
       related_issue: ${{ inputs.related_issue }}
     secrets:
       managed_set_json: ${{ secrets.LAUNCHPLANE_AUTHZ_OWNER_ACCEPTANCE_MANAGED_SET_JSON }}
+
+  reconcile-product-owner-policy-admin:
+    if: ${{ inputs.managed_set == 'product-owner-policy-admin' }}
+    uses: cbusillo/launchplane/.github/workflows/reusable-authz-policy-reconcile.yml@39aecc250d6dee91204e24673725bd1ea1ca6bda # main
+    with:
+      mode: ${{ inputs.mode }}
+      expected_managed_set_id: operator.product-owner-policy-admin
+      reviewed_plan_sha256: ${{ inputs.reviewed_plan_sha256 }}
+      reason: ${{ inputs.reason }}
+      related_issue: ${{ inputs.related_issue }}
+    secrets:
+      managed_set_json: ${{ secrets.LAUNCHPLANE_AUTHZ_PRODUCT_OWNER_POLICY_ADMIN_MANAGED_SET_JSON }}
 
   reconcile-generic-web-onboarding:
     if: ${{ inputs.managed_set == 'generic-web-onboarding' }}

--- a/control_plane/authz_grant_service.py
+++ b/control_plane/authz_grant_service.py
@@ -23,6 +23,12 @@ from control_plane.contracts.owner_acceptance import (
     OWNER_ACCEPTANCE_EVENT_WRITE_ACTION,
     OWNER_ACCEPTANCE_READ_ACTION,
 )
+from control_plane.contracts.product_owner import (
+    PRODUCT_OWNER_POLICY_READ_ACTION,
+    PRODUCT_OWNER_POLICY_WRITE_ACTION,
+    PRODUCT_OWNER_REQUIREMENT_READ_ACTION,
+    PRODUCT_OWNER_REQUIREMENT_WRITE_ACTION,
+)
 from control_plane.service_auth import (
     AuthzInstanceSelectors,
     GitHubActionsIdentity,
@@ -174,6 +180,15 @@ _OWNER_ACCEPTANCE_PERMITTED_ACTION_SETS = (
     _OWNER_ACCEPTANCE_READ_ONLY_ACTIONS,
     _OWNER_ACCEPTANCE_ACTIONS,
 )
+_PRODUCT_OWNER_POLICY_ADMIN_MANAGED_SET_ID = "operator.product-owner-policy-admin"
+_PRODUCT_OWNER_POLICY_ADMIN_ACTIONS = frozenset(
+    {
+        PRODUCT_OWNER_POLICY_READ_ACTION,
+        PRODUCT_OWNER_POLICY_WRITE_ACTION,
+        PRODUCT_OWNER_REQUIREMENT_READ_ACTION,
+        PRODUCT_OWNER_REQUIREMENT_WRITE_ACTION,
+    }
+)
 AuthzSchemaMigrationMode = Literal["reject", "migrate_v1_to_v2"]
 AuthzUnmanagedAdoptionMode = Literal["reject", "adopt_matching"]
 
@@ -213,6 +228,40 @@ def _validate_owner_acceptance_managed_set(policy: LaunchplaneAuthzPolicy) -> No
             raise ValueError(
                 "Owner Acceptance managed authz rules require either the read action alone or "
                 "the read and event-write actions together."
+            )
+
+
+def _validate_product_owner_policy_admin_managed_set(policy: LaunchplaneAuthzPolicy) -> None:
+    if any(
+        rules
+        for principal_type, rules in _authz_policy_rule_collections(policy)
+        if principal_type != "local_operators"
+    ):
+        raise ValueError(
+            "Product Owner policy administration managed authz may contain only local operator rules."
+        )
+    for rule in policy.local_operators:
+        if (
+            len(rule.subjects) != 1
+            or len(rule.token_labels) != 1
+            or any(_contains_selector_glob(value) for value in (*rule.subjects, *rule.token_labels))
+        ):
+            raise ValueError(
+                "Product Owner policy administration rules require one exact operator subject "
+                "and token label."
+            )
+        if (
+            len(rule.products) != 1
+            or len(rule.contexts) != 1
+            or any(_contains_selector_glob(value) for value in (*rule.products, *rule.contexts))
+        ):
+            raise ValueError(
+                "Product Owner policy administration rules require one exact product and system scope."
+            )
+        if frozenset(rule.actions) != _PRODUCT_OWNER_POLICY_ADMIN_ACTIONS:
+            raise ValueError(
+                "Product Owner policy administration rules require exactly the policy and "
+                "requirement read/write actions."
             )
 
 
@@ -259,6 +308,8 @@ class AuthzManagedPolicyReconcileEnvelope(BaseModel):
         self.desired_policy = _normalize_desired_authz_policy(self.desired_policy)
         if self.managed_set_id == _OWNER_ACCEPTANCE_MANAGED_SET_ID:
             _validate_owner_acceptance_managed_set(self.desired_policy)
+        if self.managed_set_id == _PRODUCT_OWNER_POLICY_ADMIN_MANAGED_SET_ID:
+            _validate_product_owner_policy_admin_managed_set(self.desired_policy)
         for principal_type, rules in _authz_policy_rule_collections(self.desired_policy):
             for rule in rules:
                 if rule.managed_set_id != self.managed_set_id or not rule.managed_rule_id:

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -442,7 +442,16 @@ numeric GitHub user IDs. Engineering viewer rules grant only
 viewer grant. Owner candidate rules use only `read_only` and may grant that read
 action plus `owner_acceptance_event.write`. Both shapes remain limited to
 product `launchplane` and context `owner-acceptance`. Product Owner membership
-remains a separate server-side requirement for event writes. Generic-web preview caller
+remains a separate server-side requirement for event writes.
+`LAUNCHPLANE_AUTHZ_PRODUCT_OWNER_POLICY_ADMIN_MANAGED_SET_JSON` owns the
+dedicated local-operator policy administration boundary and must declare the
+exact `operator.product-owner-policy-admin` managed-set identity. Each rule
+binds one exact operator subject and token label to one exact product/system
+scope and exactly the Product Owner policy and requirement read/write actions.
+It cannot grant routing, deployment, production, secret, or unrelated policy
+authority. Use this set only to apply DB-backed Owner membership and requirement
+records through the deployed service with dry-run and compare-and-swap evidence.
+Generic-web preview caller
 grants are no longer sourced from a per-product repository secret. The
 typed product-onboarding planner derives repository identity, caller workflow
 refs, immutable Launchplane worker refs, products, contexts, events, and actions

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -85,6 +85,13 @@ title: Secrets
   candidate rules may also contain `owner_acceptance_event.write`. Keep product
   Owner membership in the independently managed Owner policy; this secret grants
   workbench access but cannot satisfy Owner authority.
+- The protected
+  `LAUNCHPLANE_AUTHZ_PRODUCT_OWNER_POLICY_ADMIN_MANAGED_SET_JSON` secret contains
+  the complete `operator.product-owner-policy-admin` local-operator desired set.
+  Every rule must bind one exact operator subject and token label to one exact
+  product/system scope and exactly the Product Owner policy and requirement
+  read/write actions. Product identities, repository identities, and Owner
+  memberships remain DB-backed runtime records and do not belong in this secret.
 
 ## DB-Backed Secret Resolution
 

--- a/tests/test_authz_grant_service.py
+++ b/tests/test_authz_grant_service.py
@@ -657,6 +657,91 @@ class AuthzManagedPolicyServiceTests(unittest.TestCase):
                 }
             )
 
+    def test_product_owner_policy_admin_managed_set_enforces_minimum_operator_boundary(
+        self,
+    ) -> None:
+        valid_rule = {
+            "managed_set_id": "operator.product-owner-policy-admin",
+            "managed_rule_id": "verireel.policy-admin",
+            "subjects": ["operator-subject"],
+            "token_labels": ["operator-token"],
+            "products": ["verireel"],
+            "contexts": ["verireel"],
+            "actions": [
+                "product_owner_policy.read",
+                "product_owner_policy.write",
+                "product_owner_requirement.read",
+                "product_owner_requirement.write",
+            ],
+        }
+        request_payload = {
+            "schema_version": 2,
+            "product": "launchplane",
+            "mode": "dry_run",
+            "managed_set_id": "operator.product-owner-policy-admin",
+            "desired_policy": {
+                "schema_version": 2,
+                "local_operators": [valid_rule],
+            },
+        }
+
+        AuthzManagedPolicyReconcileEnvelope.model_validate(request_payload)
+
+        invalid_rules = (
+            ({**valid_rule, "subjects": ["operator-*"]}, "one exact operator subject"),
+            ({**valid_rule, "token_labels": ["operator-*"]}, "one exact operator subject"),
+            ({**valid_rule, "token_labels": []}, "one exact operator subject"),
+            ({**valid_rule, "products": ["*"]}, "one exact product and system scope"),
+            ({**valid_rule, "contexts": ["verireel", "other"]}, "one exact product"),
+            ({**valid_rule, "instances": ["*"]}, "can only declare instances"),
+            (
+                {
+                    **valid_rule,
+                    "actions": [*valid_rule["actions"], "product_owner_routing.write"],
+                },
+                "exactly the policy and requirement read/write actions",
+            ),
+            (
+                {
+                    **valid_rule,
+                    "actions": [*valid_rule["actions"], "authz_policy_grant.write"],
+                },
+                "exactly the policy and requirement read/write actions",
+            ),
+        )
+        for invalid_rule, message in invalid_rules:
+            with self.subTest(message=message), self.assertRaisesRegex(ValidationError, message):
+                AuthzManagedPolicyReconcileEnvelope.model_validate(
+                    {
+                        **request_payload,
+                        "desired_policy": {
+                            "schema_version": 2,
+                            "local_operators": [invalid_rule],
+                        },
+                    }
+                )
+
+        with self.assertRaisesRegex(ValidationError, "only local operator rules"):
+            AuthzManagedPolicyReconcileEnvelope.model_validate(
+                {
+                    **request_payload,
+                    "desired_policy": {
+                        "schema_version": 2,
+                        "local_admins": [
+                            {
+                                "managed_set_id": "operator.product-owner-policy-admin",
+                                "managed_rule_id": "admin.invalid",
+                                "subjects": ["admin-subject"],
+                                "token_labels": ["admin-token"],
+                                "products": ["verireel"],
+                                "contexts": ["verireel"],
+                                "actions": valid_rule["actions"],
+                            }
+                        ],
+                    },
+                }
+            )
+
     def test_managed_reconcile_requires_explicit_migration_and_adoption(self) -> None:
         current_record = _active_record()
         desired_policy = {

--- a/tests/test_authz_operator_workflow.py
+++ b/tests/test_authz_operator_workflow.py
@@ -35,6 +35,7 @@ class AuthzOperatorWorkflowTests(unittest.TestCase):
                 "generic-web-onboarding",
                 "manager-preview-approval",
                 "owner-acceptance",
+                "product-owner-policy-admin",
                 "product-health-monitoring",
                 "odoo-route-binding",
                 "odoo-external-route-binding",
@@ -64,6 +65,10 @@ class AuthzOperatorWorkflowTests(unittest.TestCase):
             "reconcile-owner-acceptance": (
                 "${{ inputs.managed_set == 'owner-acceptance' }}",
                 "${{ secrets.LAUNCHPLANE_AUTHZ_OWNER_ACCEPTANCE_MANAGED_SET_JSON }}",
+            ),
+            "reconcile-product-owner-policy-admin": (
+                "${{ inputs.managed_set == 'product-owner-policy-admin' }}",
+                "${{ secrets.LAUNCHPLANE_AUTHZ_PRODUCT_OWNER_POLICY_ADMIN_MANAGED_SET_JSON }}",
             ),
             "reconcile-generic-web-onboarding": (
                 "${{ inputs.managed_set == 'generic-web-onboarding' }}",
@@ -136,6 +141,7 @@ class AuthzOperatorWorkflowTests(unittest.TestCase):
                     "reconcile-generic-web-onboarding": "operator.generic-web-onboarding",
                     "reconcile-manager-preview-approval": "operator.manager-preview-approval",
                     "reconcile-owner-acceptance": "operator.owner-acceptance",
+                    "reconcile-product-owner-policy-admin": "operator.product-owner-policy-admin",
                 }
                 if job_name in expected_managed_set_ids:
                     self.assertEqual(


### PR DESCRIPTION
## Summary

- add a dedicated `operator.product-owner-policy-admin` managed authorization set
- restrict it to one exact local operator identity and one exact product/system scope per rule
- allow only Product Owner policy and requirement read/write actions
- wire the protected managed-set secret through the existing reviewed authz reconcile workflow

## Why

VeriReel PR #310 now reaches Owner Acceptance evaluation, but returns `owner_authority_unavailable`. The approved VeriReel Owner identities cannot be installed because the deployed Product Owner policy/requirement APIs correctly return `authorization_denied` for the current operator. This change adds the missing narrow policy-administration boundary without granting routing, deployment, production, secret, or unrelated authz authority.

## Validation

- `uv run --extra dev python -m unittest tests.test_authz_grant_service tests.test_authz_operator_workflow`
- `uv run --extra dev launchplane ci unittest-shard local` (12/12 shards, 2,793 targets)
- changed-file Ruff and format checks
- targeted mypy
- config-authority audit: `status=ok`
- independent focused review: no code findings after test-coverage follow-up
- JetBrains inspection: inconclusive because the isolated worktree had no configured Python SDK; helper reported `UNKNOWN` and prohibited retry

Closes no issue; advances #2044.
