### PR TITLE
Derive service image dependency contract

### DIFF
--- a/tests/test_service_image_contract.py
+++ b/tests/test_service_image_contract.py
@@ -1,32 +1,97 @@
 from __future__ import annotations
 
+import re
 import unittest
 from pathlib import Path
 
 
+GITHUB_CLI_MODULE_CONTRACTS = {
+    "github.com/cli/cli/v2/cmd/gh": (
+        "github.com/cli/cli/v2",
+        "GITHUB_CLI_VERSION",
+    ),
+    "google.golang.org/grpc": (
+        "google.golang.org/grpc",
+        "GITHUB_CLI_GRPC_VERSION",
+    ),
+    "golang.org/x/text": (
+        "golang.org/x/text",
+        "GITHUB_CLI_X_TEXT_VERSION",
+    ),
+}
+GO_VERSION_PATTERN = re.compile(
+    r"^v(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)"
+    r"(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?"
+    r"(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$"
+)
+ARG_PATTERN = re.compile(r"^ARG\s+(?P<name>[A-Z0-9_]+)=(?P<value>\S+)\s*$", re.MULTILINE)
+GO_GET_PATTERN = re.compile(r'\bgo\s+get\s+"(?P<module>[^"@\s]+)@(?P<reference>[^"\s]+)"')
+GO_PROVENANCE_PATTERN = re.compile(
+    r'\bgo\s+version\s+-m\s+/go/bin/gh\s+\|\s+grep\s+-F\s+"'
+    r'(?P<module>[^"\s]+)"\s+\|\s+grep\s+-F\s+"\$\{(?P<argument>[A-Z0-9_]+)\}"'
+)
+
+
 class ServiceImageContractTests(unittest.TestCase):
-    def test_service_image_pins_fixed_github_cli_dependencies(self) -> None:
+    def test_service_image_relates_github_cli_dependencies(self) -> None:
         dockerfile = Path(__file__).resolve().parents[1] / "Dockerfile"
 
         dockerfile_text = dockerfile.read_text(encoding="utf-8")
+        build_stage = re.search(
+            r"(?ms)^(?P<header>FROM\s+\S*golang:\S+\s+AS\s+github-cli-build\s*)$"
+            r"(?P<body>.*?)(?=^FROM\s|\Z)",
+            dockerfile_text,
+        )
 
-        self.assertIn("GITHUB_CLI_VERSION=v2.96.0", dockerfile_text)
-        self.assertIn("GITHUB_CLI_GRPC_VERSION=v1.82.1", dockerfile_text)
-        self.assertIn("GITHUB_CLI_X_TEXT_VERSION=v0.39.0", dockerfile_text)
-        self.assertIn(
-            'go get "github.com/cli/cli/v2/cmd/gh@${GITHUB_CLI_VERSION}"',
-            dockerfile_text,
+        self.assertIsNotNone(build_stage)
+        assert build_stage is not None
+        build_stage_text = build_stage.group("body")
+
+        arguments = {
+            match.group("name"): match.group("value")
+            for match in ARG_PATTERN.finditer(build_stage_text)
+        }
+        expected_argument_names = {
+            argument_name for _, argument_name in GITHUB_CLI_MODULE_CONTRACTS.values()
+        }
+
+        self.assertTrue(expected_argument_names.issubset(arguments))
+        for argument_name in expected_argument_names:
+            self.assertRegex(arguments[argument_name], GO_VERSION_PATTERN)
+
+        go_gets = {
+            match.group("module"): match.group("reference")
+            for match in GO_GET_PATTERN.finditer(build_stage_text)
+        }
+        expected_go_gets = {
+            package_path: f"${{{argument_name}}}"
+            for package_path, (_, argument_name) in GITHUB_CLI_MODULE_CONTRACTS.items()
+        }
+
+        self.assertEqual(go_gets, expected_go_gets)
+        self.assertNotRegex(build_stage_text, r"\bgo\s+install\b")
+        self.assertNotRegex(build_stage_text, r"\bgo\s+(?:get|install)\s+[^\n]*@v\d")
+
+        self.assertRegex(
+            build_stage_text,
+            r"\bgo\s+build\s+-trimpath\s+-o\s+/go/bin/gh\s+"
+            r"github\.com/cli/cli/v2/cmd/gh\b",
         )
-        self.assertIn(
-            'go get "google.golang.org/grpc@${GITHUB_CLI_GRPC_VERSION}"',
+        provenance = {
+            (match.group("module"), match.group("argument"))
+            for match in GO_PROVENANCE_PATTERN.finditer(build_stage_text)
+        }
+        expected_provenance = {
+            (module_path, argument_name)
+            for _, (module_path, argument_name) in GITHUB_CLI_MODULE_CONTRACTS.items()
+        }
+
+        self.assertEqual(provenance, expected_provenance)
+
+        self.assertRegex(
             dockerfile_text,
+            r"(?m)^COPY\s+--from=github-cli-build\s+/go/bin/gh\s+/usr/local/bin/gh\s*$",
         )
-        self.assertIn(
-            'go get "golang.org/x/text@${GITHUB_CLI_X_TEXT_VERSION}"',
-            dockerfile_text,
-        )
-        self.assertIn("go version -m /go/bin/gh", dockerfile_text)
-        self.assertNotIn("go install github.com/cli/cli/v2/cmd/gh@v2.95.0", dockerfile_text)
 
     def test_service_image_installs_ssh_client_for_rollback_worker(self) -> None:
         dockerfile = Path(__file__).resolve().parents[1] / "Dockerfile"


### PR DESCRIPTION
## Summary
- replace duplicated exact Go tool versions with ARG-to-module relationship checks
- require semantic version shape, variable-based `go get`, provenance checks, and output/copy contracts
- permit unrelated future Docker build arguments

## Validation
- changed-file Ruff format clean; whole Ruff check clean
- mypy: 682 source files clean
- unit suite: 12 shards / 2795 targets passed
- JetBrains changed-files inspection green
- Opus and Gemini final review: approve

Whole-repo Ruff format reports 39 pre-existing unrelated files.

Fixes #2071