### PR TITLE
Add audited preview feedback remediation

### DIFF
--- a/control_plane/contracts/preview_pr_feedback_remediation.py
+++ b/control_plane/contracts/preview_pr_feedback_remediation.py
@@ -1,0 +1,158 @@
+import hashlib
+import json
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+PreviewPrFeedbackRemediationMode = Literal["dry-run", "apply"]
+PreviewPrFeedbackRemediationAction = Literal["delete_comment", "replace_comment", "none"]
+PreviewPrFeedbackRemediationOutcome = Literal[
+    "planned", "deleted", "replaced", "already_absent", "failed"
+]
+PreviewPrFeedbackTerminalStatus = Literal[
+    "destroyed", "failed", "cleanup_failed", "unsupported", "cleared"
+]
+
+
+class PreviewPrFeedbackRemediationRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    mode: PreviewPrFeedbackRemediationMode = "dry-run"
+    product: str
+    context: str
+    repository: str
+    pull_request_url: str
+    terminal_status: PreviewPrFeedbackTerminalStatus
+    reason: str
+    related_issue: str
+    confirmation: str = ""
+
+    @model_validator(mode="after")
+    def _validate_request(self) -> "PreviewPrFeedbackRemediationRequest":
+        for field_name in (
+            "product",
+            "context",
+            "repository",
+            "pull_request_url",
+            "reason",
+            "related_issue",
+        ):
+            value = getattr(self, field_name).strip()
+            if not value:
+                raise ValueError(f"preview PR feedback remediation requires {field_name}")
+            setattr(self, field_name, value)
+        self.confirmation = self.confirmation.strip()
+        if self.mode == "apply" and self.confirmation != self.expected_confirmation:
+            raise ValueError("preview PR feedback remediation apply requires exact confirmation")
+        return self
+
+    @property
+    def expected_confirmation(self) -> str:
+        return f"remediate preview feedback {self.pull_request_url} to {self.terminal_status}"
+
+    def continuity_payload(self) -> dict[str, object]:
+        return {
+            "schema_version": self.schema_version,
+            "product": self.product,
+            "context": self.context,
+            "repository": self.repository,
+            "pull_request_url": self.pull_request_url,
+            "terminal_status": self.terminal_status,
+            "reason": self.reason,
+            "related_issue": self.related_issue,
+        }
+
+    @property
+    def continuity_sha256(self) -> str:
+        canonical = json.dumps(self.continuity_payload(), sort_keys=True, separators=(",", ":"))
+        return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+class PreviewPrFeedbackObservation(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    state: Literal["present", "absent"]
+    digest_sha256: str
+    body_sha256: str = ""
+    excerpt: str = Field(default="", max_length=500)
+    marker: str = ""
+    comment_id: int = Field(default=0, ge=0)
+    comment_url: str = ""
+    comment_author_id: int = Field(default=0, ge=0)
+    comment_author_login: str = ""
+    token_actor_id: int = Field(ge=1)
+    token_actor_login: str
+
+
+class PreviewPrFeedbackMutationEvidence(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    attempted: bool = False
+    mutated: bool = False
+    method: Literal["", "DELETE", "PATCH"] = ""
+    comment_id: int = Field(default=0, ge=0)
+    before_digest_sha256: str = ""
+    after_digest_sha256: str = ""
+    verified_absent: bool = False
+    error_message: str = ""
+
+
+class PreviewPrFeedbackRemediationRecord(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    remediation_id: str
+    product: str
+    context: str
+    repository: str
+    pull_request_url: str
+    pull_request_number: int = Field(ge=1)
+    mode: PreviewPrFeedbackRemediationMode
+    terminal_status: PreviewPrFeedbackTerminalStatus
+    actor: str
+    reason: str
+    related_issue: str
+    trace_id: str
+    idempotency_key: str
+    requested_at: str
+    continuity_sha256: str
+    observation: PreviewPrFeedbackObservation
+    planned_action: PreviewPrFeedbackRemediationAction
+    outcome: PreviewPrFeedbackRemediationOutcome
+    mutation_evidence: PreviewPrFeedbackMutationEvidence = Field(
+        default_factory=PreviewPrFeedbackMutationEvidence
+    )
+    companion_feedback_id: str = ""
+
+    @model_validator(mode="after")
+    def _validate_record(self) -> "PreviewPrFeedbackRemediationRecord":
+        required = (
+            self.remediation_id,
+            self.product,
+            self.context,
+            self.repository,
+            self.pull_request_url,
+            self.actor,
+            self.reason,
+            self.related_issue,
+            self.trace_id,
+            self.idempotency_key,
+            self.requested_at,
+        )
+        if not all(value.strip() for value in required):
+            raise ValueError("preview PR feedback remediation audit fields must be complete")
+        for digest in (self.continuity_sha256, self.observation.digest_sha256):
+            if len(digest) != 64 or any(
+                character not in "0123456789abcdef" for character in digest
+            ):
+                raise ValueError("preview PR feedback remediation digests must be SHA-256")
+        if self.mode == "dry-run" and self.outcome != "planned":
+            raise ValueError("preview PR feedback remediation dry-run outcome must be planned")
+        if self.mode == "apply" and self.outcome == "planned":
+            raise ValueError("preview PR feedback remediation apply requires a terminal outcome")
+        return self
+
+
+def build_preview_pr_feedback_remediation_id(*, trace_id: str) -> str:
+    return f"preview-pr-feedback-remediation-{trace_id.strip()}"

--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -571,6 +571,10 @@ from control_plane.contracts.preview_pr_feedback_record import (
     PreviewPrFeedbackRecord,
     PreviewPrFeedbackStatus,
 )
+from control_plane.contracts.preview_pr_feedback_remediation import (
+    PreviewPrFeedbackRemediationRecord,
+    PreviewPrFeedbackRemediationRequest,
+)
 from control_plane.contracts.private_health_endpoint_record import PrivateHealthEndpointRecord
 from control_plane.contracts.route_binding_record import (
     EnvironmentRouteBindingRecord,
@@ -700,6 +704,16 @@ from control_plane.workflows.preview_pr_feedback import (
     EveryCodeWorkRequestReadStore,
     PreviewPrFeedbackPreviewReadStore,
     build_preview_pr_feedback_record,
+)
+from control_plane.preview_pr_feedback_remediation import (
+    PreviewPrFeedbackRemediationStore,
+    PreviewPrFeedbackRemediationApplyError,
+    apply_remediation,
+    bind_preview_pr_feedback_target,
+    build_remediation_record,
+    matching_dry_run,
+    observe_managed_preview_pr_feedback,
+    resolve_remediation_token,
 )
 from control_plane.workflows.launchplane_self_deploy import execute_launchplane_self_deploy
 from control_plane.workflows.ship import utc_now_timestamp
@@ -908,6 +922,7 @@ _PREVIEW_PR_FEEDBACK_NOTIFICATION_POLICY_APPLY_ROUTE = (
     "/v1/previews/pr-feedback/notification-policies/apply"
 )
 _PREVIEW_PR_FEEDBACK_ROUTE = "/v1/previews/pr-feedback"
+_PREVIEW_PR_FEEDBACK_REMEDIATION_ROUTE = "/v1/previews/pr-feedback/remediation"
 _PREVIEW_DESIRED_STATE_ROUTE = "/v1/previews/desired-state"
 _PREVIEW_LIFECYCLE_PLAN_ROUTE = "/v1/previews/lifecycle-plan"
 _PREVIEW_LIFECYCLE_CLEANUP_ROUTE = "/v1/previews/lifecycle-cleanup"
@@ -2314,6 +2329,25 @@ class _PreviewPrFeedbackWriteStore(Protocol):
     ) -> object: ...
 
 
+class _PreviewPrFeedbackRemediationWriteStore(
+    _PreviewPrFeedbackWriteStore,
+    PreviewPrFeedbackRemediationStore,
+    Protocol,
+):
+    def write_preview_pr_feedback_remediation_record(
+        self,
+        record: PreviewPrFeedbackRemediationRecord,
+    ) -> object: ...
+
+    def write_preview_pr_feedback_remediation_bundle(
+        self,
+        *,
+        remediation_record: PreviewPrFeedbackRemediationRecord,
+        feedback_record: PreviewPrFeedbackRecord,
+        idempotency_record: LaunchplaneIdempotencyRecord,
+    ) -> object: ...
+
+
 class _PreviewLifecyclePlanApplyStore(Protocol):
     def list_preview_inventory_scan_records(
         self,
@@ -2881,6 +2915,29 @@ def require_preview_pr_feedback_write_store(
             "write_preview_pr_feedback_record"
         )
     return cast(_PreviewPrFeedbackWriteStore, record_store)
+
+
+def require_preview_pr_feedback_remediation_write_store(
+    record_store: object,
+) -> _PreviewPrFeedbackRemediationWriteStore:
+    required_methods = (
+        "read_product_profile_record",
+        "list_preview_pr_feedback_remediation_records",
+        "write_preview_pr_feedback_record",
+        "write_preview_pr_feedback_remediation_record",
+        "write_preview_pr_feedback_remediation_bundle",
+    )
+    missing_methods = [
+        method_name
+        for method_name in required_methods
+        if not callable(getattr(record_store, method_name, None))
+    ]
+    if missing_methods:
+        raise TypeError(
+            "Launchplane record store does not support preview PR feedback remediation "
+            f"writes: {', '.join(missing_methods)}"
+        )
+    return cast(_PreviewPrFeedbackRemediationWriteStore, record_store)
 
 
 def supports_every_code_work_requests(record_store: object) -> bool:
@@ -16261,6 +16318,198 @@ def create_launchplane_fastapi_app(
         )
         return response
 
+    async def remediate_preview_pr_feedback(
+        request: Request,
+        remediation_request: PreviewPrFeedbackRemediationRequest,
+        identity: Annotated[LaunchplaneIdentity, Depends(read_write_identity)],
+        record_store: Annotated[object, Depends(get_record_store)],
+        idempotency_key: Annotated[str, Header(alias="Idempotency-Key")] = "",
+    ) -> AcceptedEvidenceResponse:
+        trace_id = next_trace_id()
+        if not isinstance(identity, LocalOperatorIdentity | LocalAdminIdentity):
+            raise _launchplane_http_error(
+                status_code=403,
+                trace_id=trace_id,
+                code="authorization_denied",
+                message="Preview PR feedback remediation requires a local operator identity.",
+            )
+        action = (
+            "preview_pr_feedback_remediation.plan"
+            if remediation_request.mode == "dry-run"
+            else "preview_pr_feedback_remediation.apply"
+        )
+        if not resolved_authz_policy_runtime.policy.allows(
+            identity=identity,
+            action=action,
+            product=remediation_request.product,
+            context=remediation_request.context,
+        ):
+            raise _launchplane_http_error(
+                status_code=403,
+                trace_id=trace_id,
+                code="authorization_denied",
+                message="Identity is not authorized for preview PR feedback remediation.",
+            )
+        if not idempotency_key.strip():
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="idempotency_key_required",
+                message="Preview PR feedback remediation requires Idempotency-Key.",
+            )
+        try:
+            remediation_store = require_preview_pr_feedback_remediation_write_store(record_store)
+            target = bind_preview_pr_feedback_target(
+                record_store=remediation_store,
+                request=remediation_request,
+            )
+            token = resolve_remediation_token(
+                control_plane_root=resolved_control_plane_root,
+                context=remediation_request.context,
+            )
+            observation = observe_managed_preview_pr_feedback(
+                target=target,
+                token=token,
+            )
+        except FileNotFoundError as error:
+            raise _launchplane_http_error(
+                status_code=404,
+                trace_id=trace_id,
+                code="product_profile_not_found",
+                message=str(error),
+            ) from error
+        except (TypeError, ValueError, click.ClickException) as error:
+            raise _launchplane_http_error(
+                status_code=409,
+                trace_id=trace_id,
+                code="preview_pr_feedback_remediation_observation_failed",
+                message=str(error),
+            ) from error
+
+        actor = launchplane_identity_actor(identity)
+        requested_at = utc_now_timestamp()
+        if remediation_request.mode == "dry-run":
+            remediation_record = build_remediation_record(
+                request=remediation_request,
+                target=target,
+                actor=actor,
+                trace_id=trace_id,
+                idempotency_key=idempotency_key.strip(),
+                requested_at=requested_at,
+                observation=observation,
+            )
+            remediation_store.write_preview_pr_feedback_remediation_record(remediation_record)
+            return accepted_evidence_response(
+                trace_id=trace_id,
+                records={"preview_pr_feedback_remediation_id": remediation_record.remediation_id},
+                result=remediation_record.model_dump(mode="json"),
+            )
+
+        (
+            normalized_key,
+            payload_fingerprint,
+            replayed_response,
+        ) = await replay_apply_idempotency(
+            request=request,
+            record_store=record_store,
+            identity=identity,
+            route_path=_PREVIEW_PR_FEEDBACK_REMEDIATION_ROUTE,
+            idempotency_key=idempotency_key,
+            trace_id=trace_id,
+            check_replay=True,
+        )
+        if replayed_response is not None:
+            return replayed_response
+        dry_run_record = matching_dry_run(
+            record_store=remediation_store,
+            actor=actor,
+            idempotency_key=normalized_key,
+            continuity_sha256=remediation_request.continuity_sha256,
+        )
+        if dry_run_record is None:
+            raise _launchplane_http_error(
+                status_code=409,
+                trace_id=trace_id,
+                code="matching_dry_run_required",
+                message="Preview PR feedback remediation apply requires a prior matching dry-run.",
+            )
+        if (dry_run_record.observation.state == "absent" and observation.state != "absent") or (
+            dry_run_record.observation.state == "present"
+            and observation.state == "present"
+            and dry_run_record.observation.digest_sha256 != observation.digest_sha256
+        ):
+            raise _launchplane_http_error(
+                status_code=409,
+                trace_id=trace_id,
+                code="preview_pr_feedback_remediation_observation_changed",
+                message="Managed preview feedback changed after the reviewed dry-run.",
+            )
+        try:
+            outcome, mutation_evidence, feedback_record = apply_remediation(
+                request=remediation_request,
+                target=target,
+                token=token,
+                observation=observation,
+                requested_at=requested_at,
+            )
+        except PreviewPrFeedbackRemediationApplyError as error:
+            failed_record = build_remediation_record(
+                request=remediation_request,
+                target=target,
+                actor=actor,
+                trace_id=trace_id,
+                idempotency_key=normalized_key,
+                requested_at=requested_at,
+                observation=observation,
+                outcome="failed",
+                mutation_evidence=error.mutation_evidence,
+            )
+            failed_record.mutation_evidence.error_message = str(error)
+            remediation_store.write_preview_pr_feedback_remediation_record(failed_record)
+            raise _launchplane_http_error(
+                status_code=409,
+                trace_id=trace_id,
+                code="preview_pr_feedback_remediation_apply_failed",
+                message=str(error),
+            ) from error
+        remediation_record = build_remediation_record(
+            request=remediation_request,
+            target=target,
+            actor=actor,
+            trace_id=trace_id,
+            idempotency_key=normalized_key,
+            requested_at=requested_at,
+            observation=observation,
+            outcome=outcome,
+            mutation_evidence=mutation_evidence,
+            companion_feedback_id=feedback_record.feedback_id,
+        )
+        response = accepted_evidence_response(
+            trace_id=trace_id,
+            records={
+                "preview_pr_feedback_remediation_id": remediation_record.remediation_id,
+                "preview_pr_feedback_id": feedback_record.feedback_id,
+            },
+            result=remediation_record.model_dump(mode="json"),
+        )
+        idempotency_record = LaunchplaneIdempotencyRecord(
+            record_id=build_launchplane_idempotency_record_id(response_trace_id=trace_id),
+            scope=idempotency_scope(identity),
+            route_path=_PREVIEW_PR_FEEDBACK_REMEDIATION_ROUTE,
+            idempotency_key=normalized_key,
+            request_fingerprint=payload_fingerprint,
+            response_status_code=202,
+            response_trace_id=trace_id,
+            recorded_at=requested_at,
+            response_payload=response.model_dump(mode="json", exclude_none=True),
+        )
+        remediation_store.write_preview_pr_feedback_remediation_bundle(
+            remediation_record=remediation_record,
+            feedback_record=feedback_record,
+            idempotency_record=idempotency_record,
+        )
+        return response
+
     async def apply_preview_pr_feedback(
         request: Request,
         feedback_request: PreviewPrFeedbackEnvelope,
@@ -18475,6 +18724,24 @@ def create_launchplane_fastapi_app(
         response_model_exclude_none=True,
         operation_id="apply_preview_pr_feedback_notification_policy",
         summary="Apply preview PR feedback notification policy",
+        responses={
+            400: {"model": LaunchplaneErrorResponse},
+            401: {"model": LaunchplaneErrorResponse},
+            403: {"model": LaunchplaneErrorResponse},
+            409: {"model": LaunchplaneErrorResponse},
+            503: {"model": LaunchplaneErrorResponse},
+        },
+    )
+
+    app.add_api_route(
+        _PREVIEW_PR_FEEDBACK_REMEDIATION_ROUTE,
+        remediate_preview_pr_feedback,
+        methods=["POST"],
+        status_code=202,
+        response_model=AcceptedEvidenceResponse,
+        response_model_exclude_none=True,
+        operation_id="remediate_preview_pr_feedback",
+        summary="Remediate managed preview PR feedback",
         responses={
             400: {"model": LaunchplaneErrorResponse},
             401: {"model": LaunchplaneErrorResponse},

--- a/control_plane/preview_pr_feedback_remediation.py
+++ b/control_plane/preview_pr_feedback_remediation.py
@@ -1,0 +1,423 @@
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from collections.abc import Callable
+from typing import Literal, Protocol, cast
+from urllib.parse import quote
+
+import click
+
+from control_plane.contracts.preview_pr_feedback_record import (
+    PreviewPrFeedbackRecord,
+    build_preview_pr_feedback_id,
+)
+from control_plane.contracts.preview_pr_feedback_remediation import (
+    PreviewPrFeedbackMutationEvidence,
+    PreviewPrFeedbackObservation,
+    PreviewPrFeedbackRemediationAction,
+    PreviewPrFeedbackRemediationRecord,
+    PreviewPrFeedbackRemediationRequest,
+    build_preview_pr_feedback_remediation_id,
+)
+from control_plane.contracts.product_profile_record import LaunchplaneProductProfileRecord
+from control_plane.workflows.launchplane import (
+    delete_github_issue_comment,
+    github_api_request,
+    github_pull_request_reference,
+    resolve_launchplane_github_token,
+    update_github_issue_comment,
+)
+from control_plane.workflows.preview_pr_feedback import (
+    DEFAULT_PREVIEW_FEEDBACK_MARKER,
+    LEGACY_PREVIEW_FEEDBACK_MARKERS,
+    render_preview_pr_feedback_markdown,
+)
+
+
+MANAGED_PREVIEW_FEEDBACK_MARKERS = (
+    DEFAULT_PREVIEW_FEEDBACK_MARKER,
+    *LEGACY_PREVIEW_FEEDBACK_MARKERS,
+)
+MAX_COMMENT_SCAN_PAGES = 10
+GitHubApiRequest = Callable[..., object]
+
+
+class PreviewPrFeedbackRemediationStore(Protocol):
+    def read_product_profile_record(self, product: str) -> LaunchplaneProductProfileRecord: ...
+
+    def list_preview_pr_feedback_remediation_records(
+        self,
+        *,
+        actor: str = "",
+        idempotency_key: str = "",
+        mode: str = "",
+        limit: int | None = None,
+    ) -> tuple[PreviewPrFeedbackRemediationRecord, ...]: ...
+
+
+@dataclass(frozen=True)
+class BoundPreviewPrFeedbackTarget:
+    profile: LaunchplaneProductProfileRecord
+    owner: str
+    repo: str
+    pr_number: int
+
+
+class PreviewPrFeedbackRemediationApplyError(click.ClickException):
+    def __init__(
+        self,
+        message: str,
+        *,
+        mutation_evidence: PreviewPrFeedbackMutationEvidence,
+    ) -> None:
+        super().__init__(message)
+        self.mutation_evidence = mutation_evidence
+
+
+def bind_preview_pr_feedback_target(
+    *,
+    record_store: PreviewPrFeedbackRemediationStore,
+    request: PreviewPrFeedbackRemediationRequest,
+) -> BoundPreviewPrFeedbackTarget:
+    profile = record_store.read_product_profile_record(request.product)
+    if not profile.preview.enabled or not profile.preview.context.strip():
+        raise ValueError("Product profile does not define an enabled preview context.")
+    if request.context != profile.preview.context.strip():
+        raise ValueError("Preview feedback remediation context does not match product profile.")
+    if request.repository.casefold() != profile.repository.strip().casefold():
+        raise ValueError("Preview feedback remediation repository does not match product profile.")
+    reference = github_pull_request_reference(pr_url=request.pull_request_url)
+    if reference is None:
+        raise ValueError("Preview feedback remediation requires a GitHub pull request URL.")
+    if not request.pull_request_url.casefold().startswith("https://github.com/"):
+        raise ValueError("Preview feedback remediation requires an HTTPS GitHub pull request URL.")
+    referenced_repository = f"{reference['owner']}/{reference['repo']}"
+    if referenced_repository.casefold() != request.repository.casefold():
+        raise ValueError("Preview feedback remediation PR URL does not match repository.")
+    return BoundPreviewPrFeedbackTarget(
+        profile=profile,
+        owner=reference["owner"],
+        repo=reference["repo"],
+        pr_number=reference["pr_number"],
+    )
+
+
+def _actor(payload: object) -> tuple[int, str]:
+    if not isinstance(payload, dict):
+        raise click.ClickException("GitHub authenticated user response must be an object.")
+    actor_id = payload.get("id")
+    login = payload.get("login")
+    if not isinstance(actor_id, int) or isinstance(actor_id, bool) or actor_id < 1:
+        raise click.ClickException("GitHub token identity is missing a stable actor id.")
+    if not isinstance(login, str) or not login.strip():
+        raise click.ClickException("GitHub token identity is missing a login.")
+    return actor_id, login.strip()
+
+
+def _comment_actor(comment: dict[str, object]) -> tuple[int, str]:
+    user = comment.get("user")
+    if not isinstance(user, dict):
+        return 0, ""
+    actor_id = user.get("id")
+    login = user.get("login")
+    return (
+        actor_id if isinstance(actor_id, int) and not isinstance(actor_id, bool) else 0,
+        login.strip() if isinstance(login, str) else "",
+    )
+
+
+def _observation_digest(payload: dict[str, object]) -> str:
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def observe_managed_preview_pr_feedback(
+    *,
+    target: BoundPreviewPrFeedbackTarget,
+    token: str,
+    api_request: GitHubApiRequest = github_api_request,
+) -> PreviewPrFeedbackObservation:
+    token_actor_id, token_actor_login = _actor(api_request(path="/user", token=token))
+    marker_comments: list[tuple[dict[str, object], str]] = []
+    page = 1
+    while True:
+        payload = api_request(
+            path=(
+                f"/repos/{quote(target.owner)}/{quote(target.repo)}/issues/"
+                f"{target.pr_number}/comments?per_page=100&page={page}"
+            ),
+            token=token,
+        )
+        if not isinstance(payload, list):
+            raise click.ClickException("GitHub issue comments response must be a list.")
+        for item in payload:
+            if not isinstance(item, dict):
+                continue
+            body = item.get("body")
+            if not isinstance(body, str):
+                continue
+            matched_markers = [
+                marker for marker in MANAGED_PREVIEW_FEEDBACK_MARKERS if marker in body
+            ]
+            if len(matched_markers) > 1:
+                raise click.ClickException("Managed preview feedback marker match is ambiguous.")
+            if matched_markers:
+                marker_comments.append((cast(dict[str, object], item), matched_markers[0]))
+        if len(payload) < 100:
+            break
+        if page >= MAX_COMMENT_SCAN_PAGES:
+            raise click.ClickException(
+                "Managed preview feedback comment scan exceeded its safe page limit."
+            )
+        page += 1
+    foreign = [
+        comment
+        for comment, _marker in marker_comments
+        if _comment_actor(comment)[0] != token_actor_id
+    ]
+    if foreign:
+        raise click.ClickException(
+            "Managed preview feedback marker is owned by a different GitHub actor."
+        )
+    if len(marker_comments) > 1:
+        raise click.ClickException("Multiple owned managed preview feedback comments were found.")
+    if not marker_comments:
+        digest_payload = {"state": "absent", "token_actor_id": token_actor_id}
+        return PreviewPrFeedbackObservation(
+            state="absent",
+            digest_sha256=_observation_digest(digest_payload),
+            token_actor_id=token_actor_id,
+            token_actor_login=token_actor_login,
+        )
+    comment, marker = marker_comments[0]
+    comment_id = comment.get("id")
+    body = comment.get("body")
+    if not isinstance(comment_id, int) or isinstance(comment_id, bool) or comment_id < 1:
+        raise click.ClickException("Managed preview feedback comment is missing a numeric id.")
+    if not isinstance(body, str):
+        raise click.ClickException("Managed preview feedback comment is missing its body.")
+    author_id, author_login = _comment_actor(comment)
+    comment_url = comment.get("html_url")
+    normalized_url = comment_url.strip() if isinstance(comment_url, str) else ""
+    digest_payload = {
+        "state": "present",
+        "marker": marker,
+        "comment_id": comment_id,
+        "comment_url": normalized_url,
+        "comment_author_id": author_id,
+        "body_sha256": hashlib.sha256(body.encode("utf-8")).hexdigest(),
+        "token_actor_id": token_actor_id,
+    }
+    return PreviewPrFeedbackObservation(
+        state="present",
+        digest_sha256=_observation_digest(digest_payload),
+        body_sha256=hashlib.sha256(body.encode("utf-8")).hexdigest(),
+        excerpt=body[:500],
+        marker=marker,
+        comment_id=comment_id,
+        comment_url=normalized_url,
+        comment_author_id=author_id,
+        comment_author_login=author_login,
+        token_actor_id=token_actor_id,
+        token_actor_login=token_actor_login,
+    )
+
+
+def remediation_action(
+    *, request: PreviewPrFeedbackRemediationRequest, observation: PreviewPrFeedbackObservation
+) -> PreviewPrFeedbackRemediationAction:
+    if observation.state == "absent":
+        return "none"
+    return "delete_comment" if request.terminal_status == "cleared" else "replace_comment"
+
+
+def matching_dry_run(
+    *,
+    record_store: PreviewPrFeedbackRemediationStore,
+    actor: str,
+    idempotency_key: str,
+    continuity_sha256: str,
+) -> PreviewPrFeedbackRemediationRecord | None:
+    for record in record_store.list_preview_pr_feedback_remediation_records(
+        actor=actor,
+        idempotency_key=idempotency_key,
+        mode="dry-run",
+        limit=1,
+    ):
+        if record.mode == "dry-run" and record.continuity_sha256 == continuity_sha256:
+            return record
+    return None
+
+
+def build_remediation_record(
+    *,
+    request: PreviewPrFeedbackRemediationRequest,
+    target: BoundPreviewPrFeedbackTarget,
+    actor: str,
+    trace_id: str,
+    idempotency_key: str,
+    requested_at: str,
+    observation: PreviewPrFeedbackObservation,
+    outcome: Literal["planned", "deleted", "replaced", "already_absent", "failed"] = "planned",
+    mutation_evidence: PreviewPrFeedbackMutationEvidence | None = None,
+    companion_feedback_id: str = "",
+) -> PreviewPrFeedbackRemediationRecord:
+    return PreviewPrFeedbackRemediationRecord(
+        remediation_id=build_preview_pr_feedback_remediation_id(trace_id=trace_id),
+        product=request.product,
+        context=request.context,
+        repository=request.repository,
+        pull_request_url=request.pull_request_url,
+        pull_request_number=target.pr_number,
+        mode=request.mode,
+        terminal_status=request.terminal_status,
+        actor=actor,
+        reason=request.reason,
+        related_issue=request.related_issue,
+        trace_id=trace_id,
+        idempotency_key=idempotency_key,
+        requested_at=requested_at,
+        continuity_sha256=request.continuity_sha256,
+        observation=observation,
+        planned_action=remediation_action(request=request, observation=observation),
+        outcome=outcome,
+        mutation_evidence=mutation_evidence or PreviewPrFeedbackMutationEvidence(),
+        companion_feedback_id=companion_feedback_id,
+    )
+
+
+def apply_remediation(
+    *,
+    request: PreviewPrFeedbackRemediationRequest,
+    target: BoundPreviewPrFeedbackTarget,
+    token: str,
+    observation: PreviewPrFeedbackObservation,
+    requested_at: str,
+    api_request: GitHubApiRequest = github_api_request,
+) -> tuple[
+    Literal["deleted", "replaced", "already_absent"],
+    PreviewPrFeedbackMutationEvidence,
+    PreviewPrFeedbackRecord,
+]:
+    comment_markdown = render_preview_pr_feedback_markdown(
+        marker=observation.marker or DEFAULT_PREVIEW_FEEDBACK_MARKER,
+        status=request.terminal_status,
+        anchor_pr_number=target.pr_number,
+    )
+    feedback_id = build_preview_pr_feedback_id(
+        context_name=request.context,
+        anchor_pr_number=target.pr_number,
+        requested_at=requested_at,
+    )
+    outcome: Literal["deleted", "replaced", "already_absent"]
+    if observation.state == "absent":
+        outcome = "already_absent"
+        evidence = PreviewPrFeedbackMutationEvidence(verified_absent=True)
+        delivery_status = "skipped"
+        delivery_action = "no_existing_comment"
+        comment_id = 0
+        comment_url = ""
+    elif request.terminal_status == "cleared":
+        evidence = PreviewPrFeedbackMutationEvidence(
+            attempted=True,
+            method="DELETE",
+            comment_id=observation.comment_id,
+            before_digest_sha256=observation.digest_sha256,
+        )
+        try:
+            delete_github_issue_comment(
+                owner=target.owner,
+                repo=target.repo,
+                comment_id=observation.comment_id,
+                token=token,
+            )
+            evidence.mutated = True
+            after = observe_managed_preview_pr_feedback(
+                target=target, token=token, api_request=api_request
+            )
+            evidence.after_digest_sha256 = after.digest_sha256
+            evidence.verified_absent = after.state == "absent"
+        except click.ClickException as error:
+            raise PreviewPrFeedbackRemediationApplyError(
+                str(error), mutation_evidence=evidence
+            ) from error
+        if not evidence.verified_absent:
+            raise PreviewPrFeedbackRemediationApplyError(
+                "Managed preview feedback deletion could not be verified.",
+                mutation_evidence=evidence,
+            )
+        outcome = "deleted"
+        delivery_status = "delivered"
+        delivery_action = "deleted_comment"
+        comment_id = observation.comment_id
+        comment_url = observation.comment_url
+    else:
+        evidence = PreviewPrFeedbackMutationEvidence(
+            attempted=True,
+            method="PATCH",
+            comment_id=observation.comment_id,
+            before_digest_sha256=observation.digest_sha256,
+        )
+        try:
+            update_github_issue_comment(
+                owner=target.owner,
+                repo=target.repo,
+                comment_id=observation.comment_id,
+                token=token,
+                body=comment_markdown,
+            )
+            evidence.mutated = True
+            after = observe_managed_preview_pr_feedback(
+                target=target, token=token, api_request=api_request
+            )
+            evidence.after_digest_sha256 = after.digest_sha256
+        except click.ClickException as error:
+            raise PreviewPrFeedbackRemediationApplyError(
+                str(error), mutation_evidence=evidence
+            ) from error
+        expected_body_sha256 = hashlib.sha256(comment_markdown.encode("utf-8")).hexdigest()
+        if (
+            after.state != "present"
+            or after.comment_id != observation.comment_id
+            or after.body_sha256 != expected_body_sha256
+        ):
+            raise PreviewPrFeedbackRemediationApplyError(
+                "Managed preview feedback replacement could not be verified.",
+                mutation_evidence=evidence,
+            )
+        outcome = "replaced"
+        delivery_status = "delivered"
+        delivery_action = "updated_comment"
+        comment_id = observation.comment_id
+        comment_url = after.comment_url
+    feedback = PreviewPrFeedbackRecord(
+        feedback_id=feedback_id,
+        product=request.product,
+        context=request.context,
+        source="operator-remediation",
+        requested_at=requested_at,
+        repository=request.repository,
+        anchor_repo=target.repo,
+        anchor_pr_number=target.pr_number,
+        anchor_pr_url=request.pull_request_url,
+        status=request.terminal_status,
+        marker=observation.marker or DEFAULT_PREVIEW_FEEDBACK_MARKER,
+        comment_markdown=comment_markdown,
+        delivery_status=cast(Literal["delivered", "skipped", "failed"], delivery_status),
+        delivery_action=delivery_action,
+        comment_id=comment_id,
+        comment_url=comment_url,
+    )
+    return outcome, evidence, feedback
+
+
+def resolve_remediation_token(*, control_plane_root: Path, context: str) -> str:
+    token = resolve_launchplane_github_token(
+        control_plane_root=control_plane_root, context_name=context
+    )
+    if not token:
+        raise click.ClickException(
+            "Launchplane runtime records do not expose GITHUB_TOKEN for this context."
+        )
+    return token

--- a/control_plane/storage/filesystem.py
+++ b/control_plane/storage/filesystem.py
@@ -115,6 +115,9 @@ from control_plane.contracts.preview_pr_feedback_notifications import (
     PreviewPrFeedbackNotificationPolicyRecord,
 )
 from control_plane.contracts.preview_pr_feedback_record import PreviewPrFeedbackRecord
+from control_plane.contracts.preview_pr_feedback_remediation import (
+    PreviewPrFeedbackRemediationRecord,
+)
 from control_plane.contracts.preview_record import PreviewRecord
 from control_plane.contracts.private_health_endpoint_record import PrivateHealthEndpointRecord
 from control_plane.contracts.repository_human_admission import (
@@ -1253,7 +1256,9 @@ class FilesystemRecordStore:
                 )
                 if existing.repository_id == record.repository_id
             )
-            same_id = tuple(existing for existing in records if existing.record_id == record.record_id)
+            same_id = tuple(
+                existing for existing in records if existing.record_id == record.record_id
+            )
             if same_id:
                 if len(same_id) != 1 or same_id[0].policy_digest != record.policy_digest:
                     raise ChangeImpactPolicyConflictError(
@@ -5821,6 +5826,49 @@ class FilesystemRecordStore:
         if limit is not None:
             records = records[:limit]
         return tuple(records)
+
+    def write_preview_pr_feedback_remediation_record(
+        self, record: PreviewPrFeedbackRemediationRecord
+    ) -> Path:
+        return self._write_model(
+            "launchplane_preview_pr_feedback_remediations",
+            record.remediation_id,
+            record,
+        )
+
+    def list_preview_pr_feedback_remediation_records(
+        self,
+        *,
+        actor: str = "",
+        idempotency_key: str = "",
+        mode: str = "",
+        limit: int | None = None,
+    ) -> tuple[PreviewPrFeedbackRemediationRecord, ...]:
+        records = [
+            record
+            for record in self._list_models(
+                PreviewPrFeedbackRemediationRecord,
+                "launchplane_preview_pr_feedback_remediations",
+            )
+            if (not actor or record.actor == actor)
+            and (not idempotency_key or record.idempotency_key == idempotency_key)
+            and (not mode or record.mode == mode)
+        ]
+        records.sort(key=lambda record: (record.requested_at, record.remediation_id), reverse=True)
+        if limit is not None:
+            records = records[:limit]
+        return tuple(records)
+
+    def write_preview_pr_feedback_remediation_bundle(
+        self,
+        *,
+        remediation_record: PreviewPrFeedbackRemediationRecord,
+        feedback_record: PreviewPrFeedbackRecord,
+        idempotency_record: LaunchplaneIdempotencyRecord,
+    ) -> None:
+        self.write_preview_pr_feedback_remediation_record(remediation_record)
+        self.write_preview_pr_feedback_record(feedback_record)
+        self.write_idempotency_record(idempotency_record)
 
     def write_preview_pr_feedback_notification_policy_record(
         self, record: PreviewPrFeedbackNotificationPolicyRecord

--- a/control_plane/storage/migrations/versions/a4c6e8f0b2d5_add_preview_pr_feedback_remediations.py
+++ b/control_plane/storage/migrations/versions/a4c6e8f0b2d5_add_preview_pr_feedback_remediations.py
@@ -1,0 +1,88 @@
+"""add preview PR feedback remediations
+
+Revision ID: a4c6e8f0b2d5
+Revises: f3a5c7e9b1d4
+Create Date: 2026-08-10 00:00:00.000000+00:00
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision: str = "a4c6e8f0b2d5"
+down_revision: str | None = "f3a5c7e9b1d4"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_TABLE = "launchplane_preview_pr_feedback_remediations"
+
+
+def _table_exists() -> bool:
+    return _TABLE in set(sa.inspect(op.get_bind()).get_table_names())
+
+
+def _index_exists(index_name: str) -> bool:
+    if not _table_exists():
+        return False
+    return index_name in {
+        str(index["name"])
+        for index in sa.inspect(op.get_bind()).get_indexes(_TABLE)
+    }
+
+
+def upgrade() -> None:
+    if not _table_exists():
+        op.create_table(
+            _TABLE,
+            sa.Column("remediation_id", sa.String(), nullable=False),
+            sa.Column("product", sa.String(), nullable=False),
+            sa.Column("context", sa.String(), nullable=False),
+            sa.Column("repository", sa.String(), nullable=False),
+            sa.Column("pull_request_number", sa.Integer(), nullable=False),
+            sa.Column("actor", sa.String(), nullable=False),
+            sa.Column("idempotency_key", sa.String(), nullable=False),
+            sa.Column("requested_at", sa.String(), nullable=False),
+            sa.Column("mode", sa.String(), nullable=False),
+            sa.Column("outcome", sa.String(), nullable=False),
+            sa.Column(
+                "payload",
+                sa.JSON().with_variant(
+                    postgresql.JSONB(astext_type=sa.Text()),
+                    "postgresql",
+                ),
+                nullable=False,
+            ),
+            sa.PrimaryKeyConstraint("remediation_id"),
+        )
+    target_index = "launchplane_preview_pr_feedback_remediations_target_idx"
+    if not _index_exists(target_index):
+        op.create_index(
+            target_index,
+            _TABLE,
+            ["repository", "pull_request_number", sa.text("requested_at DESC")],
+        )
+    idempotency_index = "launchplane_preview_pr_feedback_remediations_idempotency_idx"
+    if not _index_exists(idempotency_index):
+        op.create_index(
+            idempotency_index,
+            _TABLE,
+            ["actor", "idempotency_key", sa.text("requested_at DESC")],
+        )
+
+
+def downgrade() -> None:
+    if not _table_exists():
+        return
+    op.drop_index(
+        "launchplane_preview_pr_feedback_remediations_idempotency_idx",
+        table_name=_TABLE,
+    )
+    op.drop_index(
+        "launchplane_preview_pr_feedback_remediations_target_idx",
+        table_name=_TABLE,
+    )
+    op.drop_table(_TABLE)

--- a/control_plane/storage/postgres.py
+++ b/control_plane/storage/postgres.py
@@ -164,6 +164,9 @@ from control_plane.contracts.preview_pr_feedback_notifications import (
     PreviewPrFeedbackNotificationPolicyRecord,
 )
 from control_plane.contracts.preview_pr_feedback_record import PreviewPrFeedbackRecord
+from control_plane.contracts.preview_pr_feedback_remediation import (
+    PreviewPrFeedbackRemediationRecord,
+)
 from control_plane.contracts.preview_record import PreviewRecord
 from control_plane.contracts.preview_summary import LaunchplanePreviewSummary
 from control_plane.contracts.private_health_endpoint_record import (
@@ -1536,6 +1539,36 @@ class LaunchplanePreviewPrFeedbackRow(Base):
     requested_at: Mapped[str] = mapped_column(String, nullable=False)
     status: Mapped[str] = mapped_column(String, nullable=False)
     delivery_status: Mapped[str] = mapped_column(String, nullable=False)
+    payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
+
+
+class LaunchplanePreviewPrFeedbackRemediationRow(Base):
+    __tablename__ = "launchplane_preview_pr_feedback_remediations"
+    __table_args__ = (
+        Index(
+            "launchplane_preview_pr_feedback_remediations_target_idx",
+            "repository",
+            "pull_request_number",
+            desc("requested_at"),
+        ),
+        Index(
+            "launchplane_preview_pr_feedback_remediations_idempotency_idx",
+            "actor",
+            "idempotency_key",
+            desc("requested_at"),
+        ),
+    )
+
+    remediation_id: Mapped[str] = mapped_column(String, primary_key=True)
+    product: Mapped[str] = mapped_column(String, nullable=False)
+    context: Mapped[str] = mapped_column(String, nullable=False)
+    repository: Mapped[str] = mapped_column(String, nullable=False)
+    pull_request_number: Mapped[int] = mapped_column(Integer, nullable=False)
+    actor: Mapped[str] = mapped_column(String, nullable=False)
+    idempotency_key: Mapped[str] = mapped_column(String, nullable=False)
+    requested_at: Mapped[str] = mapped_column(String, nullable=False)
+    mode: Mapped[str] = mapped_column(String, nullable=False)
+    outcome: Mapped[str] = mapped_column(String, nullable=False)
     payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
 
 
@@ -12267,6 +12300,92 @@ class PostgresRecordStore(HumanSessionStore):
             ),
             limit=limit,
         )
+
+    def write_preview_pr_feedback_remediation_record(
+        self, record: PreviewPrFeedbackRemediationRecord
+    ) -> None:
+        self._write_row(
+            LaunchplanePreviewPrFeedbackRemediationRow(
+                remediation_id=record.remediation_id,
+                product=record.product,
+                context=record.context,
+                repository=record.repository,
+                pull_request_number=record.pull_request_number,
+                actor=record.actor,
+                idempotency_key=record.idempotency_key,
+                requested_at=record.requested_at,
+                mode=record.mode,
+                outcome=record.outcome,
+                payload=self._payload_dict(record),
+            )
+        )
+
+    def list_preview_pr_feedback_remediation_records(
+        self,
+        *,
+        actor: str = "",
+        idempotency_key: str = "",
+        mode: str = "",
+        limit: int | None = None,
+    ) -> tuple[PreviewPrFeedbackRemediationRecord, ...]:
+        filters: list[object] = []
+        if actor:
+            filters.append(LaunchplanePreviewPrFeedbackRemediationRow.actor == actor)
+        if idempotency_key:
+            filters.append(
+                LaunchplanePreviewPrFeedbackRemediationRow.idempotency_key == idempotency_key
+            )
+        if mode:
+            filters.append(LaunchplanePreviewPrFeedbackRemediationRow.mode == mode)
+        return self._list_models(
+            model_type=PreviewPrFeedbackRemediationRecord,
+            orm_model=LaunchplanePreviewPrFeedbackRemediationRow,
+            filters=filters,
+            order_by=(
+                LaunchplanePreviewPrFeedbackRemediationRow.requested_at.desc(),
+                LaunchplanePreviewPrFeedbackRemediationRow.remediation_id.desc(),
+            ),
+            limit=limit,
+        )
+
+    def write_preview_pr_feedback_remediation_bundle(
+        self,
+        *,
+        remediation_record: PreviewPrFeedbackRemediationRecord,
+        feedback_record: PreviewPrFeedbackRecord,
+        idempotency_record: LaunchplaneIdempotencyRecord,
+    ) -> None:
+        with self._session_factory() as session:
+            session.merge(
+                LaunchplanePreviewPrFeedbackRemediationRow(
+                    remediation_id=remediation_record.remediation_id,
+                    product=remediation_record.product,
+                    context=remediation_record.context,
+                    repository=remediation_record.repository,
+                    pull_request_number=remediation_record.pull_request_number,
+                    actor=remediation_record.actor,
+                    idempotency_key=remediation_record.idempotency_key,
+                    requested_at=remediation_record.requested_at,
+                    mode=remediation_record.mode,
+                    outcome=remediation_record.outcome,
+                    payload=self._payload_dict(remediation_record),
+                )
+            )
+            session.merge(
+                LaunchplanePreviewPrFeedbackRow(
+                    feedback_id=feedback_record.feedback_id,
+                    product=feedback_record.product,
+                    context=feedback_record.context,
+                    anchor_repo=feedback_record.anchor_repo,
+                    anchor_pr_number=feedback_record.anchor_pr_number,
+                    requested_at=feedback_record.requested_at,
+                    status=feedback_record.status,
+                    delivery_status=feedback_record.delivery_status,
+                    payload=self._payload_dict(feedback_record),
+                )
+            )
+            session.merge(self._idempotency_row(idempotency_record))
+            session.commit()
 
     def write_preview_pr_feedback_notification_policy_record(
         self, record: PreviewPrFeedbackNotificationPolicyRecord

--- a/control_plane/storage/schema_invariants.py
+++ b/control_plane/storage/schema_invariants.py
@@ -10,7 +10,7 @@ from sqlalchemy.engine import Engine
 from sqlalchemy.exc import SQLAlchemyError
 
 AUTHZ_COMPATIBILITY_FLOOR_REVISION = "f3b5d7e9a1c2"
-EXPECTED_ALEMBIC_HEAD_REVISION = "f3a5c7e9b1d4"
+EXPECTED_ALEMBIC_HEAD_REVISION = "a4c6e8f0b2d5"
 RUNTIME_COMPATIBLE_ALEMBIC_REVISIONS = (EXPECTED_ALEMBIC_HEAD_REVISION,)
 _AUTHZ_POLICY_TABLE = "launchplane_authz_policies"
 _AUTHZ_POLICY_WRITE_FENCE_TRIGGER = "launchplane_authz_policy_write_fence"

--- a/control_plane/workflows/preview_pr_feedback.py
+++ b/control_plane/workflows/preview_pr_feedback.py
@@ -859,6 +859,31 @@ def _render_preview_pr_feedback_markdown(
     return "\n".join(line for line in lines if line is not None)
 
 
+def render_preview_pr_feedback_markdown(
+    *,
+    marker: str,
+    status: PreviewPrFeedbackStatus,
+    anchor_pr_number: int,
+    preview_url: str = "",
+    immutable_image_reference: str = "",
+    refresh_image_reference: str = "",
+    revision: str = "",
+    run_url: str = "",
+    failure_summary: str = "",
+) -> str:
+    return _render_preview_pr_feedback_markdown(
+        marker=marker,
+        status=status,
+        anchor_pr_number=anchor_pr_number,
+        preview_url=preview_url,
+        immutable_image_reference=immutable_image_reference,
+        refresh_image_reference=refresh_image_reference,
+        revision=revision,
+        run_url=run_url,
+        failure_summary=failure_summary,
+    )
+
+
 def _find_preview_pr_feedback_comment(
     *,
     owner: str,

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -2393,6 +2393,22 @@ context's managed-secret-backed `GITHUB_TOKEN` in Launchplane runtime records;
 do not add repo-local defaults or service-host env fallbacks for product GitHub
 tokens.
 
+### Preview Feedback Remediation
+
+Use `POST /v1/previews/pr-feedback/remediation` only when a historical preview
+workflow identity cannot be replayed under current authorization. Submit one
+product/repository/PR per request. Run `dry-run` first with a stable
+`Idempotency-Key`, inspect the observed marker ownership and planned action,
+then submit `apply` with the same key and the request contract's exact
+confirmation phrase. Stop if the product profile, PR URL, token actor, marker
+owner, or observation differs. An absent comment is reconciled as
+`already_absent` with `mutated=false`; it is not rewritten as a deletion.
+
+The route uses the context-scoped preview `GITHUB_TOKEN`, accepts only local
+operator/admin identities with `preview_pr_feedback_remediation.plan` or
+`.apply`, and never grants this mutation to preview workflow OIDC identities.
+Attach the remediation and companion feedback record ids to the governing issue.
+
 ### VeriReel Preview Evidence Handoff
 
 VeriReel already computes the route, PR slug, image tags, and workflow run URL

--- a/docs/preview-workflow-contract.md
+++ b/docs/preview-workflow-contract.md
@@ -462,6 +462,12 @@ workflows should not render fallback PR comments themselves; missing runtime
 GitHub credentials and GitHub API failures are Launchplane-owned operator
 signals.
 
+Historical runs keep the caller identity from the workflow revision they ran.
+Launchplane intentionally continues to deny retired or renamed caller refs;
+operators must not widen managed authorization to make an obsolete run replay.
+When a stale Launchplane-owned feedback comment remains, use the audited
+operator remediation route to dry-run and reconcile that exact PR instead.
+
 Product repos should call the reusable preview feedback workflow instead of
 assembling `/v1/previews/pr-feedback` payloads, markers, or idempotency keys in
 repo-local scripts.

--- a/docs/records.md
+++ b/docs/records.md
@@ -1210,6 +1210,15 @@ failures remain inspectable even when no Every Code session starts.
 
 ## Preview PR Feedback Notification Records
 
+Preview PR feedback remediation records are stored under
+`launchplane_preview_pr_feedback_remediations`. Each record binds the operator,
+reason, related issue, product/context/repository/PR, idempotency key, reviewed
+request digest, bounded managed-comment observation, planned action, outcome,
+and mutation evidence. Dry-runs are durable. Successful applies also write a
+companion preview PR feedback record so existing lifecycle projections reflect
+the reconciled terminal state. `already_absent` explicitly records that no
+GitHub write occurred.
+
 Preview PR feedback notification policy records are DB-backed Launchplane
 records under `launchplane_preview_pr_feedback_notification_policies`. They
 select enabled destinations for skipped or failed `/v1/previews/pr-feedback`

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -388,10 +388,20 @@ cleanup scope so the store is always closed.
     `preview_pr_feedback.write` or matching lifecycle authorization,
     preview PR feedback write-capable storage, optional `Idempotency-Key` replay/conflict
     handling, and preview PR feedback notification delivery attempts)
+  - `POST /v1/previews/pr-feedback/remediation` (local-operator/admin bearer
+    identities only, distinct plan/apply authorization, exact product/context/
+    repository/PR binding, durable dry-run evidence, reviewed-state continuity,
+    idempotent apply, and Launchplane-owned marker plus author verification)
   - `POST /v1/previews/pr-feedback/notification-policies/apply` (native FastAPI
     for bearer-token callers, DB-backed storage, explicit product/context scope,
     local-operator reason enforcement, and optional `Idempotency-Key`
     replay/conflict handling)
+
+No GitHub Actions identity is authorized through the remediation route. An
+apply requires the same `Idempotency-Key` as its matching dry-run, an exact
+confirmation phrase, a non-empty reason and related issue, and an unchanged
+managed-comment observation. If the managed comment is already absent, apply
+records `already_absent` without claiming a GitHub mutation.
 - work graph chooser route:
   - `GET /v1/agent/context`
   - `GET /v1/repo-product-mapping`

--- a/frontend/generated/openapi-canonical.json
+++ b/frontend/generated/openapi-canonical.json
@@ -13857,6 +13857,77 @@
         "title": "PreviewPrFeedbackNotificationPolicyRecord",
         "type": "object"
       },
+      "PreviewPrFeedbackRemediationRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "confirmation": {
+            "default": "",
+            "title": "Confirmation",
+            "type": "string"
+          },
+          "context": {
+            "title": "Context",
+            "type": "string"
+          },
+          "mode": {
+            "default": "dry-run",
+            "enum": [
+              "dry-run",
+              "apply"
+            ],
+            "title": "Mode",
+            "type": "string"
+          },
+          "product": {
+            "title": "Product",
+            "type": "string"
+          },
+          "pull_request_url": {
+            "title": "Pull Request Url",
+            "type": "string"
+          },
+          "reason": {
+            "title": "Reason",
+            "type": "string"
+          },
+          "related_issue": {
+            "title": "Related Issue",
+            "type": "string"
+          },
+          "repository": {
+            "title": "Repository",
+            "type": "string"
+          },
+          "schema_version": {
+            "default": 1,
+            "minimum": 1.0,
+            "title": "Schema Version",
+            "type": "integer"
+          },
+          "terminal_status": {
+            "enum": [
+              "destroyed",
+              "failed",
+              "cleanup_failed",
+              "unsupported",
+              "cleared"
+            ],
+            "title": "Terminal Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "product",
+          "context",
+          "repository",
+          "pull_request_url",
+          "terminal_status",
+          "reason",
+          "related_issue"
+        ],
+        "title": "PreviewPrFeedbackRemediationRequest",
+        "type": "object"
+      },
       "PreviewPullRequestSummary": {
         "additionalProperties": false,
         "properties": {
@@ -53876,6 +53947,106 @@
           }
         },
         "summary": "Apply preview PR feedback notification policy"
+      }
+    },
+    "/v1/previews/pr-feedback/remediation": {
+      "post": {
+        "operationId": "remediate_preview_pr_feedback",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Idempotency-Key",
+            "required": false,
+            "schema": {
+              "default": "",
+              "title": "Idempotency-Key",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "Authorization",
+            "required": false,
+            "schema": {
+              "default": "",
+              "title": "Authorization",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PreviewPrFeedbackRemediationRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AcceptedEvidenceResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "summary": "Remediate managed preview PR feedback"
       }
     },
     "/v1/previews/readiness": {

--- a/tests/test_http_app_preview_pr_feedback_remediation.py
+++ b/tests/test_http_app_preview_pr_feedback_remediation.py
@@ -1,0 +1,155 @@
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import cast
+from unittest.mock import patch
+
+from control_plane.contracts.preview_pr_feedback_remediation import (
+    PreviewPrFeedbackObservation,
+)
+from control_plane.contracts.product_profile_record import LaunchplaneProductProfileRecord
+from control_plane.http_app import create_launchplane_fastapi_app
+from control_plane.storage.filesystem import FilesystemRecordStore
+from tests.http_app_test_support import (
+    _asgi_request,
+    _local_operator_bearer_config,
+)
+from tests.support.auth import _identity, _local_operator_policy, _StubVerifier
+from tests.support.profiles import _generic_site_profile_payload
+
+
+def _payload(*, mode: str) -> dict[str, object]:
+    pull_request_url = "https://github.com/cbusillo/verireel/pull/311"
+    payload: dict[str, object] = {
+        "mode": mode,
+        "product": "verireel",
+        "context": "verireel-preview",
+        "repository": "cbusillo/verireel",
+        "pull_request_url": pull_request_url,
+        "terminal_status": "cleared",
+        "reason": "Clear a stale cleanup warning from a retired workflow identity.",
+        "related_issue": "cbusillo/launchplane#2076",
+    }
+    if mode == "apply":
+        payload["confirmation"] = f"remediate preview feedback {pull_request_url} to cleared"
+    return payload
+
+
+class PreviewPrFeedbackRemediationHttpTests(unittest.IsolatedAsyncioTestCase):
+    async def test_operator_dry_run_and_apply_record_already_absent(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=root / "state")
+            profile_payload = _generic_site_profile_payload(product="verireel")
+            profile_payload["repository"] = "cbusillo/verireel"
+            preview_payload = cast(dict[str, object], profile_payload["preview"])
+            preview_payload["context"] = "verireel-preview"
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(profile_payload)
+            )
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_local_operator_policy(
+                    actions=(
+                        "preview_pr_feedback_remediation.plan",
+                        "preview_pr_feedback_remediation.apply",
+                    ),
+                    products=("verireel",),
+                    contexts=("verireel-preview",),
+                ),
+                bearer_identity_config=_local_operator_bearer_config(
+                    token_label="local-owner-write"
+                ),
+                control_plane_root_path=root,
+                record_store_factory=lambda: store,
+            )
+            observation = PreviewPrFeedbackObservation(
+                state="absent",
+                digest_sha256="a" * 64,
+                token_actor_id=101,
+                token_actor_login="launchplane-bot",
+            )
+            headers = {
+                "Authorization": "Bearer local-operator-token",
+                "Idempotency-Key": "preview-feedback-remediation-verireel-311",
+            }
+            with (
+                patch("control_plane.http_app.resolve_remediation_token", return_value="token"),
+                patch(
+                    "control_plane.http_app.observe_managed_preview_pr_feedback",
+                    return_value=observation,
+                ),
+            ):
+                missing_key = await _asgi_request(
+                    app,
+                    "POST",
+                    "/v1/previews/pr-feedback/remediation",
+                    headers={"Authorization": "Bearer local-operator-token"},
+                    payload=_payload(mode="dry-run"),
+                )
+                unmatched_apply = await _asgi_request(
+                    app,
+                    "POST",
+                    "/v1/previews/pr-feedback/remediation",
+                    headers={
+                        "Authorization": "Bearer local-operator-token",
+                        "Idempotency-Key": "preview-feedback-remediation-unmatched",
+                    },
+                    payload=_payload(mode="apply"),
+                )
+                dry_run = await _asgi_request(
+                    app,
+                    "POST",
+                    "/v1/previews/pr-feedback/remediation",
+                    headers=headers,
+                    payload=_payload(mode="dry-run"),
+                )
+                apply = await _asgi_request(
+                    app,
+                    "POST",
+                    "/v1/previews/pr-feedback/remediation",
+                    headers=headers,
+                    payload=_payload(mode="apply"),
+                )
+
+            self.assertEqual(missing_key.status_code, 400, missing_key.text)
+            self.assertEqual(unmatched_apply.status_code, 409, unmatched_apply.text)
+            self.assertEqual(unmatched_apply.json()["error"]["code"], "matching_dry_run_required")
+            self.assertEqual(dry_run.status_code, 202, dry_run.text)
+            self.assertEqual(apply.status_code, 202, apply.text)
+            self.assertEqual(apply.json()["result"]["outcome"], "already_absent")
+            self.assertFalse(apply.json()["result"]["mutation_evidence"]["mutated"])
+            records = store.list_preview_pr_feedback_remediation_records(
+                actor="local-operator:local-owner-agent",
+                idempotency_key="preview-feedback-remediation-verireel-311",
+            )
+            self.assertEqual({record.mode for record in records}, {"apply", "dry-run"})
+
+    async def test_github_actions_identity_cannot_use_operator_route(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_local_operator_policy(
+                actions=("preview_pr_feedback_remediation.plan",),
+            ),
+            record_store_factory=lambda: FilesystemRecordStore(
+                state_dir=Path("/tmp/launchplane-remediation-test")
+            ),
+        )
+
+        response = await _asgi_request(
+            app,
+            "POST",
+            "/v1/previews/pr-feedback/remediation",
+            headers={
+                "Authorization": "Bearer valid-token",
+                "Idempotency-Key": "denied",
+            },
+            payload=_payload(mode="dry-run"),
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.json()["error"]["code"], "authorization_denied")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_preview_pr_feedback_remediation.py
+++ b/tests/test_preview_pr_feedback_remediation.py
@@ -1,0 +1,284 @@
+import unittest
+from collections.abc import Callable
+from types import SimpleNamespace
+from typing import Literal
+from unittest.mock import patch
+
+import click
+
+from control_plane.contracts.preview_pr_feedback_remediation import (
+    PreviewPrFeedbackObservation,
+    PreviewPrFeedbackRemediationRequest,
+    PreviewPrFeedbackTerminalStatus,
+)
+from control_plane.preview_pr_feedback_remediation import (
+    BoundPreviewPrFeedbackTarget,
+    PreviewPrFeedbackRemediationApplyError,
+    apply_remediation,
+    bind_preview_pr_feedback_target,
+    observe_managed_preview_pr_feedback,
+)
+from control_plane.workflows.preview_pr_feedback import (
+    DEFAULT_PREVIEW_FEEDBACK_MARKER,
+    render_preview_pr_feedback_markdown,
+)
+
+
+def _request(
+    *,
+    mode: Literal["dry-run", "apply"] = "dry-run",
+    terminal_status: PreviewPrFeedbackTerminalStatus = "cleared",
+) -> PreviewPrFeedbackRemediationRequest:
+    confirmation = ""
+    pull_request_url = "https://github.com/cbusillo/verireel/pull/311"
+    if mode == "apply":
+        confirmation = f"remediate preview feedback {pull_request_url} to {terminal_status}"
+    return PreviewPrFeedbackRemediationRequest(
+        mode=mode,
+        product="verireel",
+        context="verireel-preview",
+        repository="cbusillo/verireel",
+        pull_request_url=pull_request_url,
+        terminal_status=terminal_status,
+        reason="Clear a stale cleanup warning from a retired workflow identity.",
+        related_issue="cbusillo/launchplane#2076",
+        confirmation=confirmation,
+    )
+
+
+def _target() -> BoundPreviewPrFeedbackTarget:
+    store = SimpleNamespace(
+        read_product_profile_record=lambda _product: SimpleNamespace(
+            repository="cbusillo/verireel",
+            preview=SimpleNamespace(enabled=True, context="verireel-preview"),
+        )
+    )
+    return bind_preview_pr_feedback_target(record_store=store, request=_request())
+
+
+def _api_with_comments(
+    comments: list[dict[str, object]],
+) -> Callable[..., object]:
+    def api_request(*, path: str, token: str) -> object:
+        self_token = token
+        if path == "/user":
+            return {"id": 101, "login": "launchplane-bot"}
+        if "comments?per_page=100&page=1" in path:
+            return comments
+        raise AssertionError((path, self_token))
+
+    return api_request
+
+
+class PreviewPrFeedbackRemediationTests(unittest.TestCase):
+    def _present_observation(self, *, body: str = "old") -> PreviewPrFeedbackObservation:
+        return observe_managed_preview_pr_feedback(
+            target=_target(),
+            token="token",
+            api_request=_api_with_comments(
+                [
+                    {
+                        "id": 55,
+                        "body": f"{DEFAULT_PREVIEW_FEEDBACK_MARKER}\n{body}",
+                        "html_url": "https://github.com/cbusillo/verireel/pull/311#issuecomment-55",
+                        "user": {"id": 101, "login": "launchplane-bot"},
+                    }
+                ]
+            ),
+        )
+
+    def test_absent_comment_plans_record_only_and_applies_truthful_reconciliation(
+        self,
+    ) -> None:
+        target = _target()
+        observation = observe_managed_preview_pr_feedback(
+            target=target,
+            token="token",
+            api_request=_api_with_comments([]),
+        )
+
+        self.assertEqual(observation.state, "absent")
+        with (
+            patch(
+                "control_plane.preview_pr_feedback_remediation.delete_github_issue_comment"
+            ) as delete_comment,
+            patch(
+                "control_plane.preview_pr_feedback_remediation.update_github_issue_comment"
+            ) as update_comment,
+        ):
+            outcome, evidence, feedback = apply_remediation(
+                request=_request(mode="apply"),
+                target=target,
+                token="token",
+                observation=observation,
+                requested_at="2026-08-10T21:00:00Z",
+                api_request=_api_with_comments([]),
+            )
+
+        self.assertEqual(outcome, "already_absent")
+        self.assertFalse(evidence.attempted)
+        self.assertTrue(evidence.verified_absent)
+        self.assertEqual(feedback.status, "cleared")
+        self.assertEqual(feedback.delivery_action, "no_existing_comment")
+        delete_comment.assert_not_called()
+        update_comment.assert_not_called()
+
+    def test_owned_marker_comment_is_observed(self) -> None:
+        observation = observe_managed_preview_pr_feedback(
+            target=_target(),
+            token="token",
+            api_request=_api_with_comments(
+                [
+                    {
+                        "id": 55,
+                        "body": f"{DEFAULT_PREVIEW_FEEDBACK_MARKER}\nPreview failed.",
+                        "html_url": "https://github.com/cbusillo/verireel/pull/311#issuecomment-55",
+                        "user": {"id": 101, "login": "launchplane-bot"},
+                    }
+                ]
+            ),
+        )
+
+        self.assertEqual(observation.state, "present")
+        self.assertEqual(observation.comment_id, 55)
+        self.assertEqual(observation.comment_author_id, observation.token_actor_id)
+
+    def test_delete_mutation_is_verified_and_recorded(self) -> None:
+        observation = self._present_observation()
+        with patch(
+            "control_plane.preview_pr_feedback_remediation.delete_github_issue_comment"
+        ) as delete_comment:
+            outcome, evidence, feedback = apply_remediation(
+                request=_request(mode="apply"),
+                target=_target(),
+                token="token",
+                observation=observation,
+                requested_at="2026-08-10T21:00:01Z",
+                api_request=_api_with_comments([]),
+            )
+
+        self.assertEqual(outcome, "deleted")
+        self.assertTrue(evidence.attempted)
+        self.assertTrue(evidence.mutated)
+        self.assertTrue(evidence.verified_absent)
+        self.assertEqual(feedback.delivery_action, "deleted_comment")
+        delete_comment.assert_called_once()
+
+    def test_replace_mutation_verifies_rendered_body(self) -> None:
+        observation = self._present_observation()
+        rendered = render_preview_pr_feedback_markdown(
+            marker=DEFAULT_PREVIEW_FEEDBACK_MARKER,
+            status="unsupported",
+            anchor_pr_number=311,
+        )
+        with patch(
+            "control_plane.preview_pr_feedback_remediation.update_github_issue_comment"
+        ) as update_comment:
+            outcome, evidence, feedback = apply_remediation(
+                request=_request(mode="apply", terminal_status="unsupported"),
+                target=_target(),
+                token="token",
+                observation=observation,
+                requested_at="2026-08-10T21:00:02Z",
+                api_request=_api_with_comments(
+                    [
+                        {
+                            "id": 55,
+                            "body": rendered,
+                            "html_url": "https://github.com/cbusillo/verireel/pull/311#issuecomment-55",
+                            "user": {"id": 101, "login": "launchplane-bot"},
+                        }
+                    ]
+                ),
+            )
+
+        self.assertEqual(outcome, "replaced")
+        self.assertTrue(evidence.mutated)
+        self.assertEqual(feedback.delivery_action, "updated_comment")
+        self.assertEqual(update_comment.call_args.kwargs["body"], rendered)
+
+    def test_post_delete_verification_failure_preserves_mutation_evidence(self) -> None:
+        observation = self._present_observation()
+
+        def failed_api_request(*, path: str, token: str) -> object:
+            raise click.ClickException(f"verification unavailable for {path}")
+
+        with (
+            patch("control_plane.preview_pr_feedback_remediation.delete_github_issue_comment"),
+            self.assertRaises(PreviewPrFeedbackRemediationApplyError) as caught,
+        ):
+            apply_remediation(
+                request=_request(mode="apply"),
+                target=_target(),
+                token="token",
+                observation=observation,
+                requested_at="2026-08-10T21:00:03Z",
+                api_request=failed_api_request,
+            )
+
+        self.assertTrue(caught.exception.mutation_evidence.attempted)
+        self.assertTrue(caught.exception.mutation_evidence.mutated)
+        self.assertEqual(caught.exception.mutation_evidence.method, "DELETE")
+
+    def test_foreign_marker_comment_is_refused(self) -> None:
+        with self.assertRaisesRegex(click.ClickException, "different GitHub actor"):
+            observe_managed_preview_pr_feedback(
+                target=_target(),
+                token="token",
+                api_request=_api_with_comments(
+                    [
+                        {
+                            "id": 56,
+                            "body": DEFAULT_PREVIEW_FEEDBACK_MARKER,
+                            "user": {"id": 202, "login": "contributor"},
+                        }
+                    ]
+                ),
+            )
+
+    def test_multiple_owned_marker_comments_are_refused(self) -> None:
+        comments: list[dict[str, object]] = [
+            {
+                "id": comment_id,
+                "body": DEFAULT_PREVIEW_FEEDBACK_MARKER,
+                "user": {"id": 101, "login": "launchplane-bot"},
+            }
+            for comment_id in (57, 58)
+        ]
+        with self.assertRaisesRegex(click.ClickException, "Multiple owned"):
+            observe_managed_preview_pr_feedback(
+                target=_target(),
+                token="token",
+                api_request=_api_with_comments(comments),
+            )
+
+    def test_comment_scan_page_limit_fails_closed(self) -> None:
+        calls = 0
+
+        def api_request(*, path: str, token: str) -> object:
+            nonlocal calls
+            if path == "/user":
+                return {"id": 101, "login": "launchplane-bot"}
+            calls += 1
+            return [{"id": page_item, "body": "unmanaged"} for page_item in range(100)]
+
+        with self.assertRaisesRegex(click.ClickException, "safe page limit"):
+            observe_managed_preview_pr_feedback(
+                target=_target(),
+                token="token",
+                api_request=api_request,
+            )
+        self.assertEqual(calls, 10)
+
+    def test_request_rejects_non_terminal_status(self) -> None:
+        with self.assertRaises(ValueError):
+            PreviewPrFeedbackRemediationRequest.model_validate(
+                {
+                    **_request().model_dump(mode="json"),
+                    "terminal_status": "ready",
+                }
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_schema_migration.py
+++ b/tests/test_schema_migration.py
@@ -1072,7 +1072,7 @@ class SchemaMigrationTests(unittest.TestCase):
             for primary_key in CRITICAL_PRIMARY_KEYS
         }
 
-        self.assertEqual(EXPECTED_ALEMBIC_HEAD_REVISION, "f3a5c7e9b1d4")
+        self.assertEqual(EXPECTED_ALEMBIC_HEAD_REVISION, "a4c6e8f0b2d5")
         self.assertEqual(
             column_types[("launchplane_repository_human_role_policies", "payload")],
             ("jsonb",),


### PR DESCRIPTION
## Summary
- add an operator-only preview PR feedback remediation endpoint with distinct plan/apply authorization
- bind remediation to the product profile, exact repository/PR, Launchplane-managed marker, and token-owned comment
- persist durable dry-run/apply evidence, truthful mutation outcomes, companion feedback records, and atomic Postgres idempotency
- add migration, OpenAPI, operations/contracts docs, and regression coverage for absent/delete/replace/failure paths

## Validation
- `uv run --extra dev launchplane ci unittest-shard local` (12/12 shards, 2801 targets)
- `uv run --extra dev mypy control_plane tests`
- changed-file Ruff and format checks
- `pnpm --dir frontend validate`
- OpenAPI drift check
- config-authority audit
- Opus final review: approve
- Gemini final review: approve

Refs #2076
