### PR TITLE
feat: add detached application retirement dispatch wrapper

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -163,6 +163,7 @@
     "Product Prelaunch Rebuild Policy",
     "Product Retirement",
     "Reusable Product Retirement",
+    "Detached Application Retirement",
     "Reusable Detached Application Retirement",
     "Product Preview TLS",
     "Reusable Generic Web Onboarding Apply",

--- a/.github/workflows/detached-application-retirement.yml
+++ b/.github/workflows/detached-application-retirement.yml
@@ -1,0 +1,86 @@
+---
+name: Detached Application Retirement
+
+"on":
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: Persist a reviewed plan or apply that exact persisted plan.
+        required: true
+        type: string
+      project_name:
+        description: Exact Dokploy project name.
+        required: true
+        type: string
+      environment_name:
+        description: Exact Dokploy environment name.
+        required: true
+        type: string
+      application_name:
+        description: Exact globally unique detached Dokploy application name.
+        required: true
+        type: string
+      candidate_target_sha256:
+        description: SHA-256 of the detached application identifier.
+        required: true
+        type: string
+      expected_protected_target_sha256_json:
+        # yamllint disable-line rule:line-length
+        description: Sorted non-empty JSON array of protected application target SHA-256 values.
+        required: true
+        type: string
+      operator_idempotency_key:
+        # yamllint disable-line rule:line-length
+        description: Stable operator-selected key reused for retries of this retirement intent.
+        required: true
+        type: string
+      reason:
+        # yamllint disable-line rule:line-length
+        description: Required single-line operator reason bound into plan continuity.
+        required: true
+        type: string
+      related_issue:
+        # yamllint disable-line rule:line-length
+        description: Required issue or change reference bound into plan continuity.
+        required: true
+        type: string
+      reviewed_plan_record_id:
+        # yamllint disable-line rule:line-length
+        description: Persisted plan record id returned by the reviewed plan; required for apply.
+        required: false
+        default: ""
+        type: string
+      reviewed_plan_sha256:
+        # yamllint disable-line rule:line-length
+        description: Plan SHA-256 returned by the reviewed plan; required for apply.
+        required: false
+        default: ""
+        type: string
+      confirmation:
+        # yamllint disable-line rule:line-length
+        description: Exact target-bound apply confirmation returned by the plan contract.
+        required: false
+        default: ""
+        type: string
+
+jobs:
+  retire:
+    # yamllint disable-line rule:line-length
+    uses: cbusillo/launchplane/.github/workflows/reusable-detached-application-retirement.yml@11d53d2840a6f1898785d7c8f1553c202caa3fbf  # main
+    permissions:
+      contents: read
+      id-token: write
+    with:
+      mode: ${{ inputs.mode }}
+      project_name: ${{ inputs.project_name }}
+      environment_name: ${{ inputs.environment_name }}
+      application_name: ${{ inputs.application_name }}
+      candidate_target_sha256: ${{ inputs.candidate_target_sha256 }}
+      # yamllint disable-line rule:line-length
+      expected_protected_target_sha256_json: ${{ inputs.expected_protected_target_sha256_json }}
+      operator_idempotency_key: ${{ inputs.operator_idempotency_key }}
+      reason: ${{ inputs.reason }}
+      related_issue: ${{ inputs.related_issue }}
+      reviewed_plan_record_id: ${{ inputs.reviewed_plan_record_id }}
+      reviewed_plan_sha256: ${{ inputs.reviewed_plan_sha256 }}
+      confirmation: ${{ inputs.confirmation }}

--- a/docs/github-actions-security.md
+++ b/docs/github-actions-security.md
@@ -75,7 +75,7 @@ written to the workflow log by the upstream implementation.
   generic-web onboarding/preview-authz protected apply, route-binding
   reconciliation, exact-instance product health-policy mutation,
   protected immutable product retirement,
-  reusable-only detached application retirement,
+  protected immutable detached application retirement,
   exact-instance immutable Odoo artifact publication, and exact-instance Odoo
   target-replacement plan/apply workers whose actions are separately authorized.
   It also includes exact-instance redacted target-log diagnostics and Odoo

--- a/docs/github-actions-security.md
+++ b/docs/github-actions-security.md
@@ -96,15 +96,20 @@ The security workflow runs this policy for both same-repository and fork pull
 requests before actionlint. The unit-test suite runs it as well, so a mutable
 reference cannot pass the required CI path.
 
-Detached application retirement follows a two-phase trust rollout. The first
-phase lands only the service contract, persistence, managed authz selector/
-secret routing, and a protected `workflow_call` worker. No dispatch workflow may
-call that worker in the same phase, and no live managed secret or rule is
-configured. The service additionally rejects GitHub Actions identities whose
-`job_workflow_ref` is not the exact reusable workflow path at a 40-character
-commit SHA. A later thin dispatch caller must be pinned to the merged worker SHA
-and authorized as an exact caller/worker pair before provider mutation is
-possible.
+Detached application retirement follows a two-phase trust rollout. Phase one
+landed only the service contract, persistence, managed authz selector/secret
+routing, and a protected `workflow_call` worker. Phase two adds the thin
+`workflow_dispatch` caller at
+`.github/workflows/detached-application-retirement.yml`, pinned to the exact
+merged worker identity
+`cbusillo/launchplane/.github/workflows/reusable-detached-application-retirement.yml@11d53d2840a6f1898785d7c8f1553c202caa3fbf`.
+The caller has only `contents: read` and `id-token: write`; it has no runner,
+steps, environment, or concurrency of its own. No live managed secret or rule
+is configured by this change. The service additionally rejects GitHub Actions
+identities whose `job_workflow_ref` is not the exact reusable workflow path at a
+40-character commit SHA. After the wrapper is merged and deployed, the exact
+caller `workflow_ref` and worker `job_workflow_ref` must be configured together
+before any protected plan/apply run or provider mutation is possible.
 
 ## Provenance And Updates
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -2568,11 +2568,23 @@ job_workflow_ref=cbusillo/launchplane/.github/workflows/reusable-product-retirem
 ## Detached Application Retirement
 
 Phase one provides **Reusable Detached Application Retirement** as a
-`workflow_call`-only worker. It is intentionally uncalled: do not add or invoke
-a `workflow_dispatch` wrapper, configure the future live authz managed-set
-secret, deploy this branch, or attempt a provider mutation as part of phase one.
-The worker uses the protected `launchplane-authz-admin` environment, OIDC,
-target-digest concurrency, exact input validation, and redacted evidence.
+`workflow_call`-only worker. Phase two adds the thin
+**Detached Application Retirement** `workflow_dispatch` wrapper, pinned to the
+exact merged worker SHA below. The wrapper only defines the manual inputs,
+forwards them unchanged, and grants `contents: read` plus `id-token: write`; it
+does not define a runner, environment, steps, or concurrency. Do not configure
+the live authz managed-set secret, deploy this branch, or attempt a provider
+mutation as part of this code phase. The worker uses the protected
+`launchplane-authz-admin` environment, OIDC, target-digest concurrency, exact
+input validation, and redacted evidence.
+
+The protected identity pair to configure only after this wrapper is merged and
+deployed is:
+
+```text
+workflow_ref=cbusillo/launchplane/.github/workflows/detached-application-retirement.yml@refs/heads/main
+job_workflow_ref=cbusillo/launchplane/.github/workflows/reusable-detached-application-retirement.yml@11d53d2840a6f1898785d7c8f1553c202caa3fbf
+```
 
 The future operator sequence is plan then apply. Inputs are exact Dokploy
 project/environment/application names, the candidate target SHA-256, a sorted
@@ -2593,8 +2605,9 @@ protected fingerprints, and zero authority writes.
 Managed authz routing is reserved through the
 `detached-application-retirement` selector, managed-set ID
 `operator.detached-application-retirement`, and secret name
-`LAUNCHPLANE_AUTHZ_DETACHED_APPLICATION_RETIREMENT_MANAGED_SET_JSON`. Phase one
-does not create or populate that secret and does not reconcile a live rule. A
-later phase must first pin a thin caller to the exact merged reusable-worker SHA,
-then authorize the exact caller `workflow_ref` and immutable worker
-`job_workflow_ref` before any protected plan/apply run.
+`LAUNCHPLANE_AUTHZ_DETACHED_APPLICATION_RETIREMENT_MANAGED_SET_JSON`. Neither
+phase creates or populates that secret or reconciles a live rule. The remaining
+sequence is: merge and deploy this wrapper, configure the exact caller and
+worker authz pair through the managed authz path, then run the reviewed plan and
+apply sequence. Never substitute a mutable ref, a checked-in target value, or a
+local CLI live-target fallback.

--- a/tests/test_detached_application_retirement_operator_workflow.py
+++ b/tests/test_detached_application_retirement_operator_workflow.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+from pathlib import Path
+import re
+import subprocess
+from tempfile import TemporaryDirectory
+import unittest
+
+from tests.support.workflows import Workflow
+from tests.support.workflows import load_workflow
+
+
+WRAPPER_PATH = Path(".github/workflows/detached-application-retirement.yml")
+WORKER_REFERENCE = (
+    "cbusillo/launchplane/.github/workflows/"
+    "reusable-detached-application-retirement.yml@"
+    "11d53d2840a6f1898785d7c8f1553c202caa3fbf"
+)
+INPUT_NAMES = (
+    "mode",
+    "project_name",
+    "environment_name",
+    "application_name",
+    "candidate_target_sha256",
+    "expected_protected_target_sha256_json",
+    "operator_idempotency_key",
+    "reason",
+    "related_issue",
+    "reviewed_plan_record_id",
+    "reviewed_plan_sha256",
+    "confirmation",
+)
+
+
+def _load_pinned_workflow(reference: str) -> Workflow:
+    source, separator, revision = reference.partition("@")
+    if not separator:
+        raise AssertionError(f"pinned workflow reference is missing a revision: {reference}")
+    relative_path = Path(source).relative_to("cbusillo/launchplane")
+    result = subprocess.run(
+        ["git", "show", f"{revision}:{relative_path.as_posix()}"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode:
+        raise AssertionError(
+            f"could not read {relative_path} at pinned revision {revision}: {result.stderr}"
+        )
+    with TemporaryDirectory() as temporary_directory_name:
+        workflow_path = Path(temporary_directory_name) / relative_path.name
+        workflow_path.write_text(result.stdout, encoding="utf-8")
+        return load_workflow(workflow_path)
+
+
+class DetachedApplicationRetirementOperatorWorkflowTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.wrapper = load_workflow(WRAPPER_PATH)
+        self.worker_reference = self.wrapper.job_uses("retire")
+        self.worker = _load_pinned_workflow(self.worker_reference)
+
+    def test_wrapper_is_exactly_pinned_and_thin(self) -> None:
+        trigger = self.wrapper.data["on"]
+        assert isinstance(trigger, dict)
+        self.assertEqual(set(trigger), {"workflow_dispatch"})
+        dispatch = trigger["workflow_dispatch"]
+        assert isinstance(dispatch, dict)
+        dispatch_inputs = dispatch["inputs"]
+        assert isinstance(dispatch_inputs, dict)
+        self.assertEqual(tuple(dispatch_inputs), INPUT_NAMES)
+        self.assertEqual(self.worker_reference, WORKER_REFERENCE)
+        self.assertRegex(self.worker_reference.rsplit("@", maxsplit=1)[1], r"^[0-9a-f]{40}$")
+        self.assertEqual(self.wrapper.permissions, {})
+        self.assertNotIn("concurrency", self.wrapper.data)
+        self.assertEqual(set(self.wrapper.jobs), {"retire"})
+        job = self.wrapper.job("retire")
+        self.assertEqual(set(job), {"uses", "permissions", "with"})
+        self.assertEqual(
+            self.wrapper.job_permissions("retire"),
+            {"contents": "read", "id-token": "write"},
+        )
+        for forbidden_key in ("environment", "runs-on", "steps", "concurrency"):
+            self.assertNotIn(forbidden_key, job)
+        wrapper_text = WRAPPER_PATH.read_text(encoding="utf-8")
+        self.assertNotRegex(
+            wrapper_text,
+            re.compile(r"(?:@(?:main|master|refs/heads/|v\d)|uses:\s*[^\n]+@(?![0-9a-f]{40}))"),
+        )
+
+    def test_wrapper_mirrors_worker_inputs_and_passes_each_unchanged(self) -> None:
+        worker_trigger = self.worker.data["on"]
+        assert isinstance(worker_trigger, dict)
+        worker_call = worker_trigger["workflow_call"]
+        assert isinstance(worker_call, dict)
+        worker_inputs = worker_call["inputs"]
+        assert isinstance(worker_inputs, dict)
+        wrapper_trigger = self.wrapper.data["on"]
+        assert isinstance(wrapper_trigger, dict)
+        wrapper_dispatch = wrapper_trigger["workflow_dispatch"]
+        assert isinstance(wrapper_dispatch, dict)
+        wrapper_inputs = wrapper_dispatch["inputs"]
+        assert isinstance(wrapper_inputs, dict)
+        self.assertEqual(tuple(worker_inputs), INPUT_NAMES)
+        self.assertEqual(tuple(wrapper_inputs), INPUT_NAMES)
+        for name in INPUT_NAMES:
+            worker_input = worker_inputs[name]
+            wrapper_input = wrapper_inputs[name]
+            assert isinstance(worker_input, dict)
+            assert isinstance(wrapper_input, dict)
+            self.assertEqual(wrapper_input["description"], worker_input["description"])
+            self.assertEqual(wrapper_input["required"], worker_input["required"])
+            self.assertEqual(wrapper_input["type"], worker_input["type"])
+            if "default" in worker_input:
+                self.assertEqual(wrapper_input["default"], worker_input["default"])
+        wrapper_values = self.wrapper.job("retire")["with"]
+        assert isinstance(wrapper_values, dict)
+        self.assertEqual(
+            wrapper_values,
+            {name: f"${{{{ inputs.{name} }}}}" for name in INPUT_NAMES},
+        )
+
+    def test_caller_and_worker_authz_contract_is_explicit(self) -> None:
+        self.assertEqual(
+            self.worker.permissions,
+            {"contents": "read", "id-token": "write"},
+        )
+        worker_job = self.worker.job("retire")
+        self.assertEqual(
+            self.worker.job_permissions("retire"),
+            {"contents": "read", "id-token": "write"},
+        )
+        self.assertEqual(worker_job["environment"], "launchplane-authz-admin")
+        validation = self.worker.step_named("retire", "Validate exact detached application intent")
+        self.assertIsNotNone(validation)
+        assert validation is not None
+        self.assertIn("github.repository", validation.run)
+        self.assertIn("cbusillo/launchplane", validation.run)
+        self.assertIn("LAUNCHPLANE_URL", validation.run)
+        self.assertIn("candidate_target_sha256", validation.run)
+        self.assertIn("EXPECTED_PROTECTED_TARGET_SHA256_JSON", validation.run)
+
+    def test_operations_documentation_binds_exact_caller_and_worker(self) -> None:
+        operations = Path("docs/operations.md").read_text(encoding="utf-8")
+        self.assertIn(
+            "workflow_ref=cbusillo/launchplane/.github/workflows/"
+            "detached-application-retirement.yml@refs/heads/main",
+            operations,
+        )
+        self.assertIn(f"job_workflow_ref={WORKER_REFERENCE}", operations)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_detached_application_retirement_workflow.py
+++ b/tests/test_detached_application_retirement_workflow.py
@@ -82,19 +82,22 @@ class DetachedApplicationRetirementWorkflowTests(unittest.TestCase):
             "detached-application-retirement-response.json",
         )
 
-    def test_no_mutable_dispatch_wrapper_exists(self) -> None:
-        for workflow_path in Path(".github/workflows").glob("*.yml"):
-            if workflow_path == self.path:
-                continue
-            workflow = load_workflow(workflow_path)
-            trigger = workflow.data.get("on")
-            if not isinstance(trigger, dict) or "workflow_dispatch" not in trigger:
-                continue
-            self.assertNotIn(
-                "reusable-detached-application-retirement.yml",
-                workflow_path.read_text(encoding="utf-8"),
-                workflow_path.as_posix(),
-            )
+    def test_dispatch_wrapper_is_pinned_to_the_merged_worker(self) -> None:
+        wrapper_path = Path(".github/workflows/detached-application-retirement.yml")
+        wrapper = load_workflow(wrapper_path)
+        trigger = wrapper.data["on"]
+        assert isinstance(trigger, dict)
+        self.assertEqual(set(trigger), {"workflow_dispatch"})
+        self.assertEqual(
+            wrapper.job_uses("retire"),
+            "cbusillo/launchplane/.github/workflows/"
+            "reusable-detached-application-retirement.yml@"
+            "11d53d2840a6f1898785d7c8f1553c202caa3fbf",
+        )
+        self.assertEqual(
+            wrapper.job_permissions("retire"),
+            {"contents": "read", "id-token": "write"},
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_github_actions_security.py
+++ b/tests/test_github_actions_security.py
@@ -107,6 +107,9 @@ PINNED_SELF_REUSABLE_WORKFLOWS: Mapping[Path, frozenset[str]] = {
     Path(".github/workflows/product-retirement.yml"): frozenset(
         {"cbusillo/launchplane/.github/workflows/reusable-product-retirement.yml"}
     ),
+    Path(".github/workflows/detached-application-retirement.yml"): frozenset(
+        {"cbusillo/launchplane/.github/workflows/reusable-detached-application-retirement.yml"}
+    ),
 }
 
 
@@ -275,6 +278,12 @@ APPROVED_REMOTE_ACTIONS: Mapping[str, ActionClassification] = {
         ActionClassification(
             "First-party same-repository",
             "protected immutable product retirement",
+        )
+    ),
+    "cbusillo/launchplane/.github/workflows/reusable-detached-application-retirement.yml": (
+        ActionClassification(
+            "First-party same-repository",
+            "protected immutable detached application retirement",
         )
     ),
     "docker/build-push-action": ActionClassification(
@@ -540,6 +549,7 @@ class GitHubActionsSecurityTests(TestCase):
         self.assertIn("First-party cross-repository", policy)
         self.assertIn("High-privilege", policy)
         self.assertIn("protected immutable product retirement", policy)
+        self.assertIn("reusable-only detached application retirement", policy)
         self.assertIn("container image", policy)
         self.assertIn("MUTABLE_REFERENCE_ALLOWLIST", policy)
         self.assertIn("Dependabot", policy)

--- a/tests/test_github_actions_security.py
+++ b/tests/test_github_actions_security.py
@@ -549,7 +549,7 @@ class GitHubActionsSecurityTests(TestCase):
         self.assertIn("First-party cross-repository", policy)
         self.assertIn("High-privilege", policy)
         self.assertIn("protected immutable product retirement", policy)
-        self.assertIn("reusable-only detached application retirement", policy)
+        self.assertIn("protected immutable detached application retirement", policy)
         self.assertIn("container image", policy)
         self.assertIn("MUTABLE_REFERENCE_ALLOWLIST", policy)
         self.assertIn("Dependabot", policy)


### PR DESCRIPTION
## Summary

- Add the thin `workflow_dispatch` wrapper for detached application retirement.
- Pin the caller to reusable worker SHA `11d53d2840a6f1898785d7c8f1553c202caa3fbf` and pass every worker input unchanged.
- Update Actions security policy, important-workflow metadata, workflow tests, and operations/security docs.
- Preserve the two-phase boundary: no live authz secret/rule configuration, dispatch, deploy, or provider mutation in this change.

## Validation

- Targeted workflow/security tests pass.
- Full 12-shard unittest gate passes (`2,848` targets).
- Changed-file Ruff format check/lint and targeted mypy pass.
- Full-workflow `actionlint` and wrapper `yamllint` pass.
- Config-authority audit exits with `status: ok`; its normal coverage-gap inventory remains informational.
- Markdownlint reports only two pre-existing `docs/operations.md` line-length findings outside this change.

Refs #2100