### PR TITLE
Clarify Owner product review semantics

### DIFF
--- a/docs/owner-acceptance.md
+++ b/docs/owner-acceptance.md
@@ -9,6 +9,13 @@ review of pull requests. Every affected product receives an independent binding
 and decision. It does not authorize production, merge trains, tenant admission,
 promotion, GitHub required checks, or manager-preview flows.
 
+The persisted human action remains `accepted` because the event records the
+Owner's durable product judgment. The workbench presents that action as
+**Owner product review: accepted** and explicitly separates it from technical
+checks, engineering review, merge readiness, merge admission, and production
+authorization. A product review event never claims that any of those independent
+gates passed.
+
 Launchplane is the only authority. GitHub comments, reviews, checked-in files,
 workflow inputs, local operator bearer tokens, agents, and workers cannot create
 Owner acceptance or impersonate an Owner.
@@ -238,6 +245,11 @@ require a reason, revoke requires explicit confirmation, replay preserves the
 same idempotency key, and `409 owner_acceptance_binding_changed` refreshes the
 Current item without auto-resubmitting. Every receipt remains shadow,
 non-authoritative, and has no merge or production enforcement effect.
+Before submission, the UI labels the control as **Product review action** and
+states that recording it does not indicate technical checks passed, make the PR
+merge-ready, or authorize production. The stored API and ledger action remains
+`accepted`; the human-facing label clarifies its scope rather than introducing a
+second semantic state.
 
 ## Advisory GitHub Projection
 

--- a/frontend/src/EngineeringOps.tsx
+++ b/frontend/src/EngineeringOps.tsx
@@ -66,10 +66,10 @@ const ENGINEERING_SURFACES = [
   },
   {
     detail:
-      "Review current Owner acceptance decisions for repository pull requests. Shadow mode — no mutations exposed.",
+      "Review exact-change product judgments separately from technical, merge, and production readiness.",
     icon: UserCheck,
     label: "Read only",
-    title: "Owner acceptance",
+    title: "Owner product review",
     view: "owner-acceptance" as const,
   },
 ];

--- a/frontend/src/EngineeringOwnerAcceptanceRoute.tsx
+++ b/frontend/src/EngineeringOwnerAcceptanceRoute.tsx
@@ -143,22 +143,24 @@ export function EngineeringOwnerAcceptanceRoute({
           state={currentResource.state}
         />
       }
-      description="Review current pull requests that may need Owner attention, then inspect recorded acceptance history. Launchplane discovers current items automatically from active change-impact repositories."
+      description="Review the product behavior of current pull requests, then inspect recorded review history. Launchplane discovers current items automatically from active change-impact repositories."
       icon={UserCheck}
-      title="Owner acceptance"
+      title="Owner product review"
       view="owner-acceptance"
     >
-      <EngineeringBoundaryNote title="Shadow mode — automatic Current items and recorded evidence">
-        All decisions are <code>mode: shadow</code>, <code>authoritative: false</code>,{" "}
-        <code>enforcement_effect: none</code>. Current items come from open pull requests
-        in repositories with active change-impact policy records and are evaluated
-        server-side. Recorded entries are{" "}
+      <EngineeringBoundaryNote title="Shadow mode — product review evidence only">
+        Owner product review is separate from technical checks, engineering review, merge
+        readiness and admission, and production authorization. All decisions are{" "}
+        <code>mode: shadow</code>, <code>authoritative: false</code>,{" "}
+        <code>enforcement_effect: none</code>. Current items come from open pull requests in
+        repositories with active change-impact policy records and are evaluated server-side.
+        Recorded entries are{" "}
         <strong>Recorded</strong> — derived from the persisted acceptance event ledger
         with no live GitHub calls. Recorded queue rows remain read-only.
       </EngineeringBoundaryNote>
 
       <EngineeringResourceGate
-        noun="Current Owner acceptance items"
+        noun="Current Owner product review items"
         refresh={currentResource.refresh}
         state={currentResource.state}
       >
@@ -251,7 +253,7 @@ function OwnerAcceptanceCurrentItems({
     );
   }
   return (
-    <section className="engineering-owner-current" aria-label="Current Owner acceptance items">
+    <section className="engineering-owner-current" aria-label="Current Owner product review items">
       <header className="engineering-owner-current-header">
         <div>
           <span>Current items</span>
@@ -553,7 +555,7 @@ function OwnerAcceptanceDecisionDetails({
           data-status={ownerAcceptanceDecisionTone(decision.status)}
         >
           <StatusIcon status={ownerAcceptanceDecisionTone(decision.status)} />
-          Current: {humanizeStatus(decision.status)}
+          Owner product review: {humanizeStatus(decision.status)}
         </span>
         <span>reason: {humanizeStatus(decision.reason_code)}</span>
         {decision.evaluated_at ? (
@@ -596,16 +598,17 @@ function OwnerAcceptanceReadOnlyNotice() {
   return (
     <section
       className="engineering-owner-acceptance-read-only"
-      aria-label="Read-only Owner acceptance visibility"
+      aria-label="Read-only product review visibility"
     >
       <header>
         <ShieldOff size={16} aria-hidden="true" />
-        <strong>Read-only engineering visibility</strong>
+        <strong>Read-only product review visibility</strong>
       </header>
       <p>
-        You can inspect the Current decision and exact server-issued bindings, but this
-        session is not authorized to submit Owner events. Launchplane rechecks both
-        event-write access and current product Owner authority for every submission.
+        You can inspect the current product-review decision and exact server-issued
+        bindings, but this session is not authorized to submit Owner events. Launchplane
+        rechecks both event-write access and current product Owner authority for every
+        submission.
       </p>
     </section>
   );
@@ -725,21 +728,21 @@ function OwnerAcceptanceActionPanel({
     !busy;
 
   return (
-    <section className="engineering-owner-action-panel" aria-label={`Owner action for ${binding.product}`}>
+    <section className="engineering-owner-action-panel" aria-label={`Owner product review for ${binding.product}`}>
       <header>
         <div><strong>{binding.product}</strong><span>{binding.system} · {binding.action} · {binding.environment}</span></div>
         <code>{binding.binding_sha256.slice(0, 12)}</code>
       </header>
-      <p>Act only on this Current binding. Launchplane revalidates the exact change and your Owner authority at write time.</p>
+      <p><strong>Product review only.</strong> Record your judgment of this exact change. This does not indicate that technical checks passed, make the pull request merge-ready, or authorize production. Launchplane revalidates the exact change and your Owner authority at write time.</p>
       <label>
-        <span>Owner action</span>
+        <span>Product review action</span>
         <select value={action} disabled={operation.state.requiresIdempotencyContinuity} onChange={(event) => {
           setAction(event.target.value as OwnerAcceptanceHumanAction);
           setConfirmRevoke(false);
         }}>
-          <option value="accepted">Accept</option>
-          <option value="changes_requested">Request changes</option>
-          <option value="revoked">Revoke</option>
+          <option value="accepted">Accept product change</option>
+          <option value="changes_requested">Request product changes</option>
+          <option value="revoked">Revoke prior product acceptance</option>
         </select>
       </label>
       {reasonRequired ? <label><span>Reason</span><textarea value={reason} maxLength={4000} disabled={operation.state.requiresIdempotencyContinuity} onChange={(event) => setReason(event.target.value)} /></label> : null}
@@ -753,11 +756,11 @@ function OwnerAcceptanceActionPanel({
             setReason("");
             setConfirmRevoke(false);
           }
-        }}>{busy ? "Submitting…" : "Submit Owner action"}</button>
+        }}>{busy ? "Recording…" : "Record product review"}</button>
         {busy ? <button className="button" type="button" onClick={operation.cancel}>Cancel wait</button> : null}
       </div>
       {failure && failure.code !== "owner_acceptance_binding_changed" ? <p className="engineering-owner-action-message" role="alert">{failure.message}{failure.traceId ? <code>{failure.traceId}</code> : null}</p> : null}
-      {operation.state.receipt ? <p className="engineering-owner-action-message" data-tone="success">{operation.state.receipt.replayed ? "Owner action was already recorded (idempotent replay)." : "Owner action recorded in shadow mode."} No merge or production authority was granted.<code>{operation.state.receipt.traceId}</code></p> : null}
+      {operation.state.receipt ? <p className="engineering-owner-action-message" data-tone="success" role="status">{operation.state.receipt.replayed ? "Owner product review was already recorded (idempotent replay)." : "Owner product review recorded in shadow mode."} No merge or production authority was granted.<code>{operation.state.receipt.traceId}</code></p> : null}
       {operation.state.requiresIdempotencyContinuity ? <p className="engineering-owner-action-message" role="status">Outcome uncertain. Retry only this unchanged action; the idempotency key is preserved.</p> : null}
     </section>
   );
@@ -805,7 +808,7 @@ function OwnerAcceptanceContent({
           <strong>{data.candidate}</strong>
         </div>
         <div className="engineering-metric" data-tone={accepted ? "pass" : "unknown"}>
-          <span>Accepted shown</span>
+          <span>Product accepted shown</span>
           <strong>{accepted}</strong>
         </div>
         <div className="engineering-metric" data-tone={actioned ? "blocked" : "pass"}>
@@ -865,7 +868,7 @@ function OwnerAcceptanceContent({
             onChange={(e) => onStatusFilter(e.target.value as OwnerAcceptanceStatusFilter)}
           >
             <option value="all">All statuses</option>
-            <option value="accepted">Accepted</option>
+            <option value="accepted">Product accepted</option>
             <option value="changes_requested">Changes requested</option>
             <option value="revoked">Revoked</option>
             <option value="stale">Stale</option>
@@ -905,7 +908,7 @@ function OwnerAcceptanceContent({
           detail={
             statusFilter !== "all" || repositoryFilter
               ? "No recorded entries match the current filters."
-              : "No recorded Owner acceptance events yet. Owners do not appear here until they submit an action; use Current evaluation above to inspect a never-acted PR."
+              : "No recorded Owner product reviews yet. Owners do not appear here until they submit an action; use Current items or the exact lookup fallback to inspect a never-acted PR."
           }
           icon={History}
           title="No recorded entries"
@@ -942,7 +945,7 @@ function OwnerAcceptanceEntryCard({ entry }: { entry: OwnerAcceptanceQueueEntry 
         </div>
         <span className="engineering-status-chip" data-status={tone}>
           <StatusIcon status={tone} />
-          {humanizeStatus(entry.ledger_status)}
+          Owner product review: {humanizeStatus(entry.ledger_status)}
         </span>
       </header>
 

--- a/frontend/src/route-model.ts
+++ b/frontend/src/route-model.ts
@@ -70,7 +70,7 @@ export function engineeringViewLabel(view: EngineeringView): string {
     return "Tenant admission";
   }
   if (view === "owner-acceptance") {
-    return "Owner acceptance";
+    return "Owner product review";
   }
   return "Engineering Ops";
 }

--- a/frontend/tests/browser/operator-journeys.spec.ts
+++ b/frontend/tests/browser/operator-journeys.spec.ts
@@ -746,13 +746,13 @@ test.describe("operator journeys", () => {
     await page.goto("/ui/engineering/owner-acceptance?fixture=products");
 
     await expect(
-      page.getByRole("heading", { level: 1, name: "Owner acceptance" }),
+      page.getByRole("heading", { level: 1, name: "Owner product review" }),
     ).toBeFocused();
     await expect(
-      page.getByRole("link", { name: "Owner acceptance", exact: true }),
+      page.getByRole("link", { name: "Owner product review", exact: true }),
     ).toBeVisible();
     await expect(
-      page.getByText("Shadow mode — automatic Current items and recorded evidence"),
+      page.getByText("Shadow mode — product review evidence only"),
     ).toBeVisible();
     const recordedHistory = page.getByLabel("Recorded Owner acceptance history");
     await expect(recordedHistory.getByText(/Recorded/).first()).toBeVisible();
@@ -782,9 +782,9 @@ test.describe("operator journeys", () => {
 
     await page.goto("/ui/engineering/owner-acceptance?fixture=products");
 
-    await expect(page.getByLabel("Current Owner acceptance items")).toBeVisible();
+    await expect(page.getByLabel("Current Owner product review items")).toBeVisible();
     await expect(page.getByText("Fixture pull request requiring current Owner review")).toBeVisible();
-    await expect(page.getByRole("region", { name: /Owner action for/ })).toBeVisible();
+    await expect(page.getByRole("region", { name: /Owner product review for/ })).toBeVisible();
     await expect(page.getByRole("textbox", { name: "Repository (owner/repo)" })).toHaveCount(0);
     await assertDocumentBasics(page);
     diagnostics.assertClean();
@@ -820,8 +820,8 @@ test.describe("operator journeys", () => {
     await page.getByRole("button", { name: "Look up" }).click();
 
     await expect(page.getByLabel("Current evaluation result")).toBeVisible();
-    await expect(page.getByText("Read-only engineering visibility")).toBeVisible();
-    await expect(page.getByRole("region", { name: /Owner action for/ })).toHaveCount(0);
+    await expect(page.getByText("Read-only product review visibility")).toBeVisible();
+    await expect(page.getByRole("region", { name: /Owner product review for/ })).toHaveCount(0);
     await assertDocumentBasics(page);
     await captureScreenshot(page, testInfo, "owner-acceptance-current-read-only");
     diagnostics.assertClean();
@@ -832,10 +832,13 @@ test.describe("operator journeys", () => {
 
     await page.goto("/ui/engineering/owner-acceptance?fixture=products");
 
-    const panel = page.getByRole("region", { name: /Owner action for/ });
+    const panel = page.getByRole("region", { name: /Owner product review for/ });
     await expect(panel).toBeVisible();
-    await expect(panel.getByText("Act only on this Current binding.")).toBeVisible();
-    await panel.getByRole("button", { name: "Submit Owner action" }).click();
+    await expect(panel.getByText("Product review only.", { exact: true })).toBeVisible();
+    await expect(panel.getByText(/does not indicate that technical checks passed/i)).toBeVisible();
+    await expect(panel.getByText(/make the pull request merge-ready/i)).toBeVisible();
+    await expect(panel.getByText(/or authorize production/i)).toBeVisible();
+    await panel.getByRole("button", { name: "Record product review" }).click();
     await expect(panel.getByText(/recorded in shadow mode/i)).toBeVisible();
     await expect(panel.getByText(/No merge or production authority/i)).toBeVisible();
     diagnostics.assertClean();
@@ -846,8 +849,8 @@ test.describe("operator journeys", () => {
 
     await page.goto("/ui/engineering/owner-acceptance?fixture=products");
 
-    const panel = page.getByRole("region", { name: /Owner action for/ });
-    const submit = panel.getByRole("button", { name: "Submit Owner action" });
+    const panel = page.getByRole("region", { name: /Owner product review for/ });
+    const submit = panel.getByRole("button", { name: "Record product review" });
     await panel.getByRole("combobox").selectOption("changes_requested");
     await expect(submit).toBeDisabled();
     await panel.getByRole("textbox", { name: "Reason" }).fill("Please correct the product flow.");
@@ -863,19 +866,19 @@ test.describe("operator journeys", () => {
     const diagnostics = monitorBrowser(page);
 
     await page.goto("/ui/engineering/owner-acceptance?fixture=missing");
-    const panel = page.getByRole("region", { name: /Owner action for/ });
+    const panel = page.getByRole("region", { name: /Owner product review for/ });
     await panel.getByRole("combobox").selectOption("revoked");
     await panel.getByRole("textbox", { name: "Reason" }).fill("Revoke the reviewed binding.");
     await panel.getByRole("checkbox").check();
-    await panel.getByRole("button", { name: "Submit Owner action" }).click();
+    await panel.getByRole("button", { name: "Record product review" }).click();
 
     await expect(page.getByText(/reviewed binding changed/i)).toBeVisible();
     await expect(page.getByText(/explicitly submit again/i)).toBeVisible();
-    const refreshedPanel = page.getByRole("region", { name: /Owner action for/ });
+    const refreshedPanel = page.getByRole("region", { name: /Owner product review for/ });
     await expect(refreshedPanel.getByText("bbbbbbbbbbbb", { exact: true })).toBeVisible();
     await expect(refreshedPanel.getByRole("combobox")).toHaveValue("accepted");
     await expect(refreshedPanel.getByRole("checkbox")).toHaveCount(0);
-    await expect(refreshedPanel.getByRole("button", { name: "Submit Owner action" })).toBeEnabled();
+    await expect(refreshedPanel.getByRole("button", { name: "Record product review" })).toBeEnabled();
     diagnostics.assertClean();
   });
 
@@ -942,7 +945,7 @@ test.describe("operator journeys", () => {
     await page.goto("/ui/engineering/owner-acceptance?fixture=products");
 
     const activeLink = page.getByRole("link", {
-      name: "Owner acceptance",
+      name: "Owner product review",
       exact: true,
     });
     await expect(activeLink).toBeVisible();

--- a/frontend/tests/engineering-router.test.mjs
+++ b/frontend/tests/engineering-router.test.mjs
@@ -43,4 +43,5 @@ test("engineering labels are route-specific", () => {
   assert.equal(engineeringViewLabel("issue-inbox"), "Issue inbox");
   assert.equal(engineeringViewLabel("every-code"), "Every Code");
   assert.equal(engineeringViewLabel("tenant-admission"), "Tenant admission");
+  assert.equal(engineeringViewLabel("owner-acceptance"), "Owner product review");
 });


### PR DESCRIPTION
## Summary

- present durable Owner acceptance events as **Owner product review** throughout the workbench
- state before submission that product review does not prove technical checks, merge readiness/admission, or production authorization
- preserve the API and append-only ledger action value `accepted`
- align navigation, status chips, recorded history, tests, and durable docs with the scoped vocabulary

## Validation

- `pnpm --dir frontend validate`
- `pnpm --dir frontend test:browser` (76 journeys; 30 screenshots)
- `uv run --extra dev launchplane ci unittest-shard local` (2,794 targets)
- `uv run launchplane service audit-config-authority --control-plane-root .`
- local browser review at desktop and narrow Playwright viewports
- Opus semantic review: vocabulary/API separation is correct after reconciling its browser-test blocker
- JetBrains `changed_files`: inconclusive because the isolated PyCharm project has no Python SDK; no code finding was produced

Refs #2051
Refs #2044
