### PR TITLE
Add preview remediation operator authorization set

### DIFF
--- a/.github/workflows/authz-policy-reconcile.yml
+++ b/.github/workflows/authz-policy-reconcile.yml
@@ -25,6 +25,7 @@ name: Manage Launchplane Authorization
           - owner-acceptance
           - product-owner-policy-admin
           - product-health-monitoring
+          - preview-feedback-remediation
           - odoo-route-binding
           - odoo-external-route-binding
           - odoo-testing-ingress-route
@@ -134,6 +135,18 @@ jobs:
       related_issue: ${{ inputs.related_issue }}
     secrets:
       managed_set_json: ${{ secrets.LAUNCHPLANE_AUTHZ_PRODUCT_HEALTH_MONITORING_MANAGED_SET_JSON }}
+
+  reconcile-preview-feedback-remediation:
+    if: ${{ inputs.managed_set == 'preview-feedback-remediation' }}
+    uses: cbusillo/launchplane/.github/workflows/reusable-authz-policy-reconcile.yml@39aecc250d6dee91204e24673725bd1ea1ca6bda # main
+    with:
+      mode: ${{ inputs.mode }}
+      expected_managed_set_id: operator.preview-feedback-remediation
+      reviewed_plan_sha256: ${{ inputs.reviewed_plan_sha256 }}
+      reason: ${{ inputs.reason }}
+      related_issue: ${{ inputs.related_issue }}
+    secrets:
+      managed_set_json: ${{ secrets.LAUNCHPLANE_AUTHZ_PREVIEW_FEEDBACK_REMEDIATION_MANAGED_SET_JSON }}
 
   reconcile-odoo-route-binding:
     if: ${{ inputs.managed_set == 'odoo-route-binding' }}

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -468,7 +468,9 @@ repository, product context, target, domain, or per-product preview rules;
 `LAUNCHPLANE_AUTHZ_PRODUCT_HEALTH_MONITORING_MANAGED_SET_JSON` owns the generic
 Product Health Monitoring wrapper's exact immutable worker grant;
 `LAUNCHPLANE_AUTHZ_ODOO_ROUTE_BINDING_MANAGED_SET_JSON` owns the independent
-Odoo stable managed route-binding set; and
+Odoo stable managed route-binding set.
+`LAUNCHPLANE_AUTHZ_PREVIEW_FEEDBACK_REMEDIATION_MANAGED_SET_JSON` owns the
+local-operator-only VeriReel preview-feedback remediation plan/apply grants; and
 `LAUNCHPLANE_AUTHZ_ODOO_EXTERNAL_ROUTE_BINDING_MANAGED_SET_JSON` owns the
 testing-first external route-binding set.
 `LAUNCHPLANE_AUTHZ_ODOO_TESTING_INGRESS_ROUTE_MANAGED_SET_JSON` owns narrow

--- a/tests/test_authz_operator_workflow.py
+++ b/tests/test_authz_operator_workflow.py
@@ -37,6 +37,7 @@ class AuthzOperatorWorkflowTests(unittest.TestCase):
                 "owner-acceptance",
                 "product-owner-policy-admin",
                 "product-health-monitoring",
+                "preview-feedback-remediation",
                 "odoo-route-binding",
                 "odoo-external-route-binding",
                 "odoo-testing-ingress-route",
@@ -77,6 +78,10 @@ class AuthzOperatorWorkflowTests(unittest.TestCase):
             "reconcile-product-health-monitoring": (
                 "${{ inputs.managed_set == 'product-health-monitoring' }}",
                 "${{ secrets.LAUNCHPLANE_AUTHZ_PRODUCT_HEALTH_MONITORING_MANAGED_SET_JSON }}",
+            ),
+            "reconcile-preview-feedback-remediation": (
+                "${{ inputs.managed_set == 'preview-feedback-remediation' }}",
+                "${{ secrets.LAUNCHPLANE_AUTHZ_PREVIEW_FEEDBACK_REMEDIATION_MANAGED_SET_JSON }}",
             ),
             "reconcile-odoo-route-binding": (
                 "${{ inputs.managed_set == 'odoo-route-binding' }}",
@@ -142,6 +147,9 @@ class AuthzOperatorWorkflowTests(unittest.TestCase):
                     "reconcile-manager-preview-approval": "operator.manager-preview-approval",
                     "reconcile-owner-acceptance": "operator.owner-acceptance",
                     "reconcile-product-owner-policy-admin": "operator.product-owner-policy-admin",
+                    "reconcile-preview-feedback-remediation": (
+                        "operator.preview-feedback-remediation"
+                    ),
                 }
                 if job_name in expected_managed_set_ids:
                     self.assertEqual(


### PR DESCRIPTION
## Summary
- add a dedicated protected managed authorization set for preview-feedback remediation
- bind the wrapper to `operator.preview-feedback-remediation` and a distinct unreadable secret
- preserve the primary managed set and all existing operator sets unchanged
- update workflow contract tests and operator documentation

## Validation
- `uv run --extra dev python -m unittest tests.test_authz_operator_workflow`
- Opus final review: approve
- Gemini final review: approve

Related: #2076
