### PR TITLE
Bind preview runtime identity to canonical generations

### DIFF
--- a/control_plane/contracts/runtime_identity.py
+++ b/control_plane/contracts/runtime_identity.py
@@ -129,6 +129,8 @@ def compare_runtime_identity(
         "deployment_record_id",
         "artifact_id",
         "source_git_ref",
+        "preview_id",
+        "preview_generation_id",
     ):
         expected_value = str(getattr(expected, field_name) or "")
         observed_value = str(getattr(observed, field_name) or "")

--- a/control_plane/launchplane_mutations.py
+++ b/control_plane/launchplane_mutations.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Protocol, cast
 
@@ -20,6 +21,8 @@ from control_plane.workflows.launchplane import (
     build_preview_generation_record_from_request,
     build_preview_record_from_request,
     find_preview_record,
+    generate_preview_generation_id,
+    generate_preview_id,
 )
 
 
@@ -47,6 +50,55 @@ class _PreviewGenerationEvidenceWriteStore(Protocol):
         preview_record: PreviewRecord,
         generation_record: PreviewGenerationRecord,
     ) -> tuple[object, object]: ...
+
+
+@dataclass(frozen=True, slots=True)
+class LaunchplanePreviewGenerationIdentity:
+    preview_id: str
+    generation_id: str
+    sequence: int
+
+
+def resolve_next_launchplane_preview_generation_identity(
+    *,
+    record_store: PreviewMutationRecordStore,
+    context: str,
+    anchor_repo: str,
+    anchor_pr_number: int,
+) -> LaunchplanePreviewGenerationIdentity:
+    preview = find_preview_record(
+        record_store=record_store,
+        context_name=context,
+        anchor_repo=anchor_repo,
+        anchor_pr_number=anchor_pr_number,
+    )
+    preview_id = (
+        preview.preview_id
+        if preview is not None
+        else generate_preview_id(
+            context_name=context,
+            anchor_repo=anchor_repo,
+            anchor_pr_number=anchor_pr_number,
+        )
+    )
+    generations = record_store.list_preview_generation_records(preview_id=preview_id)
+    sequence = max((generation.sequence for generation in generations), default=0) + 1
+    return LaunchplanePreviewGenerationIdentity(
+        preview_id=preview_id,
+        generation_id=generate_preview_generation_id(
+            preview_id=preview_id,
+            sequence=sequence,
+        ),
+        sequence=sequence,
+    )
+
+
+def resolve_launchplane_preview_id(*, context: str, anchor_repo: str, anchor_pr_number: int) -> str:
+    return generate_preview_id(
+        context_name=context,
+        anchor_repo=anchor_repo,
+        anchor_pr_number=anchor_pr_number,
+    )
 
 
 def control_plane_root() -> Path:

--- a/control_plane/storage/postgres.py
+++ b/control_plane/storage/postgres.py
@@ -8021,6 +8021,24 @@ class PostgresRecordStore(HumanSessionStore):
             )
         )
 
+    @contextmanager
+    def serialize_preview_refresh(self, *, preview_id: str) -> Iterator[None]:
+        normalized_preview_id = preview_id.strip()
+        if not normalized_preview_id:
+            raise ValueError("Preview refresh serialization requires preview_id.")
+        if self._engine.dialect.name != "postgresql":
+            yield
+            return
+        with self._session_factory() as session:
+            session.execute(
+                text("select pg_advisory_xact_lock(hashtextextended(:lock_name, 0))"),
+                {"lock_name": f"launchplane-preview-refresh:{normalized_preview_id}"},
+            )
+            try:
+                yield
+            finally:
+                session.commit()
+
     def write_preview_generation_evidence_records(
         self,
         *,
@@ -11489,8 +11507,7 @@ class PostgresRecordStore(HumanSessionStore):
             filters.append(LaunchplaneEngineeringReviewDecisionRow.repository == repository)
         if pull_request_number is not None:
             filters.append(
-                LaunchplaneEngineeringReviewDecisionRow.pull_request_number
-                == pull_request_number
+                LaunchplaneEngineeringReviewDecisionRow.pull_request_number == pull_request_number
             )
         if head_sha:
             filters.append(LaunchplaneEngineeringReviewDecisionRow.head_sha == head_sha)
@@ -15005,7 +15022,9 @@ class PostgresRecordStore(HumanSessionStore):
                 self._read_payload(model_type=ChangeImpactPolicyRecord, payload=row.payload)
                 for row in rows
             )
-            same_id = tuple(existing for existing in records if existing.record_id == record.record_id)
+            same_id = tuple(
+                existing for existing in records if existing.record_id == record.record_id
+            )
             if same_id:
                 if len(same_id) != 1 or same_id[0].policy_digest != record.policy_digest:
                     raise ChangeImpactPolicyConflictError(
@@ -15095,7 +15114,9 @@ class PostgresRecordStore(HumanSessionStore):
         if repository_id:
             filters.append(LaunchplaneChangeImpactPolicyRow.repository_id == repository_id)
         if repository:
-            filters.append(LaunchplaneChangeImpactPolicyRow.repository == repository.strip().lower())
+            filters.append(
+                LaunchplaneChangeImpactPolicyRow.repository == repository.strip().lower()
+            )
         if status:
             filters.append(LaunchplaneChangeImpactPolicyRow.status == status)
         return self._list_models(
@@ -15407,9 +15428,9 @@ class PostgresRecordStore(HumanSessionStore):
             self.write_preview_generation_record(generation_record)
             counts["preview_generations"] += 1
         if hasattr(filesystem_store, "list_manager_preview_approval_event_records"):
-            for manager_approval_event in (
-                filesystem_store.list_manager_preview_approval_event_records()
-            ):
+            for (
+                manager_approval_event
+            ) in filesystem_store.list_manager_preview_approval_event_records():
                 self.write_manager_preview_approval_event_record(manager_approval_event)
                 counts["manager_preview_approval_events"] += 1
         if hasattr(filesystem_store, "list_owner_acceptance_event_records"):

--- a/control_plane/verireel_read_http.py
+++ b/control_plane/verireel_read_http.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+from contextlib import nullcontext
 from pathlib import Path
-from typing import cast
+from typing import ContextManager, Protocol, cast
 
 import click
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
@@ -35,9 +36,12 @@ from control_plane.drivers.generic_web_preview_dispatch import (
 )
 from control_plane.drivers.registry import read_driver_descriptor
 from control_plane.launchplane_mutations import (
+    LaunchplanePreviewGenerationIdentity,
     LaunchplaneMutationStore,
     apply_launchplane_destroy_preview_if_present,
     apply_launchplane_generation_evidence,
+    resolve_launchplane_preview_id,
+    resolve_next_launchplane_preview_generation_identity,
 )
 from control_plane.runtime_key_safety import RuntimeKeySafetyPolicyReadStore
 from control_plane.workflows.evidence_ingestion import (
@@ -74,6 +78,21 @@ VERIREEL_PREVIEW_REFRESH_ROUTE = "/v1/drivers/verireel/preview-refresh"
 VERIREEL_PREVIEW_INVENTORY_ROUTE = "/v1/drivers/verireel/preview-inventory"
 VERIREEL_PREVIEW_DESTROY_ROUTE = "/v1/drivers/verireel/preview-destroy"
 VERIREEL_PREVIEW_VERIFICATION_ROUTE = "/v1/drivers/verireel/preview-verification"
+
+
+class _PreviewRefreshSerializationStore(Protocol):
+    def serialize_preview_refresh(self, *, preview_id: str) -> ContextManager[None]: ...
+
+
+def _preview_refresh_serialization(
+    *, record_store: object, preview_id: str
+) -> ContextManager[None]:
+    serialize = getattr(record_store, "serialize_preview_refresh", None)
+    if not callable(serialize):
+        return nullcontext()
+    return cast(_PreviewRefreshSerializationStore, record_store).serialize_preview_refresh(
+        preview_id=preview_id
+    )
 
 
 class VeriReelRouteDependencyError(ValueError):
@@ -362,32 +381,47 @@ def apply_verireel_preview_refresh_result(
     record_store: object,
     request: VeriReelPreviewRefreshEnvelope,
 ) -> tuple[dict[str, object], dict[str, object]]:
-    try:
-        driver_result = execute_verireel_preview_refresh(
-            control_plane_root=control_plane_root,
-            record_store=_runtime_key_safety_store_or_none(record_store),
-            request=request.refresh,
-        )
-    except VeriReelPreviewRefreshConfigError as error:
-        now = utc_now_timestamp()
-        error_message = (
-            str(error).strip() or "VeriReel preview refresh configuration is incomplete."
-        )
-        driver_result = VeriReelPreviewRefreshResult(
-            refresh_status="fail",
-            refresh_started_at=now,
-            refresh_finished_at=now,
-            application_name="",
-            application_id="",
-            preview_url=_verireel_preview_url_for_failed_records(request=request.refresh),
-            error_message=error_message,
-        )
-    records = apply_verireel_preview_refresh_records(
-        control_plane_root=control_plane_root,
-        record_store=record_store,
-        request=request.refresh,
-        driver_result=driver_result,
+    preview_id = resolve_launchplane_preview_id(
+        context=request.refresh.context,
+        anchor_repo=request.refresh.anchor_repo,
+        anchor_pr_number=request.refresh.anchor_pr_number,
     )
+    with _preview_refresh_serialization(record_store=record_store, preview_id=preview_id):
+        generation_identity = resolve_next_launchplane_preview_generation_identity(
+            record_store=cast(LaunchplaneMutationStore, record_store),
+            context=request.refresh.context,
+            anchor_repo=request.refresh.anchor_repo,
+            anchor_pr_number=request.refresh.anchor_pr_number,
+        )
+        try:
+            driver_result = execute_verireel_preview_refresh(
+                control_plane_root=control_plane_root,
+                record_store=_runtime_key_safety_store_or_none(record_store),
+                request=request.refresh,
+                preview_id=generation_identity.preview_id,
+                preview_generation_id=generation_identity.generation_id,
+            )
+        except VeriReelPreviewRefreshConfigError as error:
+            now = utc_now_timestamp()
+            error_message = (
+                str(error).strip() or "VeriReel preview refresh configuration is incomplete."
+            )
+            driver_result = VeriReelPreviewRefreshResult(
+                refresh_status="fail",
+                refresh_started_at=now,
+                refresh_finished_at=now,
+                application_name="",
+                application_id="",
+                preview_url=_verireel_preview_url_for_failed_records(request=request.refresh),
+                error_message=error_message,
+            )
+        records = apply_verireel_preview_refresh_records(
+            control_plane_root=control_plane_root,
+            record_store=record_store,
+            request=request.refresh,
+            driver_result=driver_result,
+            generation_identity=generation_identity,
+        )
     return records, driver_result.model_dump(mode="json")
 
 
@@ -483,6 +517,7 @@ def apply_verireel_preview_refresh_records(
     record_store: object,
     request: VeriReelPreviewRefreshRequest,
     driver_result: VeriReelPreviewRefreshResult,
+    generation_identity: LaunchplanePreviewGenerationIdentity,
 ) -> dict[str, object]:
     requested_at = (
         driver_result.refresh_started_at.strip() or driver_result.refresh_finished_at.strip()
@@ -510,6 +545,8 @@ def apply_verireel_preview_refresh_records(
         anchor_pr_number=request.anchor_pr_number,
         anchor_pr_url=request.anchor_pr_url,
         anchor_head_sha=request.anchor_head_sha,
+        sequence=generation_identity.sequence,
+        generation_id=generation_identity.generation_id,
         state="verifying" if refresh_passed else "failed",
         requested_reason="external_preview_refresh",
         requested_at=requested_at,

--- a/control_plane/workflows/verireel_preview_driver.py
+++ b/control_plane/workflows/verireel_preview_driver.py
@@ -62,6 +62,8 @@ def _expected_preview_slug(anchor_pr_number: int) -> str:
 def _build_preview_runtime_identity(
     *,
     request: "VeriReelPreviewRefreshRequest",
+    preview_id: str = "",
+    preview_generation_id: str = "",
     deployed_at: str = "",
 ) -> RuntimeIdentity:
     return RuntimeIdentity(
@@ -76,7 +78,8 @@ def _build_preview_runtime_identity(
         artifact_id=request.image_reference,
         source_git_ref=request.anchor_head_sha,
         image_reference=request.image_reference,
-        preview_id=request.preview_slug,
+        preview_id=preview_id.strip() or request.preview_slug,
+        preview_generation_id=preview_generation_id.strip(),
         deployed_at=deployed_at,
     )
 
@@ -1221,6 +1224,8 @@ def execute_verireel_preview_refresh(
     control_plane_root: Path,
     request: VeriReelPreviewRefreshRequest,
     record_store: RuntimeKeySafetyPolicyReadStore | None = None,
+    preview_id: str = "",
+    preview_generation_id: str = "",
 ) -> VeriReelPreviewRefreshResult:
     try:
         host, token = dokploy_source.read_dokploy_config(control_plane_root=control_plane_root)
@@ -1301,7 +1306,11 @@ def execute_verireel_preview_refresh(
             ),
             timeout_seconds=request.timeout_seconds,
         )
-        expected_runtime_identity = _build_preview_runtime_identity(request=request)
+        expected_runtime_identity = _build_preview_runtime_identity(
+            request=request,
+            preview_id=preview_id,
+            preview_generation_id=preview_generation_id,
+        )
         env_text = dokploy_api.render_dokploy_env_text_with_overrides(
             str(template_application.get("env") or ""),
             updates={

--- a/docs/preview-workflow-contract.md
+++ b/docs/preview-workflow-contract.md
@@ -145,6 +145,13 @@ generic response records successful readiness and smoke evidence and persists th
 same exact runtime identity injected into the serving application. Later product
 verification may advance that generation from verifying to ready, but it must not
 replace or fabricate the serving artifact or source revision.
+Before driver-owned provisioning starts, Launchplane resolves the canonical
+preview record ID and next generation ID from the DB-backed preview history.
+DB-backed execution serializes refreshes by canonical preview ID, then injects
+both values into the expected runtime identity, requires the live health endpoint
+to echo them, and persists that observed identity on the same explicit generation.
+Product-local preview slugs are not substitutes for Launchplane's canonical
+preview and generation identities.
 
 Preview comment updates that are not part of the lifecycle workflow use
 `cbusillo/launchplane/.github/workflows/reusable-preview-pr-feedback.yml@<launchplane-sha>`.

--- a/tests/test_launchplane_mutations.py
+++ b/tests/test_launchplane_mutations.py
@@ -15,6 +15,7 @@ from control_plane.launchplane_mutations import (
     apply_launchplane_destroy_preview,
     apply_launchplane_destroy_preview_if_present,
     apply_launchplane_generation_evidence,
+    resolve_next_launchplane_preview_generation_identity,
     upsert_launchplane_preview_from_request,
 )
 
@@ -137,6 +138,44 @@ def _generation_request(**updates: object) -> PreviewGenerationMutationRequest:
 
 
 class LaunchplaneMutationTests(unittest.TestCase):
+    def test_next_preview_generation_identity_uses_canonical_record_ids(self) -> None:
+        store = _FakePreviewMutationStore()
+
+        first = resolve_next_launchplane_preview_generation_identity(
+            record_store=store,
+            context="site-testing",
+            anchor_repo="cbusillo/site",
+            anchor_pr_number=42,
+        )
+        apply_launchplane_generation_evidence(
+            control_plane_root_path=Path("/launchplane"),
+            record_store=store,
+            preview_request=_preview_request(),
+            generation_request=_generation_request(
+                sequence=first.sequence,
+                generation_id=first.generation_id,
+            ),
+        )
+        second = resolve_next_launchplane_preview_generation_identity(
+            record_store=store,
+            context="site-testing",
+            anchor_repo="cbusillo/site",
+            anchor_pr_number=42,
+        )
+
+        self.assertEqual(first.preview_id, "preview-site-testing-cbusillo-site-pr-42")
+        self.assertEqual(
+            first.generation_id,
+            "preview-site-testing-cbusillo-site-pr-42-generation-0001",
+        )
+        self.assertEqual(first.sequence, 1)
+        self.assertEqual(second.preview_id, first.preview_id)
+        self.assertEqual(
+            second.generation_id,
+            "preview-site-testing-cbusillo-site-pr-42-generation-0002",
+        )
+        self.assertEqual(second.sequence, 2)
+
     def test_upsert_preview_uses_structural_store_boundary(self) -> None:
         store = _FakePreviewMutationStore()
 

--- a/tests/test_runtime_identity.py
+++ b/tests/test_runtime_identity.py
@@ -82,6 +82,31 @@ class RuntimeIdentityTests(unittest.TestCase):
         self.assertIn("artifact_id", detail)
         self.assertIn("source_git_ref", detail)
 
+    def test_compare_runtime_identity_reports_preview_binding_mismatches(self) -> None:
+        expected = RuntimeIdentity(
+            product="verireel",
+            context="verireel-testing",
+            instance="pr-310",
+            environment_kind="preview",
+            deployment_record_id="verireel-testing-pr-310",
+            artifact_id="artifact-a",
+            source_git_ref="abc123",
+            preview_id="preview-verireel-testing-verireel-pr-310",
+            preview_generation_id=("preview-verireel-testing-verireel-pr-310-generation-0007"),
+        )
+        observed = expected.model_copy(
+            update={
+                "preview_id": "pr-310",
+                "preview_generation_id": "",
+            }
+        )
+
+        status, detail = compare_runtime_identity(expected=expected, observed=observed)
+
+        self.assertEqual(status, "mismatch")
+        self.assertIn("preview_id", detail)
+        self.assertIn("preview_generation_id", detail)
+
     def test_health_payload_runtime_identity_status_marks_non_json_unverifiable(self) -> None:
         expected = RuntimeIdentity(
             product="sellyouroutboard",

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -9,7 +9,7 @@ from collections.abc import Mapping
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any, Literal, cast
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 from click import ClickException, Command
 from click.testing import CliRunner
@@ -112,6 +112,7 @@ from control_plane.workflows.verireel_preview_driver import (
     VeriReelPreviewInventoryItem,
     VeriReelPreviewInventoryResult,
     VeriReelPreviewRefreshConfigError,
+    VeriReelPreviewRefreshRequest,
     VeriReelPreviewRefreshResult,
     VeriReelPreviewRefreshTransportError,
 )
@@ -10041,7 +10042,10 @@ class LaunchplaneServiceTests(unittest.TestCase):
                         artifact_id="ghcr.io/every/verireel-app:pr-123-sha-6b3c9d7",
                         source_git_ref="6b3c9d7e8f901234567890abcdef1234567890ab",
                         image_reference="ghcr.io/every/verireel-app:pr-123-sha-6b3c9d7",
-                        preview_id="pr-123",
+                        preview_id="preview-verireel-testing-verireel-pr-123",
+                        preview_generation_id=(
+                            "preview-verireel-testing-verireel-pr-123-generation-0001"
+                        ),
                     ),
                 ),
             ) as execute_mock:
@@ -10106,10 +10110,24 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 "6b3c9d7e8f901234567890abcdef1234567890ab",
             )
             self.assertEqual(
+                generation.runtime_identity.preview_id,
+                "preview-verireel-testing-verireel-pr-123",
+            )
+            self.assertEqual(
+                generation.runtime_identity.preview_generation_id,
+                "preview-verireel-testing-verireel-pr-123-generation-0001",
+            )
+            self.assertEqual(
                 generation.resolved_manifest_fingerprint,
                 "verireel-preview-manifest-pr-123-6b3c9d7",
             )
-            execute_mock.assert_called_once()
+            execute_mock.assert_called_once_with(
+                control_plane_root=root,
+                record_store=ANY,
+                request=VeriReelPreviewRefreshRequest.model_validate(refresh_payload["refresh"]),
+                preview_id="preview-verireel-testing-verireel-pr-123",
+                preview_generation_id=("preview-verireel-testing-verireel-pr-123-generation-0001"),
+            )
 
     def test_verireel_preview_refresh_driver_rejects_unauthorized_workflow(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:

--- a/tests/test_verireel_preview_driver.py
+++ b/tests/test_verireel_preview_driver.py
@@ -190,6 +190,19 @@ def _refresh_request() -> VeriReelPreviewRefreshRequest:
 
 
 class VeriReelPreviewDriverTests(unittest.TestCase):
+    def test_preview_runtime_identity_uses_launchplane_preview_binding(self) -> None:
+        identity = _build_preview_runtime_identity(
+            request=_refresh_request(),
+            preview_id="preview-verireel-testing-verireel-pr-71",
+            preview_generation_id=("preview-verireel-testing-verireel-pr-71-generation-0003"),
+        )
+
+        self.assertEqual(identity.preview_id, "preview-verireel-testing-verireel-pr-71")
+        self.assertEqual(
+            identity.preview_generation_id,
+            "preview-verireel-testing-verireel-pr-71-generation-0003",
+        )
+
     def test_ensure_application_uses_default_server_when_template_omits_server_id(self) -> None:
         requests: list[dict[str, object]] = []
 


### PR DESCRIPTION
Refs #2044

## Summary
- resolve canonical preview and next generation identity before VeriReel provisioning
- require live health evidence to match preview and generation IDs
- serialize DB-backed refreshes per canonical preview before sequence allocation
- persist the same explicit generation identity and document the contract

## Validation
- targeted runtime/preview/owner acceptance tests: 77 passed
- Postgres/filesystem store tests: 215 passed
- full local unittest gate: 2,794 targets across 12 shards passed
- Ruff lint and format checks passed
- mypy passed for changed files
- config-authority audit passed
- JetBrains inspection attempted but inconclusive because the isolated worktree had no configured Python SDK