### PR TITLE
fix: pin product retirement reusable worker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -408,6 +408,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
 
       - name: Install uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
@@ -530,6 +532,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
 
       - name: Install uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0

--- a/.github/workflows/product-retirement.yml
+++ b/.github/workflows/product-retirement.yml
@@ -53,149 +53,20 @@ name: Product Retirement
         default: ""
         type: string
 
-permissions:
-  contents: read
-  id-token: write
-
-concurrency:
-  group: >-
-    launchplane-product-retirement-${{ inputs.product }}-${{ inputs.instance }}
-  cancel-in-progress: false
-
 jobs:
   retire:
-    runs-on: ubuntu-latest
-    environment: launchplane-authz-admin
-    env:
-      LAUNCHPLANE_URL: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}
-      MODE: ${{ inputs.mode }}
-      PRODUCT: ${{ inputs.product }}
-      INSTANCE: ${{ inputs.instance }}
-      EXPECTED_TARGET_SHA256: ${{ inputs.expected_target_sha256 }}
-      OPERATOR_IDEMPOTENCY_KEY: ${{ inputs.operator_idempotency_key }}
-      REASON: ${{ inputs.reason }}
-      RELATED_ISSUE: ${{ inputs.related_issue }}
-      REVIEWED_PLAN_RECORD_ID: ${{ inputs.reviewed_plan_record_id }}
-      REVIEWED_PLAN_SHA256: ${{ inputs.reviewed_plan_sha256 }}
-      CONFIRMATION: ${{ inputs.confirmation }}
-    steps:
-      - name: Validate exact retirement intent
-        shell: bash
-        run: |
-          set -euo pipefail
-          : "${LAUNCHPLANE_URL:?Missing LAUNCHPLANE_PUBLIC_URL variable}"
-          : "${PRODUCT:?Missing product input}"
-          : "${INSTANCE:?Missing instance input}"
-          : "${EXPECTED_TARGET_SHA256:?Missing expected_target_sha256 input}"
-          : "${OPERATOR_IDEMPOTENCY_KEY:?Missing operator_idempotency_key input}"
-          : "${REASON:?Missing reason input}"
-          : "${RELATED_ISSUE:?Missing related_issue input}"
-          if ! [[ "$EXPECTED_TARGET_SHA256" =~ ^[0-9a-f]{64}$ ]]; then
-            echo "expected_target_sha256 must be lowercase SHA-256." >&2
-            exit 1
-          fi
-          if [[ "$REASON" == *$'\n'* || "$RELATED_ISSUE" == *$'\n'* ]]; then
-            echo "reason and related_issue must be single-line values." >&2
-            exit 1
-          fi
-          if [ "$MODE" = "apply" ]; then
-            : "${REVIEWED_PLAN_RECORD_ID:?Apply requires reviewed_plan_record_id}"
-            : "${REVIEWED_PLAN_SHA256:?Apply requires reviewed_plan_sha256}"
-            expected_confirmation="retire product ${PRODUCT} instance ${INSTANCE} target ${EXPECTED_TARGET_SHA256}"
-            if [ "$CONFIRMATION" != "$expected_confirmation" ]; then
-              echo "Apply confirmation does not exactly bind product, instance, and target digest." >&2
-              exit 1
-            fi
-          elif [ -n "$REVIEWED_PLAN_RECORD_ID$REVIEWED_PLAN_SHA256$CONFIRMATION" ]; then
-            echo "Plan mode rejects apply-only review and confirmation inputs." >&2
-            exit 1
-          fi
-
-      - name: Build retirement request
-        shell: bash
-        run: |
-          set -euo pipefail
-          jq -n \
-            --arg mode "$MODE" \
-            --arg product "$PRODUCT" \
-            --arg instance "$INSTANCE" \
-            --arg target_sha256 "$EXPECTED_TARGET_SHA256" \
-            --arg reason "$REASON" \
-            --arg related_issue "$RELATED_ISSUE" \
-            --arg reviewed_plan_record_id "$REVIEWED_PLAN_RECORD_ID" \
-            --arg reviewed_plan_sha256 "$REVIEWED_PLAN_SHA256" \
-            --arg confirmation "$CONFIRMATION" \
-            '{
-              mode: $mode,
-              product: $product,
-              instance: $instance,
-              expected_target_sha256: $target_sha256,
-              reason: $reason,
-              related_issue: $related_issue,
-              reviewed_plan_record_id: $reviewed_plan_record_id,
-              reviewed_plan_sha256: $reviewed_plan_sha256,
-              confirmation: $confirmation
-            }' > product-retirement-request.json
-
-      - name: Request audited product retirement
-        id: request
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@3f063c09bab63836d2b1c880ecb995786f045893 # main
-        with:
-          launchplane-url: ${{ env.LAUNCHPLANE_URL }}
-          route-path: /v1/product-retirement
-          payload-file: product-retirement-request.json
-          idempotency-key: ${{ env.OPERATOR_IDEMPOTENCY_KEY }}
-          response-output-file: product-retirement-response.json
-
-      - name: Verify redacted retirement evidence
-        shell: bash
-        env:
-          STATUS_CODE: ${{ steps.request.outputs.status-code }}
-        run: |
-          set -euo pipefail
-          if [ "$STATUS_CODE" != "202" ]; then
-            jq '{trace_id, error}' product-retirement-response.json >&2
-            exit 1
-          fi
-          test "$(jq -r '.result.mode' product-retirement-response.json)" = "$MODE"
-          test "$(jq -r '.result.product' product-retirement-response.json)" = "$PRODUCT"
-          test "$(jq -r '.result.instance' product-retirement-response.json)" = "$INSTANCE"
-          test "$(jq -r '.result.target_id_sha256' product-retirement-response.json)" = "$EXPECTED_TARGET_SHA256"
-          if jq -e '.. | objects | has("target_id") or has("domain_ids") or has("provider_operation_key")' product-retirement-response.json >/dev/null; then
-            echo "Retirement response exposed an internal provider identifier." >&2
-            exit 1
-          fi
-          if [ "$MODE" = "plan" ]; then
-            test "$(jq -r '.result.outcome' product-retirement-response.json)" = "planned"
-          else
-            outcome="$(jq -r '.result.outcome' product-retirement-response.json)"
-            case "$outcome" in
-              retired|already_absent) ;;
-              *) echo "Apply did not reach a terminal retired outcome: $outcome" >&2; exit 1 ;;
-            esac
-          fi
-
-      - name: Upload redacted retirement evidence
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: product-retirement-${{ inputs.product }}-${{ inputs.instance }}-${{ inputs.mode }}
-          path: product-retirement-response.json
-          if-no-files-found: error
-
-      - name: Summarize review evidence
-        if: success()
-        shell: bash
-        run: |
-          set -euo pipefail
-          {
-            echo '## Product Retirement'
-            echo
-            echo "- Mode: ${MODE}"
-            echo "- Product: ${PRODUCT}"
-            echo "- Instance: ${INSTANCE}"
-            echo "- Target SHA-256: ${EXPECTED_TARGET_SHA256}"
-            echo "- Plan record: $(jq -r '.records.product_retirement_plan_id' product-retirement-response.json)"
-            echo "- Plan SHA-256: $(jq -r '.result.plan_sha256' product-retirement-response.json)"
-            echo "- Outcome: $(jq -r '.result.outcome' product-retirement-response.json)"
-          } >> "$GITHUB_STEP_SUMMARY"
+    uses: cbusillo/launchplane/.github/workflows/reusable-product-retirement.yml@c922d5f1a0bf3ab17a829196042a96ba89d7b693 # main
+    permissions:
+      contents: read
+      id-token: write
+    with:
+      mode: ${{ inputs.mode }}
+      product: ${{ inputs.product }}
+      instance: ${{ inputs.instance }}
+      expected_target_sha256: ${{ inputs.expected_target_sha256 }}
+      operator_idempotency_key: ${{ inputs.operator_idempotency_key }}
+      reason: ${{ inputs.reason }}
+      related_issue: ${{ inputs.related_issue }}
+      reviewed_plan_record_id: ${{ inputs.reviewed_plan_record_id }}
+      reviewed_plan_sha256: ${{ inputs.reviewed_plan_sha256 }}
+      confirmation: ${{ inputs.confirmation }}

--- a/docs/github-actions-security.md
+++ b/docs/github-actions-security.md
@@ -12,14 +12,18 @@ an immutable `sha256` manifest digest.
 
 ## Reference Classes
 
-| Reference class | Trust | Typical privilege | Required form |
-| --- | --- | --- | --- |
-| Same-repository local action or reusable workflow | Same reviewed workflow commit | Depends on the caller workflow | `./.github/actions/...` or `./.github/workflows/...` |
-| Same-repository privileged reusable worker | First-party immutable trust anchor | Authz administration, route-authority reconciliation, or exact-instance reviewed product-policy mutation | Repository-qualified path at a full reviewed SHA, limited to the approved dispatch wrappers |
-| GitHub-maintained action | GitHub-maintained | Checkout, artifacts, cache, runtime setup, GitHub API, CodeQL | Full SHA plus a release-tag provenance comment |
-| Third-party publisher | Third-party publisher | Python bootstrap, registry authentication, image build and publication | Full SHA plus a release-tag provenance comment |
-| First-party cross-repository Launchplane action | First-party cross-repository | OIDC-authenticated Launchplane requests and preview-client setup | Full SHA plus `# main` provenance |
-| Static workflow container image | Official or third-party publisher | Workflow linting, secret/vulnerability scanning, integration services | Release tag plus `@sha256:<manifest-digest>` |
+<!-- markdownlint-disable MD013 -->
+
+| Reference class                                   | Trust                              | Typical privilege                                                                                        | Required form                                                                               |
+| ------------------------------------------------- | ---------------------------------- | -------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| Same-repository local action or reusable workflow | Same reviewed workflow commit      | Depends on the caller workflow                                                                           | `./.github/actions/...` or `./.github/workflows/...`                                        |
+| Same-repository privileged reusable worker        | First-party immutable trust anchor | Authz administration, route-authority reconciliation, or exact-instance reviewed product-policy mutation | Repository-qualified path at a full reviewed SHA, limited to the approved dispatch wrappers |
+| GitHub-maintained action                          | GitHub-maintained                  | Checkout, artifacts, cache, runtime setup, GitHub API, CodeQL                                            | Full SHA plus a release-tag provenance comment                                              |
+| Third-party publisher                             | Third-party publisher              | Python bootstrap, registry authentication, image build and publication                                   | Full SHA plus a release-tag provenance comment                                              |
+| First-party cross-repository Launchplane action   | First-party cross-repository       | OIDC-authenticated Launchplane requests and preview-client setup                                         | Full SHA plus `# main` provenance                                                           |
+| Static workflow container image                   | Official or third-party publisher  | Workflow linting, secret/vulnerability scanning, integration services                                    | Release tag plus `@sha256:<manifest-digest>`                                                |
+
+<!-- markdownlint-enable MD013 -->
 
 Relative reusable-workflow references are preferred for same-repository workflow
 composition. Reusable workflows retain a SHA-pinned Launchplane composite-action
@@ -70,6 +74,7 @@ written to the workflow log by the upstream implementation.
   boundary. The approved set is limited to managed authz administration,
   generic-web onboarding/preview-authz protected apply, route-binding
   reconciliation, exact-instance product health-policy mutation,
+  protected immutable product retirement,
   exact-instance immutable Odoo artifact publication, and exact-instance Odoo
   target-replacement plan/apply workers whose actions are separately authorized.
   It also includes exact-instance redacted target-log diagnostics and Odoo

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -2526,6 +2526,7 @@ blocked instead of guessing source inputs.
   the first implementation still lives inside this repo.
 - The stable Launchplane contract should be service ingress plus Launchplane-owned
   drivers, not repo-local shell wrappers around file writes.
+
 ## Product Retirement
 
 Use the protected **Product Retirement** workflow; never delete a Dokploy
@@ -2548,4 +2549,11 @@ profile.
 Authorization rollout uses the `product-retirement` selector in **Manage
 Launchplane Authorization**, backed by managed set
 `operator.product-retirement` and secret
-`LAUNCHPLANE_AUTHZ_PRODUCT_RETIREMENT_MANAGED_SET_JSON`.
+`LAUNCHPLANE_AUTHZ_PRODUCT_RETIREMENT_MANAGED_SET_JSON`. The dispatch wrapper
+is pinned to an immutable reusable worker. Authorization must bind both the
+caller `workflow_ref` and the exact immutable `job_workflow_ref`:
+
+```text
+workflow_ref=cbusillo/launchplane/.github/workflows/product-retirement.yml@refs/heads/main
+job_workflow_ref=cbusillo/launchplane/.github/workflows/reusable-product-retirement.yml@c922d5f1a0bf3ab17a829196042a96ba89d7b693
+```

--- a/tests/test_github_actions_security.py
+++ b/tests/test_github_actions_security.py
@@ -342,15 +342,6 @@ def _container_references() -> Iterator[ContainerReference]:
 
 
 class GitHubActionsSecurityTests(TestCase):
-    def test_product_retirement_wrapper_uses_the_approved_immutable_worker(self) -> None:
-        workflow = load_workflow(".github/workflows/product-retirement.yml")
-
-        self.assertEqual(
-            workflow.job_uses("retire"),
-            "cbusillo/launchplane/.github/workflows/reusable-product-retirement.yml"
-            "@c922d5f1a0bf3ab17a829196042a96ba89d7b693",
-        )
-
     def test_product_repo_config_authority_uses_called_workflow_revision(self) -> None:
         workflow = Path(".github/workflows/reusable-product-repo-config-authority.yml").read_text(
             encoding="utf-8"
@@ -534,6 +525,7 @@ class GitHubActionsSecurityTests(TestCase):
         self.assertIn("Third-party publisher", policy)
         self.assertIn("First-party cross-repository", policy)
         self.assertIn("High-privilege", policy)
+        self.assertIn("protected immutable product retirement", policy)
         self.assertIn("container image", policy)
         self.assertIn("MUTABLE_REFERENCE_ALLOWLIST", policy)
         self.assertIn("Dependabot", policy)

--- a/tests/test_github_actions_security.py
+++ b/tests/test_github_actions_security.py
@@ -107,6 +107,9 @@ PINNED_SELF_REUSABLE_WORKFLOWS: Mapping[Path, frozenset[str]] = {
     Path(".github/workflows/tracked-target-logs.yml"): frozenset(
         {"cbusillo/launchplane/.github/workflows/reusable-tracked-target-logs.yml"}
     ),
+    Path(".github/workflows/product-retirement.yml"): frozenset(
+        {"cbusillo/launchplane/.github/workflows/reusable-product-retirement.yml"}
+    ),
 }
 
 
@@ -271,6 +274,12 @@ APPROVED_REMOTE_ACTIONS: Mapping[str, ActionClassification] = {
             "exact-instance redacted target-log diagnostics",
         )
     ),
+    "cbusillo/launchplane/.github/workflows/reusable-product-retirement.yml": (
+        ActionClassification(
+            "First-party same-repository",
+            "protected immutable product retirement",
+        )
+    ),
     "docker/build-push-action": ActionClassification(
         "Third-party publisher", "container build and publication"
     ),
@@ -333,6 +342,15 @@ def _container_references() -> Iterator[ContainerReference]:
 
 
 class GitHubActionsSecurityTests(TestCase):
+    def test_product_retirement_wrapper_uses_the_approved_immutable_worker(self) -> None:
+        workflow = load_workflow(".github/workflows/product-retirement.yml")
+
+        self.assertEqual(
+            workflow.job_uses("retire"),
+            "cbusillo/launchplane/.github/workflows/reusable-product-retirement.yml"
+            "@c922d5f1a0bf3ab17a829196042a96ba89d7b693",
+        )
+
     def test_product_repo_config_authority_uses_called_workflow_revision(self) -> None:
         workflow = Path(".github/workflows/reusable-product-repo-config-authority.yml").read_text(
             encoding="utf-8"

--- a/tests/test_product_retirement_operator_workflow.py
+++ b/tests/test_product_retirement_operator_workflow.py
@@ -1,14 +1,35 @@
 import re
+import subprocess
 import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
 
+from tests.support.workflows import Workflow
 from tests.support.workflows import load_workflow
 
 
-class ProductRetirementOperatorWorkflowTests(unittest.TestCase):
-    WORKER_REFERENCE = (
-        "cbusillo/launchplane/.github/workflows/reusable-product-retirement.yml"
-        "@c922d5f1a0bf3ab17a829196042a96ba89d7b693"
+def _load_pinned_workflow(reference: str) -> Workflow:
+    source, separator, revision = reference.partition("@")
+    if not separator:
+        raise AssertionError(f"pinned workflow reference is missing a revision: {reference}")
+    relative_path = Path(source).relative_to("cbusillo/launchplane")
+    result = subprocess.run(
+        ["git", "show", f"{revision}:{relative_path.as_posix()}"],
+        check=False,
+        capture_output=True,
+        text=True,
     )
+    if result.returncode:
+        raise AssertionError(
+            f"could not read {relative_path} at pinned revision {revision}: {result.stderr}"
+        )
+    with TemporaryDirectory() as temporary_directory_name:
+        workflow_path = Path(temporary_directory_name) / relative_path.name
+        workflow_path.write_text(result.stdout, encoding="utf-8")
+        return load_workflow(workflow_path)
+
+
+class ProductRetirementOperatorWorkflowTests(unittest.TestCase):
     INPUT_NAMES = (
         "mode",
         "product",
@@ -24,9 +45,8 @@ class ProductRetirementOperatorWorkflowTests(unittest.TestCase):
 
     def setUp(self) -> None:
         self.workflow = load_workflow(".github/workflows/product-retirement.yml")
-        self.reusable_workflow = load_workflow(
-            ".github/workflows/reusable-product-retirement.yml"
-        )
+        self.worker_reference = self.workflow.job_uses("retire")
+        self.reusable_workflow = _load_pinned_workflow(self.worker_reference)
 
     def test_wrapper_is_an_immutable_thin_dispatch_contract(self) -> None:
         trigger = self.workflow.data["on"]
@@ -55,7 +75,11 @@ class ProductRetirementOperatorWorkflowTests(unittest.TestCase):
         self.assertNotIn("concurrency", self.workflow.data)
 
         job = self.workflow.job("retire")
-        self.assertEqual(job["uses"], self.WORKER_REFERENCE)
+        self.assertEqual(
+            self.worker_reference.partition("@")[0],
+            "cbusillo/launchplane/.github/workflows/reusable-product-retirement.yml",
+        )
+        self.assertRegex(self.worker_reference.partition("@")[2], r"^[0-9a-f]{40}$")
         self.assertEqual(
             set(job),
             {"uses", "permissions", "with"},
@@ -73,6 +97,13 @@ class ProductRetirementOperatorWorkflowTests(unittest.TestCase):
             wrapper_inputs,
             {name: f"${{{{ inputs.{name} }}}}" for name in self.INPUT_NAMES},
         )
+
+    def test_operations_documentation_binds_wrapper_and_pinned_worker(self) -> None:
+        operations = Path("docs/operations.md").read_text(encoding="utf-8")
+        wrapper_reference = f"cbusillo/launchplane/{self.workflow.path.as_posix()}@refs/heads/main"
+
+        self.assertIn(f"workflow_ref={wrapper_reference}", operations)
+        self.assertIn(f"job_workflow_ref={self.worker_reference}", operations)
 
     def test_reusable_worker_matches_protected_dispatch_contract(self) -> None:
         trigger = self.reusable_workflow.data["on"]

--- a/tests/test_product_retirement_operator_workflow.py
+++ b/tests/test_product_retirement_operator_workflow.py
@@ -48,6 +48,16 @@ class ProductRetirementOperatorWorkflowTests(unittest.TestCase):
         self.worker_reference = self.workflow.job_uses("retire")
         self.reusable_workflow = _load_pinned_workflow(self.worker_reference)
 
+    def test_ci_test_jobs_fetch_full_history_for_pinned_worker(self) -> None:
+        ci_workflow = load_workflow(".github/workflows/ci.yml")
+
+        for job_id in ("test_shards", "test_fork"):
+            with self.subTest(job_id=job_id):
+                checkout = ci_workflow.step_named(job_id, "Checkout")
+                self.assertIsNotNone(checkout)
+                assert checkout is not None
+                self.assertEqual(checkout.with_values.get("fetch-depth"), 0)
+
     def test_wrapper_is_an_immutable_thin_dispatch_contract(self) -> None:
         trigger = self.workflow.data["on"]
         assert isinstance(trigger, dict)

--- a/tests/test_product_retirement_operator_workflow.py
+++ b/tests/test_product_retirement_operator_workflow.py
@@ -5,13 +5,30 @@ from tests.support.workflows import load_workflow
 
 
 class ProductRetirementOperatorWorkflowTests(unittest.TestCase):
+    WORKER_REFERENCE = (
+        "cbusillo/launchplane/.github/workflows/reusable-product-retirement.yml"
+        "@c922d5f1a0bf3ab17a829196042a96ba89d7b693"
+    )
+    INPUT_NAMES = (
+        "mode",
+        "product",
+        "instance",
+        "expected_target_sha256",
+        "operator_idempotency_key",
+        "reason",
+        "related_issue",
+        "reviewed_plan_record_id",
+        "reviewed_plan_sha256",
+        "confirmation",
+    )
+
     def setUp(self) -> None:
         self.workflow = load_workflow(".github/workflows/product-retirement.yml")
         self.reusable_workflow = load_workflow(
             ".github/workflows/reusable-product-retirement.yml"
         )
 
-    def test_workflow_is_protected_exact_and_redacted(self) -> None:
+    def test_wrapper_is_an_immutable_thin_dispatch_contract(self) -> None:
         trigger = self.workflow.data["on"]
         assert isinstance(trigger, dict)
         self.assertEqual(set(trigger), {"workflow_dispatch"})
@@ -19,6 +36,7 @@ class ProductRetirementOperatorWorkflowTests(unittest.TestCase):
         assert isinstance(dispatch, dict)
         inputs = dispatch["inputs"]
         assert isinstance(inputs, dict)
+        self.assertEqual(tuple(inputs), self.INPUT_NAMES)
         mode_input = inputs["mode"]
         assert isinstance(mode_input, dict)
         self.assertEqual(mode_input["options"], ["plan", "apply"])
@@ -33,39 +51,28 @@ class ProductRetirementOperatorWorkflowTests(unittest.TestCase):
             input_contract = inputs[required_input]
             assert isinstance(input_contract, dict)
             self.assertTrue(input_contract["required"])
+        self.assertEqual(self.workflow.permissions, {})
+        self.assertNotIn("concurrency", self.workflow.data)
+
         job = self.workflow.job("retire")
-        self.assertEqual(job["environment"], "launchplane-authz-admin")
+        self.assertEqual(job["uses"], self.WORKER_REFERENCE)
+        self.assertEqual(
+            set(job),
+            {"uses", "permissions", "with"},
+        )
         self.assertEqual(
             self.workflow.job_permissions("retire"),
             {"contents": "read", "id-token": "write"},
         )
-        request_step = self.workflow.step_named("retire", "Request audited product retirement")
-        self.assertIsNotNone(request_step)
-        assert request_step is not None
-        action = request_step.data["uses"]
-        assert isinstance(action, str)
-        self.assertRegex(
-            action,
-            re.compile(r"^cbusillo/launchplane/\.github/actions/launchplane-request@[0-9a-f]{40}$"),
+        for forbidden_key in ("runs-on", "environment", "steps", "concurrency"):
+            self.assertNotIn(forbidden_key, job)
+
+        wrapper_inputs = job["with"]
+        assert isinstance(wrapper_inputs, dict)
+        self.assertEqual(
+            wrapper_inputs,
+            {name: f"${{{{ inputs.{name} }}}}" for name in self.INPUT_NAMES},
         )
-        request_inputs = request_step.data["with"]
-        assert isinstance(request_inputs, dict)
-        self.assertEqual(request_inputs["route-path"], "/v1/product-retirement")
-        validation = self.workflow.step_named("retire", "Validate exact retirement intent")
-        self.assertIsNotNone(validation)
-        assert validation is not None
-        self.assertIn("exactly bind product, instance, and target digest", validation.run)
-        evidence = self.workflow.step_named("retire", "Verify redacted retirement evidence")
-        self.assertIsNotNone(evidence)
-        assert evidence is not None
-        self.assertIn("provider_operation_key", evidence.run)
-        self.assertIn("target_id", evidence.run)
-        upload = self.workflow.step_named("retire", "Upload redacted retirement evidence")
-        self.assertIsNotNone(upload)
-        assert upload is not None
-        upload_inputs = upload.data["with"]
-        assert isinstance(upload_inputs, dict)
-        self.assertEqual(upload_inputs["path"], "product-retirement-response.json")
 
     def test_reusable_worker_matches_protected_dispatch_contract(self) -> None:
         trigger = self.reusable_workflow.data["on"]
@@ -82,7 +89,8 @@ class ProductRetirementOperatorWorkflowTests(unittest.TestCase):
         assert isinstance(dispatch, dict)
         dispatch_inputs = dispatch["inputs"]
         assert isinstance(dispatch_inputs, dict)
-        self.assertEqual(set(reusable_inputs), set(dispatch_inputs))
+        self.assertEqual(tuple(reusable_inputs), self.INPUT_NAMES)
+        self.assertEqual(tuple(dispatch_inputs), self.INPUT_NAMES)
         for name, dispatch_input in dispatch_inputs.items():
             assert isinstance(dispatch_input, dict)
             reusable_input = reusable_inputs[name]
@@ -92,6 +100,17 @@ class ProductRetirementOperatorWorkflowTests(unittest.TestCase):
                 self.assertEqual(reusable_input["default"], dispatch_input["default"])
             self.assertEqual(reusable_input["type"], "string")
 
+        self.assertEqual(
+            self.reusable_workflow.permissions,
+            {"contents": "read", "id-token": "write"},
+        )
+        self.assertEqual(
+            self.reusable_workflow.data["concurrency"],
+            {
+                "group": "launchplane-product-retirement-${{ inputs.product }}-${{ inputs.instance }}",
+                "cancel-in-progress": False,
+            },
+        )
         job = self.reusable_workflow.job("retire")
         self.assertEqual(job["runs-on"], "ubuntu-latest")
         self.assertEqual(job["environment"], "launchplane-authz-admin")


### PR DESCRIPTION
## Summary
- replace the Product Retirement dispatch workflow with a thin call to the immutable reusable worker
- pass all ten dispatch inputs through exactly and grant the called job only `contents: read` and `id-token: write`
- keep environment protection, mutation steps, and concurrency in the reusable worker; document caller and worker OIDC identities

## Validation
- `uv run --extra dev python -m unittest tests.test_product_retirement_operator_workflow tests.test_github_actions_security`
- `docker run --rm -v "${PWD}:/repo" -w /repo rhysd/actionlint:1.7.12@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667 -config-file .github/actionlint.yaml`
- `git diff --check`

Refs #2008 #2080
