### PR TITLE
Retire preview authz without GitHub metadata

### DIFF
--- a/.github/workflows/generic-web-preview-authorization.yml
+++ b/.github/workflows/generic-web-preview-authorization.yml
@@ -26,8 +26,9 @@ name: Generic Web Preview Authorization
         required: true
         type: string
       repository:
-        description: Product repository in owner/name form.
-        required: true
+        description: >-
+          Optional owner/name assertion when retiring; required for onboard, expand, and contract.
+        required: false
         type: string
       preview_context:
         description: Optional preview context; defaults to <product>-preview.
@@ -122,9 +123,11 @@ jobs:
           product = required("PRODUCT", 63).lower()
           if re.fullmatch(r"[a-z0-9][a-z0-9-]{0,62}", product) is None:
               raise SystemExit("product must use lowercase letters, numbers, and hyphens.")
-          repository = required("REPOSITORY")
+          repository = optional("REPOSITORY")
           repository_match = re.fullmatch(r"([A-Za-z0-9_.-]+)/([A-Za-z0-9_.-]+)", repository)
-          if repository_match is None:
+          if operation != "retire" and repository_match is None:
+              raise SystemExit("repository must use owner/name form.")
+          if repository and repository_match is None:
               raise SystemExit("repository must use owner/name form.")
           preview_context = optional("PREVIEW_CONTEXT") or f"{product}-preview"
           launchplane_sha = (optional("LAUNCHPLANE_SHA", 40) or os.environ["GITHUB_SHA"]).lower()
@@ -137,14 +140,15 @@ jobs:
           required("RELATED_ISSUE")
           with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as handle:
               handle.write(f"product={product}\n")
-              handle.write(f"repository_owner={repository_match.group(1)}\n")
-              handle.write(f"repository_name={repository_match.group(2)}\n")
+              handle.write(f"repository_owner={repository_match.group(1) if repository_match else ''}\n")
+              handle.write(f"repository_name={repository_match.group(2) if repository_match else ''}\n")
               handle.write(f"preview_context={preview_context}\n")
               handle.write(f"launchplane_sha={launchplane_sha}\n")
           PY
 
       - name: Mint repository metadata token
         id: repository-token
+        if: ${{ inputs.operation != 'retire' }}
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ vars.LAUNCHPLANE_ONBOARDING_GITHUB_APP_CLIENT_ID }}
@@ -155,6 +159,7 @@ jobs:
 
       - name: Resolve immutable repository identity
         id: repository
+        if: ${{ inputs.operation != 'retire' }}
         shell: bash
         env:
           GH_TOKEN: ${{ steps.repository-token.outputs.token }}

--- a/control_plane/generic_web_preview_authz.py
+++ b/control_plane/generic_web_preview_authz.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
+import hashlib
 import re
+from dataclasses import dataclass
 from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from control_plane.authz_grant_service import AuthzManagedPolicyReconcileEnvelope
+from control_plane.contracts.product_profile_record import LaunchplaneProductProfileRecord
 from control_plane.service_auth import GitHubActionsPolicyRule, LaunchplaneAuthzPolicy
 
 
@@ -24,6 +27,7 @@ _REPOSITORY_PATTERN = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
 _COMMIT_SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
 _DEFAULT_BRANCH_PATTERN = re.compile(r"^[A-Za-z0-9._/-]+$")
 GenericWebPreviewAuthzOperation = Literal["onboard", "expand", "contract", "retire"]
+GenericWebPreviewRetirementAuthoritySource = Literal["current_product_rules", "product_profile"]
 
 
 class GenericWebPreviewAuthzPlanRequest(BaseModel):
@@ -33,9 +37,9 @@ class GenericWebPreviewAuthzPlanRequest(BaseModel):
     product: Literal["launchplane"] = "launchplane"
     operation: GenericWebPreviewAuthzOperation = "onboard"
     target_product: str
-    repository: str
-    repository_id: str
-    repository_owner_id: str
+    repository: str = ""
+    repository_id: str = ""
+    repository_owner_id: str = ""
     default_branch: str = "main"
     preview_context: str = ""
     launchplane_sha: str
@@ -59,14 +63,29 @@ class GenericWebPreviewAuthzPlanRequest(BaseModel):
                 "generic-web preview authz target_product must use lowercase letters, "
                 "numbers, and hyphens"
             )
-        if _REPOSITORY_PATTERN.fullmatch(self.repository) is None:
+        if self.repository and _REPOSITORY_PATTERN.fullmatch(self.repository) is None:
             raise ValueError("generic-web preview authz repository must use owner/name form")
+        if self.operation != "retire" and not self.repository:
+            raise ValueError("generic-web preview authz requires repository")
+        if bool(self.repository_id) != bool(self.repository_owner_id):
+            raise ValueError(
+                "generic-web preview authz repository assertions require both repository_id "
+                "and repository_owner_id when either is supplied"
+            )
         for label, value in (
             ("repository_id", self.repository_id),
             ("repository_owner_id", self.repository_owner_id),
         ):
-            if not value.isdecimal():
+            if value and not value.isdecimal():
                 raise ValueError(f"generic-web preview authz {label} must be a numeric GitHub ID")
+        if self.operation != "retire" and not self.repository_id:
+            raise ValueError(
+                "generic-web preview authz requires immutable repository identity for non-retire"
+            )
+        if self.operation == "retire" and self.include_ingress_operator:
+            raise ValueError(
+                "generic-web preview authz retire rejects include_ingress_operator=true"
+            )
         if _DEFAULT_BRANCH_PATTERN.fullmatch(self.default_branch) is None:
             raise ValueError("generic-web preview authz default_branch is invalid")
         if not self.preview_context:
@@ -90,12 +109,32 @@ class GenericWebPreviewAuthzPlanResult(BaseModel):
     plan_sha256: str
     configuration: dict[str, object]
     diff: dict[str, object]
+    retirement_authority: GenericWebPreviewRetirementAuthorityEvidence | None = None
+
+
+class GenericWebPreviewRetirementAuthorityEvidence(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    authority_sources: tuple[GenericWebPreviewRetirementAuthoritySource, ...]
+    managed_rule_ids: tuple[str, ...]
+    managed_rule_count: int = Field(ge=1)
+    repository_identity_sha256: str
+
+
+@dataclass(frozen=True)
+class GenericWebPreviewRetirementAuthority:
+    repository: str
+    repository_id: str
+    repository_owner_id: str
+    evidence: GenericWebPreviewRetirementAuthorityEvidence
 
 
 def build_generic_web_preview_authz_reconcile_request(
     *,
     current_policy: LaunchplaneAuthzPolicy,
     request: GenericWebPreviewAuthzPlanRequest,
+    profile: LaunchplaneProductProfileRecord | None = None,
+    retirement_authority: GenericWebPreviewRetirementAuthority | None = None,
 ) -> AuthzManagedPolicyReconcileEnvelope:
     retained_github_rules = tuple(
         rule
@@ -139,6 +178,19 @@ def build_generic_web_preview_authz_reconcile_request(
         raise ValueError(
             f"generic-web preview authz {request.operation} requires current product rules"
         )
+    if request.operation == "retire":
+        resolved_retirement_authority = (
+            retirement_authority
+            or resolve_generic_web_preview_retirement_authority(
+                current_target_rules=current_target_rules,
+                request=request,
+                profile=profile,
+            )
+        )
+        _validate_retirement_assertions(
+            request=request,
+            authority=resolved_retirement_authority,
+        )
     desired_github_rules = tuple(
         rule
         for rule in retained_github_rules
@@ -172,6 +224,117 @@ def build_generic_web_preview_authz_reconcile_request(
         reason=request.reason,
         related_issue=request.related_issue,
         desired_policy=desired_policy,
+    )
+
+
+def resolve_generic_web_preview_retirement_authority(
+    *,
+    current_target_rules: tuple[GitHubActionsPolicyRule, ...],
+    request: GenericWebPreviewAuthzPlanRequest,
+    profile: LaunchplaneProductProfileRecord | None,
+) -> GenericWebPreviewRetirementAuthority:
+    if not current_target_rules:
+        raise ValueError("generic-web preview authz retire requires current product rules")
+    product_repository_rules = tuple(
+        rule for rule in current_target_rules if not _is_ingress_operator_rule(rule)
+    )
+    if not product_repository_rules:
+        raise ValueError(
+            "generic-web preview authz retire requires product repository rules after "
+            "excluding ingress-operator rules"
+        )
+    complete_identities = {
+        (rule.repository, rule.repository_id, rule.repository_owner_id)
+        for rule in product_repository_rules
+        if rule.repository_id and rule.repository_owner_id
+    }
+    rule_repositories = {rule.repository for rule in product_repository_rules}
+    if len(rule_repositories) != 1 or len(complete_identities) > 1:
+        raise ValueError("generic-web preview authz retire found ambiguous repository identities")
+    repository = next(iter(rule_repositories))
+    has_name_only_rules = any(
+        not rule.repository_id and not rule.repository_owner_id for rule in product_repository_rules
+    )
+    if complete_identities:
+        _, repository_id, repository_owner_id = next(iter(complete_identities))
+    else:
+        repository_id = ""
+        repository_owner_id = ""
+    authority_sources: list[GenericWebPreviewRetirementAuthoritySource] = ["current_product_rules"]
+    if profile is not None:
+        if profile.repository != repository:
+            raise ValueError(
+                "generic-web preview authz retire found product profile and rule repository disagreement"
+            )
+        authority_sources.append("product_profile")
+        if profile.repository_id and profile.repository_owner_id:
+            profile_identity = (
+                profile.repository,
+                profile.repository_id,
+                profile.repository_owner_id,
+            )
+            if complete_identities and profile_identity not in complete_identities:
+                raise ValueError(
+                    "generic-web preview authz retire found product profile and rule identity disagreement"
+                )
+            repository_id = profile.repository_id
+            repository_owner_id = profile.repository_owner_id
+    if has_name_only_rules and not (
+        profile and profile.repository_id and profile.repository_owner_id
+    ):
+        raise ValueError(
+            "generic-web preview authz retire requires a matching product profile with complete "
+            "repository identity for legacy name-only rules"
+        )
+    if not repository_id or not repository_owner_id:
+        raise ValueError("generic-web preview authz retire found incomplete repository identity")
+    managed_rule_ids = tuple(
+        sorted(rule.managed_rule_id for rule in current_target_rules if rule.managed_rule_id)
+    )
+    identity_digest = hashlib.sha256(
+        "\x00".join((repository, repository_id, repository_owner_id)).encode("utf-8")
+    ).hexdigest()
+    return GenericWebPreviewRetirementAuthority(
+        repository=repository,
+        repository_id=repository_id,
+        repository_owner_id=repository_owner_id,
+        evidence=GenericWebPreviewRetirementAuthorityEvidence(
+            authority_sources=tuple(authority_sources),
+            managed_rule_ids=managed_rule_ids,
+            managed_rule_count=len(current_target_rules),
+            repository_identity_sha256=identity_digest,
+        ),
+    )
+
+
+def _validate_retirement_assertions(
+    *,
+    request: GenericWebPreviewAuthzPlanRequest,
+    authority: GenericWebPreviewRetirementAuthority,
+) -> None:
+    if request.repository and request.repository != authority.repository:
+        raise ValueError(
+            "generic-web preview authz retire repository assertion does not match authority"
+        )
+    if request.repository_id and (
+        request.repository_id != authority.repository_id
+        or request.repository_owner_id != authority.repository_owner_id
+    ):
+        raise ValueError(
+            "generic-web preview authz retire repository identity assertion does not match authority"
+        )
+
+
+def _is_ingress_operator_rule(rule: GitHubActionsPolicyRule) -> bool:
+    ingress_workflow_refs = {
+        "ingress_route.plan": _INGRESS_PLAN_WORKFLOW_REF,
+        "ingress_route.apply": _INGRESS_APPLY_WORKFLOW_REF,
+    }
+    action = rule.actions[0] if len(rule.actions) == 1 else ""
+    return (
+        rule.repository == _LAUNCHPLANE_REPOSITORY
+        and action in ingress_workflow_refs
+        and rule.workflow_refs == (ingress_workflow_refs[action],)
     )
 
 

--- a/control_plane/generic_web_preview_authz.py
+++ b/control_plane/generic_web_preview_authz.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import re
 from dataclasses import dataclass
+from fnmatch import fnmatchcase
 from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
@@ -129,13 +130,31 @@ class GenericWebPreviewRetirementAuthority:
     evidence: GenericWebPreviewRetirementAuthorityEvidence
 
 
+@dataclass(frozen=True)
+class GenericWebPreviewAuthzReconcilePlan:
+    reconcile_request: AuthzManagedPolicyReconcileEnvelope
+    retirement_authority: GenericWebPreviewRetirementAuthority | None
+
+
 def build_generic_web_preview_authz_reconcile_request(
     *,
     current_policy: LaunchplaneAuthzPolicy,
     request: GenericWebPreviewAuthzPlanRequest,
     profile: LaunchplaneProductProfileRecord | None = None,
-    retirement_authority: GenericWebPreviewRetirementAuthority | None = None,
 ) -> AuthzManagedPolicyReconcileEnvelope:
+    return plan_generic_web_preview_authz_reconcile(
+        current_policy=current_policy,
+        request=request,
+        profile=profile,
+    ).reconcile_request
+
+
+def plan_generic_web_preview_authz_reconcile(
+    *,
+    current_policy: LaunchplaneAuthzPolicy,
+    request: GenericWebPreviewAuthzPlanRequest,
+    profile: LaunchplaneProductProfileRecord | None = None,
+) -> GenericWebPreviewAuthzReconcilePlan:
     retained_github_rules = tuple(
         rule
         for rule in current_policy.github_actions
@@ -161,8 +180,9 @@ def build_generic_web_preview_authz_reconcile_request(
         for rule in current_policy.local_admins
         if rule.managed_set_id == GENERIC_WEB_PREVIEW_MANAGED_SET_ID
     )
-    current_target_rules = tuple(
-        rule for rule in retained_github_rules if request.target_product in rule.products
+    current_target_rules = generic_web_preview_managed_target_rules(
+        current_policy=current_policy,
+        target_product=request.target_product,
     )
     if request.operation == "onboard" and current_target_rules:
         generated_rules = _desired_generic_web_preview_rules(
@@ -178,18 +198,19 @@ def build_generic_web_preview_authz_reconcile_request(
         raise ValueError(
             f"generic-web preview authz {request.operation} requires current product rules"
         )
+    retirement_authority = None
     if request.operation == "retire":
-        resolved_retirement_authority = (
-            retirement_authority
-            or resolve_generic_web_preview_retirement_authority(
-                current_target_rules=current_target_rules,
-                request=request,
-                profile=profile,
-            )
+        _validate_retirement_product_selectors(
+            current_target_rules=current_target_rules,
+            target_product=request.target_product,
+        )
+        retirement_authority = resolve_generic_web_preview_retirement_authority(
+            current_target_rules=current_target_rules,
+            profile=profile,
         )
         _validate_retirement_assertions(
             request=request,
-            authority=resolved_retirement_authority,
+            authority=retirement_authority,
         )
     desired_github_rules = tuple(
         rule
@@ -217,20 +238,22 @@ def build_generic_web_preview_authz_reconcile_request(
         local_operators=retained_operator_rules,
         local_admins=retained_admin_rules,
     )
-    return AuthzManagedPolicyReconcileEnvelope(
-        product="launchplane",
-        mode="dry_run",
-        managed_set_id=GENERIC_WEB_PREVIEW_MANAGED_SET_ID,
-        reason=request.reason,
-        related_issue=request.related_issue,
-        desired_policy=desired_policy,
+    return GenericWebPreviewAuthzReconcilePlan(
+        reconcile_request=AuthzManagedPolicyReconcileEnvelope(
+            product="launchplane",
+            mode="dry_run",
+            managed_set_id=GENERIC_WEB_PREVIEW_MANAGED_SET_ID,
+            reason=request.reason,
+            related_issue=request.related_issue,
+            desired_policy=desired_policy,
+        ),
+        retirement_authority=retirement_authority,
     )
 
 
 def resolve_generic_web_preview_retirement_authority(
     *,
     current_target_rules: tuple[GitHubActionsPolicyRule, ...],
-    request: GenericWebPreviewAuthzPlanRequest,
     profile: LaunchplaneProductProfileRecord | None,
 ) -> GenericWebPreviewRetirementAuthority:
     if not current_target_rules:
@@ -305,6 +328,37 @@ def resolve_generic_web_preview_retirement_authority(
             repository_identity_sha256=identity_digest,
         ),
     )
+
+
+def generic_web_preview_managed_target_rules(
+    *,
+    current_policy: LaunchplaneAuthzPolicy,
+    target_product: str,
+) -> tuple[GitHubActionsPolicyRule, ...]:
+    return tuple(
+        rule
+        for rule in current_policy.github_actions
+        if rule.managed_set_id == GENERIC_WEB_PREVIEW_MANAGED_SET_ID
+        and _rule_authorizes_product(rule=rule, target_product=target_product)
+    )
+
+
+def _rule_authorizes_product(*, rule: GitHubActionsPolicyRule, target_product: str) -> bool:
+    return not rule.products or any(
+        fnmatchcase(target_product, product_selector) for product_selector in rule.products
+    )
+
+
+def _validate_retirement_product_selectors(
+    *,
+    current_target_rules: tuple[GitHubActionsPolicyRule, ...],
+    target_product: str,
+) -> None:
+    if any(rule.products != (target_product,) for rule in current_target_rules):
+        raise ValueError(
+            "generic-web preview authz retire requires every current managed preview rule "
+            "authorizing the target to use the exact singleton target product selector"
+        )
 
 
 def _validate_retirement_assertions(

--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -46,8 +46,7 @@ from control_plane.generic_web_onboarding import (
 from control_plane.generic_web_preview_authz import (
     GenericWebPreviewAuthzPlanResult,
     GenericWebPreviewAuthzPlanRequest,
-    build_generic_web_preview_authz_reconcile_request,
-    resolve_generic_web_preview_retirement_authority,
+    plan_generic_web_preview_authz_reconcile,
 )
 from control_plane import (
     product_prelaunch_rebuild_policy as control_plane_product_prelaunch_rebuild_policy,
@@ -13560,7 +13559,6 @@ def create_launchplane_fastapi_app(
         observed_record = active_records[0]
         try:
             profile = None
-            retirement_authority = None
             if planning_request.operation == "retire":
                 profile_store = require_product_profile_read_store(database_store)
                 try:
@@ -13569,23 +13567,12 @@ def create_launchplane_fastapi_app(
                     )
                 except (FileNotFoundError, KeyError):
                     profile = None
-                current_target_rules = tuple(
-                    rule
-                    for rule in observed_record.policy.github_actions
-                    if rule.managed_set_id == "operator.generic-web-preview"
-                    and planning_request.target_product in rule.products
-                )
-                retirement_authority = resolve_generic_web_preview_retirement_authority(
-                    current_target_rules=current_target_rules,
-                    request=planning_request,
-                    profile=profile,
-                )
-            reconcile_request = build_generic_web_preview_authz_reconcile_request(
+            reconcile_plan = plan_generic_web_preview_authz_reconcile(
                 current_policy=observed_record.policy,
                 request=planning_request,
                 profile=profile,
-                retirement_authority=retirement_authority,
             )
+            reconcile_request = reconcile_plan.reconcile_request
             (
                 _,
                 current_record,
@@ -13629,7 +13616,9 @@ def create_launchplane_fastapi_app(
             configuration=reconcile_request.model_dump(mode="json"),
             diff=diff.model_dump(mode="json"),
             retirement_authority=(
-                retirement_authority.evidence if retirement_authority is not None else None
+                reconcile_plan.retirement_authority.evidence
+                if reconcile_plan.retirement_authority is not None
+                else None
             ),
         )
         return accepted_evidence_response(

--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -47,6 +47,7 @@ from control_plane.generic_web_preview_authz import (
     GenericWebPreviewAuthzPlanResult,
     GenericWebPreviewAuthzPlanRequest,
     build_generic_web_preview_authz_reconcile_request,
+    resolve_generic_web_preview_retirement_authority,
 )
 from control_plane import (
     product_prelaunch_rebuild_policy as control_plane_product_prelaunch_rebuild_policy,
@@ -13558,9 +13559,32 @@ def create_launchplane_fastapi_app(
             )
         observed_record = active_records[0]
         try:
+            profile = None
+            retirement_authority = None
+            if planning_request.operation == "retire":
+                profile_store = require_product_profile_read_store(database_store)
+                try:
+                    profile = profile_store.read_product_profile_record(
+                        planning_request.target_product
+                    )
+                except (FileNotFoundError, KeyError):
+                    profile = None
+                current_target_rules = tuple(
+                    rule
+                    for rule in observed_record.policy.github_actions
+                    if rule.managed_set_id == "operator.generic-web-preview"
+                    and planning_request.target_product in rule.products
+                )
+                retirement_authority = resolve_generic_web_preview_retirement_authority(
+                    current_target_rules=current_target_rules,
+                    request=planning_request,
+                    profile=profile,
+                )
             reconcile_request = build_generic_web_preview_authz_reconcile_request(
                 current_policy=observed_record.policy,
                 request=planning_request,
+                profile=profile,
+                retirement_authority=retirement_authority,
             )
             (
                 _,
@@ -13604,6 +13628,9 @@ def create_launchplane_fastapi_app(
             plan_sha256=diff.plan_sha256,
             configuration=reconcile_request.model_dump(mode="json"),
             diff=diff.model_dump(mode="json"),
+            retirement_authority=(
+                retirement_authority.evidence if retirement_authority is not None else None
+            ),
         )
         return accepted_evidence_response(
             trace_id=trace_id,

--- a/docs/new-product-repo.md
+++ b/docs/new-product-repo.md
@@ -88,6 +88,14 @@ ingress workflow identity from the active policy and fails closed when no single
 template exists; operators do not hand-author authz JSON or edit a per-product
 policy secret.
 
+When retiring a product after its repository has been archived or its onboarding
+GitHub App installation is gone, use `Generic Web Preview Authorization` with
+`operation=retire`. Repository input is optional assertion-only for retirement;
+Launchplane resolves immutable authority from the active product preview rules
+and cross-checks the product profile when available. Retirement cannot include
+the ingress operator and removes all target-product preview rules, including
+scoped ingress rules, without querying GitHub.
+
 The conventional product-repo caller files are
 `.github/workflows/launchplane-preview.yml` for pull-request refresh,
 verification, and feedback, and

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -388,6 +388,7 @@ Current implementation scope:
 - `POST /v1/previews/lifecycle-plan`
 - `POST /v1/drivers/verireel/preview-refresh`
 - `POST /v1/drivers/verireel/preview-destroy`
+
 - `POST /v1/drivers/verireel/testing-deploy`
 - `POST /v1/drivers/verireel/testing-verification`
 - `POST /v1/drivers/verireel/prod-deploy`
@@ -398,6 +399,13 @@ Current implementation scope:
 - `POST /v1/drivers/odoo/prod-backup-gate`
 - `POST /v1/drivers/odoo/prod-promotion`
 - `POST /v1/drivers/odoo/prod-rollback`
+
+`Generic Web Preview Authorization` preserves live GitHub App metadata lookup
+for onboarding and rule rotation. Retirement is different: it can remove a
+product's preview authorization after archival or GitHub App offboarding without
+minting a product-repository token or calling the GitHub API. The service derives
+and verifies the retired repository authority from active Launchplane records;
+the caller's optional repository fields only assert that derived identity.
 
 Privileged product rollback routes should stay behind narrow delegated-worker
 contracts rather than being absorbed into the main API host. Product-private

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -388,7 +388,6 @@ Current implementation scope:
 - `POST /v1/previews/lifecycle-plan`
 - `POST /v1/drivers/verireel/preview-refresh`
 - `POST /v1/drivers/verireel/preview-destroy`
-
 - `POST /v1/drivers/verireel/testing-deploy`
 - `POST /v1/drivers/verireel/testing-verification`
 - `POST /v1/drivers/verireel/prod-deploy`

--- a/docs/records.md
+++ b/docs/records.md
@@ -488,6 +488,10 @@ an ORM column/table or remains only in the evidence payload.
   authorization, but it reports `job_workflow_refs_not_singleton`. Readiness-safe
   expansion uses two separately identified exact rules, one immutable worker SHA
   per rule, followed by reviewed contraction of the old rule.
+  Generic-web preview retirement plan evidence additionally records bounded
+  authority sources, target managed rule IDs/count, and a SHA-256 digest of the
+  resolved repository identity. It never records or returns raw numeric
+  repository or owner IDs in that evidence.
   Production tracked-log reads and website-bootstrap writes use separate exact
   caller/worker rule identities. Their workflow artifacts are scoped by run and
   attempt so retries preserve distinct evidence without turning observation or

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -2034,6 +2034,22 @@ The manual `Generic Web Preview Authorization` workflow is the operator surface
 for reviewed onboarding, expand/contract rotations, and product-rule retirement
 through this same planner and writer contract.
 
+For `onboard`, `expand`, and `contract`, that workflow retains its live GitHub
+App repository metadata resolution. For `retire`, it mints no repository-scoped
+App token and makes no GitHub API request: the service derives one immutable
+repository authority from the current target product's
+`operator.generic-web-preview` rules. Launchplane-owned ingress-operator rules
+are excluded only from that identity derivation and are still removed with every
+other target-product rule. A matching product profile is cross-checked when it
+exists; legacy name-only rules require that profile to supply both immutable
+IDs. Caller repository values are optional assertions for retirement, never
+authority. Missing target/product-repository rules, ambiguity, incomplete
+identity, profile disagreement, partial or mismatched assertions, and
+`include_ingress_operator=true` fail closed. The plan returns bounded authority
+sources, managed rule IDs/count, and a SHA-256 identity digest, never raw numeric
+repository IDs; the existing plan digest, policy CAS, protected apply, and
+idempotency boundaries remain unchanged.
+
 Product context audit, cutover, and legacy cleanup routes expose copied or
 deleted runtime identity records under neutral `provider_targets` and
 `provider_target_ids` response groups. Dokploy target records remain

--- a/frontend/generated/openapi-canonical.json
+++ b/frontend/generated/openapi-canonical.json
@@ -6526,14 +6526,17 @@
             "type": "string"
           },
           "repository": {
+            "default": "",
             "title": "Repository",
             "type": "string"
           },
           "repository_id": {
+            "default": "",
             "title": "Repository Id",
             "type": "string"
           },
           "repository_owner_id": {
+            "default": "",
             "title": "Repository Owner Id",
             "type": "string"
           },
@@ -6550,9 +6553,6 @@
         },
         "required": [
           "target_product",
-          "repository",
-          "repository_id",
-          "repository_owner_id",
           "launchplane_sha",
           "reason",
           "related_issue"

--- a/tests/test_docs_contracts.py
+++ b/tests/test_docs_contracts.py
@@ -19,6 +19,18 @@ def _assert_no_workflow_violations(
 
 
 class DocsContractsTests(TestCase):
+    def test_generic_web_preview_retirement_authority_is_documented(self) -> None:
+        operations = Path("docs/operations.md").read_text(encoding="utf-8")
+        service_boundary = Path("docs/service-boundary.md").read_text(encoding="utf-8")
+        records = Path("docs/records.md").read_text(encoding="utf-8")
+        new_product_repo = Path("docs/new-product-repo.md").read_text(encoding="utf-8")
+
+        self.assertIn("without querying GitHub", new_product_repo)
+        self.assertIn("mints no repository-scoped", service_boundary)
+        self.assertIn("Caller repository values are optional assertions", service_boundary)
+        self.assertIn("SHA-256 digest of the", records)
+        self.assertIn("after archival or GitHub App offboarding", operations)
+
     def test_protected_operator_workflows_require_exact_run_babysitter(self) -> None:
         agents = Path("AGENTS.md").read_text(encoding="utf-8")
         operations = Path("docs/operations.md").read_text(encoding="utf-8")

--- a/tests/test_generic_web_preview_authz.py
+++ b/tests/test_generic_web_preview_authz.py
@@ -293,9 +293,6 @@ class GenericWebPreviewAuthzTests(unittest.TestCase):
 
         authority = resolve_generic_web_preview_retirement_authority(
             current_target_rules=target_rules,
-            request=_request(
-                operation="retire", repository="", repository_id="", repository_owner_id=""
-            ),
             profile=None,
         )
 
@@ -353,20 +350,14 @@ class GenericWebPreviewAuthzTests(unittest.TestCase):
             )
             for rule in generic_web_preview_rules(_request())
         )
-        retire_request = _request(
-            operation="retire", repository="", repository_id="", repository_owner_id=""
-        )
-
         with self.assertRaisesRegex(ValueError, "matching product profile with complete"):
             resolve_generic_web_preview_retirement_authority(
                 current_target_rules=target_rules,
-                request=retire_request,
                 profile=None,
             )
 
         authority = resolve_generic_web_preview_retirement_authority(
             current_target_rules=target_rules,
-            request=retire_request,
             profile=_profile(),
         )
 
@@ -385,14 +376,9 @@ class GenericWebPreviewAuthzTests(unittest.TestCase):
                 "repository_id": "789",
             }
         )
-        retire_request = _request(
-            operation="retire", repository="", repository_id="", repository_owner_id=""
-        )
-
         with self.assertRaisesRegex(ValueError, "ambiguous repository identities"):
             resolve_generic_web_preview_retirement_authority(
                 current_target_rules=(*target_rules[1:], mismatched_rule),
-                request=retire_request,
                 profile=None,
             )
         with self.assertRaisesRegex(ValueError, "after excluding ingress-operator"):
@@ -404,7 +390,6 @@ class GenericWebPreviewAuthzTests(unittest.TestCase):
                     ),
                     request=_request(include_ingress_operator=True),
                 ),
-                request=retire_request,
                 profile=None,
             )
 
@@ -422,20 +407,15 @@ class GenericWebPreviewAuthzTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "ambiguous repository identities"):
             resolve_generic_web_preview_retirement_authority(
                 current_target_rules=(*target_rules[1:], ingress_trap),
-                request=_request(
-                    operation="retire", repository="", repository_id="", repository_owner_id=""
-                ),
                 profile=None,
             )
 
     def test_retire_rejects_profile_or_caller_assertion_disagreement(self) -> None:
         target_rules = generic_web_preview_rules(_request())
-        retire_request = _request(operation="retire")
 
         with self.assertRaisesRegex(ValueError, "profile and rule identity disagreement"):
             resolve_generic_web_preview_retirement_authority(
                 current_target_rules=target_rules,
-                request=retire_request,
                 profile=_profile(repository_id="789"),
             )
         with self.assertRaisesRegex(ValueError, "assertion does not match authority"):
@@ -455,6 +435,42 @@ class GenericWebPreviewAuthzTests(unittest.TestCase):
                 request=_request(
                     operation="retire", repository_id="789", repository_owner_id="456"
                 ),
+            )
+
+    def test_retire_rejects_multi_product_current_rule(self) -> None:
+        target_rules = generic_web_preview_rules(_request())
+        multi_product_rule = GitHubActionsPolicyRule.model_validate(
+            {
+                **target_rules[0].model_dump(mode="json"),
+                "products": ["demo-web", "other-web"],
+            }
+        )
+
+        with self.assertRaisesRegex(ValueError, "exact singleton target product selector"):
+            build_generic_web_preview_authz_reconcile_request(
+                current_policy=LaunchplaneAuthzPolicy(
+                    schema_version=2,
+                    github_actions=(*target_rules[1:], multi_product_rule),
+                ),
+                request=_request(operation="retire"),
+            )
+
+    def test_retire_rejects_wildcard_current_rule(self) -> None:
+        target_rules = generic_web_preview_rules(_request())
+        wildcard_rule = GitHubActionsPolicyRule.model_validate(
+            {
+                **target_rules[0].model_dump(mode="json"),
+                "products": ["demo-*"],
+            }
+        )
+
+        with self.assertRaisesRegex(ValueError, "exact singleton target product selector"):
+            build_generic_web_preview_authz_reconcile_request(
+                current_policy=LaunchplaneAuthzPolicy(
+                    schema_version=2,
+                    github_actions=(*target_rules[1:], wildcard_rule),
+                ),
+                request=_request(operation="retire"),
             )
 
     def test_retire_request_rejects_partial_assertions_and_ingress_expansion(self) -> None:

--- a/tests/test_generic_web_preview_authz.py
+++ b/tests/test_generic_web_preview_authz.py
@@ -1,12 +1,17 @@
 import unittest
 from pathlib import Path
 
+from control_plane.contracts.product_profile_record import (
+    LaunchplaneProductProfileRecord,
+    ProductImageProfile,
+)
 from control_plane.generic_web_preview_authz import (
     GENERIC_WEB_PREVIEW_MANAGED_SET_ID,
     GenericWebPreviewAuthzPlanRequest,
     build_generic_web_preview_authz_reconcile_request,
     generic_web_preview_ingress_operator_rules,
     generic_web_preview_rules,
+    resolve_generic_web_preview_retirement_authority,
 )
 from control_plane.service_auth import GitHubActionsPolicyRule, LaunchplaneAuthzPolicy
 
@@ -61,6 +66,25 @@ def _ingress_templates() -> tuple[GitHubActionsPolicyRule, ...]:
             contexts=("template",),
             actions=("ingress_route.apply",),
         ),
+    )
+
+
+def _profile(
+    *,
+    repository: str = "example/demo-web",
+    repository_id: str = "123",
+    repository_owner_id: str = "456",
+) -> LaunchplaneProductProfileRecord:
+    return LaunchplaneProductProfileRecord(
+        product="demo-web",
+        display_name="Demo Web",
+        repository=repository,
+        repository_id=repository_id,
+        repository_owner_id=repository_owner_id,
+        driver_id="generic-web",
+        image=ProductImageProfile(),
+        updated_at="2026-08-11T00:00:00Z",
+        source="test",
     )
 
 
@@ -263,6 +287,187 @@ class GenericWebPreviewAuthzTests(unittest.TestCase):
             {rule.products[0] for rule in retired.desired_policy.github_actions},
             {"other-web"},
         )
+
+    def test_retire_derives_complete_rule_identity_without_profile(self) -> None:
+        target_rules = generic_web_preview_rules(_request())
+
+        authority = resolve_generic_web_preview_retirement_authority(
+            current_target_rules=target_rules,
+            request=_request(
+                operation="retire", repository="", repository_id="", repository_owner_id=""
+            ),
+            profile=None,
+        )
+
+        self.assertEqual(authority.repository, "example/demo-web")
+        self.assertEqual(authority.evidence.authority_sources, ("current_product_rules",))
+        self.assertEqual(authority.evidence.managed_rule_count, 6)
+        self.assertEqual(len(authority.evidence.repository_identity_sha256), 64)
+        evidence = authority.evidence.model_dump_json()
+        self.assertNotIn('"123"', evidence)
+        self.assertNotIn('"456"', evidence)
+
+    def test_retire_ignores_ingress_identity_but_removes_ingress_rules(self) -> None:
+        request = _request()
+        target_rules = generic_web_preview_rules(request)
+        ingress_rules = generic_web_preview_ingress_operator_rules(
+            current_policy=LaunchplaneAuthzPolicy(
+                schema_version=2,
+                github_actions=(*target_rules, *_ingress_templates()),
+            ),
+            request=_request(include_ingress_operator=True),
+        )
+        other_rules = generic_web_preview_rules(
+            _request(
+                target_product="other-web",
+                repository="example/other-web",
+                repository_id="789",
+                preview_context="other-web-preview",
+            )
+        )
+        current_policy = LaunchplaneAuthzPolicy(
+            schema_version=2,
+            github_actions=(*target_rules, *ingress_rules, *other_rules),
+        )
+
+        retired = build_generic_web_preview_authz_reconcile_request(
+            current_policy=current_policy,
+            request=_request(
+                operation="retire", repository="", repository_id="", repository_owner_id=""
+            ),
+        )
+
+        self.assertEqual(len(retired.desired_policy.github_actions), 6)
+        self.assertEqual(
+            {rule.products for rule in retired.desired_policy.github_actions}, {("other-web",)}
+        )
+
+    def test_retire_legacy_name_only_rules_require_matching_complete_profile(self) -> None:
+        target_rules = tuple(
+            GitHubActionsPolicyRule.model_validate(
+                {
+                    **rule.model_dump(mode="json"),
+                    "repository_id": "",
+                    "repository_owner_id": "",
+                }
+            )
+            for rule in generic_web_preview_rules(_request())
+        )
+        retire_request = _request(
+            operation="retire", repository="", repository_id="", repository_owner_id=""
+        )
+
+        with self.assertRaisesRegex(ValueError, "matching product profile with complete"):
+            resolve_generic_web_preview_retirement_authority(
+                current_target_rules=target_rules,
+                request=retire_request,
+                profile=None,
+            )
+
+        authority = resolve_generic_web_preview_retirement_authority(
+            current_target_rules=target_rules,
+            request=retire_request,
+            profile=_profile(),
+        )
+
+        self.assertEqual(authority.repository_id, "123")
+        self.assertEqual(
+            authority.evidence.authority_sources,
+            ("current_product_rules", "product_profile"),
+        )
+
+    def test_retire_rejects_ambiguous_or_incomplete_rule_identity(self) -> None:
+        target_rules = generic_web_preview_rules(_request())
+        mismatched_rule = GitHubActionsPolicyRule.model_validate(
+            {
+                **target_rules[0].model_dump(mode="json"),
+                "repository": "example/other-web",
+                "repository_id": "789",
+            }
+        )
+        retire_request = _request(
+            operation="retire", repository="", repository_id="", repository_owner_id=""
+        )
+
+        with self.assertRaisesRegex(ValueError, "ambiguous repository identities"):
+            resolve_generic_web_preview_retirement_authority(
+                current_target_rules=(*target_rules[1:], mismatched_rule),
+                request=retire_request,
+                profile=None,
+            )
+        with self.assertRaisesRegex(ValueError, "after excluding ingress-operator"):
+            resolve_generic_web_preview_retirement_authority(
+                current_target_rules=generic_web_preview_ingress_operator_rules(
+                    current_policy=LaunchplaneAuthzPolicy(
+                        schema_version=2,
+                        github_actions=(*target_rules, *_ingress_templates()),
+                    ),
+                    request=_request(include_ingress_operator=True),
+                ),
+                request=retire_request,
+                profile=None,
+            )
+
+    def test_retire_does_not_mistake_a_product_rule_for_ingress_operator_authority(self) -> None:
+        target_rules = generic_web_preview_rules(_request())
+        ingress_trap = GitHubActionsPolicyRule.model_validate(
+            {
+                **target_rules[0].model_dump(mode="json"),
+                "repository": "cbusillo/launchplane",
+                "repository_id": "999",
+                "actions": ["ingress_route.plan"],
+            }
+        )
+
+        with self.assertRaisesRegex(ValueError, "ambiguous repository identities"):
+            resolve_generic_web_preview_retirement_authority(
+                current_target_rules=(*target_rules[1:], ingress_trap),
+                request=_request(
+                    operation="retire", repository="", repository_id="", repository_owner_id=""
+                ),
+                profile=None,
+            )
+
+    def test_retire_rejects_profile_or_caller_assertion_disagreement(self) -> None:
+        target_rules = generic_web_preview_rules(_request())
+        retire_request = _request(operation="retire")
+
+        with self.assertRaisesRegex(ValueError, "profile and rule identity disagreement"):
+            resolve_generic_web_preview_retirement_authority(
+                current_target_rules=target_rules,
+                request=retire_request,
+                profile=_profile(repository_id="789"),
+            )
+        with self.assertRaisesRegex(ValueError, "assertion does not match authority"):
+            build_generic_web_preview_authz_reconcile_request(
+                current_policy=LaunchplaneAuthzPolicy(
+                    schema_version=2,
+                    github_actions=target_rules,
+                ),
+                request=_request(operation="retire", repository="example/other-web"),
+            )
+        with self.assertRaisesRegex(ValueError, "identity assertion does not match authority"):
+            build_generic_web_preview_authz_reconcile_request(
+                current_policy=LaunchplaneAuthzPolicy(
+                    schema_version=2,
+                    github_actions=target_rules,
+                ),
+                request=_request(
+                    operation="retire", repository_id="789", repository_owner_id="456"
+                ),
+            )
+
+    def test_retire_request_rejects_partial_assertions_and_ingress_expansion(self) -> None:
+        with self.assertRaisesRegex(ValueError, "require both repository_id"):
+            _request(operation="retire", repository_id="123", repository_owner_id="")
+        with self.assertRaisesRegex(ValueError, "rejects include_ingress_operator=true"):
+            _request(operation="retire", include_ingress_operator=True)
+
+    def test_non_retire_requires_live_repository_identity(self) -> None:
+        with self.assertRaisesRegex(ValueError, "requires repository"):
+            _request(operation="onboard", repository="")
+        with self.assertRaisesRegex(ValueError, "requires immutable repository identity"):
+            _request(operation="expand", repository_id="", repository_owner_id="")
 
 
 if __name__ == "__main__":

--- a/tests/test_github_actions_security.py
+++ b/tests/test_github_actions_security.py
@@ -39,10 +39,7 @@ PINNED_SELF_REUSABLE_WORKFLOWS: Mapping[Path, frozenset[str]] = {
         {"cbusillo/launchplane/.github/workflows/reusable-generic-web-onboarding-apply.yml"}
     ),
     Path(".github/workflows/generic-web-preview-authorization.yml"): frozenset(
-        {
-            "cbusillo/launchplane/.github/workflows/"
-            "reusable-generic-web-preview-authz-apply.yml"
-        }
+        {"cbusillo/launchplane/.github/workflows/reusable-generic-web-preview-authz-apply.yml"}
     ),
     Path(".github/workflows/authz-policy-reconcile.yml"): frozenset(
         {"cbusillo/launchplane/.github/workflows/reusable-authz-policy-reconcile.yml"}
@@ -513,6 +510,23 @@ class GitHubActionsSecurityTests(TestCase):
         _assert_no_workflow_violations(
             self,
             check_security_policy_runs_for_all_pull_requests(security_workflow),
+        )
+
+    def test_retirement_skips_repository_app_token_and_github_metadata_calls(self) -> None:
+        workflow = load_workflow(".github/workflows/generic-web-preview-authorization.yml")
+
+        for step_name in (
+            "Mint repository metadata token",
+            "Resolve immutable repository identity",
+        ):
+            step = workflow.step_named("plan", step_name)
+            self.assertIsNotNone(step)
+            assert step is not None
+            self.assertEqual(step.data.get("if"), "${{ inputs.operation != 'retire' }}")
+        token_step = workflow.step_named("plan", "Mint repository metadata token")
+        assert token_step is not None
+        self.assertEqual(
+            token_step.uses.split("@", maxsplit=1)[0], "actions/create-github-app-token"
         )
 
     def test_documentation_and_dependabot_preserve_reviewable_pin_updates(self) -> None:

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -2378,11 +2378,12 @@ class ProductOnboardingTests(unittest.TestCase):
         self.assertIn("Generic Web Preview Authorization", workflow_text)
         for operation in ("onboard", "expand", "contract", "retire"):
             self.assertIn(f"- {operation}", workflow_text)
-        self.assertIn(
-            "operation must be onboard, expand, contract, or retire.", workflow_text
-        )
+        self.assertIn("operation must be onboard, expand, contract, or retire.", workflow_text)
         self.assertIn("actions/create-github-app-token@", workflow_text)
         self.assertIn("permission-contents: read", workflow_text)
+        self.assertIn("Optional owner/name assertion when retiring", workflow_text)
+        self.assertIn("repository_match.group(1) if repository_match else ''", workflow_text)
+        self.assertIn("repository_match.group(2) if repository_match else ''", workflow_text)
         self.assertIn(
             "/v1/authz-policies/managed-rule-sets/generic-web-preview/plan",
             workflow_text,

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -5445,8 +5445,42 @@ class LaunchplaneServiceTests(unittest.TestCase):
             store = PostgresRecordStore(database_url=database_url)
             try:
                 active_record = store.list_authz_policy_records(status="active", limit=1)[0]
+                store.write_product_profile_record(
+                    LaunchplaneProductProfileRecord.model_validate(
+                        {
+                            "product": "demo-web",
+                            "display_name": "Demo Web",
+                            "repository": "example/demo-web",
+                            "repository_id": "123",
+                            "repository_owner_id": "456",
+                            "driver_id": "generic-web",
+                            "image": {},
+                            "updated_at": "2026-08-11T00:00:00Z",
+                            "source": "test",
+                        }
+                    )
+                )
             finally:
                 store.close()
+            retire_status, retire_payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/authz-policies/managed-rule-sets/generic-web-preview/plan",
+                payload={
+                    "schema_version": 1,
+                    "product": "launchplane",
+                    "operation": "retire",
+                    "target_product": "demo-web",
+                    "repository": "",
+                    "repository_id": "",
+                    "repository_owner_id": "",
+                    "default_branch": "",
+                    "preview_context": "",
+                    "launchplane_sha": "a" * 40,
+                    "reason": "Retire demo web.",
+                    "related_issue": "#2097",
+                },
+            )
 
         self.assertEqual(plan_status, 202)
         self.assertEqual(plan_payload["records"]["target_rule_count"], "6")
@@ -5464,6 +5498,17 @@ class LaunchplaneServiceTests(unittest.TestCase):
         )
         self.assertEqual(len(managed_rules), 6)
         self.assertEqual({rule.products for rule in managed_rules}, {("demo-web",)})
+        self.assertEqual(retire_status, 202)
+        self.assertEqual(retire_payload["result"]["target_rule_count"], 0)
+        retirement_authority = retire_payload["result"]["retirement_authority"]
+        self.assertEqual(
+            retirement_authority["authority_sources"],
+            ["current_product_rules", "product_profile"],
+        )
+        self.assertEqual(retirement_authority["managed_rule_count"], 6)
+        self.assertEqual(len(retirement_authority["repository_identity_sha256"]), 64)
+        self.assertNotIn('"123"', json.dumps(retirement_authority))
+        self.assertNotIn('"456"', json.dumps(retirement_authority))
 
     def test_generic_web_preview_authz_plan_denies_missing_planner_authority(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -81,6 +81,10 @@ from control_plane.contracts.runner_lane_registration import (
     plan_runner_lane_registration,
 )
 from control_plane.every_code_github_webhook import handle_every_code_github_webhook_request
+from control_plane.generic_web_preview_authz import (
+    GenericWebPreviewAuthzPlanRequest,
+    generic_web_preview_rules,
+)
 from control_plane.http_app import LaunchplaneAuthzPolicyRuntime
 from control_plane.http_app import create_launchplane_fastapi_app
 from control_plane.http_app import idempotency_request_fingerprint
@@ -5442,9 +5446,39 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 },
                 headers={"Idempotency-Key": "generic-web-preview-demo-web"},
             )
+            other_plan_status, other_plan_payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/authz-policies/managed-rule-sets/generic-web-preview/plan",
+                payload={
+                    "schema_version": 1,
+                    "product": "launchplane",
+                    "operation": "onboard",
+                    "target_product": "other-web",
+                    "repository": "example/other-web",
+                    "repository_id": "789",
+                    "repository_owner_id": "456",
+                    "default_branch": "main",
+                    "preview_context": "other-web-preview",
+                    "launchplane_sha": "a" * 40,
+                    "reason": "Onboard other web.",
+                    "related_issue": "#1971",
+                },
+            )
+            other_configuration = other_plan_payload["result"]["configuration"]
+            other_reconcile_status, other_reconcile_payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/authz-policies/managed-rule-sets/reconcile",
+                payload={
+                    **other_configuration,
+                    "mode": "apply",
+                    "reviewed_plan_sha256": other_plan_payload["result"]["plan_sha256"],
+                },
+                headers={"Idempotency-Key": "generic-web-preview-other-web"},
+            )
             store = PostgresRecordStore(database_url=database_url)
             try:
-                active_record = store.list_authz_policy_records(status="active", limit=1)[0]
                 store.write_product_profile_record(
                     LaunchplaneProductProfileRecord.model_validate(
                         {
@@ -5481,8 +5515,25 @@ class LaunchplaneServiceTests(unittest.TestCase):
                     "related_issue": "#2097",
                 },
             )
+            retire_reconcile_status, retire_reconcile_payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/authz-policies/managed-rule-sets/reconcile",
+                payload={
+                    **retire_payload["result"]["configuration"],
+                    "mode": "apply",
+                    "reviewed_plan_sha256": retire_payload["result"]["plan_sha256"],
+                },
+                headers={"Idempotency-Key": "generic-web-preview-retire-demo-web"},
+            )
+            store = PostgresRecordStore(database_url=database_url)
+            try:
+                active_record = store.list_authz_policy_records(status="active", limit=1)[0]
+            finally:
+                store.close()
 
         self.assertEqual(plan_status, 202)
+        self.assertIsNone(plan_payload["result"]["retirement_authority"])
         self.assertEqual(plan_payload["records"]["target_rule_count"], "6")
         self.assertEqual(plan_payload["result"]["diff"]["added_rule_count"], 6)
         self.assertEqual(
@@ -5491,15 +5542,26 @@ class LaunchplaneServiceTests(unittest.TestCase):
         )
         self.assertEqual(reconcile_status, 202)
         self.assertEqual(reconcile_payload["result"]["diff"]["plan_sha256"], plan_sha256)
+        self.assertEqual(other_plan_status, 202)
+        self.assertEqual(other_reconcile_status, 202)
+        self.assertEqual(
+            other_reconcile_payload["result"]["diff"]["added_rule_count"],
+            6,
+        )
         managed_rules = tuple(
             rule
             for rule in active_record.policy.github_actions
             if rule.managed_set_id == "operator.generic-web-preview"
         )
         self.assertEqual(len(managed_rules), 6)
-        self.assertEqual({rule.products for rule in managed_rules}, {("demo-web",)})
+        self.assertEqual({rule.products for rule in managed_rules}, {("other-web",)})
         self.assertEqual(retire_status, 202)
         self.assertEqual(retire_payload["result"]["target_rule_count"], 0)
+        self.assertEqual(retire_reconcile_status, 202)
+        self.assertEqual(
+            retire_reconcile_payload["result"]["diff"]["removed_rule_count"],
+            6,
+        )
         retirement_authority = retire_payload["result"]["retirement_authority"]
         self.assertEqual(
             retirement_authority["authority_sources"],
@@ -5509,6 +5571,118 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(len(retirement_authority["repository_identity_sha256"]), 64)
         self.assertNotIn('"123"', json.dumps(retirement_authority))
         self.assertNotIn('"456"', json.dumps(retirement_authority))
+
+    def test_generic_web_preview_authz_plan_rejects_non_exact_retirement_product_selectors(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            workflow_ref = (
+                "cbusillo/launchplane/.github/workflows/product-onboarding.yml@refs/heads/main"
+            )
+            planner_policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "schema_version": 2,
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/launchplane",
+                            "workflow_refs": [workflow_ref],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["launchplane"],
+                            "contexts": ["launchplane"],
+                            "actions": [
+                                "authz_policy_grant.write",
+                                "generic_web_preview_authz.plan",
+                            ],
+                        }
+                    ],
+                }
+            )
+            app = create_launchplane_fastapi_test_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/launchplane",
+                        workflow_ref=workflow_ref,
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=planner_policy,
+                control_plane_root_path=root,
+                database_url=database_url,
+            )
+            generated_rules = generic_web_preview_rules(
+                GenericWebPreviewAuthzPlanRequest.model_validate(
+                    {
+                        "schema_version": 1,
+                        "product": "launchplane",
+                        "target_product": "demo-web",
+                        "repository": "example/demo-web",
+                        "repository_id": "123",
+                        "repository_owner_id": "456",
+                        "default_branch": "main",
+                        "preview_context": "demo-web-preview",
+                        "launchplane_sha": "a" * 40,
+                        "reason": "Onboard demo web.",
+                        "related_issue": "#1970",
+                    }
+                )
+            )
+            retire_payload = {
+                "schema_version": 1,
+                "product": "launchplane",
+                "operation": "retire",
+                "target_product": "demo-web",
+                "repository": "",
+                "repository_id": "",
+                "repository_owner_id": "",
+                "default_branch": "",
+                "preview_context": "",
+                "launchplane_sha": "a" * 40,
+                "reason": "Retire demo web.",
+                "related_issue": "#2097",
+            }
+            store = _HostedAuthzPolicyStore(database_url=database_url)
+            try:
+                for label, products in (
+                    ("multi-product", ("demo-web", "other-web")),
+                    ("wildcard", ("demo-*",)),
+                ):
+                    with self.subTest(selector=label):
+                        unsafe_rule = generated_rules[0].model_copy(update={"products": products})
+                        store.write_authz_policy_record(
+                            LaunchplaneAuthzPolicyRecord(
+                                record_id=f"seed-{label}",
+                                source=f"test:{label}",
+                                updated_at="2026-08-11T00:00:00Z",
+                                policy=LaunchplaneAuthzPolicy(
+                                    schema_version=2,
+                                    github_actions=(
+                                        *planner_policy.github_actions,
+                                        *generated_rules[1:],
+                                        unsafe_rule,
+                                    ),
+                                ),
+                            )
+                        )
+                        status_code, payload = _invoke_app(
+                            app,
+                            method="POST",
+                            path="/v1/authz-policies/managed-rule-sets/generic-web-preview/plan",
+                            payload=retire_payload,
+                        )
+                        self.assertEqual(status_code, 400)
+                        self.assertEqual(
+                            payload["error"]["code"],
+                            "invalid_generic_web_preview_authz_plan",
+                        )
+                        self.assertIn(
+                            "exact singleton target product selector",
+                            payload["error"]["message"],
+                        )
+            finally:
+                store.close()
 
     def test_generic_web_preview_authz_plan_denies_missing_planner_authority(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary
- derive retirement repository authority from active generic-web preview rules and an optional cross-checked product profile
- skip repository App token minting and GitHub metadata resolution only for `retire`; retain current behavior for `onboard`, `expand`, and `contract`
- return redacted retirement authority evidence while preserving the digest-bound reusable apply contract

## Validation
- `uv run --extra dev launchplane ci unittest-shard local`
- `uv run --extra dev ruff check .`
- `uv run --extra dev mypy control_plane tests`
- `pnpm --dir frontend check:openapi-drift`
- `actionlint -config-file .github/actionlint.yaml .github/workflows/*.yml`
- JetBrains changed-file inspection: clean

Refs #2097
Refs #2008

No live workflow dispatch, deployment, canary mutation, or GitHub App access proof was performed.