### PR TITLE
feat: add detached application retirement phase one

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -163,6 +163,7 @@
     "Product Prelaunch Rebuild Policy",
     "Product Retirement",
     "Reusable Product Retirement",
+    "Reusable Detached Application Retirement",
     "Product Preview TLS",
     "Reusable Generic Web Onboarding Apply",
     "Reusable Generic Web Preview Authorization Apply",

--- a/.github/workflows/authz-policy-reconcile.yml
+++ b/.github/workflows/authz-policy-reconcile.yml
@@ -26,6 +26,7 @@ name: Manage Launchplane Authorization
           - product-owner-policy-admin
           - product-health-monitoring
           - product-retirement
+          - detached-application-retirement
           - preview-feedback-remediation
           - odoo-route-binding
           - odoo-external-route-binding
@@ -113,6 +114,18 @@ jobs:
       related_issue: ${{ inputs.related_issue }}
     secrets:
       managed_set_json: ${{ secrets.LAUNCHPLANE_AUTHZ_PRODUCT_OWNER_POLICY_ADMIN_MANAGED_SET_JSON }}
+
+  reconcile-detached-application-retirement:
+    if: ${{ inputs.managed_set == 'detached-application-retirement' }}
+    uses: cbusillo/launchplane/.github/workflows/reusable-authz-policy-reconcile.yml@39aecc250d6dee91204e24673725bd1ea1ca6bda # main
+    with:
+      mode: ${{ inputs.mode }}
+      expected_managed_set_id: operator.detached-application-retirement
+      reviewed_plan_sha256: ${{ inputs.reviewed_plan_sha256 }}
+      reason: ${{ inputs.reason }}
+      related_issue: ${{ inputs.related_issue }}
+    secrets:
+      managed_set_json: ${{ secrets.LAUNCHPLANE_AUTHZ_DETACHED_APPLICATION_RETIREMENT_MANAGED_SET_JSON }}
 
   reconcile-generic-web-onboarding:
     if: ${{ inputs.managed_set == 'generic-web-onboarding' }}

--- a/.github/workflows/reusable-detached-application-retirement.yml
+++ b/.github/workflows/reusable-detached-application-retirement.yml
@@ -1,0 +1,236 @@
+---
+name: Reusable Detached Application Retirement
+
+"on":
+  workflow_call:
+    inputs:
+      mode:
+        description: Persist a reviewed plan or apply that exact persisted plan.
+        required: true
+        type: string
+      project_name:
+        description: Exact Dokploy project name.
+        required: true
+        type: string
+      environment_name:
+        description: Exact Dokploy environment name.
+        required: true
+        type: string
+      application_name:
+        description: Exact globally unique detached Dokploy application name.
+        required: true
+        type: string
+      candidate_target_sha256:
+        description: SHA-256 of the detached application identifier.
+        required: true
+        type: string
+      expected_protected_target_sha256_json:
+        description: Sorted non-empty JSON array of protected application target SHA-256 values.
+        required: true
+        type: string
+      operator_idempotency_key:
+        description: Stable operator-selected key reused for retries of this retirement intent.
+        required: true
+        type: string
+      reason:
+        description: Required single-line operator reason bound into plan continuity.
+        required: true
+        type: string
+      related_issue:
+        description: Required issue or change reference bound into plan continuity.
+        required: true
+        type: string
+      reviewed_plan_record_id:
+        description: Persisted plan record id returned by the reviewed plan; required for apply.
+        required: false
+        default: ""
+        type: string
+      reviewed_plan_sha256:
+        description: Plan SHA-256 returned by the reviewed plan; required for apply.
+        required: false
+        default: ""
+        type: string
+      confirmation:
+        description: Exact target-bound apply confirmation returned by the plan contract.
+        required: false
+        default: ""
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: >-
+    launchplane-detached-application-retirement-${{ inputs.candidate_target_sha256 }}
+  cancel-in-progress: false
+
+jobs:
+  retire:
+    runs-on: ubuntu-latest
+    environment: launchplane-authz-admin
+    env:
+      LAUNCHPLANE_URL: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}
+      MODE: ${{ inputs.mode }}
+      PROJECT_NAME: ${{ inputs.project_name }}
+      ENVIRONMENT_NAME: ${{ inputs.environment_name }}
+      APPLICATION_NAME: ${{ inputs.application_name }}
+      CANDIDATE_TARGET_SHA256: ${{ inputs.candidate_target_sha256 }}
+      EXPECTED_PROTECTED_TARGET_SHA256_JSON: >-
+        ${{ inputs.expected_protected_target_sha256_json }}
+      OPERATOR_IDEMPOTENCY_KEY: ${{ inputs.operator_idempotency_key }}
+      REASON: ${{ inputs.reason }}
+      RELATED_ISSUE: ${{ inputs.related_issue }}
+      REVIEWED_PLAN_RECORD_ID: ${{ inputs.reviewed_plan_record_id }}
+      REVIEWED_PLAN_SHA256: ${{ inputs.reviewed_plan_sha256 }}
+      CONFIRMATION: ${{ inputs.confirmation }}
+    steps:
+      - name: Validate exact detached application intent
+        shell: bash
+        run: |
+          set -euo pipefail
+          : "${LAUNCHPLANE_URL:?Missing LAUNCHPLANE_PUBLIC_URL variable}"
+          : "${PROJECT_NAME:?Missing project_name input}"
+          : "${ENVIRONMENT_NAME:?Missing environment_name input}"
+          : "${APPLICATION_NAME:?Missing application_name input}"
+          : "${CANDIDATE_TARGET_SHA256:?Missing candidate_target_sha256 input}"
+          : "${EXPECTED_PROTECTED_TARGET_SHA256_JSON:?Missing protected target digest input}"
+          : "${OPERATOR_IDEMPOTENCY_KEY:?Missing operator_idempotency_key input}"
+          : "${REASON:?Missing reason input}"
+          : "${RELATED_ISSUE:?Missing related_issue input}"
+          if ! [[ "$CANDIDATE_TARGET_SHA256" =~ ^[0-9a-f]{64}$ ]]; then
+            echo "candidate_target_sha256 must be lowercase SHA-256." >&2
+            exit 1
+          fi
+          if [[ "$REASON" == *$'\n'* || "$RELATED_ISSUE" == *$'\n'* ]]; then
+            echo "reason and related_issue must be single-line values." >&2
+            exit 1
+          fi
+          protected="$(jq -cer '
+            if type != "array" or length == 0 then error("non-empty array required") else . end
+            | if all(.[]; type == "string" and test("^[0-9a-f]{64}$"))
+              then . else error("protected targets must be SHA-256") end
+            | if . == (unique | sort) then . else error("protected targets must be sorted unique") end
+          ' <<< "$EXPECTED_PROTECTED_TARGET_SHA256_JSON")"
+          if jq -e --arg candidate "$CANDIDATE_TARGET_SHA256" 'index($candidate) != null' \
+            <<< "$protected" >/dev/null; then
+            echo "candidate target cannot be protected." >&2
+            exit 1
+          fi
+          printf '%s\n' "$protected" > protected-targets.json
+          case "$MODE" in
+            plan|apply) ;;
+            *) echo "mode must be plan or apply." >&2; exit 1 ;;
+          esac
+          if [ "$MODE" = "apply" ]; then
+            : "${REVIEWED_PLAN_RECORD_ID:?Apply requires reviewed_plan_record_id}"
+            if ! [[ "$REVIEWED_PLAN_SHA256" =~ ^[0-9a-f]{64}$ ]]; then
+              echo "Apply requires reviewed_plan_sha256." >&2
+              exit 1
+            fi
+            expected_confirmation="retire detached Dokploy application ${PROJECT_NAME}/${ENVIRONMENT_NAME}/${APPLICATION_NAME} target ${CANDIDATE_TARGET_SHA256}"
+            if [ "$CONFIRMATION" != "$expected_confirmation" ]; then
+              echo "Apply confirmation does not exactly bind the detached application." >&2
+              exit 1
+            fi
+          elif [ -n "$REVIEWED_PLAN_RECORD_ID$REVIEWED_PLAN_SHA256$CONFIRMATION" ]; then
+            echo "Plan mode rejects apply-only review and confirmation inputs." >&2
+            exit 1
+          fi
+
+      - name: Build detached application retirement request
+        shell: bash
+        run: |
+          set -euo pipefail
+          jq -n \
+            --arg mode "$MODE" \
+            --arg project_name "$PROJECT_NAME" \
+            --arg environment_name "$ENVIRONMENT_NAME" \
+            --arg application_name "$APPLICATION_NAME" \
+            --arg candidate_target_sha256 "$CANDIDATE_TARGET_SHA256" \
+            --slurpfile protected protected-targets.json \
+            --arg reason "$REASON" \
+            --arg related_issue "$RELATED_ISSUE" \
+            --arg reviewed_plan_record_id "$REVIEWED_PLAN_RECORD_ID" \
+            --arg reviewed_plan_sha256 "$REVIEWED_PLAN_SHA256" \
+            --arg confirmation "$CONFIRMATION" \
+            '{
+              mode: $mode,
+              project_name: $project_name,
+              environment_name: $environment_name,
+              application_name: $application_name,
+              candidate_target_sha256: $candidate_target_sha256,
+              expected_protected_target_sha256: $protected[0],
+              reason: $reason,
+              related_issue: $related_issue,
+              reviewed_plan_record_id: $reviewed_plan_record_id,
+              reviewed_plan_sha256: $reviewed_plan_sha256,
+              confirmation: $confirmation
+            }' > detached-application-retirement-request.json
+
+      - name: Request audited detached application retirement
+        id: request
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@3f063c09bab63836d2b1c880ecb995786f045893 # main
+        with:
+          launchplane-url: ${{ env.LAUNCHPLANE_URL }}
+          route-path: /v1/detached-application-retirement
+          payload-file: detached-application-retirement-request.json
+          idempotency-key: ${{ env.OPERATOR_IDEMPOTENCY_KEY }}
+          response-output-file: detached-application-retirement-response.json
+
+      - name: Verify redacted detached application evidence
+        shell: bash
+        env:
+          STATUS_CODE: ${{ steps.request.outputs.status-code }}
+        run: |
+          set -euo pipefail
+          if [ "$STATUS_CODE" != "202" ]; then
+            jq '{trace_id, error}' detached-application-retirement-response.json >&2
+            exit 1
+          fi
+          test "$(jq -r '.result.mode' detached-application-retirement-response.json)" = "$MODE"
+          test "$(jq -r '.result.candidate_target_sha256' detached-application-retirement-response.json)" = "$CANDIDATE_TARGET_SHA256"
+          jq -e --slurpfile protected protected-targets.json \
+            '.result.protected_target_sha256 == $protected[0] and .result.authority_write_count == 0' \
+            detached-application-retirement-response.json >/dev/null
+          if jq -e '.. | objects | has("application_id") or has("project_id") or has("environment_id") or has("provider_operation_key")' \
+            detached-application-retirement-response.json >/dev/null; then
+            echo "Detached application response exposed a provider identifier." >&2
+            exit 1
+          fi
+          if [ "$MODE" = "plan" ]; then
+            test "$(jq -r '.result.outcome' detached-application-retirement-response.json)" = "planned"
+          else
+            outcome="$(jq -r '.result.outcome' detached-application-retirement-response.json)"
+            case "$outcome" in
+              retired|already_absent) ;;
+              *) echo "Apply did not reach a terminal retirement outcome: $outcome" >&2; exit 1 ;;
+            esac
+            test "$(jq -r '.result.provider_absence_verified' detached-application-retirement-response.json)" = "true"
+            test "$(jq -r '.result.protected_targets_unchanged' detached-application-retirement-response.json)" = "true"
+          fi
+
+      - name: Upload redacted detached application evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: detached-application-retirement-${{ inputs.mode }}-${{ github.run_id }}
+          path: detached-application-retirement-response.json
+          if-no-files-found: error
+
+      - name: Summarize detached application evidence
+        if: success()
+        shell: bash
+        run: |
+          set -euo pipefail
+          {
+            echo '## Detached Application Retirement'
+            echo
+            echo "- Mode: ${MODE}"
+            echo "- Candidate target SHA-256: ${CANDIDATE_TARGET_SHA256}"
+            echo "- Protected target count: $(jq -r '.result.protected_target_count' detached-application-retirement-response.json)"
+            echo "- Authority source count: $(jq -r '.result.authority_source_count' detached-application-retirement-response.json)"
+            echo "- Plan record: $(jq -r '.records.detached_application_retirement_plan_id' detached-application-retirement-response.json)"
+            echo "- Plan SHA-256: $(jq -r '.result.plan_sha256' detached-application-retirement-response.json)"
+            echo "- Outcome: $(jq -r '.result.outcome' detached-application-retirement-response.json)"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/reusable-detached-application-retirement.yml
+++ b/.github/workflows/reusable-detached-application-retirement.yml
@@ -89,6 +89,10 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          if [ "${{ github.repository }}" != "cbusillo/launchplane" ]; then
+            echo "Caller repository must be cbusillo/launchplane." >&2
+            exit 1
+          fi
           : "${LAUNCHPLANE_URL:?Missing LAUNCHPLANE_PUBLIC_URL variable}"
           : "${PROJECT_NAME:?Missing project_name input}"
           : "${ENVIRONMENT_NAME:?Missing environment_name input}"

--- a/control_plane/contracts/detached_application_retirement.py
+++ b/control_plane/contracts/detached_application_retirement.py
@@ -116,6 +116,7 @@ class DetachedApplicationRetirementIdentity(BaseModel):
     subject: str = ""
     repository: str = ""
     workflow_ref: str = ""
+    job_workflow_ref: str = ""
     environment: str = ""
 
     @model_validator(mode="after")
@@ -126,6 +127,7 @@ class DetachedApplicationRetirementIdentity(BaseModel):
             "subject",
             "repository",
             "workflow_ref",
+            "job_workflow_ref",
             "environment",
         ):
             setattr(self, field_name, str(getattr(self, field_name)).strip())

--- a/control_plane/contracts/detached_application_retirement.py
+++ b/control_plane/contracts/detached_application_retirement.py
@@ -1,0 +1,408 @@
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from control_plane.contracts.product_retirement import canonical_sha256, provider_identifier_sha256
+
+
+DetachedApplicationRetirementMode = Literal["plan", "apply"]
+DetachedApplicationRetirementOutcome = Literal[
+    "planned",
+    "retired",
+    "already_absent",
+    "reconcile_required",
+    "failed",
+]
+DeploymentHistoryState = Literal["present", "no_history"]
+MAX_DETACHED_APPLICATION_RETIREMENT_ERROR_MESSAGE_LENGTH = 1000
+
+
+class DetachedApplicationRetirementRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: Literal[1] = 1
+    mode: DetachedApplicationRetirementMode = "plan"
+    project_name: str
+    environment_name: str
+    application_name: str
+    candidate_target_sha256: str
+    expected_protected_target_sha256: tuple[str, ...]
+    reason: str
+    related_issue: str
+    reviewed_plan_record_id: str = ""
+    reviewed_plan_sha256: str = ""
+    confirmation: str = ""
+
+    @model_validator(mode="after")
+    def _validate_request(self) -> "DetachedApplicationRetirementRequest":
+        for field_name in (
+            "project_name",
+            "environment_name",
+            "application_name",
+            "candidate_target_sha256",
+            "reason",
+            "related_issue",
+        ):
+            value = str(getattr(self, field_name)).strip()
+            setattr(self, field_name, value)
+            if not value:
+                raise ValueError(f"Detached application retirement requires {field_name}.")
+        self.candidate_target_sha256 = self.candidate_target_sha256.lower()
+        _require_sha256(self.candidate_target_sha256, "candidate_target_sha256")
+        protected = tuple(value.strip().lower() for value in self.expected_protected_target_sha256)
+        if not protected or any(not value for value in protected):
+            raise ValueError("Detached application retirement requires protected target digests.")
+        for digest in protected:
+            _require_sha256(digest, "expected_protected_target_sha256")
+        if protected != tuple(sorted(set(protected))):
+            raise ValueError(
+                "Detached application retirement protected target digests must be unique and sorted."
+            )
+        if self.candidate_target_sha256 in protected:
+            raise ValueError(
+                "Detached application retirement candidate cannot be a protected target."
+            )
+        self.expected_protected_target_sha256 = protected
+        self.reviewed_plan_record_id = self.reviewed_plan_record_id.strip()
+        self.reviewed_plan_sha256 = self.reviewed_plan_sha256.strip().lower()
+        self.confirmation = self.confirmation.strip()
+        if self.mode == "plan":
+            if self.reviewed_plan_record_id or self.reviewed_plan_sha256 or self.confirmation:
+                raise ValueError("Detached application retirement plan rejects apply-only fields.")
+            return self
+        if not self.reviewed_plan_record_id:
+            raise ValueError(
+                "Detached application retirement apply requires reviewed_plan_record_id."
+            )
+        _require_sha256(self.reviewed_plan_sha256, "reviewed_plan_sha256")
+        if self.confirmation != self.expected_confirmation:
+            raise ValueError(
+                "Detached application retirement apply requires exact target-bound confirmation."
+            )
+        return self
+
+    @property
+    def expected_confirmation(self) -> str:
+        return (
+            "retire detached Dokploy application "
+            f"{self.project_name}/{self.environment_name}/{self.application_name} "
+            f"target {self.candidate_target_sha256}"
+        )
+
+    def continuity_payload(self) -> dict[str, object]:
+        return {
+            "schema_version": self.schema_version,
+            "project_name": self.project_name,
+            "environment_name": self.environment_name,
+            "application_name": self.application_name,
+            "candidate_target_sha256": self.candidate_target_sha256,
+            "expected_protected_target_sha256": self.expected_protected_target_sha256,
+            "reason": self.reason,
+            "related_issue": self.related_issue,
+        }
+
+    @property
+    def continuity_sha256(self) -> str:
+        return canonical_sha256(self.continuity_payload())
+
+
+class DetachedApplicationRetirementIdentity(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    actor: str
+    identity_kind: str
+    subject: str = ""
+    repository: str = ""
+    workflow_ref: str = ""
+    environment: str = ""
+
+    @model_validator(mode="after")
+    def _validate_identity(self) -> "DetachedApplicationRetirementIdentity":
+        for field_name in (
+            "actor",
+            "identity_kind",
+            "subject",
+            "repository",
+            "workflow_ref",
+            "environment",
+        ):
+            setattr(self, field_name, str(getattr(self, field_name)).strip())
+        if not self.actor or not self.identity_kind:
+            raise ValueError("Detached application retirement identity is incomplete.")
+        return self
+
+
+class DetachedApplicationProviderObservation(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    observed_at: str
+    provider_id: Literal["dokploy"] = "dokploy"
+    target_type: Literal["application"] = "application"
+    project_id: str
+    project_name: str
+    environment_id: str
+    environment_name: str
+    application_id: str
+    application_name: str
+    target_id_sha256: str
+    state: Literal["present", "absent"]
+    application_state: str = ""
+    application_fingerprint_sha256: str = ""
+    domain_ids: tuple[str, ...] = ()
+    domain_id_sha256: tuple[str, ...] = ()
+    domain_host_sha256: tuple[str, ...] = ()
+    deployment_history_state: DeploymentHistoryState | Literal[""] = ""
+    latest_deployment_sha256: str = ""
+    safe_to_retire: bool = False
+
+    @model_validator(mode="after")
+    def _validate_observation(self) -> "DetachedApplicationProviderObservation":
+        for field_name in (
+            "observed_at",
+            "project_id",
+            "project_name",
+            "environment_id",
+            "environment_name",
+            "application_id",
+            "application_name",
+            "application_state",
+            "application_fingerprint_sha256",
+            "deployment_history_state",
+            "latest_deployment_sha256",
+        ):
+            setattr(self, field_name, str(getattr(self, field_name)).strip())
+        if not self.observed_at or not self.application_id:
+            raise ValueError("Detached application provider observation is incomplete.")
+        _require_sha256(self.target_id_sha256, "target_id_sha256")
+        if self.target_id_sha256 != provider_identifier_sha256(self.application_id):
+            raise ValueError("Detached application target digest does not match target id.")
+        if len(self.domain_ids) != len(self.domain_id_sha256):
+            raise ValueError("Detached application domain identifiers require matching digests.")
+        if tuple(provider_identifier_sha256(value) for value in self.domain_ids) != tuple(
+            self.domain_id_sha256
+        ):
+            raise ValueError("Detached application domain identifier digests do not match.")
+        for digest in (
+            self.application_fingerprint_sha256,
+            *self.domain_id_sha256,
+            *self.domain_host_sha256,
+        ):
+            if digest:
+                _require_sha256(digest, "provider observation digest")
+        if self.latest_deployment_sha256:
+            _require_sha256(self.latest_deployment_sha256, "latest_deployment_sha256")
+        if self.state == "present":
+            if not all(
+                (
+                    self.project_id,
+                    self.project_name,
+                    self.environment_id,
+                    self.environment_name,
+                    self.application_name,
+                    self.application_state,
+                    self.application_fingerprint_sha256,
+                    self.deployment_history_state,
+                )
+            ):
+                raise ValueError(
+                    "Present detached application observations require complete evidence."
+                )
+        elif self.safe_to_retire:
+            raise ValueError("Absent detached applications cannot be marked safe to retire.")
+        if self.safe_to_retire and not (
+            self.state == "present"
+            and self.application_state == "idle"
+            and self.deployment_history_state == "no_history"
+            and not self.latest_deployment_sha256
+            and not self.domain_ids
+        ):
+            raise ValueError("Detached application safe-to-retire evidence is inconsistent.")
+        return self
+
+
+class DetachedApplicationProtectedTargetSnapshot(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    application_id: str
+    target_id_sha256: str
+    application_name: str
+    application_fingerprint_sha256: str
+    domain_count: int = Field(ge=0)
+    domains_sha256: str
+    deployment_history_state: DeploymentHistoryState
+    deployment_history_sha256: str
+
+    @model_validator(mode="after")
+    def _validate_snapshot(self) -> "DetachedApplicationProtectedTargetSnapshot":
+        self.application_id = self.application_id.strip()
+        self.application_name = self.application_name.strip()
+        if not self.application_id or not self.application_name:
+            raise ValueError("Protected detached application snapshot is incomplete.")
+        if self.target_id_sha256 != provider_identifier_sha256(self.application_id):
+            raise ValueError("Protected detached application target digest does not match id.")
+        for digest in (
+            self.target_id_sha256,
+            self.application_fingerprint_sha256,
+            self.domains_sha256,
+            self.deployment_history_sha256,
+        ):
+            _require_sha256(digest, "protected target digest")
+        return self
+
+
+class DetachedApplicationAuthorityAbsenceSource(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    source: str
+    record_count: int = Field(ge=0)
+    records_sha256: str
+    match_count: Literal[0] = 0
+
+    @model_validator(mode="after")
+    def _validate_source(self) -> "DetachedApplicationAuthorityAbsenceSource":
+        self.source = self.source.strip()
+        if not self.source:
+            raise ValueError("Authority absence source requires a source name.")
+        _require_sha256(self.records_sha256, "authority source digest")
+        return self
+
+
+class DetachedApplicationAuthorityAbsenceProof(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    candidate_target_sha256: str
+    candidate_application_name_sha256: str
+    source_count: int = Field(ge=1)
+    record_count: int = Field(ge=0)
+    sources: tuple[DetachedApplicationAuthorityAbsenceSource, ...]
+    match_count: Literal[0] = 0
+    authority_write_count: Literal[0] = 0
+
+    @model_validator(mode="after")
+    def _validate_proof(self) -> "DetachedApplicationAuthorityAbsenceProof":
+        _require_sha256(self.candidate_target_sha256, "authority target digest")
+        _require_sha256(
+            self.candidate_application_name_sha256,
+            "authority application-name digest",
+        )
+        if not self.sources or self.source_count != len(self.sources):
+            raise ValueError("Authority absence proof requires every bounded source.")
+        if self.record_count != sum(source.record_count for source in self.sources):
+            raise ValueError("Authority absence proof record count is inconsistent.")
+        names = tuple(source.source for source in self.sources)
+        if names != tuple(sorted(set(names))):
+            raise ValueError("Authority absence proof sources must be unique and sorted.")
+        return self
+
+
+class DetachedApplicationRetirementMutationEvidence(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    provider_operation_key: str = ""
+    reconciliation_key: str = ""
+    provider_effect_phases: tuple[str, ...] = ()
+    provider_effect_attempted: bool = False
+    provider_effect_performed: bool = False
+    provider_absence_verified: bool = False
+    protected_targets_unchanged: bool = False
+    authority_write_count: Literal[0] = 0
+    error_code: str = ""
+    error_message: str = Field(
+        default="",
+        max_length=MAX_DETACHED_APPLICATION_RETIREMENT_ERROR_MESSAGE_LENGTH,
+    )
+
+
+class DetachedApplicationRetirementRecord(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: Literal[1] = 1
+    record_id: str
+    plan_record_id: str
+    mode: DetachedApplicationRetirementMode
+    outcome: DetachedApplicationRetirementOutcome
+    project_name: str
+    environment_name: str
+    application_name: str
+    identity: DetachedApplicationRetirementIdentity
+    reason: str
+    related_issue: str
+    idempotency_key: str
+    trace_id: str
+    requested_at: str
+    recorded_at: str
+    completed_at: str = ""
+    continuity_sha256: str
+    plan_sha256: str
+    reviewed_plan_record_id: str = ""
+    reviewed_plan_sha256: str = ""
+    candidate_observation: DetachedApplicationProviderObservation
+    authority_absence_proof: DetachedApplicationAuthorityAbsenceProof
+    protected_targets: tuple[DetachedApplicationProtectedTargetSnapshot, ...]
+    mutation_evidence: DetachedApplicationRetirementMutationEvidence = Field(
+        default_factory=DetachedApplicationRetirementMutationEvidence
+    )
+    authority_write_count: Literal[0] = 0
+
+    @model_validator(mode="after")
+    def _validate_record(self) -> "DetachedApplicationRetirementRecord":
+        for field_name in (
+            "record_id",
+            "plan_record_id",
+            "project_name",
+            "environment_name",
+            "application_name",
+            "reason",
+            "related_issue",
+            "idempotency_key",
+            "trace_id",
+            "requested_at",
+            "recorded_at",
+        ):
+            value = str(getattr(self, field_name)).strip()
+            setattr(self, field_name, value)
+            if not value:
+                raise ValueError(f"Detached application retirement record requires {field_name}.")
+        for digest in (self.continuity_sha256, self.plan_sha256):
+            _require_sha256(digest, "retirement record digest")
+        protected_digests = tuple(target.target_id_sha256 for target in self.protected_targets)
+        if not protected_digests or protected_digests != tuple(sorted(set(protected_digests))):
+            raise ValueError(
+                "Detached application protected snapshots must be non-empty, unique, and sorted."
+            )
+        if self.candidate_observation.target_id_sha256 in protected_digests:
+            raise ValueError("Detached application candidate cannot be protected.")
+        if self.mode == "plan":
+            if self.outcome != "planned" or self.record_id != self.plan_record_id:
+                raise ValueError("Detached application plans require one planned plan record.")
+            if self.reviewed_plan_record_id or self.reviewed_plan_sha256:
+                raise ValueError("Detached application plans reject reviewed-plan fields.")
+        else:
+            if self.outcome == "planned":
+                raise ValueError("Detached application apply records require terminal outcomes.")
+            if not self.completed_at.strip():
+                raise ValueError("Detached application apply records require completed_at.")
+            if self.reviewed_plan_record_id != self.plan_record_id:
+                raise ValueError("Detached application apply must bind its plan record.")
+            _require_sha256(self.reviewed_plan_sha256, "reviewed_plan_sha256")
+            if self.reviewed_plan_sha256 != self.plan_sha256:
+                raise ValueError("Detached application apply must bind its plan digest.")
+        return self
+
+
+def build_detached_application_retirement_record_id(*, trace_id: str, outcome: str) -> str:
+    normalized_trace_id = trace_id.strip()
+    normalized_outcome = outcome.strip()
+    if not normalized_trace_id or not normalized_outcome:
+        raise ValueError("Detached application retirement ids require trace and outcome.")
+    return f"detached-application-retirement-{normalized_trace_id}-{normalized_outcome}"
+
+
+def _require_sha256(value: str, field_name: str) -> None:
+    normalized = value.strip().lower()
+    if len(normalized) != 64 or any(
+        character not in "0123456789abcdef" for character in normalized
+    ):
+        raise ValueError(f"Detached application retirement {field_name} must be SHA-256.")

--- a/control_plane/detached_application_retirement.py
+++ b/control_plane/detached_application_retirement.py
@@ -187,6 +187,67 @@ class DetachedApplicationRetirementStore(Protocol):
 
     def list_product_profile_records(self, *, driver_id: str = "") -> tuple[object, ...]: ...
 
+    def list_product_retirement_records(
+        self,
+        *,
+        product: str = "",
+        actor: str = "",
+        mode: str = "",
+        idempotency_key: str = "",
+        limit: int | None = None,
+    ) -> tuple[object, ...]: ...
+
+    def list_odoo_stable_target_replacement_operation_records(
+        self,
+        *,
+        product: str = "",
+        context_name: str = "",
+        instance_name: str = "",
+        idempotency_key: str = "",
+        idempotency_scope: str = "",
+        statuses: tuple[str, ...] = (),
+        limit: int | None = None,
+    ) -> tuple[object, ...]: ...
+
+    def list_runtime_environment_delete_events(
+        self,
+        *,
+        scope: str = "",
+        context_name: str = "",
+        instance_name: str = "",
+    ) -> tuple[object, ...]: ...
+
+    def list_odoo_stable_bootstrap_operation_records(
+        self,
+        *,
+        product: str = "",
+        context_name: str = "",
+        instance_name: str = "",
+        idempotency_key: str = "",
+        statuses: tuple[str, ...] = (),
+        limit: int | None = None,
+    ) -> tuple[object, ...]: ...
+
+    def list_verireel_prod_backup_gate_operation_records(
+        self,
+        *,
+        product: str = "",
+        context_name: str = "",
+        instance_name: str = "",
+        backup_record_id: str = "",
+        statuses: tuple[str, ...] = (),
+        limit: int | None = None,
+    ) -> tuple[object, ...]: ...
+
+    def list_promotion_records(
+        self,
+        *,
+        context_name: str = "",
+        from_instance_name: str = "",
+        to_instance_name: str = "",
+        limit: int | None = None,
+    ) -> tuple[object, ...]: ...
+
 
 @dataclass(frozen=True)
 class _DiscoveredApplication:
@@ -231,7 +292,12 @@ _AUTHORITY_SOURCES: tuple[
     ("dokploy_target_id", lambda store: store.list_dokploy_target_id_records()),
     ("edge_endpoint", lambda store: store.list_edge_endpoint_records()),
     ("environment_inventory", lambda store: store.list_environment_inventory()),
+    (
+        "odoo_stable_bootstrap",
+        lambda store: store.list_odoo_stable_bootstrap_operation_records(),
+    ),
     ("product_profile", lambda store: store.list_product_profile_records()),
+    ("product_retirement", lambda store: store.list_product_retirement_records()),
     ("provider_target", lambda store: store.list_provider_target_records()),
     ("preview", lambda store: store.list_preview_records()),
     ("preview_desired_state", lambda store: store.list_preview_desired_state_records()),
@@ -240,10 +306,23 @@ _AUTHORITY_SOURCES: tuple[
     ("preview_inventory", lambda store: store.list_preview_inventory_scan_records()),
     ("preview_lifecycle_cleanup", lambda store: store.list_preview_lifecycle_cleanup_records()),
     ("preview_lifecycle_plan", lambda store: store.list_preview_lifecycle_plan_records()),
+    ("promotion", lambda store: store.list_promotion_records()),
     ("route_binding", lambda store: store.list_route_binding_records()),
     ("runtime_environment", lambda store: store.list_runtime_environment_records()),
+    (
+        "runtime_environment_delete",
+        lambda store: store.list_runtime_environment_delete_events(),
+    ),
+    (
+        "stable_target_replacement",
+        lambda store: store.list_odoo_stable_target_replacement_operation_records(),
+    ),
     ("secret", lambda store: store.list_secret_records()),
     ("secret_binding", lambda store: store.list_secret_bindings()),
+    (
+        "verireel_prod_backup_gate",
+        lambda store: store.list_verireel_prod_backup_gate_operation_records(),
+    ),
 )
 
 
@@ -563,7 +642,7 @@ class DokployDetachedApplicationRetirementAdapter:
         provider_effect_phase: str,
         reconciliation_key: str,
     ) -> ProviderObservation:
-        del provider_operation_key, provider_effect_phase, reconciliation_key
+        del reconciliation_key
         try:
             discovery, proof = self._rediscover()
         except (click.ClickException, OSError, TimeoutError, ValueError):
@@ -571,6 +650,21 @@ class DokployDetachedApplicationRetirementAdapter:
         if not self._protected_and_authority_unchanged(discovery=discovery, proof=proof):
             return ProviderObservation(outcome="unknown")
         if discovery.candidate.state == "absent":
+            if provider_effect_phase == "delete_application":
+                self._phases = [provider_effect_phase]
+                self._provider_effect_attempted = True
+                self._provider_effect_performed = True
+                terminal = self._write_terminal_record(
+                    outcome="retired",
+                    provider_operation_key=provider_operation_key,
+                    provider_absence_verified=True,
+                    protected_targets_unchanged=True,
+                )
+                return ProviderObservation(
+                    outcome="present",
+                    response_status_code=202,
+                    response_payload=redacted_detached_application_retirement_response(terminal),
+                )
             return ProviderObservation(outcome="absent", retry_safe=True)
         if _same_candidate_evidence(
             planned=self._plan.candidate_observation,
@@ -716,7 +810,10 @@ class DokployDetachedApplicationRetirementAdapter:
     ) -> bool:
         return (
             discovery.protected_targets == self._plan.protected_targets
-            and proof == self._plan.authority_absence_proof
+            and _authority_absence_proof_allows_reconciliation(
+                planned=self._plan.authority_absence_proof,
+                current=proof,
+            )
         )
 
     def _checkpoint(self, lease: ProviderOperationLease, phase: str) -> None:
@@ -1177,7 +1274,7 @@ def _payload_references_candidate(
     if not isinstance(payload, str):
         return False
     normalized_value = payload.strip()
-    if normalized_value == candidate_target_id:
+    if candidate_target_id in normalized_value:
         return True
     normalized_key = re.sub(r"[^a-z0-9]+", "_", key.strip().lower()).strip("_")
     return (
@@ -1194,6 +1291,20 @@ def _same_candidate_evidence(
     if current.state != "present" or not current.safe_to_retire:
         return False
     return planned.model_copy(update={"observed_at": current.observed_at}) == current
+
+
+def _authority_absence_proof_allows_reconciliation(
+    *,
+    planned: DetachedApplicationAuthorityAbsenceProof,
+    current: DetachedApplicationAuthorityAbsenceProof,
+) -> bool:
+    return (
+        current.match_count == 0
+        and current.candidate_target_sha256 == planned.candidate_target_sha256
+        and current.candidate_application_name_sha256 == planned.candidate_application_name_sha256
+        and tuple(source.source for source in current.sources)
+        == tuple(source.source for source in planned.sources)
+    )
 
 
 def _required_identifier(
@@ -1266,3 +1377,14 @@ def _redacted_error_message(value: str) -> str:
     if not normalized:
         return ""
     return normalized[:MAX_DETACHED_APPLICATION_RETIREMENT_ERROR_MESSAGE_LENGTH]
+
+
+def redacted_detached_application_retirement_error(error: BaseException) -> str:
+    if isinstance(error, dokploy_api.DokployRequestFailed):
+        status = f" ({error.status_code})" if error.status_code is not None else ""
+        return _redacted_error_message(
+            f"Dokploy API {error.method.strip().upper()} request failed{status}."
+        )
+    if isinstance(error, DetachedApplicationRetirementBlockedError):
+        return _redacted_error_message(str(error))
+    return "Detached application retirement provider request failed."

--- a/control_plane/detached_application_retirement.py
+++ b/control_plane/detached_application_retirement.py
@@ -1,0 +1,1268 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+import re
+from typing import Literal, Protocol, cast
+
+import click
+from pydantic import BaseModel
+
+from control_plane.contracts.detached_application_retirement import (
+    MAX_DETACHED_APPLICATION_RETIREMENT_ERROR_MESSAGE_LENGTH,
+    DetachedApplicationAuthorityAbsenceProof,
+    DetachedApplicationAuthorityAbsenceSource,
+    DetachedApplicationProtectedTargetSnapshot,
+    DetachedApplicationProviderObservation,
+    DetachedApplicationRetirementIdentity,
+    DetachedApplicationRetirementMutationEvidence,
+    DetachedApplicationRetirementRecord,
+    DetachedApplicationRetirementRequest,
+    build_detached_application_retirement_record_id,
+)
+from control_plane.contracts.product_retirement import canonical_sha256, provider_identifier_sha256
+from control_plane.dokploy import api as dokploy_api
+from control_plane.dokploy import source as dokploy_source
+from control_plane.provider_operations import (
+    ProviderMutationOutcome,
+    ProviderMutationRejectedError,
+    ProviderMutationUnknownError,
+    ProviderObservation,
+    ProviderOperationLease,
+    build_provider_operation_key,
+)
+
+
+class DetachedApplicationRetirementBlockedError(ValueError):
+    pass
+
+
+class DetachedApplicationRetirementStore(Protocol):
+    def write_detached_application_retirement_record(
+        self, record: DetachedApplicationRetirementRecord
+    ) -> object: ...
+
+    def read_detached_application_retirement_record(
+        self, record_id: str
+    ) -> DetachedApplicationRetirementRecord: ...
+
+    def list_detached_application_retirement_records(
+        self,
+        *,
+        candidate_target_sha256: str = "",
+        actor: str = "",
+        mode: str = "",
+        idempotency_key: str = "",
+        limit: int | None = None,
+    ) -> tuple[DetachedApplicationRetirementRecord, ...]: ...
+
+    def list_provider_target_records(self, *, provider_id: str = "") -> tuple[object, ...]: ...
+
+    def list_dokploy_target_records(self) -> tuple[object, ...]: ...
+
+    def list_dokploy_target_id_records(self) -> tuple[object, ...]: ...
+
+    def list_runtime_environment_records(
+        self,
+        *,
+        scope: str = "",
+        context_name: str = "",
+        instance_name: str = "",
+    ) -> tuple[object, ...]: ...
+
+    def list_preview_records(
+        self,
+        *,
+        context_name: str = "",
+        anchor_repo: str = "",
+        anchor_pr_number: int | None = None,
+        limit: int | None = None,
+    ) -> tuple[object, ...]: ...
+
+    def list_preview_enablement_records(
+        self,
+        *,
+        product: str = "",
+        context_name: str = "",
+        repository: str = "",
+        status: str = "",
+        limit: int | None = None,
+    ) -> tuple[object, ...]: ...
+
+    def list_preview_generation_records(
+        self,
+        *,
+        product: str = "",
+        context_name: str = "",
+        repository: str = "",
+        pull_request_number: int | None = None,
+        limit: int | None = None,
+    ) -> tuple[object, ...]: ...
+
+    def list_preview_inventory_scan_records(
+        self,
+        *,
+        context_name: str = "",
+        status: str = "",
+        limit: int | None = None,
+    ) -> tuple[object, ...]: ...
+
+    def list_preview_desired_state_records(
+        self,
+        *,
+        product: str = "",
+        context_name: str = "",
+        repository: str = "",
+        pull_request_number: int | None = None,
+        limit: int | None = None,
+    ) -> tuple[object, ...]: ...
+
+    def list_preview_lifecycle_plan_records(
+        self,
+        *,
+        product: str = "",
+        context_name: str = "",
+        repository: str = "",
+        pull_request_number: int | None = None,
+        limit: int | None = None,
+    ) -> tuple[object, ...]: ...
+
+    def list_preview_lifecycle_cleanup_records(
+        self,
+        *,
+        product: str = "",
+        context_name: str = "",
+        repository: str = "",
+        pull_request_number: int | None = None,
+        limit: int | None = None,
+    ) -> tuple[object, ...]: ...
+
+    def list_deployment_records(
+        self,
+        *,
+        context_name: str = "",
+        instance_name: str = "",
+        limit: int | None = None,
+    ) -> tuple[object, ...]: ...
+
+    def list_environment_inventory(self) -> tuple[object, ...]: ...
+
+    def list_route_binding_records(
+        self,
+        *,
+        product: str = "",
+        context_name: str = "",
+        instance_name: str = "",
+        status: str = "",
+        limit: int | None = None,
+    ) -> tuple[object, ...]: ...
+
+    def list_edge_endpoint_records(
+        self,
+        *,
+        product: str = "",
+        context_name: str = "",
+        instance_name: str = "",
+        limit: int | None = None,
+    ) -> tuple[object, ...]: ...
+
+    def list_secret_records(
+        self,
+        *,
+        integration: str = "",
+        context_name: str = "",
+        instance_name: str = "",
+        limit: int | None = None,
+    ) -> tuple[object, ...]: ...
+
+    def list_secret_bindings(
+        self,
+        *,
+        integration: str = "",
+        context_name: str = "",
+        instance_name: str = "",
+        limit: int | None = None,
+    ) -> tuple[object, ...]: ...
+
+    def list_product_profile_records(self, *, driver_id: str = "") -> tuple[object, ...]: ...
+
+
+@dataclass(frozen=True)
+class _DiscoveredApplication:
+    project_id: str
+    project_name: str
+    environment_id: str
+    environment_name: str
+    application_id: str
+    application_name: str
+
+
+@dataclass(frozen=True)
+class DetachedApplicationDiscovery:
+    candidate: DetachedApplicationProviderObservation
+    protected_targets: tuple[DetachedApplicationProtectedTargetSnapshot, ...]
+
+
+@dataclass(frozen=True)
+class _ParsedProjects:
+    projects: tuple[tuple[str, str], ...]
+    environments: tuple[tuple[str, str, str, str], ...]
+    applications: tuple[_DiscoveredApplication, ...]
+
+
+_AUTHORITATIVE_PROVIDER_NAME_KEYS = frozenset(
+    {
+        "application",
+        "application_name",
+        "app_name",
+        "display_name",
+        "dokploy_application",
+        "dokploy_application_name",
+        "provider_application",
+        "provider_application_name",
+    }
+)
+_AUTHORITY_SOURCES: tuple[
+    tuple[str, Callable[[DetachedApplicationRetirementStore], tuple[object, ...]]], ...
+] = (
+    ("deployment", lambda store: store.list_deployment_records()),
+    ("dokploy_target", lambda store: store.list_dokploy_target_records()),
+    ("dokploy_target_id", lambda store: store.list_dokploy_target_id_records()),
+    ("edge_endpoint", lambda store: store.list_edge_endpoint_records()),
+    ("environment_inventory", lambda store: store.list_environment_inventory()),
+    ("product_profile", lambda store: store.list_product_profile_records()),
+    ("provider_target", lambda store: store.list_provider_target_records()),
+    ("preview", lambda store: store.list_preview_records()),
+    ("preview_desired_state", lambda store: store.list_preview_desired_state_records()),
+    ("preview_enablement", lambda store: store.list_preview_enablement_records()),
+    ("preview_generation", lambda store: store.list_preview_generation_records()),
+    ("preview_inventory", lambda store: store.list_preview_inventory_scan_records()),
+    ("preview_lifecycle_cleanup", lambda store: store.list_preview_lifecycle_cleanup_records()),
+    ("preview_lifecycle_plan", lambda store: store.list_preview_lifecycle_plan_records()),
+    ("route_binding", lambda store: store.list_route_binding_records()),
+    ("runtime_environment", lambda store: store.list_runtime_environment_records()),
+    ("secret", lambda store: store.list_secret_records()),
+    ("secret_binding", lambda store: store.list_secret_bindings()),
+)
+
+
+def discover_detached_application(
+    *,
+    control_plane_root: Path,
+    request: DetachedApplicationRetirementRequest,
+    observed_at: str,
+    absent_application_id: str = "",
+) -> DetachedApplicationDiscovery:
+    host, token = dokploy_source.read_dokploy_config(control_plane_root=control_plane_root)
+    projects = dokploy_api.fetch_dokploy_projects(host=host, token=token)
+    parsed = _parse_projects(projects)
+    applications = parsed.applications
+    matching_projects = {
+        project_id
+        for project_id, project_name in parsed.projects
+        if project_name == request.project_name
+    }
+    if len(matching_projects) != 1:
+        raise DetachedApplicationRetirementBlockedError(
+            "Detached application retirement requires exactly one project name match."
+        )
+    matching_environments = {
+        environment_id
+        for project_id, project_name, environment_id, environment_name in parsed.environments
+        if project_id in matching_projects
+        and project_name == request.project_name
+        and environment_name == request.environment_name
+    }
+    if len(matching_environments) != 1:
+        raise DetachedApplicationRetirementBlockedError(
+            "Detached application retirement requires exactly one environment name match."
+        )
+    global_name_matches = tuple(
+        application
+        for application in applications
+        if application.application_name == request.application_name
+    )
+    if len(global_name_matches) > 1:
+        raise DetachedApplicationRetirementBlockedError(
+            "Detached application retirement requires a globally unique application name."
+        )
+    exact_matches = tuple(
+        application
+        for application in global_name_matches
+        if application.project_name == request.project_name
+        and application.environment_name == request.environment_name
+    )
+    if len(exact_matches) == 1:
+        candidate_reference = exact_matches[0]
+        if (
+            absent_application_id.strip()
+            and candidate_reference.application_id != absent_application_id.strip()
+        ):
+            raise DetachedApplicationRetirementBlockedError(
+                "Detached application name now resolves to a different provider target."
+            )
+        candidate = _observe_present_application(
+            host=host,
+            token=token,
+            reference=candidate_reference,
+            observed_at=observed_at,
+            candidate=True,
+        )
+        if candidate.target_id_sha256 != request.candidate_target_sha256:
+            raise DetachedApplicationRetirementBlockedError(
+                "Detached application candidate digest does not match provider discovery."
+            )
+        protected_references = tuple(
+            application
+            for application in applications
+            if application.project_id == candidate_reference.project_id
+            and application.application_id != candidate_reference.application_id
+        )
+    elif global_name_matches:
+        raise DetachedApplicationRetirementBlockedError(
+            "Detached application name moved outside the reviewed project environment."
+        )
+    else:
+        normalized_absent_id = absent_application_id.strip()
+        if not normalized_absent_id:
+            raise DetachedApplicationRetirementBlockedError(
+                "Detached application retirement candidate is absent during planning."
+            )
+        if provider_identifier_sha256(normalized_absent_id) != request.candidate_target_sha256:
+            raise DetachedApplicationRetirementBlockedError(
+                "Stored detached application identifier does not match reviewed digest."
+            )
+        try:
+            dokploy_api.fetch_dokploy_target_payload(
+                host=host,
+                token=token,
+                target_type="application",
+                target_id=normalized_absent_id,
+            )
+        except dokploy_api.DokployRequestFailed as error:
+            if error.status_code != 404:
+                raise
+        else:
+            raise DetachedApplicationRetirementBlockedError(
+                "Detached application name disappeared but its reviewed target still exists."
+            )
+        project_id = next(iter(matching_projects))
+        environment_id = next(iter(matching_environments))
+        candidate = DetachedApplicationProviderObservation(
+            observed_at=observed_at,
+            project_id=project_id,
+            project_name=request.project_name,
+            environment_id=environment_id,
+            environment_name=request.environment_name,
+            application_id=normalized_absent_id,
+            application_name=request.application_name,
+            target_id_sha256=request.candidate_target_sha256,
+            state="absent",
+        )
+        protected_references = tuple(
+            application for application in applications if application.project_id == project_id
+        )
+    protected_target_sha256 = tuple(
+        sorted(provider_identifier_sha256(item.application_id) for item in protected_references)
+    )
+    if protected_target_sha256 != request.expected_protected_target_sha256:
+        raise DetachedApplicationRetirementBlockedError(
+            "Detached application protected target set changed or is incomplete."
+        )
+    protected_targets = tuple(
+        sorted(
+            (
+                _observe_protected_application(host=host, token=token, reference=reference)
+                for reference in protected_references
+            ),
+            key=lambda target: target.target_id_sha256,
+        )
+    )
+    return DetachedApplicationDiscovery(candidate=candidate, protected_targets=protected_targets)
+
+
+def prove_detached_application_authority_absence(
+    *,
+    record_store: DetachedApplicationRetirementStore,
+    candidate_target_id: str,
+    candidate_application_name: str,
+) -> DetachedApplicationAuthorityAbsenceProof:
+    normalized_target_id = candidate_target_id.strip()
+    normalized_application_name = candidate_application_name.strip()
+    if not normalized_target_id or not normalized_application_name:
+        raise ValueError("Detached application authority proof requires candidate identity.")
+    sources: list[DetachedApplicationAuthorityAbsenceSource] = []
+    total_record_count = 0
+    for source_name, loader in _AUTHORITY_SOURCES:
+        records = loader(record_store)
+        payloads = tuple(
+            sorted(
+                (_record_payload(record) for record in records),
+                key=canonical_sha256,
+            )
+        )
+        for payload in payloads:
+            if _payload_references_candidate(
+                payload,
+                candidate_target_id=normalized_target_id,
+                candidate_application_name=normalized_application_name,
+            ):
+                raise DetachedApplicationRetirementBlockedError(
+                    f"Detached application remains referenced by Launchplane {source_name} authority."
+                )
+        total_record_count += len(payloads)
+        sources.append(
+            DetachedApplicationAuthorityAbsenceSource(
+                source=source_name,
+                record_count=len(payloads),
+                records_sha256=canonical_sha256(payloads),
+            )
+        )
+    return DetachedApplicationAuthorityAbsenceProof(
+        candidate_target_sha256=provider_identifier_sha256(normalized_target_id),
+        candidate_application_name_sha256=provider_identifier_sha256(normalized_application_name),
+        source_count=len(sources),
+        record_count=total_record_count,
+        sources=tuple(sorted(sources, key=lambda source: source.source)),
+    )
+
+
+def build_detached_application_retirement_plan_record(
+    *,
+    request: DetachedApplicationRetirementRequest,
+    identity: DetachedApplicationRetirementIdentity,
+    trace_id: str,
+    idempotency_key: str,
+    requested_at: str,
+    discovery: DetachedApplicationDiscovery,
+    authority_absence_proof: DetachedApplicationAuthorityAbsenceProof,
+) -> DetachedApplicationRetirementRecord:
+    if request.mode != "plan":
+        raise ValueError("Detached application retirement plan requires plan mode.")
+    if not discovery.candidate.safe_to_retire:
+        raise DetachedApplicationRetirementBlockedError(
+            "Detached application retirement requires idle, domainless, no-history evidence."
+        )
+    if authority_absence_proof.candidate_target_sha256 != request.candidate_target_sha256:
+        raise DetachedApplicationRetirementBlockedError(
+            "Detached application authority proof does not bind the candidate."
+        )
+    plan_payload = {
+        "continuity_sha256": request.continuity_sha256,
+        "candidate_observation": discovery.candidate.model_dump(mode="json"),
+        "authority_absence_proof": authority_absence_proof.model_dump(mode="json"),
+        "protected_targets": tuple(
+            target.model_dump(mode="json") for target in discovery.protected_targets
+        ),
+    }
+    record_id = (
+        "detached-application-retirement-plan-"
+        + canonical_sha256(
+            {
+                "candidate_target_sha256": request.candidate_target_sha256,
+                "actor": identity.actor,
+                "idempotency_key": idempotency_key,
+            }
+        )[:32]
+    )
+    return DetachedApplicationRetirementRecord(
+        record_id=record_id,
+        plan_record_id=record_id,
+        mode="plan",
+        outcome="planned",
+        project_name=request.project_name,
+        environment_name=request.environment_name,
+        application_name=request.application_name,
+        identity=identity,
+        reason=request.reason,
+        related_issue=request.related_issue,
+        idempotency_key=idempotency_key,
+        trace_id=trace_id,
+        requested_at=requested_at,
+        recorded_at=requested_at,
+        continuity_sha256=request.continuity_sha256,
+        plan_sha256=canonical_sha256(plan_payload),
+        candidate_observation=discovery.candidate,
+        authority_absence_proof=authority_absence_proof,
+        protected_targets=discovery.protected_targets,
+    )
+
+
+def validate_reviewed_detached_application_retirement_plan(
+    *,
+    request: DetachedApplicationRetirementRequest,
+    plan: DetachedApplicationRetirementRecord,
+) -> None:
+    if plan.mode != "plan" or plan.outcome != "planned":
+        raise DetachedApplicationRetirementBlockedError(
+            "Reviewed detached application retirement record is not a plan."
+        )
+    if request.reviewed_plan_record_id != plan.record_id:
+        raise DetachedApplicationRetirementBlockedError(
+            "Reviewed detached application retirement plan id changed."
+        )
+    if request.reviewed_plan_sha256 != plan.plan_sha256:
+        raise DetachedApplicationRetirementBlockedError(
+            "Reviewed detached application retirement plan digest changed."
+        )
+    if request.continuity_sha256 != plan.continuity_sha256:
+        raise DetachedApplicationRetirementBlockedError(
+            "Detached application retirement apply does not match reviewed intent."
+        )
+
+
+class DokployDetachedApplicationRetirementAdapter:
+    def __init__(
+        self,
+        *,
+        control_plane_root: Path,
+        record_store: DetachedApplicationRetirementStore,
+        request: DetachedApplicationRetirementRequest,
+        plan: DetachedApplicationRetirementRecord,
+        identity: DetachedApplicationRetirementIdentity,
+        trace_id: str,
+        idempotency_key: str,
+        requested_at: str,
+    ) -> None:
+        self._control_plane_root = control_plane_root
+        self._record_store = record_store
+        self._request = request
+        self._plan = plan
+        self._identity = identity
+        self._trace_id = trace_id
+        self._idempotency_key = idempotency_key
+        self._requested_at = requested_at
+        self._phases: list[str] = []
+        self._provider_effect_attempted = False
+        self._provider_effect_performed = False
+        self._started = False
+        self._latest_discovery: DetachedApplicationDiscovery | None = None
+        self._latest_absence_proof: DetachedApplicationAuthorityAbsenceProof | None = None
+
+    def target_key(self) -> str:
+        return (
+            f"provider-target:dokploy:application:{self._plan.candidate_observation.application_id}"
+        )
+
+    def reconciliation_key(self) -> str:
+        return f"detached-application-retirement:{self._plan.plan_sha256}"
+
+    def provider_operation_key(self, *, scope: str, route_path: str, fingerprint: str) -> str:
+        return build_provider_operation_key(
+            scope=scope,
+            route_path=route_path,
+            idempotency_key=self._idempotency_key,
+            request_fingerprint=fingerprint,
+            reconciliation_key=self.reconciliation_key(),
+        )
+
+    def observe(
+        self,
+        provider_operation_key: str,
+        provider_effect_phase: str,
+        reconciliation_key: str,
+    ) -> ProviderObservation:
+        del provider_operation_key, provider_effect_phase, reconciliation_key
+        try:
+            discovery, proof = self._rediscover()
+        except (click.ClickException, OSError, TimeoutError, ValueError):
+            return ProviderObservation(outcome="unknown")
+        if not self._protected_and_authority_unchanged(discovery=discovery, proof=proof):
+            return ProviderObservation(outcome="unknown")
+        if discovery.candidate.state == "absent":
+            return ProviderObservation(outcome="absent", retry_safe=True)
+        if _same_candidate_evidence(
+            planned=self._plan.candidate_observation,
+            current=discovery.candidate,
+        ):
+            return ProviderObservation(outcome="absent", retry_safe=True)
+        return ProviderObservation(outcome="unknown")
+
+    def apply(
+        self, provider_operation_key: str, lease: ProviderOperationLease
+    ) -> ProviderMutationOutcome:
+        self._started = True
+        try:
+            discovery, proof = self._rediscover()
+            if not self._protected_and_authority_unchanged(discovery=discovery, proof=proof):
+                raise DetachedApplicationRetirementBlockedError(
+                    "Detached application retirement evidence changed after planning."
+                )
+            if discovery.candidate.state == "present" and not _same_candidate_evidence(
+                planned=self._plan.candidate_observation,
+                current=discovery.candidate,
+            ):
+                raise DetachedApplicationRetirementBlockedError(
+                    "Detached application provider evidence changed after planning."
+                )
+        except (
+            click.ClickException,
+            FileNotFoundError,
+            OSError,
+            TimeoutError,
+            ValueError,
+        ) as error:
+            raise ProviderMutationRejectedError(error) from error
+        if discovery.candidate.state == "absent":
+            terminal = self._write_terminal_record(
+                outcome="already_absent",
+                provider_operation_key=provider_operation_key,
+                provider_absence_verified=True,
+                protected_targets_unchanged=True,
+            )
+            return ProviderMutationOutcome(
+                response_status_code=202,
+                response_payload=redacted_detached_application_retirement_response(terminal),
+                provider_effect_performed=False,
+            )
+        self._checkpoint(lease, "delete_application")
+        self._provider_effect_attempted = True
+        try:
+            host, token = dokploy_source.read_dokploy_config(
+                control_plane_root=self._control_plane_root
+            )
+            dokploy_api.delete_dokploy_application(
+                host=host,
+                token=token,
+                application_id=discovery.candidate.application_id,
+            )
+            self._provider_effect_performed = True
+        except dokploy_api.DokployRequestFailed as error:
+            if error.status_code != 404:
+                raise self._unknown_provider_error() from error
+        except (
+            click.ClickException,
+            FileNotFoundError,
+            OSError,
+            TimeoutError,
+            ValueError,
+        ) as error:
+            raise self._unknown_provider_error() from error
+        lease.assert_current()
+        try:
+            after_discovery, after_proof = self._rediscover()
+        except (
+            click.ClickException,
+            FileNotFoundError,
+            OSError,
+            TimeoutError,
+            ValueError,
+        ) as error:
+            raise self._unknown_provider_error() from error
+        if after_discovery.candidate.state != "absent":
+            raise self._unknown_provider_error()
+        if not self._protected_and_authority_unchanged(
+            discovery=after_discovery,
+            proof=after_proof,
+        ):
+            raise self._unknown_provider_error()
+        terminal = self._write_terminal_record(
+            outcome="retired",
+            provider_operation_key=provider_operation_key,
+            provider_absence_verified=True,
+            protected_targets_unchanged=True,
+        )
+        return ProviderMutationOutcome(
+            response_status_code=202,
+            response_payload=redacted_detached_application_retirement_response(terminal),
+            provider_effect_performed=self._provider_effect_performed,
+        )
+
+    def terminal_record(
+        self,
+        *,
+        outcome: Literal["reconcile_required", "failed"],
+        provider_operation_key: str,
+        error_code: str,
+        error_message: str,
+    ) -> DetachedApplicationRetirementRecord:
+        return self._build_terminal_record(
+            outcome=outcome,
+            provider_operation_key=provider_operation_key,
+            provider_absence_verified=False,
+            protected_targets_unchanged=False,
+            error_code=error_code,
+            error_message=_redacted_error_message(error_message),
+        )
+
+    @property
+    def started(self) -> bool:
+        return self._started
+
+    def _rediscover(
+        self,
+    ) -> tuple[DetachedApplicationDiscovery, DetachedApplicationAuthorityAbsenceProof]:
+        discovery = discover_detached_application(
+            control_plane_root=self._control_plane_root,
+            request=self._request,
+            observed_at=self._requested_at,
+            absent_application_id=self._plan.candidate_observation.application_id,
+        )
+        proof = prove_detached_application_authority_absence(
+            record_store=self._record_store,
+            candidate_target_id=self._plan.candidate_observation.application_id,
+            candidate_application_name=self._plan.application_name,
+        )
+        self._latest_discovery = discovery
+        self._latest_absence_proof = proof
+        return discovery, proof
+
+    def _protected_and_authority_unchanged(
+        self,
+        *,
+        discovery: DetachedApplicationDiscovery,
+        proof: DetachedApplicationAuthorityAbsenceProof,
+    ) -> bool:
+        return (
+            discovery.protected_targets == self._plan.protected_targets
+            and proof == self._plan.authority_absence_proof
+        )
+
+    def _checkpoint(self, lease: ProviderOperationLease, phase: str) -> None:
+        lease.checkpoint_effect(phase)
+        self._phases.append(phase)
+
+    def _unknown_provider_error(self) -> ProviderMutationUnknownError:
+        return ProviderMutationUnknownError(
+            "Dokploy application deletion outcome requires reconciliation."
+        )
+
+    def _write_terminal_record(
+        self,
+        *,
+        outcome: Literal["retired", "already_absent"],
+        provider_operation_key: str,
+        provider_absence_verified: bool,
+        protected_targets_unchanged: bool,
+    ) -> DetachedApplicationRetirementRecord:
+        record = self._build_terminal_record(
+            outcome=outcome,
+            provider_operation_key=provider_operation_key,
+            provider_absence_verified=provider_absence_verified,
+            protected_targets_unchanged=protected_targets_unchanged,
+        )
+        self._record_store.write_detached_application_retirement_record(record)
+        return record
+
+    def _build_terminal_record(
+        self,
+        *,
+        outcome: Literal[
+            "retired",
+            "already_absent",
+            "reconcile_required",
+            "failed",
+        ],
+        provider_operation_key: str,
+        provider_absence_verified: bool,
+        protected_targets_unchanged: bool,
+        error_code: str = "",
+        error_message: str = "",
+    ) -> DetachedApplicationRetirementRecord:
+        discovery = self._latest_discovery
+        proof = self._latest_absence_proof
+        return DetachedApplicationRetirementRecord(
+            record_id=build_detached_application_retirement_record_id(
+                trace_id=self._trace_id,
+                outcome=outcome,
+            ),
+            plan_record_id=self._plan.record_id,
+            mode="apply",
+            outcome=outcome,
+            project_name=self._plan.project_name,
+            environment_name=self._plan.environment_name,
+            application_name=self._plan.application_name,
+            identity=self._identity,
+            reason=self._request.reason,
+            related_issue=self._request.related_issue,
+            idempotency_key=self._idempotency_key,
+            trace_id=self._trace_id,
+            requested_at=self._requested_at,
+            recorded_at=self._requested_at,
+            completed_at=self._requested_at,
+            continuity_sha256=self._plan.continuity_sha256,
+            plan_sha256=self._plan.plan_sha256,
+            reviewed_plan_record_id=self._plan.record_id,
+            reviewed_plan_sha256=self._plan.plan_sha256,
+            candidate_observation=(
+                discovery.candidate if discovery is not None else self._plan.candidate_observation
+            ),
+            authority_absence_proof=(
+                proof if proof is not None else self._plan.authority_absence_proof
+            ),
+            protected_targets=(
+                discovery.protected_targets
+                if discovery is not None
+                else self._plan.protected_targets
+            ),
+            mutation_evidence=DetachedApplicationRetirementMutationEvidence(
+                provider_operation_key=provider_operation_key,
+                reconciliation_key=self.reconciliation_key(),
+                provider_effect_phases=tuple(self._phases),
+                provider_effect_attempted=self._provider_effect_attempted,
+                provider_effect_performed=self._provider_effect_performed,
+                provider_absence_verified=provider_absence_verified,
+                protected_targets_unchanged=protected_targets_unchanged,
+                error_code=error_code.strip(),
+                error_message=_redacted_error_message(error_message),
+            ),
+        )
+
+
+def redacted_detached_application_retirement_response(
+    record: DetachedApplicationRetirementRecord,
+) -> dict[str, object]:
+    mutation = record.mutation_evidence
+    return {
+        "trace_id": record.trace_id,
+        "records": {
+            "detached_application_retirement_plan_id": record.plan_record_id,
+            "detached_application_retirement_record_id": record.record_id,
+        },
+        "result": {
+            "mode": record.mode,
+            "outcome": record.outcome,
+            "plan_sha256": record.plan_sha256,
+            "continuity_sha256": record.continuity_sha256,
+            "candidate_target_sha256": record.candidate_observation.target_id_sha256,
+            "protected_target_sha256": tuple(
+                target.target_id_sha256 for target in record.protected_targets
+            ),
+            "protected_target_count": len(record.protected_targets),
+            "authority_source_count": record.authority_absence_proof.source_count,
+            "authority_record_count": record.authority_absence_proof.record_count,
+            "authority_source_digests": tuple(
+                {
+                    "source": source.source,
+                    "count": source.record_count,
+                    "sha256": source.records_sha256,
+                }
+                for source in record.authority_absence_proof.sources
+            ),
+            "authority_write_count": record.authority_write_count,
+            "provider_operation_sha256": (
+                provider_identifier_sha256(mutation.provider_operation_key)
+                if mutation.provider_operation_key
+                else ""
+            ),
+            "provider_effect_phases": mutation.provider_effect_phases,
+            "provider_effect_attempted": mutation.provider_effect_attempted,
+            "provider_effect_performed": mutation.provider_effect_performed,
+            "provider_absence_verified": mutation.provider_absence_verified,
+            "protected_targets_unchanged": mutation.protected_targets_unchanged,
+            "error_code": mutation.error_code,
+            "error_message": mutation.error_message,
+        },
+    }
+
+
+def _parse_projects(projects: Sequence[Mapping[str, object]]) -> _ParsedProjects:
+    applications: list[_DiscoveredApplication] = []
+    parsed_projects: list[tuple[str, str]] = []
+    parsed_environments: list[tuple[str, str, str, str]] = []
+    project_keys: set[tuple[str, str]] = set()
+    environment_keys: set[tuple[str, str, str]] = set()
+    application_ids: set[str] = set()
+    for project in projects:
+        project_id = _required_identifier(project, "projectId", "id", label="project id")
+        project_name = _required_string(project, "name", label="project name")
+        project_key = (project_id, project_name)
+        if project_key in project_keys:
+            raise DetachedApplicationRetirementBlockedError(
+                "Dokploy project.all contains duplicate project evidence."
+            )
+        project_keys.add(project_key)
+        parsed_projects.append(project_key)
+        raw_environments = project.get("environments")
+        if not isinstance(raw_environments, list):
+            raise DetachedApplicationRetirementBlockedError(
+                "Dokploy project.all project environments are malformed."
+            )
+        for raw_environment in raw_environments:
+            if not isinstance(raw_environment, Mapping):
+                raise DetachedApplicationRetirementBlockedError(
+                    "Dokploy project.all contains a malformed environment."
+                )
+            environment = cast(Mapping[str, object], raw_environment)
+            environment_id = _required_identifier(
+                environment,
+                "environmentId",
+                "id",
+                label="environment id",
+            )
+            environment_name = _required_string(
+                environment,
+                "name",
+                label="environment name",
+            )
+            environment_key = (project_id, environment_id, environment_name)
+            if environment_key in environment_keys:
+                raise DetachedApplicationRetirementBlockedError(
+                    "Dokploy project.all contains duplicate environment evidence."
+                )
+            environment_keys.add(environment_key)
+            parsed_environments.append((project_id, project_name, environment_id, environment_name))
+            raw_applications = environment.get("applications")
+            if not isinstance(raw_applications, list):
+                raise DetachedApplicationRetirementBlockedError(
+                    "Dokploy project.all environment applications are malformed."
+                )
+            for raw_application in raw_applications:
+                if not isinstance(raw_application, Mapping):
+                    raise DetachedApplicationRetirementBlockedError(
+                        "Dokploy project.all contains a malformed application."
+                    )
+                application = cast(Mapping[str, object], raw_application)
+                application_id = _required_identifier(
+                    application,
+                    "applicationId",
+                    "id",
+                    label="application id",
+                )
+                application_name = _required_application_name(application)
+                if application_id in application_ids:
+                    raise DetachedApplicationRetirementBlockedError(
+                        "Dokploy project.all contains duplicate application identifiers."
+                    )
+                application_ids.add(application_id)
+                nested_environment_id = _optional_string(application, "environmentId")
+                if nested_environment_id and nested_environment_id != environment_id:
+                    raise DetachedApplicationRetirementBlockedError(
+                        "Dokploy application environment evidence is inconsistent."
+                    )
+                nested_project_id = _optional_string(application, "projectId")
+                if nested_project_id and nested_project_id != project_id:
+                    raise DetachedApplicationRetirementBlockedError(
+                        "Dokploy application project evidence is inconsistent."
+                    )
+                applications.append(
+                    _DiscoveredApplication(
+                        project_id=project_id,
+                        project_name=project_name,
+                        environment_id=environment_id,
+                        environment_name=environment_name,
+                        application_id=application_id,
+                        application_name=application_name,
+                    )
+                )
+    return _ParsedProjects(
+        projects=tuple(parsed_projects),
+        environments=tuple(parsed_environments),
+        applications=tuple(applications),
+    )
+
+
+def _observe_present_application(
+    *,
+    host: str,
+    token: str,
+    reference: _DiscoveredApplication,
+    observed_at: str,
+    candidate: bool,
+) -> DetachedApplicationProviderObservation:
+    payload = dokploy_api.fetch_dokploy_target_payload(
+        host=host,
+        token=token,
+        target_type="application",
+        target_id=reference.application_id,
+    )
+    _validate_application_payload(payload=payload, reference=reference)
+    domains = _fetch_strict_application_domains(
+        host=host,
+        token=token,
+        application_id=reference.application_id,
+    )
+    deployment_history = dokploy_api.deployment_history_for_target(
+        host=host,
+        token=token,
+        target_type="application",
+        target_id=reference.application_id,
+    )
+    if deployment_history.state == "unknown":
+        raise DetachedApplicationRetirementBlockedError(
+            "Dokploy deployment history evidence is unknown."
+        )
+    application_state = _application_state(payload)
+    domain_pairs = _normalized_domains(domains)
+    latest_deployment_sha256 = (
+        canonical_sha256(deployment_history.latest_deployment)
+        if deployment_history.latest_deployment is not None
+        else ""
+    )
+    safe_to_retire = bool(
+        candidate
+        and application_state == "idle"
+        and deployment_history.state == "no_history"
+        and deployment_history.latest_deployment is None
+        and not domain_pairs
+    )
+    return DetachedApplicationProviderObservation(
+        observed_at=observed_at,
+        project_id=reference.project_id,
+        project_name=reference.project_name,
+        environment_id=reference.environment_id,
+        environment_name=reference.environment_name,
+        application_id=reference.application_id,
+        application_name=reference.application_name,
+        target_id_sha256=provider_identifier_sha256(reference.application_id),
+        state="present",
+        application_state=application_state,
+        application_fingerprint_sha256=canonical_sha256(payload),
+        domain_ids=tuple(domain_id for domain_id, _host in domain_pairs),
+        domain_id_sha256=tuple(
+            provider_identifier_sha256(domain_id) for domain_id, _host in domain_pairs
+        ),
+        domain_host_sha256=tuple(
+            provider_identifier_sha256(host_name) for _domain_id, host_name in domain_pairs
+        ),
+        deployment_history_state=deployment_history.state,
+        latest_deployment_sha256=latest_deployment_sha256,
+        safe_to_retire=safe_to_retire,
+    )
+
+
+def _observe_protected_application(
+    *,
+    host: str,
+    token: str,
+    reference: _DiscoveredApplication,
+) -> DetachedApplicationProtectedTargetSnapshot:
+    payload = dokploy_api.fetch_dokploy_target_payload(
+        host=host,
+        token=token,
+        target_type="application",
+        target_id=reference.application_id,
+    )
+    _validate_application_payload(payload=payload, reference=reference)
+    domains = _fetch_strict_application_domains(
+        host=host,
+        token=token,
+        application_id=reference.application_id,
+    )
+    deployment_history = dokploy_api.deployment_history_for_target(
+        host=host,
+        token=token,
+        target_type="application",
+        target_id=reference.application_id,
+    )
+    if deployment_history.state == "unknown":
+        raise DetachedApplicationRetirementBlockedError(
+            "Protected Dokploy deployment history evidence is unknown."
+        )
+    _application_state(payload)
+    domain_pairs = _normalized_domains(domains)
+    return DetachedApplicationProtectedTargetSnapshot(
+        application_id=reference.application_id,
+        target_id_sha256=provider_identifier_sha256(reference.application_id),
+        application_name=reference.application_name,
+        application_fingerprint_sha256=canonical_sha256(payload),
+        domain_count=len(domain_pairs),
+        domains_sha256=canonical_sha256(domain_pairs),
+        deployment_history_state=deployment_history.state,
+        deployment_history_sha256=canonical_sha256(
+            {
+                "state": deployment_history.state,
+                "latest_deployment": deployment_history.latest_deployment,
+            }
+        ),
+    )
+
+
+def _fetch_strict_application_domains(
+    *, host: str, token: str, application_id: str
+) -> tuple[dokploy_api.JsonObject, ...]:
+    payload = dokploy_api.dokploy_request(
+        host=host,
+        token=token,
+        path="/api/domain.byApplicationId",
+        query={"applicationId": application_id},
+    )
+    if not isinstance(payload, list):
+        raise DetachedApplicationRetirementBlockedError(
+            "Dokploy application domains returned malformed evidence."
+        )
+    domains: list[dokploy_api.JsonObject] = []
+    for item in payload:
+        domain = dokploy_api.as_json_object(item)
+        if domain is None:
+            raise DetachedApplicationRetirementBlockedError(
+                "Dokploy application domains contain malformed evidence."
+            )
+        domains.append(domain)
+    return tuple(domains)
+
+
+def _validate_application_payload(
+    *, payload: Mapping[str, object], reference: _DiscoveredApplication
+) -> None:
+    application_id = _required_identifier(
+        payload,
+        "applicationId",
+        "id",
+        label="application id",
+    )
+    application_name = _required_application_name(payload)
+    if application_id != reference.application_id or application_name != reference.application_name:
+        raise DetachedApplicationRetirementBlockedError(
+            "Dokploy application.one does not match project discovery."
+        )
+    environment_id = _optional_string(payload, "environmentId")
+    if environment_id and environment_id != reference.environment_id:
+        raise DetachedApplicationRetirementBlockedError(
+            "Dokploy application.one environment evidence changed."
+        )
+    project_id = _optional_string(payload, "projectId")
+    if project_id and project_id != reference.project_id:
+        raise DetachedApplicationRetirementBlockedError(
+            "Dokploy application.one project evidence changed."
+        )
+
+
+def _application_state(payload: Mapping[str, object]) -> str:
+    state = (
+        str(
+            payload.get("applicationStatus")
+            or payload.get("application_status")
+            or payload.get("status")
+            or ""
+        )
+        .strip()
+        .lower()
+    )
+    if not state:
+        raise DetachedApplicationRetirementBlockedError(
+            "Dokploy application.one is missing application state."
+        )
+    return state
+
+
+def _record_payload(record: object) -> object:
+    if isinstance(record, BaseModel):
+        return record.model_dump(mode="json", exclude_none=True)
+    if isinstance(record, Mapping):
+        return dict(record)
+    raise DetachedApplicationRetirementBlockedError(
+        "Launchplane authority source returned an unsupported record type."
+    )
+
+
+def _payload_references_candidate(
+    payload: object,
+    *,
+    candidate_target_id: str,
+    candidate_application_name: str,
+    key: str = "",
+) -> bool:
+    if isinstance(payload, Mapping):
+        return any(
+            _payload_references_candidate(
+                value,
+                candidate_target_id=candidate_target_id,
+                candidate_application_name=candidate_application_name,
+                key=str(raw_key),
+            )
+            for raw_key, value in payload.items()
+        )
+    if isinstance(payload, Sequence) and not isinstance(payload, str | bytes | bytearray):
+        return any(
+            _payload_references_candidate(
+                value,
+                candidate_target_id=candidate_target_id,
+                candidate_application_name=candidate_application_name,
+                key=key,
+            )
+            for value in payload
+        )
+    if not isinstance(payload, str):
+        return False
+    normalized_value = payload.strip()
+    if normalized_value == candidate_target_id:
+        return True
+    normalized_key = re.sub(r"[^a-z0-9]+", "_", key.strip().lower()).strip("_")
+    return (
+        normalized_key in _AUTHORITATIVE_PROVIDER_NAME_KEYS
+        and normalized_value == candidate_application_name
+    )
+
+
+def _same_candidate_evidence(
+    *,
+    planned: DetachedApplicationProviderObservation,
+    current: DetachedApplicationProviderObservation,
+) -> bool:
+    if current.state != "present" or not current.safe_to_retire:
+        return False
+    return planned.model_copy(update={"observed_at": current.observed_at}) == current
+
+
+def _required_identifier(
+    payload: Mapping[str, object], primary: str, fallback: str, *, label: str
+) -> str:
+    primary_value = _optional_string(payload, primary)
+    fallback_value = _optional_string(payload, fallback)
+    if primary_value and fallback_value and primary_value != fallback_value:
+        raise DetachedApplicationRetirementBlockedError(f"Dokploy {label} fields are inconsistent.")
+    value = primary_value or fallback_value
+    if not value:
+        raise DetachedApplicationRetirementBlockedError(f"Dokploy evidence is missing {label}.")
+    return value
+
+
+def _required_string(payload: Mapping[str, object], key: str, *, label: str) -> str:
+    value = _optional_string(payload, key)
+    if not value:
+        raise DetachedApplicationRetirementBlockedError(f"Dokploy evidence is missing {label}.")
+    return value
+
+
+def _required_application_name(payload: Mapping[str, object]) -> str:
+    name = _optional_string(payload, "name")
+    app_name = _optional_string(payload, "appName")
+    value = name or app_name
+    if not value:
+        raise DetachedApplicationRetirementBlockedError(
+            "Dokploy evidence is missing application name."
+        )
+    return value
+
+
+def _required_domain_host(payload: Mapping[str, object]) -> str:
+    host = _optional_string(payload, "host") or _optional_string(payload, "domain")
+    if not host:
+        raise DetachedApplicationRetirementBlockedError(
+            "Dokploy domain evidence is missing host identity."
+        )
+    return host.lower()
+
+
+def _normalized_domains(
+    domains: Sequence[Mapping[str, object]],
+) -> tuple[tuple[str, str], ...]:
+    return tuple(
+        sorted(
+            (
+                _required_identifier(domain, "domainId", "id", label="domain id"),
+                _required_domain_host(domain),
+            )
+            for domain in domains
+        )
+    )
+
+
+def _optional_string(payload: Mapping[str, object], key: str) -> str:
+    value = payload.get(key)
+    if value is None:
+        return ""
+    if not isinstance(value, str):
+        raise DetachedApplicationRetirementBlockedError(
+            f"Dokploy evidence field {key} must be a string."
+        )
+    return value.strip()
+
+
+def _redacted_error_message(value: str) -> str:
+    normalized = " ".join(value.split())
+    if not normalized:
+        return ""
+    return normalized[:MAX_DETACHED_APPLICATION_RETIREMENT_ERROR_MESSAGE_LENGTH]

--- a/control_plane/dokploy/api.py
+++ b/control_plane/dokploy/api.py
@@ -257,6 +257,23 @@ def fetch_dokploy_target_payload(
     return payload_as_object
 
 
+def fetch_dokploy_projects(*, host: str, token: str) -> tuple[JsonObject, ...]:
+    payload = dokploy_request(
+        host=host,
+        token=token,
+        path="/api/project.all",
+    )
+    if not isinstance(payload, list):
+        raise click.ClickException("Dokploy project.all returned an invalid response payload.")
+    projects: list[JsonObject] = []
+    for item in payload:
+        project = as_json_object(item)
+        if project is None:
+            raise click.ClickException("Dokploy project.all returned a malformed project entry.")
+        projects.append(project)
+    return tuple(projects)
+
+
 def fetch_dokploy_application_domains(
     *, host: str, token: str, application_id: str
 ) -> tuple[JsonObject, ...]:

--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -54,6 +54,9 @@ from control_plane import (
 from control_plane import product_preview_tls as control_plane_product_preview_tls
 from control_plane import product_retirement as control_plane_product_retirement
 from control_plane import (
+    detached_application_retirement as control_plane_detached_application_retirement,
+)
+from control_plane import (
     route_binding_external_reconcile as control_plane_route_binding_external_reconcile,
 )
 from control_plane import route_binding_reconcile as control_plane_route_binding_reconcile
@@ -563,6 +566,10 @@ from control_plane.contracts.product_retirement import (
     ProductRetirementIdentity,
     ProductRetirementRequest,
 )
+from control_plane.contracts.detached_application_retirement import (
+    DetachedApplicationRetirementIdentity,
+    DetachedApplicationRetirementRequest,
+)
 from control_plane.contracts.preview_desired_state_record import PreviewDesiredStateRecord
 from control_plane.contracts.preview_inventory_scan_record import PreviewInventoryScanRecord
 from control_plane.contracts.preview_lifecycle_plan_record import (
@@ -952,6 +959,7 @@ _PRODUCT_PROFILES_ROUTE = "/v1/product-profiles"
 _PRODUCT_EXPECTED_CONFIG_APPLY_ROUTE = "/v1/product-profiles/expected-config/apply"
 _PRODUCT_PREVIEW_TLS_APPLY_ROUTE = "/v1/product-profiles/preview-tls/apply"
 _PRODUCT_RETIREMENT_ROUTE = "/v1/product-retirement"
+_DETACHED_APPLICATION_RETIREMENT_ROUTE = "/v1/detached-application-retirement"
 _PRODUCT_CONTEXT_CUTOVER_APPLY_ROUTE = "/v1/product-profiles/context-cutover/apply"
 _PRODUCT_LEGACY_CONTEXT_CLEANUP_APPLY_ROUTE = "/v1/product-profiles/legacy-context-cleanup/apply"
 _PRODUCT_ONBOARDING_APPLY_ROUTE = "/v1/product-onboarding/apply"
@@ -3111,6 +3119,36 @@ def product_retirement_identity(identity: LaunchplaneIdentity) -> ProductRetirem
             getattr(identity, "workflow_ref", "") or getattr(identity, "job_workflow_ref", "") or ""
         ),
         environment=str(getattr(identity, "environment", "") or ""),
+    )
+
+
+def detached_application_retirement_identity(
+    identity: LaunchplaneIdentity,
+) -> DetachedApplicationRetirementIdentity:
+    return DetachedApplicationRetirementIdentity(
+        actor=launchplane_identity_actor(identity),
+        identity_kind=type(identity).__name__,
+        subject=str(getattr(identity, "subject", "") or ""),
+        repository=str(getattr(identity, "repository", "") or ""),
+        workflow_ref=str(
+            getattr(identity, "job_workflow_ref", "") or getattr(identity, "workflow_ref", "") or ""
+        ),
+        environment=str(getattr(identity, "environment", "") or ""),
+    )
+
+
+def detached_application_retirement_identity_allowed(identity: LaunchplaneIdentity) -> bool:
+    if isinstance(identity, LocalAdminIdentity):
+        return True
+    if not isinstance(identity, GitHubActionsIdentity):
+        return False
+    return (
+        re.fullmatch(
+            r"cbusillo/launchplane/\.github/workflows/"
+            r"reusable-detached-application-retirement\.yml@[0-9a-f]{40}",
+            identity.job_workflow_ref.strip(),
+        )
+        is not None
     )
 
 
@@ -16615,6 +16653,267 @@ def create_launchplane_fastapi_app(
                 message=str(error),
             ) from error
 
+    async def execute_detached_application_retirement(
+        request: Request,
+        retirement_request: DetachedApplicationRetirementRequest,
+        identity: Annotated[LaunchplaneIdentity, Depends(read_write_identity)],
+        record_store: Annotated[object, Depends(get_record_store)],
+        idempotency_key: Annotated[str, Header(alias="Idempotency-Key")] = "",
+    ) -> AcceptedEvidenceResponse:
+        trace_id = next_trace_id()
+        normalized_key = idempotency_key.strip()
+        if not normalized_key:
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="idempotency_key_required",
+                message="Detached application retirement requires Idempotency-Key.",
+            )
+        action = (
+            "detached_application_retirement.plan"
+            if retirement_request.mode == "plan"
+            else "detached_application_retirement.apply"
+        )
+        if not detached_application_retirement_identity_allowed(identity):
+            raise _launchplane_http_error(
+                status_code=403,
+                trace_id=trace_id,
+                code="authorization_denied",
+                message=(
+                    "Detached application retirement requires the exact reusable worker "
+                    "or a local admin identity."
+                ),
+            )
+        if not resolved_authz_policy_runtime.policy.allows(
+            identity=identity,
+            action=action,
+            product=_LAUNCHPLANE_SERVICE_CONTEXT,
+            context=_LAUNCHPLANE_SERVICE_CONTEXT,
+            target=AuthorizationTarget(scope="global"),
+        ):
+            raise _launchplane_http_error(
+                status_code=403,
+                trace_id=trace_id,
+                code="authorization_denied",
+                message="Identity is not authorized for detached application retirement.",
+                authz=_authz_diagnostic_payload(
+                    identity=identity,
+                    authz_policy_sha256_value=resolved_authz_policy_runtime.policy_sha256,
+                    authz_policy_source=resolved_authz_policy_runtime.source,
+                    action=action,
+                    product=_LAUNCHPLANE_SERVICE_CONTEXT,
+                    context=_LAUNCHPLANE_SERVICE_CONTEXT,
+                ),
+            )
+        try:
+            retirement_store = cast(
+                control_plane_detached_application_retirement.DetachedApplicationRetirementStore,
+                require_provider_operation_store(
+                    record_store=record_store,
+                    trace_id=trace_id,
+                ),
+            )
+            plan_record = None
+            if retirement_request.mode == "apply":
+                plan_record = retirement_store.read_detached_application_retirement_record(
+                    retirement_request.reviewed_plan_record_id
+                )
+                control_plane_detached_application_retirement.validate_reviewed_detached_application_retirement_plan(
+                    request=retirement_request,
+                    plan=plan_record,
+                )
+        except FileNotFoundError as error:
+            raise _launchplane_http_error(
+                status_code=404,
+                trace_id=trace_id,
+                code="detached_application_retirement_plan_not_found",
+                message="Reviewed detached application retirement plan was not found.",
+            ) from error
+        except TypeError as error:
+            raise _launchplane_http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="database_storage_required",
+                message=str(error),
+            ) from error
+        except (ValueError, click.ClickException) as error:
+            raise _launchplane_http_error(
+                status_code=409,
+                trace_id=trace_id,
+                code="detached_application_retirement_blocked",
+                message=str(error),
+            ) from error
+        actor_identity = detached_application_retirement_identity(identity)
+        requested_at = utc_now_timestamp()
+        if retirement_request.mode == "plan":
+            existing_plans = retirement_store.list_detached_application_retirement_records(
+                candidate_target_sha256=retirement_request.candidate_target_sha256,
+                actor=actor_identity.actor,
+                mode="plan",
+                idempotency_key=normalized_key,
+                limit=1,
+            )
+            if existing_plans:
+                existing_plan = existing_plans[0]
+                if existing_plan.continuity_sha256 != retirement_request.continuity_sha256:
+                    raise _launchplane_http_error(
+                        status_code=409,
+                        trace_id=trace_id,
+                        code="idempotency_key_reused",
+                        message=(
+                            "Idempotency-Key was already used for a different detached "
+                            "application retirement plan."
+                        ),
+                    )
+                return AcceptedEvidenceResponse.model_validate(
+                    control_plane_detached_application_retirement.redacted_detached_application_retirement_response(
+                        existing_plan
+                    )
+                )
+            try:
+                discovery = (
+                    control_plane_detached_application_retirement.discover_detached_application(
+                        control_plane_root=resolved_control_plane_root,
+                        request=retirement_request,
+                        observed_at=requested_at,
+                    )
+                )
+                absence_proof = control_plane_detached_application_retirement.prove_detached_application_authority_absence(
+                    record_store=retirement_store,
+                    candidate_target_id=discovery.candidate.application_id,
+                    candidate_application_name=retirement_request.application_name,
+                )
+                plan = control_plane_detached_application_retirement.build_detached_application_retirement_plan_record(
+                    request=retirement_request,
+                    identity=actor_identity,
+                    trace_id=trace_id,
+                    idempotency_key=normalized_key,
+                    requested_at=requested_at,
+                    discovery=discovery,
+                    authority_absence_proof=absence_proof,
+                )
+                retirement_store.write_detached_application_retirement_record(plan)
+                persisted_plans = retirement_store.list_detached_application_retirement_records(
+                    candidate_target_sha256=retirement_request.candidate_target_sha256,
+                    actor=actor_identity.actor,
+                    mode="plan",
+                    idempotency_key=normalized_key,
+                    limit=1,
+                )
+                if not persisted_plans:
+                    raise RuntimeError(
+                        "Detached application retirement plan reservation was not persisted."
+                    )
+                plan = persisted_plans[0]
+            except (
+                FileNotFoundError,
+                OSError,
+                TimeoutError,
+                ValueError,
+                click.ClickException,
+            ) as error:
+                raise _launchplane_http_error(
+                    status_code=409,
+                    trace_id=trace_id,
+                    code="detached_application_retirement_blocked",
+                    message=str(error),
+                ) from error
+            return AcceptedEvidenceResponse.model_validate(
+                control_plane_detached_application_retirement.redacted_detached_application_retirement_response(
+                    plan
+                )
+            )
+        if plan_record is None:
+            raise RuntimeError(
+                "Detached application retirement apply requires a reviewed plan record."
+            )
+        (
+            normalized_key,
+            payload_fingerprint,
+            replayed_response,
+        ) = await replay_apply_idempotency(
+            request=request,
+            record_store=retirement_store,
+            identity=identity,
+            route_path=_DETACHED_APPLICATION_RETIREMENT_ROUTE,
+            idempotency_key=normalized_key,
+            trace_id=trace_id,
+            check_replay=True,
+            request_payload=retirement_request.model_dump(mode="json"),
+        )
+        if replayed_response is not None:
+            return replayed_response
+        adapter = control_plane_detached_application_retirement.DokployDetachedApplicationRetirementAdapter(
+            control_plane_root=resolved_control_plane_root,
+            record_store=retirement_store,
+            request=retirement_request,
+            plan=plan_record,
+            identity=actor_identity,
+            trace_id=trace_id,
+            idempotency_key=normalized_key,
+            requested_at=requested_at,
+        )
+        provider_operation_key = adapter.provider_operation_key(
+            scope=idempotency_scope(identity),
+            route_path=_DETACHED_APPLICATION_RETIREMENT_ROUTE,
+            fingerprint=payload_fingerprint,
+        )
+        try:
+            return await run_provider_mutation(
+                record_store=retirement_store,
+                identity=identity,
+                route_path=_DETACHED_APPLICATION_RETIREMENT_ROUTE,
+                idempotency_key=normalized_key,
+                request_fingerprint=payload_fingerprint,
+                trace_id=trace_id,
+                adapter=adapter,
+                in_progress_message=(
+                    "A matching detached application retirement is already running. "
+                    "Retry with the same Idempotency-Key."
+                ),
+                reconcile_message=(
+                    "Detached application retirement requires reconciliation before retrying "
+                    "the same Idempotency-Key."
+                ),
+            )
+        except HTTPException as error:
+            if not adapter.started:
+                raise
+            detail = error.detail if isinstance(error.detail, Mapping) else {}
+            code = str(detail.get("code") or "detached_application_retirement_failed")
+            outcome: Literal["reconcile_required", "failed"] = (
+                "reconcile_required" if "reconciliation" in code else "failed"
+            )
+            terminal = adapter.terminal_record(
+                outcome=outcome,
+                provider_operation_key=provider_operation_key,
+                error_code=code,
+                error_message=str(detail.get("message") or ""),
+            )
+            retirement_store.write_detached_application_retirement_record(terminal)
+            raise
+        except (ValueError, click.ClickException) as error:
+            if not adapter.started:
+                raise _launchplane_http_error(
+                    status_code=409,
+                    trace_id=trace_id,
+                    code="detached_application_retirement_blocked",
+                    message=str(error),
+                ) from error
+            terminal = adapter.terminal_record(
+                outcome="failed",
+                provider_operation_key=provider_operation_key,
+                error_code="detached_application_retirement_blocked",
+                error_message=str(error),
+            )
+            retirement_store.write_detached_application_retirement_record(terminal)
+            raise _launchplane_http_error(
+                status_code=409,
+                trace_id=trace_id,
+                code="detached_application_retirement_blocked",
+                message=str(error),
+            ) from error
+
     async def remediate_preview_pr_feedback(
         request: Request,
         remediation_request: PreviewPrFeedbackRemediationRequest,
@@ -19057,6 +19356,25 @@ def create_launchplane_fastapi_app(
         response_model_exclude_none=True,
         operation_id="execute_product_retirement",
         summary="Plan or apply audited generic-web product retirement",
+        responses={
+            400: {"model": LaunchplaneErrorResponse},
+            401: {"model": LaunchplaneErrorResponse},
+            403: {"model": LaunchplaneErrorResponse},
+            404: {"model": LaunchplaneErrorResponse},
+            409: {"model": LaunchplaneErrorResponse},
+            503: {"model": LaunchplaneErrorResponse},
+        },
+    )
+
+    app.add_api_route(
+        _DETACHED_APPLICATION_RETIREMENT_ROUTE,
+        execute_detached_application_retirement,
+        methods=["POST"],
+        status_code=202,
+        response_model=AcceptedEvidenceResponse,
+        response_model_exclude_none=True,
+        operation_id="execute_detached_application_retirement",
+        summary="Plan or apply audited detached Dokploy application retirement",
         responses={
             400: {"model": LaunchplaneErrorResponse},
             401: {"model": LaunchplaneErrorResponse},

--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -3130,9 +3130,8 @@ def detached_application_retirement_identity(
         identity_kind=type(identity).__name__,
         subject=str(getattr(identity, "subject", "") or ""),
         repository=str(getattr(identity, "repository", "") or ""),
-        workflow_ref=str(
-            getattr(identity, "job_workflow_ref", "") or getattr(identity, "workflow_ref", "") or ""
-        ),
+        workflow_ref=str(getattr(identity, "workflow_ref", "") or ""),
+        job_workflow_ref=str(getattr(identity, "job_workflow_ref", "") or ""),
         environment=str(getattr(identity, "environment", "") or ""),
     )
 
@@ -3143,7 +3142,8 @@ def detached_application_retirement_identity_allowed(identity: LaunchplaneIdenti
     if not isinstance(identity, GitHubActionsIdentity):
         return False
     return (
-        re.fullmatch(
+        identity.repository == "cbusillo/launchplane"
+        and re.fullmatch(
             r"cbusillo/launchplane/\.github/workflows/"
             r"reusable-detached-application-retirement\.yml@[0-9a-f]{40}",
             identity.job_workflow_ref.strip(),
@@ -16737,11 +16737,14 @@ def create_launchplane_fastapi_app(
                 message=str(error),
             ) from error
         except (ValueError, click.ClickException) as error:
+            safe_message = control_plane_detached_application_retirement.redacted_detached_application_retirement_error(
+                error
+            )
             raise _launchplane_http_error(
                 status_code=409,
                 trace_id=trace_id,
                 code="detached_application_retirement_blocked",
-                message=str(error),
+                message=safe_message,
             ) from error
         actor_identity = detached_application_retirement_identity(identity)
         requested_at = utc_now_timestamp()
@@ -16812,11 +16815,14 @@ def create_launchplane_fastapi_app(
                 ValueError,
                 click.ClickException,
             ) as error:
+                safe_message = control_plane_detached_application_retirement.redacted_detached_application_retirement_error(
+                    error
+                )
                 raise _launchplane_http_error(
                     status_code=409,
                     trace_id=trace_id,
                     code="detached_application_retirement_blocked",
-                    message=str(error),
+                    message=safe_message,
                 ) from error
             return AcceptedEvidenceResponse.model_validate(
                 control_plane_detached_application_retirement.redacted_detached_application_retirement_response(
@@ -16893,25 +16899,28 @@ def create_launchplane_fastapi_app(
             retirement_store.write_detached_application_retirement_record(terminal)
             raise
         except (ValueError, click.ClickException) as error:
+            safe_message = control_plane_detached_application_retirement.redacted_detached_application_retirement_error(
+                error
+            )
             if not adapter.started:
                 raise _launchplane_http_error(
                     status_code=409,
                     trace_id=trace_id,
                     code="detached_application_retirement_blocked",
-                    message=str(error),
+                    message=safe_message,
                 ) from error
             terminal = adapter.terminal_record(
                 outcome="failed",
                 provider_operation_key=provider_operation_key,
                 error_code="detached_application_retirement_blocked",
-                error_message=str(error),
+                error_message=safe_message,
             )
             retirement_store.write_detached_application_retirement_record(terminal)
             raise _launchplane_http_error(
                 status_code=409,
                 trace_id=trace_id,
                 code="detached_application_retirement_blocked",
-                message=str(error),
+                message=safe_message,
             ) from error
 
     async def remediate_preview_pr_feedback(

--- a/control_plane/storage/filesystem.py
+++ b/control_plane/storage/filesystem.py
@@ -147,6 +147,9 @@ from control_plane.contracts.product_profile_lifecycle_migration import (
     migrate_product_profile_lifecycle_payload,
 )
 from control_plane.contracts.product_profile_record import LaunchplaneProductProfileRecord
+from control_plane.contracts.detached_application_retirement import (
+    DetachedApplicationRetirementRecord,
+)
 from control_plane.contracts.product_retirement import ProductRetirementRecord
 from control_plane.contracts.public_ingress_monitoring import (
     PublicIngressIncidentEventRecord,
@@ -3785,6 +3788,67 @@ class FilesystemRecordStore:
                 "launchplane_product_retirements",
             )
             if (not product or record.product == product)
+            and (not actor or record.identity.actor == actor)
+            and (not mode or record.mode == mode)
+            and (not idempotency_key or record.idempotency_key == idempotency_key)
+        ]
+        records.sort(key=lambda record: (record.recorded_at, record.record_id), reverse=True)
+        if limit is not None:
+            records = records[:limit]
+        return tuple(records)
+
+    def write_detached_application_retirement_record(
+        self, record: DetachedApplicationRetirementRecord
+    ) -> Path:
+        if not self._create_model_if_absent(
+            "launchplane_detached_application_retirements",
+            record.record_id,
+            record,
+        ):
+            existing = self.read_detached_application_retirement_record(record.record_id)
+            if existing != record and not (
+                record.mode == "plan"
+                and existing.mode == "plan"
+                and existing.candidate_observation.target_id_sha256
+                == record.candidate_observation.target_id_sha256
+                and existing.identity.actor == record.identity.actor
+                and existing.idempotency_key == record.idempotency_key
+                and existing.continuity_sha256 == record.continuity_sha256
+            ):
+                raise ValueError("Detached application retirement records are append-only.")
+        return self._record_path(
+            "launchplane_detached_application_retirements",
+            record.record_id,
+        )
+
+    def read_detached_application_retirement_record(
+        self, record_id: str
+    ) -> DetachedApplicationRetirementRecord:
+        return self._read_model(
+            DetachedApplicationRetirementRecord,
+            "launchplane_detached_application_retirements",
+            record_id,
+        )
+
+    def list_detached_application_retirement_records(
+        self,
+        *,
+        candidate_target_sha256: str = "",
+        actor: str = "",
+        mode: str = "",
+        idempotency_key: str = "",
+        limit: int | None = None,
+    ) -> tuple[DetachedApplicationRetirementRecord, ...]:
+        records = [
+            record
+            for record in self._list_models(
+                DetachedApplicationRetirementRecord,
+                "launchplane_detached_application_retirements",
+            )
+            if (
+                not candidate_target_sha256
+                or record.candidate_observation.target_id_sha256 == candidate_target_sha256
+            )
             and (not actor or record.identity.actor == actor)
             and (not mode or record.mode == mode)
             and (not idempotency_key or record.idempotency_key == idempotency_key)

--- a/control_plane/storage/migrations/versions/d8a0c2e4f6b8_add_detached_application_retirements.py
+++ b/control_plane/storage/migrations/versions/d8a0c2e4f6b8_add_detached_application_retirements.py
@@ -1,0 +1,96 @@
+"""Add detached application retirement records.
+
+Revision ID: d8a0c2e4f6b8
+Revises: c6e8f1b3d5a7
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision: str = "d8a0c2e4f6b8"
+down_revision: str | None = "c6e8f1b3d5a7"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_TABLE = "launchplane_detached_application_retirements"
+
+
+def _table_exists() -> bool:
+    return _TABLE in set(sa.inspect(op.get_bind()).get_table_names())
+
+
+def _index_exists(index_name: str) -> bool:
+    if not _table_exists():
+        return False
+    return index_name in {
+        str(index["name"]) for index in sa.inspect(op.get_bind()).get_indexes(_TABLE)
+    }
+
+
+def upgrade() -> None:
+    if not _table_exists():
+        op.create_table(
+            _TABLE,
+            sa.Column("record_id", sa.String(), nullable=False),
+            sa.Column("plan_record_id", sa.String(), nullable=False),
+            sa.Column("candidate_target_sha256", sa.String(length=64), nullable=False),
+            sa.Column("actor", sa.String(), nullable=False),
+            sa.Column("idempotency_key", sa.String(), nullable=False),
+            sa.Column("mode", sa.String(), nullable=False),
+            sa.Column("outcome", sa.String(), nullable=False),
+            sa.Column("recorded_at", sa.String(), nullable=False),
+            sa.Column("protected_target_count", sa.Integer(), nullable=False),
+            sa.Column(
+                "authority_write_count",
+                sa.Integer(),
+                nullable=False,
+                server_default="0",
+            ),
+            sa.Column(
+                "payload",
+                sa.JSON().with_variant(
+                    postgresql.JSONB(astext_type=sa.Text()),
+                    "postgresql",
+                ),
+                nullable=False,
+            ),
+            sa.CheckConstraint(
+                "authority_write_count = 0",
+                name="launchplane_detached_app_retirements_no_authority_writes",
+            ),
+            sa.CheckConstraint(
+                "protected_target_count > 0",
+                name="launchplane_detached_app_retirements_protected_nonempty",
+            ),
+            sa.PrimaryKeyConstraint("record_id"),
+        )
+    for index_name, first_column in (
+        ("launchplane_detached_app_retirements_candidate_idx", "candidate_target_sha256"),
+        ("launchplane_detached_app_retirements_plan_idx", "plan_record_id"),
+        ("launchplane_detached_app_retirements_idempotency_idx", "idempotency_key"),
+    ):
+        if not _index_exists(index_name):
+            op.create_index(
+                index_name,
+                _TABLE,
+                [first_column, sa.text("recorded_at DESC")],
+            )
+    if not _index_exists("launchplane_detached_app_retirements_plan_idempotency_unique"):
+        op.create_index(
+            "launchplane_detached_app_retirements_plan_idempotency_unique",
+            _TABLE,
+            ["candidate_target_sha256", "actor", "idempotency_key"],
+            unique=True,
+            postgresql_where=sa.text("mode = 'plan'"),
+            sqlite_where=sa.text("mode = 'plan'"),
+        )
+
+
+def downgrade() -> None:
+    if not _table_exists():
+        return
+    op.drop_table(_TABLE)

--- a/control_plane/storage/postgres.py
+++ b/control_plane/storage/postgres.py
@@ -198,6 +198,9 @@ from control_plane.contracts.product_profile_record import (
     product_profile_record_sha256,
 )
 from control_plane.contracts.product_retirement import ProductRetirementRecord
+from control_plane.contracts.detached_application_retirement import (
+    DetachedApplicationRetirementRecord,
+)
 from control_plane.contracts.public_ingress_monitoring import (
     PublicIngressIncidentEventRecord,
     PublicIngressIncidentReminderStateRecord,
@@ -1663,6 +1666,56 @@ class LaunchplaneProductRetirementRow(Base):
     mode: Mapped[str] = mapped_column(String, nullable=False)
     outcome: Mapped[str] = mapped_column(String, nullable=False)
     recorded_at: Mapped[str] = mapped_column(String, nullable=False)
+    payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
+
+
+class LaunchplaneDetachedApplicationRetirementRow(Base):
+    __tablename__ = "launchplane_detached_application_retirements"
+    __table_args__ = (
+        Index(
+            "launchplane_detached_app_retirements_candidate_idx",
+            "candidate_target_sha256",
+            desc("recorded_at"),
+        ),
+        Index(
+            "launchplane_detached_app_retirements_plan_idx",
+            "plan_record_id",
+            desc("recorded_at"),
+        ),
+        Index(
+            "launchplane_detached_app_retirements_idempotency_idx",
+            "idempotency_key",
+            desc("recorded_at"),
+        ),
+        Index(
+            "launchplane_detached_app_retirements_plan_idempotency_unique",
+            "candidate_target_sha256",
+            "actor",
+            "idempotency_key",
+            unique=True,
+            postgresql_where=text("mode = 'plan'"),
+            sqlite_where=text("mode = 'plan'"),
+        ),
+        CheckConstraint(
+            "authority_write_count = 0",
+            name="launchplane_detached_app_retirements_no_authority_writes",
+        ),
+        CheckConstraint(
+            "protected_target_count > 0",
+            name="launchplane_detached_app_retirements_protected_nonempty",
+        ),
+    )
+
+    record_id: Mapped[str] = mapped_column(String, primary_key=True)
+    plan_record_id: Mapped[str] = mapped_column(String, nullable=False)
+    candidate_target_sha256: Mapped[str] = mapped_column(String(64), nullable=False)
+    actor: Mapped[str] = mapped_column(String, nullable=False)
+    idempotency_key: Mapped[str] = mapped_column(String, nullable=False)
+    mode: Mapped[str] = mapped_column(String, nullable=False)
+    outcome: Mapped[str] = mapped_column(String, nullable=False)
+    recorded_at: Mapped[str] = mapped_column(String, nullable=False)
+    protected_target_count: Mapped[int] = mapped_column(Integer, nullable=False)
+    authority_write_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
     payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
 
 
@@ -13518,6 +13571,128 @@ class PostgresRecordStore(HumanSessionStore):
             return tuple(
                 self._read_payload(
                     model_type=ProductRetirementRecord,
+                    payload=row.payload,
+                )
+                for row in session.scalars(statement)
+            )
+
+    def write_detached_application_retirement_record(
+        self, record: DetachedApplicationRetirementRecord
+    ) -> None:
+        candidate_target_sha256 = record.candidate_observation.target_id_sha256
+        with self._session_factory() as session:
+            existing = session.get(
+                LaunchplaneDetachedApplicationRetirementRow,
+                record.record_id,
+            )
+            if existing is not None:
+                stored = self._read_payload(
+                    model_type=DetachedApplicationRetirementRecord,
+                    payload=existing.payload,
+                )
+                if stored != record and not (
+                    record.mode == "plan"
+                    and stored.mode == "plan"
+                    and stored.candidate_observation.target_id_sha256 == candidate_target_sha256
+                    and stored.identity.actor == record.identity.actor
+                    and stored.idempotency_key == record.idempotency_key
+                    and stored.continuity_sha256 == record.continuity_sha256
+                ):
+                    raise ValueError("Detached application retirement records are append-only.")
+                return
+            session.add(
+                LaunchplaneDetachedApplicationRetirementRow(
+                    record_id=record.record_id,
+                    plan_record_id=record.plan_record_id,
+                    candidate_target_sha256=candidate_target_sha256,
+                    actor=record.identity.actor,
+                    idempotency_key=record.idempotency_key,
+                    mode=record.mode,
+                    outcome=record.outcome,
+                    recorded_at=record.recorded_at,
+                    protected_target_count=len(record.protected_targets),
+                    authority_write_count=record.authority_write_count,
+                    payload=self._payload_dict(record),
+                )
+            )
+            try:
+                session.commit()
+            except IntegrityError as error:
+                session.rollback()
+                if record.mode != "plan":
+                    raise
+                existing_plan = session.scalar(
+                    select(LaunchplaneDetachedApplicationRetirementRow).where(
+                        LaunchplaneDetachedApplicationRetirementRow.candidate_target_sha256
+                        == candidate_target_sha256,
+                        LaunchplaneDetachedApplicationRetirementRow.actor == record.identity.actor,
+                        LaunchplaneDetachedApplicationRetirementRow.idempotency_key
+                        == record.idempotency_key,
+                        LaunchplaneDetachedApplicationRetirementRow.mode == "plan",
+                    )
+                )
+                if existing_plan is None:
+                    raise error
+                stored = self._read_payload(
+                    model_type=DetachedApplicationRetirementRecord,
+                    payload=existing_plan.payload,
+                )
+                if stored.continuity_sha256 != record.continuity_sha256:
+                    raise ValueError(
+                        "Detached application retirement plan idempotency key was reused."
+                    ) from error
+
+    def read_detached_application_retirement_record(
+        self, record_id: str
+    ) -> DetachedApplicationRetirementRecord:
+        with self._session_factory() as session:
+            row = session.get(LaunchplaneDetachedApplicationRetirementRow, record_id)
+            if row is None:
+                raise FileNotFoundError(
+                    "No Launchplane detached application retirement record found for "
+                    f"record_id={record_id!r}."
+                )
+            return self._read_payload(
+                model_type=DetachedApplicationRetirementRecord,
+                payload=row.payload,
+            )
+
+    def list_detached_application_retirement_records(
+        self,
+        *,
+        candidate_target_sha256: str = "",
+        actor: str = "",
+        mode: str = "",
+        idempotency_key: str = "",
+        limit: int | None = None,
+    ) -> tuple[DetachedApplicationRetirementRecord, ...]:
+        statement = select(LaunchplaneDetachedApplicationRetirementRow)
+        filters: list[object] = []
+        if candidate_target_sha256:
+            filters.append(
+                LaunchplaneDetachedApplicationRetirementRow.candidate_target_sha256
+                == candidate_target_sha256
+            )
+        if actor:
+            filters.append(LaunchplaneDetachedApplicationRetirementRow.actor == actor)
+        if mode:
+            filters.append(LaunchplaneDetachedApplicationRetirementRow.mode == mode)
+        if idempotency_key:
+            filters.append(
+                LaunchplaneDetachedApplicationRetirementRow.idempotency_key == idempotency_key
+            )
+        if filters:
+            statement = statement.where(*cast(Any, filters))
+        statement = statement.order_by(
+            desc(LaunchplaneDetachedApplicationRetirementRow.recorded_at),
+            desc(LaunchplaneDetachedApplicationRetirementRow.record_id),
+        )
+        if limit is not None:
+            statement = statement.limit(max(limit, 0))
+        with self._session_factory() as session:
+            return tuple(
+                self._read_payload(
+                    model_type=DetachedApplicationRetirementRecord,
                     payload=row.payload,
                 )
                 for row in session.scalars(statement)

--- a/control_plane/storage/schema_invariants.py
+++ b/control_plane/storage/schema_invariants.py
@@ -10,7 +10,7 @@ from sqlalchemy.engine import Engine
 from sqlalchemy.exc import SQLAlchemyError
 
 AUTHZ_COMPATIBILITY_FLOOR_REVISION = "f3b5d7e9a1c2"
-EXPECTED_ALEMBIC_HEAD_REVISION = "c6e8f1b3d5a7"
+EXPECTED_ALEMBIC_HEAD_REVISION = "d8a0c2e4f6b8"
 RUNTIME_COMPATIBLE_ALEMBIC_REVISIONS = (EXPECTED_ALEMBIC_HEAD_REVISION,)
 _AUTHZ_POLICY_TABLE = "launchplane_authz_policies"
 _AUTHZ_POLICY_WRITE_FENCE_TRIGGER = "launchplane_authz_policy_write_fence"
@@ -52,6 +52,11 @@ class CriticalPrimaryKey:
 
 
 CRITICAL_POSTGRES_COLUMN_TYPES: tuple[CriticalColumnType, ...] = (
+    CriticalColumnType(
+        "launchplane_detached_application_retirements",
+        "payload",
+        ("jsonb",),
+    ),
     CriticalColumnType(
         "launchplane_product_retirements",
         "payload",
@@ -398,6 +403,13 @@ _ODOO_STABLE_ACTIVE_OPERATION_PREDICATE_TOKENS = (
 )
 
 CRITICAL_SCHEMA_INDEXES: tuple[CriticalIndex, ...] = (
+    CriticalIndex(
+        "launchplane_detached_application_retirements",
+        "launchplane_detached_app_retirements_plan_idempotency_unique",
+        ("candidate_target_sha256", "actor", "idempotency_key"),
+        unique=True,
+        predicate_expression="mode='plan'",
+    ),
     CriticalIndex(
         "launchplane_authz_policies",
         "launchplane_authz_policies_revision_uidx",
@@ -827,6 +839,10 @@ CRITICAL_SCHEMA_INDEXES: tuple[CriticalIndex, ...] = (
 )
 
 CRITICAL_PRIMARY_KEYS: tuple[CriticalPrimaryKey, ...] = (
+    CriticalPrimaryKey(
+        "launchplane_detached_application_retirements",
+        ("record_id",),
+    ),
     CriticalPrimaryKey(
         "launchplane_route_bindings",
         ("product", "context", "instance"),

--- a/docs/github-actions-security.md
+++ b/docs/github-actions-security.md
@@ -75,6 +75,7 @@ written to the workflow log by the upstream implementation.
   generic-web onboarding/preview-authz protected apply, route-binding
   reconciliation, exact-instance product health-policy mutation,
   protected immutable product retirement,
+  reusable-only detached application retirement,
   exact-instance immutable Odoo artifact publication, and exact-instance Odoo
   target-replacement plan/apply workers whose actions are separately authorized.
   It also includes exact-instance redacted target-log diagnostics and Odoo
@@ -94,6 +95,16 @@ written to the workflow log by the upstream implementation.
 The security workflow runs this policy for both same-repository and fork pull
 requests before actionlint. The unit-test suite runs it as well, so a mutable
 reference cannot pass the required CI path.
+
+Detached application retirement follows a two-phase trust rollout. The first
+phase lands only the service contract, persistence, managed authz selector/
+secret routing, and a protected `workflow_call` worker. No dispatch workflow may
+call that worker in the same phase, and no live managed secret or rule is
+configured. The service additionally rejects GitHub Actions identities whose
+`job_workflow_ref` is not the exact reusable workflow path at a 40-character
+commit SHA. A later thin dispatch caller must be pinned to the merged worker SHA
+and authorized as an exact caller/worker pair before provider mutation is
+possible.
 
 ## Provenance And Updates
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -2564,3 +2564,37 @@ caller `workflow_ref` and the exact immutable `job_workflow_ref`:
 workflow_ref=cbusillo/launchplane/.github/workflows/product-retirement.yml@refs/heads/main
 job_workflow_ref=cbusillo/launchplane/.github/workflows/reusable-product-retirement.yml@c922d5f1a0bf3ab17a829196042a96ba89d7b693
 ```
+
+## Detached Application Retirement
+
+Phase one provides **Reusable Detached Application Retirement** as a
+`workflow_call`-only worker. It is intentionally uncalled: do not add or invoke
+a `workflow_dispatch` wrapper, configure the future live authz managed-set
+secret, deploy this branch, or attempt a provider mutation as part of phase one.
+The worker uses the protected `launchplane-authz-admin` environment, OIDC,
+target-digest concurrency, exact input validation, and redacted evidence.
+
+The future operator sequence is plan then apply. Inputs are exact Dokploy
+project/environment/application names, the candidate target SHA-256, a sorted
+non-empty JSON array of every other application target SHA-256 in the project,
+a stable idempotency key, reason, and issue. Apply additionally requires the
+persisted plan record/digest and the exact target-bound confirmation. Never pass
+or recover a raw target ID through workflow inputs, artifacts, summaries, issue
+comments, or local CLI fallbacks.
+
+Planning stops on ambiguous or malformed `/api/project.all` evidence, a
+non-idle candidate, any domain, any recognized deployment history, digest/set
+drift, or any Launchplane authority reference. Apply repeats all proofs under a
+durable provider-operation lease before checkpointing the sole
+`application.delete`. Reconciliation and already-absent retries reuse the same
+apply idempotency key. Completion requires candidate absence, unchanged
+protected fingerprints, and zero authority writes.
+
+Managed authz routing is reserved through the
+`detached-application-retirement` selector, managed-set ID
+`operator.detached-application-retirement`, and secret name
+`LAUNCHPLANE_AUTHZ_DETACHED_APPLICATION_RETIREMENT_MANAGED_SET_JSON`. Phase one
+does not create or populate that secret and does not reconcile a live rule. A
+later phase must first pin a thin caller to the exact merged reusable-worker SHA,
+then authorize the exact caller `workflow_ref` and immutable worker
+`job_workflow_ref` before any protected plan/apply run.

--- a/docs/records.md
+++ b/docs/records.md
@@ -2490,3 +2490,29 @@ Product profiles include `lifecycle_state` with backward-compatible default
 owner-review context-binding migration. `retiring` and `retired` profiles
 remain directly readable and appear in complete profile listings as audit
 authority; active discovery and automation filter them explicitly.
+
+## Detached application retirement records
+
+Detached Dokploy application retirement evidence is stored append-only under
+`launchplane_detached_application_retirements` in PostgreSQL and
+`state/launchplane_detached_application_retirements/` for filesystem rehearsal.
+Migration `d8a0c2e4f6b8` follows the product-retirement migration and creates
+candidate, plan, and idempotency indexes plus a partial unique plan reservation.
+Database checks require at least one protected target and
+`authority_write_count = 0`.
+
+The plan digest covers intent continuity, the complete private candidate
+observation, the bounded Launchplane authority-absence proof, and the exact
+sorted protected-provider snapshot. Private records may retain provider IDs so
+apply and reconciliation can bind the same target, but service/workflow
+evidence exposes only hashes, counts, phases, booleans, and record references.
+The absence proof contains a sorted required-source tuple with record counts,
+digests, and literal zero matches; no matched record or mutable authority field
+exists in the contract.
+
+Apply records are terminal only and reference the exact reviewed plan. Mutation
+evidence records the provider-operation/reconciliation linkage, checkpoint
+phases, whether the sole application-delete effect was attempted/performed,
+candidate absence verification, protected-target stability, and the literal
+zero authority-write count. There are no profile lifecycle, authority deletion,
+secret mutation, target rewrite, or runtime mutation fields.

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -3668,3 +3668,51 @@ already-absent applications. Mutable runtime and target records
 are removed only after provider absence is verified; runtime deletion events
 and preserved managed-secret references remain audit evidence. The profile is
 never deleted and becomes `retired` with previews disabled.
+
+## Detached application retirement
+
+`POST /v1/detached-application-retirement` is a separate bounded operation for
+one Dokploy application that is not owned by Launchplane product/runtime
+authority. It does not call product retirement and its adapter/store boundary
+has no profile, target, runtime, secret, route, inventory, deployment, or authz
+write/delete methods. The only allowed authority-write count is zero.
+
+The request accepts `plan` or `apply`, exact project/environment/application
+names, the candidate target identifier SHA-256, a sorted non-empty tuple of
+expected protected application target SHA-256 values, reason and issue, plus
+apply-only reviewed-plan identity/digest and exact confirmation. Raw target IDs
+are never accepted. The candidate digest must not be protected.
+
+Planning strictly parses `/api/project.all`, requires one exact project,
+environment, and globally unique application name, then reads
+`application.one`, domains, and deployment history. The candidate must match
+the requested digest, be exactly `idle`, have a recognized empty deployment
+history, and have zero domains. Every other application in the project is a
+protected provider target. Launchplane requires the exact expected protected
+digest set and persists each protected application fingerprint, domains, and
+history snapshot.
+
+The candidate ID must also be absent from every bounded Launchplane authority
+source capable of carrying or resolving provider-target authority. The proof
+stores only source names, record counts, and source digests, has a literal zero
+match count, and cannot be built after an ID or exact provider-application-name
+match. A tracked Dokploy `target_name` is not treated as a provider application
+name by itself; exact provider IDs and provider application ownership fields
+remain authoritative.
+
+Apply requires the exact stored plan and rederives candidate discovery,
+authority absence, and the protected snapshot under the same target-key
+namespace used by product retirement. It checkpoints immediately before the
+single `application.delete` call, treats a provider 404 as already absent,
+reconciles unknown outcomes through fresh observation, verifies candidate
+absence, and requires protected fingerprints to remain unchanged. Apply writes
+one terminal detached-retirement record and no authority records.
+
+Only a local admin or GitHub Actions running the exact SHA-pinned reusable
+worker may reach the route. Authorization actions are
+`detached_application_retirement.plan` and
+`detached_application_retirement.apply` against Launchplane's global
+control-plane context, never a product instance. Phase one adds the reusable
+`workflow_call` worker and managed authz secret routing only; it intentionally
+adds no mutable dispatch wrapper, live managed rule/secret value, deployment,
+or provider mutation.

--- a/frontend/generated/openapi-canonical.json
+++ b/frontend/generated/openapi-canonical.json
@@ -2788,6 +2788,83 @@
         "title": "DeploymentRecordResponse",
         "type": "object"
       },
+      "DetachedApplicationRetirementRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "application_name": {
+            "title": "Application Name",
+            "type": "string"
+          },
+          "candidate_target_sha256": {
+            "title": "Candidate Target Sha256",
+            "type": "string"
+          },
+          "confirmation": {
+            "default": "",
+            "title": "Confirmation",
+            "type": "string"
+          },
+          "environment_name": {
+            "title": "Environment Name",
+            "type": "string"
+          },
+          "expected_protected_target_sha256": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Expected Protected Target Sha256",
+            "type": "array"
+          },
+          "mode": {
+            "default": "plan",
+            "enum": [
+              "plan",
+              "apply"
+            ],
+            "title": "Mode",
+            "type": "string"
+          },
+          "project_name": {
+            "title": "Project Name",
+            "type": "string"
+          },
+          "reason": {
+            "title": "Reason",
+            "type": "string"
+          },
+          "related_issue": {
+            "title": "Related Issue",
+            "type": "string"
+          },
+          "reviewed_plan_record_id": {
+            "default": "",
+            "title": "Reviewed Plan Record Id",
+            "type": "string"
+          },
+          "reviewed_plan_sha256": {
+            "default": "",
+            "title": "Reviewed Plan Sha256",
+            "type": "string"
+          },
+          "schema_version": {
+            "const": 1,
+            "default": 1,
+            "title": "Schema Version",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "project_name",
+          "environment_name",
+          "application_name",
+          "candidate_target_sha256",
+          "expected_protected_target_sha256",
+          "reason",
+          "related_issue"
+        ],
+        "title": "DetachedApplicationRetirementRequest",
+        "type": "object"
+      },
       "DokployTargetIdRecord": {
         "additionalProperties": false,
         "properties": {
@@ -34057,6 +34134,116 @@
           }
         },
         "summary": "Read one deployment record"
+      }
+    },
+    "/v1/detached-application-retirement": {
+      "post": {
+        "operationId": "execute_detached_application_retirement",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Idempotency-Key",
+            "required": false,
+            "schema": {
+              "default": "",
+              "title": "Idempotency-Key",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "Authorization",
+            "required": false,
+            "schema": {
+              "default": "",
+              "title": "Authorization",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DetachedApplicationRetirementRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AcceptedEvidenceResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "summary": "Plan or apply audited detached Dokploy application retirement"
       }
     },
     "/v1/dokploy-targets/inspect": {

--- a/tests/test_authz_operator_workflow.py
+++ b/tests/test_authz_operator_workflow.py
@@ -38,6 +38,7 @@ class AuthzOperatorWorkflowTests(unittest.TestCase):
                 "product-owner-policy-admin",
                 "product-health-monitoring",
                 "product-retirement",
+                "detached-application-retirement",
                 "preview-feedback-remediation",
                 "odoo-route-binding",
                 "odoo-external-route-binding",
@@ -83,6 +84,10 @@ class AuthzOperatorWorkflowTests(unittest.TestCase):
             "reconcile-product-retirement": (
                 "${{ inputs.managed_set == 'product-retirement' }}",
                 "${{ secrets.LAUNCHPLANE_AUTHZ_PRODUCT_RETIREMENT_MANAGED_SET_JSON }}",
+            ),
+            "reconcile-detached-application-retirement": (
+                "${{ inputs.managed_set == 'detached-application-retirement' }}",
+                "${{ secrets.LAUNCHPLANE_AUTHZ_DETACHED_APPLICATION_RETIREMENT_MANAGED_SET_JSON }}",
             ),
             "reconcile-preview-feedback-remediation": (
                 "${{ inputs.managed_set == 'preview-feedback-remediation' }}",
@@ -153,6 +158,9 @@ class AuthzOperatorWorkflowTests(unittest.TestCase):
                     "reconcile-owner-acceptance": "operator.owner-acceptance",
                     "reconcile-product-owner-policy-admin": "operator.product-owner-policy-admin",
                     "reconcile-product-retirement": "operator.product-retirement",
+                    "reconcile-detached-application-retirement": (
+                        "operator.detached-application-retirement"
+                    ),
                     "reconcile-preview-feedback-remediation": (
                         "operator.preview-feedback-remediation"
                     ),

--- a/tests/test_detached_application_retirement.py
+++ b/tests/test_detached_application_retirement.py
@@ -1,0 +1,589 @@
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from collections.abc import Mapping
+from typing import cast
+from unittest.mock import patch
+
+from control_plane.contracts.detached_application_retirement import (
+    DetachedApplicationAuthorityAbsenceProof,
+    DetachedApplicationAuthorityAbsenceSource,
+    DetachedApplicationProtectedTargetSnapshot,
+    DetachedApplicationProviderObservation,
+    DetachedApplicationRetirementIdentity,
+    DetachedApplicationRetirementRecord,
+    DetachedApplicationRetirementRequest,
+)
+from control_plane.contracts.dokploy_target_record import DokployTargetRecord
+from control_plane.detached_application_retirement import (
+    DetachedApplicationDiscovery,
+    DetachedApplicationRetirementBlockedError,
+    DetachedApplicationRetirementStore,
+    DokployDetachedApplicationRetirementAdapter,
+    build_detached_application_retirement_plan_record,
+    discover_detached_application,
+    prove_detached_application_authority_absence,
+    redacted_detached_application_retirement_response,
+)
+from control_plane.dokploy import api as dokploy_api
+from control_plane.provider_operations import ProviderMutationUnknownError
+from control_plane.storage.filesystem import FilesystemRecordStore
+from control_plane.storage.postgres import PostgresRecordStore
+
+
+NOW = "2026-08-11T12:00:00Z"
+CANDIDATE_ID = "application-detached"
+PROTECTED_IDS = ("application-production", "application-testing")
+
+
+def _digest(value: str) -> str:
+    from control_plane.contracts.product_retirement import provider_identifier_sha256
+
+    return provider_identifier_sha256(value)
+
+
+class _Lease:
+    def __init__(self) -> None:
+        self.phases: list[str] = []
+
+    def assert_current(self) -> None:
+        return None
+
+    def checkpoint_effect(self, phase: str) -> None:
+        self.phases.append(phase)
+
+
+class _Store:
+    def __init__(self) -> None:
+        self.sources: dict[str, tuple[object, ...]] = {}
+        self.records: dict[str, object] = {}
+
+    def __getattr__(self, name: str) -> object:
+        if name.startswith("list_"):
+            source = name.removeprefix("list_").removesuffix("_records")
+            if source == "secret_bindings":
+                source = "secret_binding"
+            if source == "preview_inventory_scan":
+                source = "preview_inventory"
+            return lambda **_kwargs: self.sources.get(source, ())
+        raise AttributeError(name)
+
+    def write_detached_application_retirement_record(self, record: object) -> object:
+        self.records[str(getattr(record, "record_id"))] = record
+        return None
+
+
+def _request(*, mode: str = "plan", **overrides: object) -> DetachedApplicationRetirementRequest:
+    payload: dict[str, object] = {
+        "mode": mode,
+        "project_name": "example-project",
+        "environment_name": "testing",
+        "application_name": "detached-application",
+        "candidate_target_sha256": _digest(CANDIDATE_ID),
+        "expected_protected_target_sha256": tuple(sorted(_digest(item) for item in PROTECTED_IDS)),
+        "reason": "Remove detached provider application.",
+        "related_issue": "cbusillo/launchplane#2100",
+    }
+    payload.update(overrides)
+    return DetachedApplicationRetirementRequest.model_validate(payload)
+
+
+def _projects(*, include_candidate: bool = True) -> tuple[dict[str, object], ...]:
+    testing_applications: list[dict[str, object]] = [
+        {
+            "applicationId": PROTECTED_IDS[1],
+            "name": "tracked-testing-application",
+            "environmentId": "environment-testing",
+            "projectId": "project-1",
+        }
+    ]
+    if include_candidate:
+        testing_applications.append(
+            {
+                "applicationId": CANDIDATE_ID,
+                "name": "detached-application",
+                "environmentId": "environment-testing",
+                "projectId": "project-1",
+            }
+        )
+    return (
+        {
+            "projectId": "project-1",
+            "name": "example-project",
+            "environments": [
+                {
+                    "environmentId": "environment-testing",
+                    "name": "testing",
+                    "applications": testing_applications,
+                },
+                {
+                    "environmentId": "environment-production",
+                    "name": "production",
+                    "applications": [
+                        {
+                            "applicationId": PROTECTED_IDS[0],
+                            "name": "production-application",
+                            "environmentId": "environment-production",
+                            "projectId": "project-1",
+                        }
+                    ],
+                },
+            ],
+        },
+    )
+
+
+def _payloads() -> dict[str, dict[str, object]]:
+    return {
+        CANDIDATE_ID: {
+            "applicationId": CANDIDATE_ID,
+            "name": "detached-application",
+            "projectId": "project-1",
+            "environmentId": "environment-testing",
+            "applicationStatus": "idle",
+        },
+        PROTECTED_IDS[0]: {
+            "applicationId": PROTECTED_IDS[0],
+            "name": "production-application",
+            "projectId": "project-1",
+            "environmentId": "environment-production",
+            "applicationStatus": "running",
+        },
+        PROTECTED_IDS[1]: {
+            "applicationId": PROTECTED_IDS[1],
+            "name": "tracked-testing-application",
+            "projectId": "project-1",
+            "environmentId": "environment-testing",
+            "applicationStatus": "idle",
+        },
+    }
+
+
+def _discovery() -> DetachedApplicationDiscovery:
+    protected = tuple(
+        sorted(
+            (
+                DetachedApplicationProtectedTargetSnapshot(
+                    application_id=target_id,
+                    target_id_sha256=_digest(target_id),
+                    application_name=f"protected-{index}",
+                    application_fingerprint_sha256=_digest(f"fingerprint-{index}"),
+                    domain_count=0,
+                    domains_sha256=_digest(f"domains-{index}"),
+                    deployment_history_state="no_history",
+                    deployment_history_sha256=_digest(f"history-{index}"),
+                )
+                for index, target_id in enumerate(PROTECTED_IDS)
+            ),
+            key=lambda item: item.target_id_sha256,
+        )
+    )
+    return DetachedApplicationDiscovery(
+        candidate=DetachedApplicationProviderObservation(
+            observed_at=NOW,
+            project_id="project-1",
+            project_name="example-project",
+            environment_id="environment-testing",
+            environment_name="testing",
+            application_id=CANDIDATE_ID,
+            application_name="detached-application",
+            target_id_sha256=_digest(CANDIDATE_ID),
+            state="present",
+            application_state="idle",
+            application_fingerprint_sha256=_digest("candidate-fingerprint"),
+            deployment_history_state="no_history",
+            safe_to_retire=True,
+        ),
+        protected_targets=protected,
+    )
+
+
+def _proof() -> DetachedApplicationAuthorityAbsenceProof:
+    source = DetachedApplicationAuthorityAbsenceSource(
+        source="provider_target",
+        record_count=0,
+        records_sha256=_digest("empty-source"),
+    )
+    return DetachedApplicationAuthorityAbsenceProof(
+        candidate_target_sha256=_digest(CANDIDATE_ID),
+        candidate_application_name_sha256=_digest("detached-application"),
+        source_count=1,
+        record_count=0,
+        sources=(source,),
+    )
+
+
+def _plan(store: _Store | None = None) -> DetachedApplicationRetirementRecord:
+    del store
+    return build_detached_application_retirement_plan_record(
+        request=_request(),
+        identity=DetachedApplicationRetirementIdentity(actor="test", identity_kind="test"),
+        trace_id="plan-trace",
+        idempotency_key="retire-detached",
+        requested_at=NOW,
+        discovery=_discovery(),
+        authority_absence_proof=_proof(),
+    )
+
+
+class DetachedApplicationRetirementTests(unittest.TestCase):
+    def _discover(
+        self,
+        *,
+        projects: object | None = None,
+        payload_updates: Mapping[str, object] | None = None,
+        domains: Mapping[str, object] | None = None,
+        history_state: str = "no_history",
+        request: DetachedApplicationRetirementRequest | None = None,
+    ) -> DetachedApplicationDiscovery:
+        payloads = _payloads()
+        if payload_updates:
+            payloads[CANDIDATE_ID].update(payload_updates)
+
+        def fetch_payload(**kwargs: object) -> dict[str, object]:
+            return payloads[cast(str, kwargs["target_id"])]
+
+        def domain_request(**kwargs: object) -> object:
+            application_id = cast(dict[str, str], kwargs["query"])["applicationId"]
+            return (domains or {}).get(application_id, [])
+
+        history = dokploy_api.DeploymentHistory(
+            state=cast(dokploy_api.DeploymentHistoryState, history_state),
+            latest_deployment=None,
+        )
+        with (
+            patch(
+                "control_plane.detached_application_retirement.dokploy_source.read_dokploy_config",
+                return_value=("https://dokploy.invalid", "token"),
+            ),
+            patch(
+                "control_plane.detached_application_retirement.dokploy_api.fetch_dokploy_projects",
+                return_value=projects if projects is not None else _projects(),
+            ),
+            patch(
+                "control_plane.detached_application_retirement.dokploy_api.fetch_dokploy_target_payload",
+                side_effect=fetch_payload,
+            ),
+            patch(
+                "control_plane.detached_application_retirement.dokploy_api.dokploy_request",
+                side_effect=domain_request,
+            ),
+            patch(
+                "control_plane.detached_application_retirement.dokploy_api.deployment_history_for_target",
+                return_value=history,
+            ),
+        ):
+            return discover_detached_application(
+                control_plane_root=Path("."),
+                request=request or _request(),
+                observed_at=NOW,
+            )
+
+    def test_request_requires_sorted_protected_set_and_excludes_candidate(self) -> None:
+        with self.assertRaisesRegex(ValueError, "unique and sorted"):
+            _request(
+                expected_protected_target_sha256=tuple(
+                    reversed(_request().expected_protected_target_sha256)
+                )
+            )
+        with self.assertRaisesRegex(ValueError, "cannot be a protected"):
+            _request(expected_protected_target_sha256=(_digest(CANDIDATE_ID),))
+        with self.assertRaisesRegex(ValueError, "apply-only"):
+            _request(reviewed_plan_record_id="unexpected")
+
+    def test_discovery_requires_idle_no_history_zero_domains_and_exact_protected_set(self) -> None:
+        discovery = self._discover()
+        self.assertTrue(discovery.candidate.safe_to_retire)
+        self.assertEqual(
+            tuple(item.target_id_sha256 for item in discovery.protected_targets),
+            _request().expected_protected_target_sha256,
+        )
+        for payload_updates, domains, history_state, message in (
+            ({"applicationStatus": "running"}, None, "no_history", "idle"),
+            (
+                {},
+                {CANDIDATE_ID: [{"domainId": "domain-1", "host": "example.test"}]},
+                "no_history",
+                "domainless",
+            ),
+            ({}, None, "present", "no-history"),
+        ):
+            discovery = self._discover(
+                payload_updates=payload_updates,
+                domains=domains,
+                history_state=history_state,
+            )
+            with self.assertRaisesRegex(DetachedApplicationRetirementBlockedError, message):
+                build_detached_application_retirement_plan_record(
+                    request=_request(),
+                    identity=DetachedApplicationRetirementIdentity(
+                        actor="test", identity_kind="test"
+                    ),
+                    trace_id="trace",
+                    idempotency_key="key",
+                    requested_at=NOW,
+                    discovery=discovery,
+                    authority_absence_proof=_proof(),
+                )
+
+    def test_discovery_fails_closed_on_ambiguity_malformed_and_digest_drift(self) -> None:
+        duplicate = list(_projects())
+        duplicate.append(
+            {
+                "projectId": "project-2",
+                "name": "other-project",
+                "environments": [
+                    {
+                        "environmentId": "environment-2",
+                        "name": "testing",
+                        "applications": [
+                            {
+                                "applicationId": "duplicate-name",
+                                "name": "detached-application",
+                            }
+                        ],
+                    }
+                ],
+            }
+        )
+        with self.assertRaisesRegex(DetachedApplicationRetirementBlockedError, "globally unique"):
+            self._discover(projects=tuple(duplicate))
+        malformed = ({"projectId": "project-1", "name": "example-project"},)
+        with self.assertRaisesRegex(DetachedApplicationRetirementBlockedError, "environments"):
+            self._discover(projects=malformed)
+        with self.assertRaisesRegex(DetachedApplicationRetirementBlockedError, "digest"):
+            self._discover(request=_request(candidate_target_sha256="f" * 64))
+
+    def test_authority_absence_scans_every_required_source_and_preserves_target_name_distinction(
+        self,
+    ) -> None:
+        store = _Store()
+        proof = prove_detached_application_authority_absence(
+            record_store=cast(DetachedApplicationRetirementStore, store),
+            candidate_target_id=CANDIDATE_ID,
+            candidate_application_name="detached-application",
+        )
+        self.assertGreaterEqual(proof.source_count, 18)
+        source_names = tuple(source.source for source in proof.sources)
+        for source_name in source_names:
+            store = _Store()
+            method_source = source_name
+            if source_name == "environment_inventory":
+                method_source = "environment_inventory"
+            store.sources[method_source] = ({"target_id": CANDIDATE_ID},)
+            with self.assertRaisesRegex(
+                DetachedApplicationRetirementBlockedError,
+                source_name,
+            ):
+                prove_detached_application_authority_absence(
+                    record_store=cast(DetachedApplicationRetirementStore, store),
+                    candidate_target_id=CANDIDATE_ID,
+                    candidate_application_name="detached-application",
+                )
+        store = _Store()
+        store.sources["dokploy_target"] = (
+            DokployTargetRecord(
+                context="example",
+                instance="testing",
+                target_type="application",
+                target_name="detached-application",
+                updated_at=NOW,
+            ),
+        )
+        proof = prove_detached_application_authority_absence(
+            record_store=cast(DetachedApplicationRetirementStore, store),
+            candidate_target_id=CANDIDATE_ID,
+            candidate_application_name="detached-application",
+        )
+        self.assertEqual(proof.match_count, 0)
+        store.sources["provider_target"] = ({"display_name": "detached-application"},)
+        with self.assertRaisesRegex(DetachedApplicationRetirementBlockedError, "provider_target"):
+            prove_detached_application_authority_absence(
+                record_store=cast(DetachedApplicationRetirementStore, store),
+                candidate_target_id=CANDIDATE_ID,
+                candidate_application_name="detached-application",
+            )
+
+    def test_plan_is_deterministic_private_and_redacted(self) -> None:
+        plan = _plan()
+        replay = _plan()
+        self.assertEqual(plan.record_id, replay.record_id)
+        self.assertEqual(plan.plan_sha256, replay.plan_sha256)
+        private_payload = plan.model_dump(mode="json")
+        self.assertEqual(private_payload["candidate_observation"]["application_id"], CANDIDATE_ID)
+        public_payload = redacted_detached_application_retirement_response(plan)
+        serialized = json.dumps(public_payload, sort_keys=True)
+        self.assertNotIn(CANDIDATE_ID, serialized)
+        self.assertNotIn("application_id", serialized)
+        result_payload = cast(dict[str, object], public_payload["result"])
+        self.assertEqual(result_payload["authority_write_count"], 0)
+
+    def test_adapter_deletes_once_after_checkpoint_and_verifies_protected_targets(self) -> None:
+        store = _Store()
+        plan = _plan()
+        request = _request(
+            mode="apply",
+            reviewed_plan_record_id=plan.record_id,
+            reviewed_plan_sha256=plan.plan_sha256,
+            confirmation=_request().expected_confirmation,
+        )
+        absent_candidate = DetachedApplicationProviderObservation(
+            observed_at=NOW,
+            project_id="project-1",
+            project_name="example-project",
+            environment_id="environment-testing",
+            environment_name="testing",
+            application_id=CANDIDATE_ID,
+            application_name="detached-application",
+            target_id_sha256=_digest(CANDIDATE_ID),
+            state="absent",
+        )
+        absent = DetachedApplicationDiscovery(
+            candidate=absent_candidate,
+            protected_targets=plan.protected_targets,
+        )
+        adapter = DokployDetachedApplicationRetirementAdapter(
+            control_plane_root=Path("."),
+            record_store=cast(DetachedApplicationRetirementStore, store),
+            request=request,
+            plan=plan,
+            identity=DetachedApplicationRetirementIdentity(actor="test", identity_kind="test"),
+            trace_id="apply-trace",
+            idempotency_key="apply-key",
+            requested_at=NOW,
+        )
+        lease = _Lease()
+        with (
+            patch(
+                "control_plane.detached_application_retirement.discover_detached_application",
+                side_effect=(_discovery(), absent),
+            ),
+            patch(
+                "control_plane.detached_application_retirement.prove_detached_application_authority_absence",
+                return_value=plan.authority_absence_proof,
+            ),
+            patch(
+                "control_plane.detached_application_retirement.dokploy_source.read_dokploy_config",
+                return_value=("host", "token"),
+            ),
+            patch(
+                "control_plane.detached_application_retirement.dokploy_api.delete_dokploy_application"
+            ) as delete_application,
+        ):
+            result = adapter.apply("provider-operation", lease)
+        self.assertEqual(lease.phases, ["delete_application"])
+        delete_application.assert_called_once_with(
+            host="host",
+            token="token",
+            application_id=CANDIDATE_ID,
+        )
+        self.assertTrue(result.provider_effect_performed)
+        terminal = next(iter(store.records.values()))
+        self.assertEqual(getattr(terminal, "authority_write_count"), 0)
+        self.assertEqual(
+            adapter.target_key(),
+            f"provider-target:dokploy:application:{CANDIDATE_ID}",
+        )
+
+    def test_adapter_handles_already_absent_and_unknown_outcome(self) -> None:
+        store = _Store()
+        plan = _plan()
+        request = _request(
+            mode="apply",
+            reviewed_plan_record_id=plan.record_id,
+            reviewed_plan_sha256=plan.plan_sha256,
+            confirmation=_request().expected_confirmation,
+        )
+        absent = DetachedApplicationDiscovery(
+            candidate=plan.candidate_observation.model_copy(
+                update={"state": "absent", "safe_to_retire": False}
+            ),
+            protected_targets=plan.protected_targets,
+        )
+        adapter = DokployDetachedApplicationRetirementAdapter(
+            control_plane_root=Path("."),
+            record_store=cast(DetachedApplicationRetirementStore, store),
+            request=request,
+            plan=plan,
+            identity=DetachedApplicationRetirementIdentity(actor="test", identity_kind="test"),
+            trace_id="absent-trace",
+            idempotency_key="absent-key",
+            requested_at=NOW,
+        )
+        with (
+            patch(
+                "control_plane.detached_application_retirement.discover_detached_application",
+                return_value=absent,
+            ),
+            patch(
+                "control_plane.detached_application_retirement.prove_detached_application_authority_absence",
+                return_value=plan.authority_absence_proof,
+            ),
+        ):
+            result = adapter.apply("operation", _Lease())
+        self.assertFalse(result.provider_effect_performed)
+
+        adapter = DokployDetachedApplicationRetirementAdapter(
+            control_plane_root=Path("."),
+            record_store=cast(DetachedApplicationRetirementStore, _Store()),
+            request=request,
+            plan=plan,
+            identity=DetachedApplicationRetirementIdentity(actor="test", identity_kind="test"),
+            trace_id="unknown-trace",
+            idempotency_key="unknown-key",
+            requested_at=NOW,
+        )
+        with (
+            patch(
+                "control_plane.detached_application_retirement.discover_detached_application",
+                return_value=_discovery(),
+            ),
+            patch(
+                "control_plane.detached_application_retirement.prove_detached_application_authority_absence",
+                return_value=plan.authority_absence_proof,
+            ),
+            patch(
+                "control_plane.detached_application_retirement.dokploy_source.read_dokploy_config",
+                return_value=("host", "token"),
+            ),
+            patch(
+                "control_plane.detached_application_retirement.dokploy_api.delete_dokploy_application",
+                side_effect=TimeoutError,
+            ),
+        ):
+            with self.assertRaises(ProviderMutationUnknownError):
+                adapter.apply("operation", _Lease())
+
+    def test_filesystem_and_postgres_append_only_parity(self) -> None:
+        plan = _plan()
+        with TemporaryDirectory() as temporary_directory_name:
+            filesystem = FilesystemRecordStore(Path(temporary_directory_name) / "state")
+            filesystem.write_detached_application_retirement_record(plan)
+            filesystem.write_detached_application_retirement_record(plan)
+            self.assertEqual(
+                filesystem.read_detached_application_retirement_record(plan.record_id),
+                plan,
+            )
+            changed = plan.model_copy(update={"reason": "changed", "continuity_sha256": "f" * 64})
+            with self.assertRaisesRegex(ValueError, "append-only"):
+                filesystem.write_detached_application_retirement_record(changed)
+
+            database_path = Path(temporary_directory_name) / "launchplane.sqlite3"
+            postgres = PostgresRecordStore(database_url=f"sqlite+pysqlite:///{database_path}")
+            postgres.ensure_schema()
+            postgres.write_detached_application_retirement_record(plan)
+            postgres.write_detached_application_retirement_record(plan)
+            self.assertEqual(
+                postgres.list_detached_application_retirement_records(
+                    candidate_target_sha256=plan.candidate_observation.target_id_sha256
+                ),
+                (plan,),
+            )
+            with self.assertRaisesRegex(ValueError, "append-only"):
+                postgres.write_detached_application_retirement_record(changed)
+            postgres.close()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_detached_application_retirement.py
+++ b/tests/test_detached_application_retirement.py
@@ -603,8 +603,12 @@ class DetachedApplicationRetirementTests(unittest.TestCase):
                 "provider-operation", "delete_application", adapter.reconciliation_key()
             )
         self.assertEqual(observation.outcome, "present")
-        self.assertEqual(observation.response_payload["result"]["outcome"], "retired")
-        terminal = next(iter(store.records.values()))
+        result_payload = cast(dict[str, object], observation.response_payload["result"])
+        self.assertEqual(result_payload["outcome"], "retired")
+        terminal = cast(
+            DetachedApplicationRetirementRecord,
+            next(iter(store.records.values())),
+        )
         self.assertTrue(terminal.mutation_evidence.provider_effect_attempted)
         self.assertTrue(terminal.mutation_evidence.provider_effect_performed)
         self.assertEqual(terminal.mutation_evidence.provider_effect_phases, ("delete_application",))

--- a/tests/test_detached_application_retirement.py
+++ b/tests/test_detached_application_retirement.py
@@ -24,6 +24,7 @@ from control_plane.detached_application_retirement import (
     build_detached_application_retirement_plan_record,
     discover_detached_application,
     prove_detached_application_authority_absence,
+    redacted_detached_application_retirement_error,
     redacted_detached_application_retirement_response,
 )
 from control_plane.dokploy import api as dokploy_api
@@ -66,6 +67,14 @@ class _Store:
                 source = "secret_binding"
             if source == "preview_inventory_scan":
                 source = "preview_inventory"
+            if source == "runtime_environment_delete_events":
+                source = "runtime_environment_delete"
+            if source == "odoo_stable_target_replacement_operation":
+                source = "stable_target_replacement"
+            if source == "odoo_stable_bootstrap_operation":
+                source = "odoo_stable_bootstrap"
+            if source == "verireel_prod_backup_gate_operation":
+                source = "verireel_prod_backup_gate"
             return lambda **_kwargs: self.sources.get(source, ())
         raise AttributeError(name)
 
@@ -554,6 +563,130 @@ class DetachedApplicationRetirementTests(unittest.TestCase):
         ):
             with self.assertRaises(ProviderMutationUnknownError):
                 adapter.apply("operation", _Lease())
+
+    def test_reconciliation_adopts_verified_absence_after_delete_checkpoint(self) -> None:
+        store = _Store()
+        plan = _plan()
+        request = _request(
+            mode="apply",
+            reviewed_plan_record_id=plan.record_id,
+            reviewed_plan_sha256=plan.plan_sha256,
+            confirmation=_request().expected_confirmation,
+        )
+        absent = DetachedApplicationDiscovery(
+            candidate=plan.candidate_observation.model_copy(
+                update={"state": "absent", "safe_to_retire": False}
+            ),
+            protected_targets=plan.protected_targets,
+        )
+        adapter = DokployDetachedApplicationRetirementAdapter(
+            control_plane_root=Path("."),
+            record_store=cast(DetachedApplicationRetirementStore, store),
+            request=request,
+            plan=plan,
+            identity=DetachedApplicationRetirementIdentity(actor="test", identity_kind="test"),
+            trace_id="reconcile-trace",
+            idempotency_key="reconcile-key",
+            requested_at=NOW,
+        )
+        with (
+            patch(
+                "control_plane.detached_application_retirement.discover_detached_application",
+                return_value=absent,
+            ),
+            patch(
+                "control_plane.detached_application_retirement.prove_detached_application_authority_absence",
+                return_value=plan.authority_absence_proof,
+            ),
+        ):
+            observation = adapter.observe(
+                "provider-operation", "delete_application", adapter.reconciliation_key()
+            )
+        self.assertEqual(observation.outcome, "present")
+        self.assertEqual(observation.response_payload["result"]["outcome"], "retired")
+        terminal = next(iter(store.records.values()))
+        self.assertTrue(terminal.mutation_evidence.provider_effect_attempted)
+        self.assertTrue(terminal.mutation_evidence.provider_effect_performed)
+        self.assertEqual(terminal.mutation_evidence.provider_effect_phases, ("delete_application",))
+
+    def test_reconciliation_retries_present_candidate_and_tolerates_unrelated_authority_churn(
+        self,
+    ) -> None:
+        plan = _plan()
+        request = _request(
+            mode="apply",
+            reviewed_plan_record_id=plan.record_id,
+            reviewed_plan_sha256=plan.plan_sha256,
+            confirmation=_request().expected_confirmation,
+        )
+        changed_proof = plan.authority_absence_proof.model_copy(
+            update={
+                "record_count": plan.authority_absence_proof.record_count + 1,
+                "sources": tuple(
+                    source.model_copy(update={"record_count": source.record_count + 1})
+                    for source in plan.authority_absence_proof.sources
+                ),
+            }
+        )
+        adapter = DokployDetachedApplicationRetirementAdapter(
+            control_plane_root=Path("."),
+            record_store=cast(DetachedApplicationRetirementStore, _Store()),
+            request=request,
+            plan=plan,
+            identity=DetachedApplicationRetirementIdentity(actor="test", identity_kind="test"),
+            trace_id="retry-trace",
+            idempotency_key="retry-key",
+            requested_at=NOW,
+        )
+        with (
+            patch(
+                "control_plane.detached_application_retirement.discover_detached_application",
+                return_value=_discovery(),
+            ),
+            patch(
+                "control_plane.detached_application_retirement.prove_detached_application_authority_absence",
+                return_value=changed_proof,
+            ),
+        ):
+            observation = adapter.observe(
+                "provider-operation", "delete_application", adapter.reconciliation_key()
+            )
+        self.assertEqual(observation.outcome, "absent")
+        self.assertTrue(observation.retry_safe)
+
+    def test_provider_error_redaction_excludes_raw_identifiers_and_detail(self) -> None:
+        raw_identifier = "provider-secret-identifier"
+        error = dokploy_api.DokployRequestFailed(
+            method="POST",
+            path=f"/api/application.delete?applicationId={raw_identifier}",
+            detail=f"failed for {raw_identifier}",
+            status_code=500,
+        )
+        message = redacted_detached_application_retirement_error(error)
+        self.assertNotIn(raw_identifier, message)
+        self.assertNotIn("applicationId", message)
+        self.assertEqual(message, "Dokploy API POST request failed (500).")
+
+    def test_authority_absence_detects_embedded_target_id_but_not_embedded_name(self) -> None:
+        store = _Store()
+        store.sources["product_retirement"] = (
+            {"evidence": f"provider target was {CANDIDATE_ID} during retirement"},
+        )
+        with self.assertRaisesRegex(
+            DetachedApplicationRetirementBlockedError, "product_retirement"
+        ):
+            prove_detached_application_authority_absence(
+                record_store=cast(DetachedApplicationRetirementStore, store),
+                candidate_target_id=CANDIDATE_ID,
+                candidate_application_name="detached-application",
+            )
+        store.sources["product_retirement"] = ({"note": "prefix-detached-application-suffix"},)
+        proof = prove_detached_application_authority_absence(
+            record_store=cast(DetachedApplicationRetirementStore, store),
+            candidate_target_id=CANDIDATE_ID,
+            candidate_application_name="detached-application",
+        )
+        self.assertEqual(proof.match_count, 0)
 
     def test_filesystem_and_postgres_append_only_parity(self) -> None:
         plan = _plan()

--- a/tests/test_detached_application_retirement_workflow.py
+++ b/tests/test_detached_application_retirement_workflow.py
@@ -40,6 +40,7 @@ class DetachedApplicationRetirementWorkflowTests(unittest.TestCase):
         self.assertIn("protected targets must be sorted unique", validate.run)
         self.assertIn("candidate target cannot be protected", validate.run)
         self.assertIn("retire detached Dokploy application", validate.run)
+        self.assertIn("Caller repository must be cbusillo/launchplane", validate.run)
 
         request = self.workflow.step_named(
             "retire", "Request audited detached application retirement"

--- a/tests/test_detached_application_retirement_workflow.py
+++ b/tests/test_detached_application_retirement_workflow.py
@@ -1,0 +1,100 @@
+import re
+import unittest
+from pathlib import Path
+
+from tests.support.workflows import load_workflow
+
+
+class DetachedApplicationRetirementWorkflowTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.path = Path(".github/workflows/reusable-detached-application-retirement.yml")
+        self.workflow = load_workflow(self.path)
+
+    def test_worker_is_reusable_only_and_protected(self) -> None:
+        trigger = self.workflow.data["on"]
+        assert isinstance(trigger, dict)
+        self.assertEqual(set(trigger), {"workflow_call"})
+        self.assertNotIn("workflow_dispatch", trigger)
+        self.assertEqual(
+            self.workflow.permissions,
+            {"contents": "read", "id-token": "write"},
+        )
+        self.assertEqual(
+            self.workflow.data["concurrency"],
+            {
+                "group": (
+                    "launchplane-detached-application-retirement-"
+                    "${{ inputs.candidate_target_sha256 }}"
+                ),
+                "cancel-in-progress": False,
+            },
+        )
+        job = self.workflow.job("retire")
+        self.assertEqual(job["runs-on"], "ubuntu-latest")
+        self.assertEqual(job["environment"], "launchplane-authz-admin")
+
+    def test_worker_validates_exact_digest_set_and_uses_oidc_request(self) -> None:
+        validate = self.workflow.step_named("retire", "Validate exact detached application intent")
+        self.assertIsNotNone(validate)
+        assert validate is not None
+        self.assertIn("protected targets must be sorted unique", validate.run)
+        self.assertIn("candidate target cannot be protected", validate.run)
+        self.assertIn("retire detached Dokploy application", validate.run)
+
+        request = self.workflow.step_named(
+            "retire", "Request audited detached application retirement"
+        )
+        self.assertIsNotNone(request)
+        assert request is not None
+        self.assertRegex(
+            request.uses,
+            re.compile(r"^cbusillo/launchplane/\.github/actions/launchplane-request@[0-9a-f]{40}$"),
+        )
+        self.assertEqual(
+            request.with_values["route-path"],
+            "/v1/detached-application-retirement",
+        )
+
+    def test_artifact_and_summary_are_redacted(self) -> None:
+        evidence = self.workflow.step_named(
+            "retire", "Verify redacted detached application evidence"
+        )
+        self.assertIsNotNone(evidence)
+        assert evidence is not None
+        for identifier in (
+            "application_id",
+            "project_id",
+            "environment_id",
+            "provider_operation_key",
+        ):
+            self.assertIn(identifier, evidence.run)
+        self.assertIn("authority_write_count == 0", evidence.run)
+        upload = self.workflow.step_named("retire", "Upload redacted detached application evidence")
+        self.assertIsNotNone(upload)
+        assert upload is not None
+        self.assertEqual(
+            upload.uses,
+            "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
+        )
+        self.assertEqual(
+            upload.with_values["path"],
+            "detached-application-retirement-response.json",
+        )
+
+    def test_no_mutable_dispatch_wrapper_exists(self) -> None:
+        for workflow_path in Path(".github/workflows").glob("*.yml"):
+            if workflow_path == self.path:
+                continue
+            workflow = load_workflow(workflow_path)
+            trigger = workflow.data.get("on")
+            if not isinstance(trigger, dict) or "workflow_dispatch" not in trigger:
+                continue
+            self.assertNotIn(
+                "reusable-detached-application-retirement.yml",
+                workflow_path.read_text(encoding="utf-8"),
+                workflow_path.as_posix(),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_http_app_detached_application_retirement.py
+++ b/tests/test_http_app_detached_application_retirement.py
@@ -7,7 +7,11 @@ from unittest.mock import patch
 from fastapi import FastAPI
 
 from control_plane.contracts.product_retirement import provider_identifier_sha256
-from control_plane.http_app import create_launchplane_fastapi_app
+from control_plane.http_app import (
+    create_launchplane_fastapi_app,
+    detached_application_retirement_identity,
+    detached_application_retirement_identity_allowed,
+)
 from control_plane.service_auth import (
     BearerIdentityConfig,
     LaunchplaneAuthzPolicy,
@@ -136,6 +140,37 @@ class DetachedApplicationRetirementHttpTests(unittest.IsolatedAsyncioTestCase):
         schema = response.json()["components"]["schemas"]["DetachedApplicationRetirementRequest"]
         self.assertNotIn("target_id", schema["properties"])
         self.assertIn("candidate_target_sha256", schema["properties"])
+
+    def test_github_identity_requires_exact_repository_and_preserves_provenance(self) -> None:
+        worker = (
+            "cbusillo/launchplane/.github/workflows/"
+            f"reusable-detached-application-retirement.yml@{'a' * 40}"
+        )
+        identity = _identity(
+            repository="cbusillo/launchplane",
+            workflow_ref="cbusillo/launchplane/.github/workflows/caller.yml@refs/heads/task",
+            job_workflow_ref=worker,
+        )
+        self.assertTrue(detached_application_retirement_identity_allowed(identity))
+        durable = detached_application_retirement_identity(identity)
+        self.assertEqual(durable.workflow_ref, identity.workflow_ref)
+        self.assertEqual(durable.job_workflow_ref, worker)
+        self.assertFalse(
+            detached_application_retirement_identity_allowed(
+                _identity(repository="fork/launchplane", job_workflow_ref=worker)
+            )
+        )
+        self.assertFalse(
+            detached_application_retirement_identity_allowed(
+                _identity(
+                    repository="cbusillo/launchplane",
+                    job_workflow_ref=(
+                        "cbusillo/launchplane/.github/workflows/"
+                        "reusable-detached-application-retirement.yml@refs/heads/main"
+                    ),
+                )
+            )
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_http_app_detached_application_retirement.py
+++ b/tests/test_http_app_detached_application_retirement.py
@@ -1,0 +1,142 @@
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+from fastapi import FastAPI
+
+from control_plane.contracts.product_retirement import provider_identifier_sha256
+from control_plane.http_app import create_launchplane_fastapi_app
+from control_plane.service_auth import (
+    BearerIdentityConfig,
+    LaunchplaneAuthzPolicy,
+    LocalAdminPolicyRule,
+)
+from control_plane.storage.postgres import PostgresRecordStore
+from tests.http_app_test_support import _asgi_request, _local_operator_bearer_config
+from tests.support.auth import _StubVerifier, _identity
+from tests.test_detached_application_retirement import CANDIDATE_ID, _discovery, _proof, _request
+
+
+class DetachedApplicationRetirementHttpTests(unittest.IsolatedAsyncioTestCase):
+    def _app(self, store: object, *, actions: tuple[str, ...]) -> FastAPI:
+        return create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=LaunchplaneAuthzPolicy(
+                schema_version=2,
+                local_admins=(
+                    LocalAdminPolicyRule(
+                        subjects=("local-admin",),
+                        token_labels=("local-admin-write",),
+                        products=("launchplane",),
+                        contexts=("launchplane",),
+                        actions=actions,
+                    ),
+                ),
+            ),
+            bearer_identity_config=BearerIdentityConfig(
+                local_admin_token="local-admin-token",
+                local_admin_subject="local-admin",
+                local_admin_token_label="local-admin-write",
+            ),
+            control_plane_root_path=Path("."),
+            record_store_factory=lambda: store,
+        )
+
+    @property
+    def headers(self) -> dict[str, str]:
+        return {
+            "Authorization": "Bearer local-admin-token",
+            "Idempotency-Key": "retire-detached-application",
+        }
+
+    async def test_plan_is_local_admin_only_authorized_and_redacted(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=(
+                    f"sqlite+pysqlite:///{Path(temporary_directory_name) / 'launchplane.sqlite3'}"
+                )
+            )
+            store.ensure_schema()
+            denied = await _asgi_request(
+                self._app(store, actions=("operations.read",)),
+                "POST",
+                "/v1/detached-application-retirement",
+                headers=self.headers,
+                payload=_request().model_dump(mode="json"),
+            )
+            with (
+                patch(
+                    "control_plane.http_app.control_plane_detached_application_retirement."
+                    "discover_detached_application",
+                    return_value=_discovery(),
+                ),
+                patch(
+                    "control_plane.http_app.control_plane_detached_application_retirement."
+                    "prove_detached_application_authority_absence",
+                    return_value=_proof(),
+                ),
+            ):
+                planned = await _asgi_request(
+                    self._app(store, actions=("detached_application_retirement.plan",)),
+                    "POST",
+                    "/v1/detached-application-retirement",
+                    headers=self.headers,
+                    payload=_request().model_dump(mode="json"),
+                )
+            store.close()
+        self.assertEqual(denied.status_code, 403)
+        self.assertEqual(planned.status_code, 202, planned.text)
+        payload = planned.json()
+        serialized = json.dumps(payload, sort_keys=True)
+        self.assertNotIn(CANDIDATE_ID, serialized)
+        self.assertNotIn("application_id", serialized)
+        self.assertEqual(
+            payload["result"]["candidate_target_sha256"],
+            provider_identifier_sha256(CANDIDATE_ID),
+        )
+        self.assertEqual(payload["result"]["authority_write_count"], 0)
+
+    async def test_local_operator_is_rejected_even_if_policy_action_exists(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=(
+                    f"sqlite+pysqlite:///{Path(temporary_directory_name) / 'launchplane.sqlite3'}"
+                )
+            )
+            store.ensure_schema()
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=LaunchplaneAuthzPolicy(schema_version=2),
+                bearer_identity_config=_local_operator_bearer_config(),
+                control_plane_root_path=Path("."),
+                record_store_factory=lambda: store,
+            )
+            response = await _asgi_request(
+                app,
+                "POST",
+                "/v1/detached-application-retirement",
+                headers={
+                    "Authorization": "Bearer local-operator-token",
+                    "Idempotency-Key": "retire-detached-application",
+                },
+                payload=_request().model_dump(mode="json"),
+            )
+            store.close()
+        self.assertEqual(response.status_code, 403)
+
+    async def test_openapi_exposes_dedicated_request_without_raw_target_id(self) -> None:
+        app = self._app(object(), actions=())
+        response = await _asgi_request(app, "GET", "/openapi.json")
+        self.assertEqual(response.status_code, 200)
+        operation = response.json()["paths"]["/v1/detached-application-retirement"]["post"]
+        request_schema = operation["requestBody"]["content"]["application/json"]["schema"]
+        self.assertIn("DetachedApplicationRetirementRequest", request_schema["$ref"])
+        schema = response.json()["components"]["schemas"]["DetachedApplicationRetirementRequest"]
+        self.assertNotIn("target_id", schema["properties"])
+        self.assertIn("candidate_target_sha256", schema["properties"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_postgres_integration.py
+++ b/tests/test_postgres_integration.py
@@ -142,6 +142,9 @@ from tests.support.durable_operations import durable_operation_cancellation_payl
 from tests.test_product_retirement import _Store as _RetirementStore
 from tests.test_product_retirement import _observation as _retirement_observation
 from tests.test_product_retirement import _plan as _retirement_plan
+from tests.test_detached_application_retirement import (
+    _plan as _detached_application_retirement_plan,
+)
 from control_plane.storage.product_authority_bundle import ProductAuthorityBundle
 from control_plane.storage.schema_invariants import (
     AUTHZ_COMPATIBILITY_FLOOR_REVISION,
@@ -2309,6 +2312,45 @@ class RealPostgresSchemaIntegrationTests(unittest.TestCase):
 
 
 class RealPostgresStorageConcurrencyTests(unittest.TestCase):
+    def test_concurrent_detached_application_retirement_plans_reuse_one_reservation(
+        self,
+    ) -> None:
+        with _store_for_fresh_head_database() as store:
+            second_store = PostgresRecordStore(database_url=store.database_url)
+            barrier = threading.Barrier(2)
+
+            def write_plan(active_store: PostgresRecordStore, trace_id: str) -> None:
+                plan = _detached_application_retirement_plan().model_copy(
+                    update={
+                        "trace_id": trace_id,
+                        "recorded_at": f"2026-08-11T12:00:0{trace_id[-1]}Z",
+                    }
+                )
+                barrier.wait(timeout=10)
+                active_store.write_detached_application_retirement_record(plan)
+
+            try:
+                with ThreadPoolExecutor(max_workers=2) as executor:
+                    tuple(
+                        executor.map(
+                            write_plan,
+                            (store, second_store),
+                            ("plan-trace-1", "plan-trace-2"),
+                        )
+                    )
+                plans = store.list_detached_application_retirement_records(
+                    candidate_target_sha256=(
+                        _detached_application_retirement_plan().candidate_observation.target_id_sha256
+                    ),
+                    actor="test",
+                    mode="plan",
+                    idempotency_key="retire-detached",
+                )
+            finally:
+                second_store.close()
+
+        self.assertEqual(len(plans), 1)
+
     def test_concurrent_product_retirement_plan_writes_reuse_one_scoped_reservation(self) -> None:
         with _store_for_fresh_head_database() as store:
             second_store = PostgresRecordStore(database_url=store.database_url)
@@ -2316,16 +2358,26 @@ class RealPostgresStorageConcurrencyTests(unittest.TestCase):
 
             def write_plan(active_store: PostgresRecordStore, trace_id: str) -> None:
                 plan = _retirement_plan(_RetirementStore(), _retirement_observation()).model_copy(
-                    update={"trace_id": trace_id, "recorded_at": f"2026-08-11T02:00:0{trace_id[-1]}Z"}
+                    update={
+                        "trace_id": trace_id,
+                        "recorded_at": f"2026-08-11T02:00:0{trace_id[-1]}Z",
+                    }
                 )
                 barrier.wait(timeout=10)
                 active_store.write_product_retirement_record(plan)
 
             try:
                 with ThreadPoolExecutor(max_workers=2) as executor:
-                    tuple(executor.map(write_plan, (store, second_store), ("plan-trace-1", "plan-trace-2")))
+                    tuple(
+                        executor.map(
+                            write_plan, (store, second_store), ("plan-trace-1", "plan-trace-2")
+                        )
+                    )
                 plans = store.list_product_retirement_records(
-                    product="example-site", actor="test", mode="plan", idempotency_key="retire-example-site"
+                    product="example-site",
+                    actor="test",
+                    mode="plan",
+                    idempotency_key="retire-example-site",
                 )
             finally:
                 second_store.close()

--- a/tests/test_schema_migration.py
+++ b/tests/test_schema_migration.py
@@ -1293,7 +1293,24 @@ class SchemaMigrationTests(unittest.TestCase):
             for primary_key in CRITICAL_PRIMARY_KEYS
         }
 
-        self.assertEqual(EXPECTED_ALEMBIC_HEAD_REVISION, "c6e8f1b3d5a7")
+        self.assertEqual(EXPECTED_ALEMBIC_HEAD_REVISION, "d8a0c2e4f6b8")
+        self.assertEqual(
+            column_types[("launchplane_detached_application_retirements", "payload")],
+            ("jsonb",),
+        )
+        self.assertEqual(
+            indexes[
+                (
+                    "launchplane_detached_application_retirements",
+                    "launchplane_detached_app_retirements_plan_idempotency_unique",
+                )
+            ].predicate_expression,
+            "mode='plan'",
+        )
+        self.assertEqual(
+            primary_keys["launchplane_detached_application_retirements"],
+            ("record_id",),
+        )
         self.assertEqual(
             column_types[("launchplane_repository_human_role_policies", "payload")],
             ("jsonb",),


### PR DESCRIPTION
## Summary

- add a separate detached Dokploy application retirement plan/apply contract and service route
- persist append-only filesystem/PostgreSQL records at Alembic head `d8a0c2e4f6b8`
- prove exact provider discovery, Launchplane authority absence, and protected project snapshots
- reuse provider-operation lease/checkpoint/reconciliation fencing with one `application.delete` effect
- add a protected `workflow_call`-only reusable worker and future managed-authz selector/secret routing
- document the service, records, operations, and GitHub Actions security boundaries

Refs #2100
Refs #2008

## Phase Boundary

This PR intentionally does **not** add a `workflow_dispatch` wrapper, configure a live authz managed-set secret/rule, deploy Launchplane, or perform any provider mutation. It does not add a product-retirement mode and does not expose profile/target/runtime/authz write or delete methods through the detached-retirement adapter/store contract.

## Safety Contract

- request accepts names and SHA-256 digests only; no raw target ID input
- candidate must be globally unique, exactly idle, domainless, recognized `no_history`, and absent from every bounded Launchplane authority source
- every other application in the project is protected and must match the exact sorted expected digest set
- apply binds the exact persisted plan/digest/confirmation/idempotency key and fully rederives all evidence
- provider mutation uses the same target-key namespace as product retirement and checkpoints immediately before the sole application deletion
- terminal evidence exposes hashes/counts/phases/record references only and fixes `authority_write_count` at literal zero

## Validation

- targeted detached-retirement, HTTP, workflow/authz, migration, product-retirement regression, and GitHub Actions security tests
- `uv run --extra dev launchplane ci unittest-shard local` — 12/12 shards, 2,847 targets
- real PostgreSQL integration gate — 87 tests
- touched-file Ruff check and format check
- `uv run --extra dev mypy control_plane tests`
- targeted Pyright for all new detached-retirement files — clean
- full-repo Pyright attempted; existing baseline remains at 121 unrelated findings
- `pnpm --dir frontend validate` and OpenAPI drift check
- config-authority audit
- pinned-container actionlint
- pip-audit and gitleaks
- `git diff --check`
- JetBrains changed-file inspection attempted; inconclusive because the exact PyCharm worktree has no configured language SDK (`language_sdk_missing`)
