### PR TITLE
Scope app-maintenance idempotency to deployments

### DIFF
--- a/.github/workflows/reusable-product-driver-app-maintenance.yml
+++ b/.github/workflows/reusable-product-driver-app-maintenance.yml
@@ -47,6 +47,11 @@ name: Reusable Product Driver App Maintenance
         required: false
         default: ""
         type: string
+      idempotency_scope:
+        description: Optional deployment or operation id appended to the request key.
+        required: false
+        default: ""
+        type: string
       timeout-seconds:
         description: Maintenance action timeout in seconds.
         required: false
@@ -134,6 +139,7 @@ jobs:
           CONTEXT: ${{ inputs.context }}
           DRIVER: ${{ inputs.driver }}
           EMAIL: ${{ inputs.email }}
+          IDEMPOTENCY_SCOPE: ${{ inputs.idempotency_scope }}
           INSTANCE: ${{ inputs.instance }}
           INTENT: ${{ inputs.intent }}
           PREVIEW_SLUG: ${{ inputs.preview_slug }}
@@ -165,20 +171,27 @@ jobs:
             echo "timeout-seconds must be a positive integer." >&2
             exit 1
           fi
+          if [ -n "$IDEMPOTENCY_SCOPE" ] && ! [[ "$IDEMPOTENCY_SCOPE" =~ ^[A-Za-z0-9._-]{1,200}$ ]]; then
+            echo "idempotency_scope must use 1-200 letters, digits, dots, underscores, or hyphens." >&2
+            exit 1
+          fi
+          idempotency_key="$(printf '%s:%s:%s:%s:%s:%s:%s:%s:%s:%s' \
+            product-driver-app-maintenance \
+            "$DRIVER" \
+            "$PRODUCT" \
+            "$CONTEXT" \
+            "$INSTANCE" \
+            "$ACTION" \
+            "$INTENT" \
+            "$EMAIL" \
+            "$APPLICATION_NAME" \
+            "$PREVIEW_SLUG")"
+          if [ -n "$IDEMPOTENCY_SCOPE" ]; then
+            idempotency_key="${idempotency_key}:${IDEMPOTENCY_SCOPE}"
+          fi
           {
             echo "context=$CONTEXT"
-            printf '%s=%s:%s:%s:%s:%s:%s:%s:%s:%s:%s\n' \
-              idempotency_key \
-              product-driver-app-maintenance \
-              "$DRIVER" \
-              "$PRODUCT" \
-              "$CONTEXT" \
-              "$INSTANCE" \
-              "$ACTION" \
-              "$INTENT" \
-              "$EMAIL" \
-              "$APPLICATION_NAME" \
-              "$PREVIEW_SLUG"
+            echo "idempotency_key=$idempotency_key"
             echo "instance=$INSTANCE"
             echo "product=$PRODUCT"
             echo "route_path=$route_path"

--- a/docs/product-repo-contract.md
+++ b/docs/product-repo-contract.md
@@ -681,6 +681,12 @@ tested source git ref, and operation-level maintenance intent.
 The app-maintenance connector defaults to the VeriReel driver for compatibility,
 and callers can pass `driver: odoo` for the narrow Odoo post-deploy maintenance
 adapter backed by `/v1/drivers/odoo/app-maintenance`.
+Callers whose maintenance must run once for each new deployment may pass the
+Launchplane-issued deployment or operation record id as `idempotency_scope`.
+Launchplane appends that bounded primitive only to the request idempotency key;
+it does not enter the maintenance payload. Omitting the scope preserves the
+existing action/intent/user/application key for callers that require replay
+across workflow runs.
 Product repos should pass an explicit `instance` only for a workflow whose
 operator input or job purpose genuinely selects a different lane.
 Production readiness wrappers may also accept expected runtime build identity

--- a/tests/test_docs_contracts.py
+++ b/tests/test_docs_contracts.py
@@ -743,6 +743,16 @@ class DocsContractsTests(TestCase):
         self.assertIn('route_path="/v1/drivers/verireel/app-maintenance"', app_maintenance_workflow)
         self.assertIn('route_path="/v1/drivers/odoo/app-maintenance"', app_maintenance_workflow)
         self.assertIn("maintenance.intent=${{ inputs.intent }}", app_maintenance_workflow)
+        self.assertIn("idempotency_scope:", app_maintenance_workflow)
+        self.assertIn(
+            "IDEMPOTENCY_SCOPE: ${{ inputs.idempotency_scope }}",
+            app_maintenance_workflow,
+        )
+        self.assertIn(
+            'idempotency_key="${idempotency_key}:${IDEMPOTENCY_SCOPE}"',
+            app_maintenance_workflow,
+        )
+        self.assertIn("deployment or operation record id", product_repo_contract)
         self.assertIn("post_deploy_status=result.post_deploy_status", app_maintenance_workflow)
         self.assertIn("override_status=result.override_status", app_maintenance_workflow)
         self.assertIn("applied_at=result.applied_at", app_maintenance_workflow)


### PR DESCRIPTION
## Summary
- add an optional bounded `idempotency_scope` input to the reusable product-driver app-maintenance workflow
- preserve the existing idempotency key exactly when callers omit the scope
- allow stable deployment callers to append a Launchplane-issued deployment or operation record id without adding it to the maintenance payload
- document and test the contract

## Failure addressed
VeriReel testing publication run `31335956714` deployed the expected artifact but replayed the July `stable-testing-migration` maintenance record. PR #310 added schema required by the billing page, so the server-backed creator flow reached `/billing` and saw only the error fallback because the current migrations had not run.

## Validation
- `uv run --extra dev python -m unittest tests.test_docs_contracts` — 13 passed
- `uv run --extra dev launchplane ci unittest-shard local` — all 12 shards, 2,794 targets passed
- targeted Ruff dry-run and check passed
- `git diff --check`
- JetBrains changed-file inspection remained `UNKNOWN` after the allowed retry because PyCharm did not finish indexing; no code finding was returned

Closes #2055.