### PR TITLE
Use runtime Prisma binary for VeriReel maintenance

### DIFF
--- a/control_plane/workflows/verireel_app_maintenance.py
+++ b/control_plane/workflows/verireel_app_maintenance.py
@@ -144,11 +144,11 @@ class VeriReelAppMaintenanceResult(BaseModel):
 
 
 def _migration_command() -> str:
-    return "npx prisma migrate deploy --config prisma.config.ts"
+    return "./node_modules/.bin/prisma migrate deploy --config prisma.config.ts"
 
 
 def _reset_testing_command() -> str:
-    return "node prisma/reset-testing-job.mjs && npx prisma migrate deploy --schema prisma/schema.prisma && node prisma/seed.mjs"
+    return "node prisma/reset-testing-job.mjs && ./node_modules/.bin/prisma migrate deploy --schema prisma/schema.prisma && node prisma/seed.mjs"
 
 
 def _uses_internal_smoke_maintenance_api(request: VeriReelAppMaintenanceRequest) -> bool:

--- a/docs/product-repo-contract.md
+++ b/docs/product-repo-contract.md
@@ -687,6 +687,10 @@ Launchplane appends that bounded primitive only to the request idempotency key;
 it does not enter the maintenance payload. Omitting the scope preserves the
 existing action/intent/user/application key for callers that require replay
 across workflow runs.
+Driver-owned maintenance commands must use executables shipped in the product
+runtime image and must not assume package-manager CLIs remain installed. The
+VeriReel driver therefore invokes the checked-in Prisma binary directly rather
+than relying on npm or `npx` in the hardened runtime stage.
 Product repos should pass an explicit `instance` only for a workflow whose
 operator input or job purpose genuinely selects a different lane.
 Production readiness wrappers may also accept expected runtime build identity

--- a/tests/test_docs_contracts.py
+++ b/tests/test_docs_contracts.py
@@ -753,6 +753,7 @@ class DocsContractsTests(TestCase):
             app_maintenance_workflow,
         )
         self.assertIn("deployment or operation record id", product_repo_contract)
+        self.assertIn("checked-in Prisma binary directly", product_repo_contract)
         self.assertIn("post_deploy_status=result.post_deploy_status", app_maintenance_workflow)
         self.assertIn("override_status=result.override_status", app_maintenance_workflow)
         self.assertIn("applied_at=result.applied_at", app_maintenance_workflow)

--- a/tests/test_verireel_app_maintenance.py
+++ b/tests/test_verireel_app_maintenance.py
@@ -39,7 +39,10 @@ class VeriReelAppMaintenanceTests(unittest.TestCase):
         schedule_name, command = _command_for_request(request)
 
         self.assertEqual(schedule_name, "ver-apply-prisma-migrations")
-        self.assertEqual(command, "npx prisma migrate deploy --config prisma.config.ts")
+        self.assertEqual(
+            command,
+            "./node_modules/.bin/prisma migrate deploy --config prisma.config.ts",
+        )
 
     def test_owner_admin_actions_no_longer_build_product_image_script_command(self) -> None:
         request = VeriReelAppMaintenanceRequest(
@@ -300,7 +303,7 @@ class VeriReelAppMaintenanceTests(unittest.TestCase):
         self.assertEqual(schedule_name, "ver-testing-reset")
         self.assertEqual(
             command,
-            "node prisma/reset-testing-job.mjs && npx prisma migrate deploy --schema prisma/schema.prisma && node prisma/seed.mjs",
+            "node prisma/reset-testing-job.mjs && ./node_modules/.bin/prisma migrate deploy --schema prisma/schema.prisma && node prisma/seed.mjs",
         )
 
     def test_preview_target_reads_secret_from_application_one_payload(self) -> None:
@@ -388,7 +391,7 @@ class VeriReelAppMaintenanceTests(unittest.TestCase):
             token="managed-token",
             application_id="app-123",
             schedule_name="ver-apply-prisma-migrations",
-            command="npx prisma migrate deploy --config prisma.config.ts",
+            command="./node_modules/.bin/prisma migrate deploy --config prisma.config.ts",
             timeout_seconds=300,
         )
         deploy_mock.assert_not_called()


### PR DESCRIPTION
## Summary
- invoke Prisma through `./node_modules/.bin/prisma` for VeriReel migration and testing-reset maintenance
- remove the driver assumption that npm/npx remains installed in the hardened runtime image
- document and test the runtime-executable contract

## Failure addressed
VeriReel publication run `31337837992` proved deployment-scoped maintenance no longer replayed the July result. The new Dokploy schedule then exited 1 because Launchplane invoked `npx`, while VeriReel's runtime image intentionally removes npm/npx and retains the checked-in Prisma binary. Runtime logs confirmed the PR #310 billing schema remained unapplied.

## Validation
- focused app-maintenance and docs tests — 33 passed
- full local gate — all 12 shards and 2,794 targets passed with `--jobs 6`; the first default-concurrency attempt hit unrelated ASGI timeouts across six shards
- targeted Ruff dry-run and check passed
- `git diff --check`
- JetBrains changed-file inspection reported only pre-existing findings outside the changed command builders

Refs #2055.