### PR TITLE
feat: add reusable product retirement worker

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -160,6 +160,7 @@
     "Product Onboarding Manifest (Advanced)",
     "Product Prelaunch Rebuild Policy",
     "Product Retirement",
+    "Reusable Product Retirement",
     "Product Preview TLS",
     "Reusable Generic Web Onboarding Apply",
     "Reusable Generic Web Preview Authorization Apply",

--- a/.github/workflows/reusable-product-retirement.yml
+++ b/.github/workflows/reusable-product-retirement.yml
@@ -1,0 +1,197 @@
+---
+name: Reusable Product Retirement
+
+"on":
+  workflow_call:
+    inputs:
+      mode:
+        description: Persist a reviewed plan or apply that exact persisted plan.
+        required: true
+        type: string
+      product:
+        description: Exact generic-web product profile key.
+        required: true
+        type: string
+      instance:
+        description: Exact profile-owned stable instance; context is derived by Launchplane.
+        required: true
+        type: string
+      expected_target_sha256:
+        description: SHA-256 of the exact tracked provider target identifier.
+        required: true
+        type: string
+      operator_idempotency_key:
+        description: Stable operator-selected key reused for retries of this retirement intent.
+        required: true
+        type: string
+      reason:
+        description: Required single-line operator reason bound into plan continuity.
+        required: true
+        type: string
+      related_issue:
+        description: Required issue or change reference bound into plan continuity.
+        required: true
+        type: string
+      reviewed_plan_record_id:
+        description: Persisted plan record id returned by the reviewed plan; required for apply.
+        required: false
+        default: ""
+        type: string
+      reviewed_plan_sha256:
+        description: Plan SHA-256 returned by the reviewed plan; required for apply.
+        required: false
+        default: ""
+        type: string
+      confirmation:
+        description: >-
+          Exact apply phrase: retire product PRODUCT instance INSTANCE target TARGET_SHA256
+        required: false
+        default: ""
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: >-
+    launchplane-product-retirement-${{ inputs.product }}-${{ inputs.instance }}
+  cancel-in-progress: false
+
+jobs:
+  retire:
+    runs-on: ubuntu-latest
+    environment: launchplane-authz-admin
+    env:
+      LAUNCHPLANE_URL: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}
+      MODE: ${{ inputs.mode }}
+      PRODUCT: ${{ inputs.product }}
+      INSTANCE: ${{ inputs.instance }}
+      EXPECTED_TARGET_SHA256: ${{ inputs.expected_target_sha256 }}
+      OPERATOR_IDEMPOTENCY_KEY: ${{ inputs.operator_idempotency_key }}
+      REASON: ${{ inputs.reason }}
+      RELATED_ISSUE: ${{ inputs.related_issue }}
+      REVIEWED_PLAN_RECORD_ID: ${{ inputs.reviewed_plan_record_id }}
+      REVIEWED_PLAN_SHA256: ${{ inputs.reviewed_plan_sha256 }}
+      CONFIRMATION: ${{ inputs.confirmation }}
+    steps:
+      - name: Validate exact retirement intent
+        shell: bash
+        run: |
+          set -euo pipefail
+          : "${LAUNCHPLANE_URL:?Missing LAUNCHPLANE_PUBLIC_URL variable}"
+          : "${PRODUCT:?Missing product input}"
+          : "${INSTANCE:?Missing instance input}"
+          : "${EXPECTED_TARGET_SHA256:?Missing expected_target_sha256 input}"
+          : "${OPERATOR_IDEMPOTENCY_KEY:?Missing operator_idempotency_key input}"
+          : "${REASON:?Missing reason input}"
+          : "${RELATED_ISSUE:?Missing related_issue input}"
+          if ! [[ "$EXPECTED_TARGET_SHA256" =~ ^[0-9a-f]{64}$ ]]; then
+            echo "expected_target_sha256 must be lowercase SHA-256." >&2
+            exit 1
+          fi
+          if [[ "$REASON" == *$'\n'* || "$RELATED_ISSUE" == *$'\n'* ]]; then
+            echo "reason and related_issue must be single-line values." >&2
+            exit 1
+          fi
+          if [ "$MODE" = "apply" ]; then
+            : "${REVIEWED_PLAN_RECORD_ID:?Apply requires reviewed_plan_record_id}"
+            : "${REVIEWED_PLAN_SHA256:?Apply requires reviewed_plan_sha256}"
+            expected_confirmation="retire product ${PRODUCT} instance ${INSTANCE} target ${EXPECTED_TARGET_SHA256}"
+            if [ "$CONFIRMATION" != "$expected_confirmation" ]; then
+              echo "Apply confirmation does not exactly bind product, instance, and target digest." >&2
+              exit 1
+            fi
+          elif [ -n "$REVIEWED_PLAN_RECORD_ID$REVIEWED_PLAN_SHA256$CONFIRMATION" ]; then
+            echo "Plan mode rejects apply-only review and confirmation inputs." >&2
+            exit 1
+          fi
+
+      - name: Build retirement request
+        shell: bash
+        run: |
+          set -euo pipefail
+          jq -n \
+            --arg mode "$MODE" \
+            --arg product "$PRODUCT" \
+            --arg instance "$INSTANCE" \
+            --arg target_sha256 "$EXPECTED_TARGET_SHA256" \
+            --arg reason "$REASON" \
+            --arg related_issue "$RELATED_ISSUE" \
+            --arg reviewed_plan_record_id "$REVIEWED_PLAN_RECORD_ID" \
+            --arg reviewed_plan_sha256 "$REVIEWED_PLAN_SHA256" \
+            --arg confirmation "$CONFIRMATION" \
+            '{
+              mode: $mode,
+              product: $product,
+              instance: $instance,
+              expected_target_sha256: $target_sha256,
+              reason: $reason,
+              related_issue: $related_issue,
+              reviewed_plan_record_id: $reviewed_plan_record_id,
+              reviewed_plan_sha256: $reviewed_plan_sha256,
+              confirmation: $confirmation
+            }' > product-retirement-request.json
+
+      - name: Request audited product retirement
+        id: request
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@3f063c09bab63836d2b1c880ecb995786f045893 # main
+        with:
+          launchplane-url: ${{ env.LAUNCHPLANE_URL }}
+          route-path: /v1/product-retirement
+          payload-file: product-retirement-request.json
+          idempotency-key: ${{ env.OPERATOR_IDEMPOTENCY_KEY }}
+          response-output-file: product-retirement-response.json
+
+      - name: Verify redacted retirement evidence
+        shell: bash
+        env:
+          STATUS_CODE: ${{ steps.request.outputs.status-code }}
+        run: |
+          set -euo pipefail
+          if [ "$STATUS_CODE" != "202" ]; then
+            jq '{trace_id, error}' product-retirement-response.json >&2
+            exit 1
+          fi
+          test "$(jq -r '.result.mode' product-retirement-response.json)" = "$MODE"
+          test "$(jq -r '.result.product' product-retirement-response.json)" = "$PRODUCT"
+          test "$(jq -r '.result.instance' product-retirement-response.json)" = "$INSTANCE"
+          test "$(jq -r '.result.target_id_sha256' product-retirement-response.json)" = "$EXPECTED_TARGET_SHA256"
+          if jq -e '.. | objects | has("target_id") or has("domain_ids") or has("provider_operation_key")' product-retirement-response.json >/dev/null; then
+            echo "Retirement response exposed an internal provider identifier." >&2
+            exit 1
+          fi
+          if [ "$MODE" = "plan" ]; then
+            test "$(jq -r '.result.outcome' product-retirement-response.json)" = "planned"
+          else
+            outcome="$(jq -r '.result.outcome' product-retirement-response.json)"
+            case "$outcome" in
+              retired|already_absent) ;;
+              *) echo "Apply did not reach a terminal retired outcome: $outcome" >&2; exit 1 ;;
+            esac
+          fi
+
+      - name: Upload redacted retirement evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: product-retirement-${{ inputs.product }}-${{ inputs.instance }}-${{ inputs.mode }}
+          path: product-retirement-response.json
+          if-no-files-found: error
+
+      - name: Summarize review evidence
+        if: success()
+        shell: bash
+        run: |
+          set -euo pipefail
+          {
+            echo '## Product Retirement'
+            echo
+            echo "- Mode: ${MODE}"
+            echo "- Product: ${PRODUCT}"
+            echo "- Instance: ${INSTANCE}"
+            echo "- Target SHA-256: ${EXPECTED_TARGET_SHA256}"
+            echo "- Plan record: $(jq -r '.records.product_retirement_plan_id' product-retirement-response.json)"
+            echo "- Plan SHA-256: $(jq -r '.result.plan_sha256' product-retirement-response.json)"
+            echo "- Outcome: $(jq -r '.result.outcome' product-retirement-response.json)"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/reusable-product-retirement.yml
+++ b/.github/workflows/reusable-product-retirement.yml
@@ -94,6 +94,10 @@ jobs:
             echo "reason and related_issue must be single-line values." >&2
             exit 1
           fi
+          case "$MODE" in
+            plan|apply) ;;
+            *) echo "mode must be plan or apply." >&2; exit 1 ;;
+          esac
           if [ "$MODE" = "apply" ]; then
             : "${REVIEWED_PLAN_RECORD_ID:?Apply requires reviewed_plan_record_id}"
             : "${REVIEWED_PLAN_SHA256:?Apply requires reviewed_plan_sha256}"

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -557,6 +557,10 @@ workers resolve the Launchplane service URL and OIDC audience only from protecte
 repository configuration, not caller inputs. Land and validate worker behavior
 first, then advance the wrapper pin, reconcile the exact managed rule, and run
 the bounded action. Both workers retain attempt-scoped redacted evidence for 30
+days. `Product Retirement` uses the same worker-first sequence: land `Reusable
+Product Retirement` without changing the protected dispatch wrapper, then pin the
+wrapper to its merged full SHA in a separate change before authorizing or using
+that immutable worker for an operator action.
 days; the website-bootstrap worker never uploads the literal bootstrap payload
 and fails unless the service confirms that typed bootstrap intent was persisted.
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -557,12 +557,13 @@ workers resolve the Launchplane service URL and OIDC audience only from protecte
 repository configuration, not caller inputs. Land and validate worker behavior
 first, then advance the wrapper pin, reconcile the exact managed rule, and run
 the bounded action. Both workers retain attempt-scoped redacted evidence for 30
-days. `Product Retirement` uses the same worker-first sequence: land `Reusable
-Product Retirement` without changing the protected dispatch wrapper, then pin the
-wrapper to its merged full SHA in a separate change before authorizing or using
-that immutable worker for an operator action.
 days; the website-bootstrap worker never uploads the literal bootstrap payload
 and fails unless the service confirms that typed bootstrap intent was persisted.
+
+`Product Retirement` uses the same worker-first sequence: land `Reusable
+Product Retirement` without changing the protected dispatch wrapper, then pin
+the wrapper to its merged full SHA in a separate change before authorizing or
+using that immutable worker for an operator action.
 
 `Ingress Route Dry Run` and `Ingress Route Apply` accept an optional exact
 instance. When present, the service authorizes `ingress_route.plan` or

--- a/tests/test_product_retirement_operator_workflow.py
+++ b/tests/test_product_retirement_operator_workflow.py
@@ -144,6 +144,8 @@ class ProductRetirementOperatorWorkflowTests(unittest.TestCase):
         )
         self.assertIsNotNone(validation)
         assert validation is not None
+        self.assertIn('case "$MODE" in', validation.run)
+        self.assertIn('plan|apply)', validation.run)
         self.assertIn("exactly bind product, instance, and target digest", validation.run)
 
         evidence = self.reusable_workflow.step_named(

--- a/tests/test_product_retirement_operator_workflow.py
+++ b/tests/test_product_retirement_operator_workflow.py
@@ -7,6 +7,9 @@ from tests.support.workflows import load_workflow
 class ProductRetirementOperatorWorkflowTests(unittest.TestCase):
     def setUp(self) -> None:
         self.workflow = load_workflow(".github/workflows/product-retirement.yml")
+        self.reusable_workflow = load_workflow(
+            ".github/workflows/reusable-product-retirement.yml"
+        )
 
     def test_workflow_is_protected_exact_and_redacted(self) -> None:
         trigger = self.workflow.data["on"]
@@ -63,6 +66,104 @@ class ProductRetirementOperatorWorkflowTests(unittest.TestCase):
         upload_inputs = upload.data["with"]
         assert isinstance(upload_inputs, dict)
         self.assertEqual(upload_inputs["path"], "product-retirement-response.json")
+
+    def test_reusable_worker_matches_protected_dispatch_contract(self) -> None:
+        trigger = self.reusable_workflow.data["on"]
+        assert isinstance(trigger, dict)
+        self.assertEqual(set(trigger), {"workflow_call"})
+        reusable_call = trigger["workflow_call"]
+        assert isinstance(reusable_call, dict)
+        reusable_inputs = reusable_call["inputs"]
+        assert isinstance(reusable_inputs, dict)
+
+        wrapper_trigger = self.workflow.data["on"]
+        assert isinstance(wrapper_trigger, dict)
+        dispatch = wrapper_trigger["workflow_dispatch"]
+        assert isinstance(dispatch, dict)
+        dispatch_inputs = dispatch["inputs"]
+        assert isinstance(dispatch_inputs, dict)
+        self.assertEqual(set(reusable_inputs), set(dispatch_inputs))
+        for name, dispatch_input in dispatch_inputs.items():
+            assert isinstance(dispatch_input, dict)
+            reusable_input = reusable_inputs[name]
+            assert isinstance(reusable_input, dict)
+            self.assertEqual(reusable_input["required"], dispatch_input["required"])
+            if name != "mode" and "default" in dispatch_input:
+                self.assertEqual(reusable_input["default"], dispatch_input["default"])
+            self.assertEqual(reusable_input["type"], "string")
+
+        job = self.reusable_workflow.job("retire")
+        self.assertEqual(job["runs-on"], "ubuntu-latest")
+        self.assertEqual(job["environment"], "launchplane-authz-admin")
+        self.assertEqual(
+            self.reusable_workflow.job_permissions("retire"),
+            {"contents": "read", "id-token": "write"},
+        )
+        self.assertEqual(
+            job["env"],
+            {
+                "LAUNCHPLANE_URL": "${{ vars.LAUNCHPLANE_PUBLIC_URL }}",
+                "MODE": "${{ inputs.mode }}",
+                "PRODUCT": "${{ inputs.product }}",
+                "INSTANCE": "${{ inputs.instance }}",
+                "EXPECTED_TARGET_SHA256": "${{ inputs.expected_target_sha256 }}",
+                "OPERATOR_IDEMPOTENCY_KEY": "${{ inputs.operator_idempotency_key }}",
+                "REASON": "${{ inputs.reason }}",
+                "RELATED_ISSUE": "${{ inputs.related_issue }}",
+                "REVIEWED_PLAN_RECORD_ID": "${{ inputs.reviewed_plan_record_id }}",
+                "REVIEWED_PLAN_SHA256": "${{ inputs.reviewed_plan_sha256 }}",
+                "CONFIRMATION": "${{ inputs.confirmation }}",
+            },
+        )
+        self.assertEqual(
+            tuple(step.name for step in self.reusable_workflow.steps("retire")),
+            (
+                "Validate exact retirement intent",
+                "Build retirement request",
+                "Request audited product retirement",
+                "Verify redacted retirement evidence",
+                "Upload redacted retirement evidence",
+                "Summarize review evidence",
+            ),
+        )
+        request_step = self.reusable_workflow.step_named(
+            "retire", "Request audited product retirement"
+        )
+        self.assertIsNotNone(request_step)
+        assert request_step is not None
+        self.assertRegex(
+            request_step.uses,
+            re.compile(
+                r"^cbusillo/launchplane/\.github/actions/launchplane-request@[0-9a-f]{40}$"
+            ),
+        )
+        self.assertEqual(request_step.with_values["route-path"], "/v1/product-retirement")
+
+        validation = self.reusable_workflow.step_named(
+            "retire", "Validate exact retirement intent"
+        )
+        self.assertIsNotNone(validation)
+        assert validation is not None
+        self.assertIn("exactly bind product, instance, and target digest", validation.run)
+
+        evidence = self.reusable_workflow.step_named(
+            "retire", "Verify redacted retirement evidence"
+        )
+        self.assertIsNotNone(evidence)
+        assert evidence is not None
+        for identifier in ("target_id", "domain_ids", "provider_operation_key"):
+            self.assertIn(identifier, evidence.run)
+
+        upload = self.reusable_workflow.step_named(
+            "retire", "Upload redacted retirement evidence"
+        )
+        self.assertIsNotNone(upload)
+        assert upload is not None
+        self.assertEqual(
+            upload.uses,
+            "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
+        )
+        self.assertEqual(upload.with_values["path"], "product-retirement-response.json")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Add `Reusable Product Retirement`, an immutable `workflow_call` worker with the current protected retirement worker's exact validation, request, evidence, artifact, and summary behavior.
- Keep `.github/workflows/product-retirement.yml` unchanged in this phase.
- Add semantic contract coverage, important-workflow metadata, and worker-first rollout documentation.

## Rollout
This is phase 1 of the immutable OIDC worker rollout for #2008. A later wrapper PR must pin the existing dispatch workflow to this worker's merged full commit SHA before the worker is authorized or used for an operator action.

## Validation
- `uv run --extra dev python -m unittest tests.test_product_retirement_operator_workflow tests.test_authz_operator_workflow tests.test_github_actions_security`
- `docker run --rm -v "$PWD:/repo" -w /repo rhysd/actionlint:1.7.12@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667 -config-file .github/actionlint.yaml`
- `git diff --check`