### PR TITLE
Improve dark-mode Owner review row separation

### DIFF
--- a/frontend/src/engineering.css
+++ b/frontend/src/engineering.css
@@ -1746,7 +1746,7 @@
 
 .engineering-owner-current-list {
   display: grid;
-  gap: 14px;
+  gap: 16px;
 }
 
 .engineering-owner-current-item {
@@ -1756,7 +1756,6 @@
   border-radius: 12px;
   background: var(--surface);
   padding: 18px;
-  box-shadow: 0 8px 24px color-mix(in srgb, var(--text) 5%, transparent);
 }
 
 .engineering-owner-current-item > header {

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -3,9 +3,11 @@
   --bg: #0a0c0f;
   --rail: #0e1115;
   --surface: #12161b;
+  --surface-muted: #151a20;
   --surface-raised: #171c22;
   --surface-soft: #1b2128;
   --border: #29313a;
+  --border-strong: #394550;
   --border-soft: #20262d;
   --text: #e9edf2;
   --text-strong: #ffffff;
@@ -40,9 +42,11 @@
   --bg: #f2f4f6;
   --rail: #ffffff;
   --surface: #ffffff;
+  --surface-muted: #f5f7f9;
   --surface-raised: #f8fafb;
   --surface-soft: #edf1f4;
   --border: #ccd4dc;
+  --border-strong: #aeb9c4;
   --border-soft: #dfe5ea;
   --text: #20262d;
   --text-strong: #0b0e12;

--- a/frontend/tests/browser/operator-journeys.spec.ts
+++ b/frontend/tests/browser/operator-journeys.spec.ts
@@ -785,6 +785,24 @@ test.describe("operator journeys", () => {
     await expect(page.getByLabel("Current Owner product review items")).toBeVisible();
     await expect(page.getByText("Fixture pull request requiring current Owner review")).toBeVisible();
     await expect(page.getByRole("region", { name: /Owner product review for/ })).toBeVisible();
+    const currentItemVisuals = await page.locator(".engineering-owner-current-item").first().evaluate(
+      (element) => {
+        const itemStyle = getComputedStyle(element);
+        const listStyle = getComputedStyle(element.parentElement!);
+        return {
+          borderStyle: itemStyle.borderTopStyle,
+          borderWidth: itemStyle.borderTopWidth,
+          boxShadow: itemStyle.boxShadow,
+          rowGap: listStyle.rowGap,
+        };
+      },
+    );
+    expect(currentItemVisuals).toEqual({
+      borderStyle: "solid",
+      borderWidth: "1px",
+      boxShadow: "none",
+      rowGap: "16px",
+    });
     await expect(page.getByRole("textbox", { name: "Repository (owner/repo)" })).toHaveCount(0);
     await assertDocumentBasics(page);
     diagnostics.assertClean();


### PR DESCRIPTION
## Summary

- define the missing strong-border and muted-surface theme tokens for dark and light modes
- replace the overlapping light glow between Owner review rows with crisp bordered cards and a 16px gap
- add a browser regression assertion for the border, gap, and absence of the shadow

## Validation

- `pnpm --dir frontend validate` — 59 tests, OpenAPI drift, typecheck, and production build passed
- `pnpm --dir frontend test:browser` — 78 desktop/narrow journeys and 30 screenshots passed
- targeted Owner current-items browser test passed in both desktop and narrow projects
- local Safari and Chrome dark-mode visual review passed
- `git diff --check` passed
- JetBrains inspection was inconclusive because indexing/lifecycle locking did not settle; no IDE code finding was reported

Related to #2051.
