### PR TITLE
fix: discover service-scoped Dokploy applications

### DIFF
--- a/control_plane/detached_application_retirement.py
+++ b/control_plane/detached_application_retirement.py
@@ -343,8 +343,12 @@ def discover_detached_application(
         if project_name == request.project_name
     }
     if len(matching_projects) != 1:
-        raise DetachedApplicationRetirementBlockedError(
-            "Detached application retirement requires exactly one project name match."
+        return _discover_detached_application_with_service_search(
+            host=host,
+            token=token,
+            request=request,
+            observed_at=observed_at,
+            absent_application_id=absent_application_id,
         )
     matching_environments = {
         environment_id
@@ -459,6 +463,161 @@ def discover_detached_application(
         )
     )
     return DetachedApplicationDiscovery(candidate=candidate, protected_targets=protected_targets)
+
+
+def _discover_detached_application_with_service_search(
+    *,
+    host: str,
+    token: str,
+    request: DetachedApplicationRetirementRequest,
+    observed_at: str,
+    absent_application_id: str,
+) -> DetachedApplicationDiscovery:
+    matches = tuple(
+        item
+        for item in dokploy_api.search_dokploy_applications(
+            host=host,
+            token=token,
+            name=request.application_name,
+        )
+        if _required_application_name(item) == request.application_name
+    )
+    if len(matches) > 1:
+        raise DetachedApplicationRetirementBlockedError(
+            "Detached application retirement requires one globally unique accessible application name."
+        )
+    normalized_absent_id = absent_application_id.strip()
+    if matches:
+        candidate_id = _required_identifier(
+            matches[0], "applicationId", "id", label="application id"
+        )
+        if normalized_absent_id and candidate_id != normalized_absent_id:
+            raise DetachedApplicationRetirementBlockedError(
+                "Detached application name now resolves to a different provider target."
+            )
+        candidate_payload = dokploy_api.fetch_dokploy_target_payload(
+            host=host,
+            token=token,
+            target_type="application",
+            target_id=candidate_id,
+        )
+        candidate_reference = _application_reference_from_payload(candidate_payload)
+        project_items = dokploy_api.search_dokploy_applications(
+            host=host, token=token, project_id=candidate_reference.project_id
+        )
+    elif normalized_absent_id:
+        project_items = dokploy_api.search_dokploy_applications(host=host, token=token)
+        candidate_reference = None
+    else:
+        raise DetachedApplicationRetirementBlockedError(
+            "Detached application retirement candidate is absent during planning."
+        )
+    project_references: list[_DiscoveredApplication] = []
+    for item in project_items:
+        application_id = _required_identifier(item, "applicationId", "id", label="application id")
+        payload = dokploy_api.fetch_dokploy_target_payload(
+            host=host,
+            token=token,
+            target_type="application",
+            target_id=application_id,
+        )
+        reference = _application_reference_from_payload(payload)
+        if (
+            candidate_reference is not None
+            and reference.project_id != candidate_reference.project_id
+        ):
+            raise DetachedApplicationRetirementBlockedError(
+                "Dokploy application.search returned cross-project evidence."
+            )
+        if reference.project_name == request.project_name:
+            project_references.append(reference)
+    if candidate_reference is not None:
+        if (
+            candidate_reference.project_name != request.project_name
+            or candidate_reference.environment_name != request.environment_name
+            or candidate_reference.application_name != request.application_name
+        ):
+            raise DetachedApplicationRetirementBlockedError(
+                "Detached application search evidence does not match the reviewed project environment."
+            )
+        candidate = _observe_present_application(
+            host=host,
+            token=token,
+            reference=candidate_reference,
+            observed_at=observed_at,
+            candidate=True,
+        )
+    else:
+        environment_matches = tuple(
+            reference
+            for reference in project_references
+            if reference.environment_name == request.environment_name
+        )
+        if not environment_matches:
+            raise DetachedApplicationRetirementBlockedError(
+                "Detached application search cannot resolve the reviewed absent environment."
+            )
+        environment_reference = environment_matches[0]
+        candidate = DetachedApplicationProviderObservation(
+            observed_at=observed_at,
+            project_id=environment_reference.project_id,
+            project_name=request.project_name,
+            environment_id=environment_reference.environment_id,
+            environment_name=request.environment_name,
+            application_id=normalized_absent_id,
+            application_name=request.application_name,
+            target_id_sha256=request.candidate_target_sha256,
+            state="absent",
+        )
+    if candidate.target_id_sha256 != request.candidate_target_sha256:
+        raise DetachedApplicationRetirementBlockedError(
+            "Detached application candidate digest does not match provider discovery."
+        )
+    protected_references = [
+        reference
+        for reference in project_references
+        if reference.application_id != candidate.application_id
+    ]
+    protected_target_sha256 = tuple(
+        sorted(provider_identifier_sha256(item.application_id) for item in protected_references)
+    )
+    if protected_target_sha256 != request.expected_protected_target_sha256:
+        raise DetachedApplicationRetirementBlockedError(
+            "Detached application protected target set changed or is incomplete."
+        )
+    protected_targets = tuple(
+        sorted(
+            (
+                _observe_protected_application(host=host, token=token, reference=reference)
+                for reference in protected_references
+            ),
+            key=lambda target: target.target_id_sha256,
+        )
+    )
+    return DetachedApplicationDiscovery(candidate=candidate, protected_targets=protected_targets)
+
+
+def _application_reference_from_payload(payload: Mapping[str, object]) -> _DiscoveredApplication:
+    environment = payload.get("environment")
+    if not isinstance(environment, Mapping):
+        raise DetachedApplicationRetirementBlockedError(
+            "Dokploy application.one is missing environment evidence."
+        )
+    project = environment.get("project")
+    if not isinstance(project, Mapping):
+        raise DetachedApplicationRetirementBlockedError(
+            "Dokploy application.one is missing project evidence."
+        )
+    return _DiscoveredApplication(
+        project_id=_required_identifier(project, "projectId", "id", label="project id"),
+        project_name=_required_string(project, "name", label="project name"),
+        environment_id=_required_identifier(
+            environment, "environmentId", "id", label="environment id"
+        ),
+        environment_name=_required_string(environment, "name", label="environment name"),
+        application_id=_required_identifier(payload, "applicationId", "id", label="application id"),
+        application_name=_required_application_name(payload),
+    )
 
 
 def prove_detached_application_authority_absence(

--- a/control_plane/detached_application_retirement.py
+++ b/control_plane/detached_application_retirement.py
@@ -342,7 +342,11 @@ def discover_detached_application(
         for project_id, project_name in parsed.projects
         if project_name == request.project_name
     }
-    if len(matching_projects) != 1:
+    if len(matching_projects) > 1:
+        raise DetachedApplicationRetirementBlockedError(
+            "Detached application retirement requires exactly one project name match."
+        )
+    if not matching_projects:
         return _discover_detached_application_with_service_search(
             host=host,
             token=token,
@@ -506,6 +510,20 @@ def _discover_detached_application_with_service_search(
             host=host, token=token, project_id=candidate_reference.project_id
         )
     elif normalized_absent_id:
+        try:
+            dokploy_api.fetch_dokploy_target_payload(
+                host=host,
+                token=token,
+                target_type="application",
+                target_id=normalized_absent_id,
+            )
+        except dokploy_api.DokployRequestFailed as error:
+            if error.status_code != 404:
+                raise
+        else:
+            raise DetachedApplicationRetirementBlockedError(
+                "Detached application name disappeared but its reviewed target still exists."
+            )
         project_items = dokploy_api.search_dokploy_applications(host=host, token=token)
         candidate_reference = None
     else:
@@ -515,6 +533,10 @@ def _discover_detached_application_with_service_search(
     project_references: list[_DiscoveredApplication] = []
     for item in project_items:
         application_id = _required_identifier(item, "applicationId", "id", label="application id")
+        if candidate_reference is None and application_id == normalized_absent_id:
+            raise DetachedApplicationRetirementBlockedError(
+                "Detached application search still contains the reviewed target."
+            )
         payload = dokploy_api.fetch_dokploy_target_payload(
             host=host,
             token=token,
@@ -553,9 +575,9 @@ def _discover_detached_application_with_service_search(
             for reference in project_references
             if reference.environment_name == request.environment_name
         )
-        if not environment_matches:
+        if len(environment_matches) != 1:
             raise DetachedApplicationRetirementBlockedError(
-                "Detached application search cannot resolve the reviewed absent environment."
+                "Detached application search requires exactly one reviewed absent environment."
             )
         environment_reference = environment_matches[0]
         candidate = DetachedApplicationProviderObservation(

--- a/control_plane/detached_application_retirement.py
+++ b/control_plane/detached_application_retirement.py
@@ -332,6 +332,8 @@ def discover_detached_application(
     request: DetachedApplicationRetirementRequest,
     observed_at: str,
     absent_application_id: str = "",
+    absent_project_id: str = "",
+    absent_environment_id: str = "",
 ) -> DetachedApplicationDiscovery:
     host, token = dokploy_source.read_dokploy_config(control_plane_root=control_plane_root)
     projects = dokploy_api.fetch_dokploy_projects(host=host, token=token)
@@ -353,6 +355,8 @@ def discover_detached_application(
             request=request,
             observed_at=observed_at,
             absent_application_id=absent_application_id,
+            absent_project_id=absent_project_id,
+            absent_environment_id=absent_environment_id,
         )
     matching_environments = {
         environment_id
@@ -476,6 +480,8 @@ def _discover_detached_application_with_service_search(
     request: DetachedApplicationRetirementRequest,
     observed_at: str,
     absent_application_id: str,
+    absent_project_id: str,
+    absent_environment_id: str,
 ) -> DetachedApplicationDiscovery:
     matches = tuple(
         item
@@ -510,6 +516,12 @@ def _discover_detached_application_with_service_search(
             host=host, token=token, project_id=candidate_reference.project_id
         )
     elif normalized_absent_id:
+        normalized_absent_project_id = absent_project_id.strip()
+        normalized_absent_environment_id = absent_environment_id.strip()
+        if not normalized_absent_project_id or not normalized_absent_environment_id:
+            raise DetachedApplicationRetirementBlockedError(
+                "Detached application search requires reviewed absent project and environment identity."
+            )
         try:
             dokploy_api.fetch_dokploy_target_payload(
                 host=host,
@@ -524,7 +536,11 @@ def _discover_detached_application_with_service_search(
             raise DetachedApplicationRetirementBlockedError(
                 "Detached application name disappeared but its reviewed target still exists."
             )
-        project_items = dokploy_api.search_dokploy_applications(host=host, token=token)
+        project_items = dokploy_api.search_dokploy_applications(
+            host=host,
+            token=token,
+            project_id=normalized_absent_project_id,
+        )
         candidate_reference = None
     else:
         raise DetachedApplicationRetirementBlockedError(
@@ -551,7 +567,9 @@ def _discover_detached_application_with_service_search(
             raise DetachedApplicationRetirementBlockedError(
                 "Dokploy application.search returned cross-project evidence."
             )
-        if reference.project_name == request.project_name:
+        if reference.project_name == request.project_name and (
+            candidate_reference is not None or reference.project_id == normalized_absent_project_id
+        ):
             project_references.append(reference)
     if candidate_reference is not None:
         if (
@@ -570,21 +588,11 @@ def _discover_detached_application_with_service_search(
             candidate=True,
         )
     else:
-        environment_matches = tuple(
-            reference
-            for reference in project_references
-            if reference.environment_name == request.environment_name
-        )
-        if len(environment_matches) != 1:
-            raise DetachedApplicationRetirementBlockedError(
-                "Detached application search requires exactly one reviewed absent environment."
-            )
-        environment_reference = environment_matches[0]
         candidate = DetachedApplicationProviderObservation(
             observed_at=observed_at,
-            project_id=environment_reference.project_id,
+            project_id=normalized_absent_project_id,
             project_name=request.project_name,
-            environment_id=environment_reference.environment_id,
+            environment_id=normalized_absent_environment_id,
             environment_name=request.environment_name,
             application_id=normalized_absent_id,
             application_name=request.application_name,
@@ -973,6 +981,8 @@ class DokployDetachedApplicationRetirementAdapter:
             request=self._request,
             observed_at=self._requested_at,
             absent_application_id=self._plan.candidate_observation.application_id,
+            absent_project_id=self._plan.candidate_observation.project_id,
+            absent_environment_id=self._plan.candidate_observation.environment_id,
         )
         proof = prove_detached_application_authority_absence(
             record_store=self._record_store,

--- a/control_plane/dokploy/api.py
+++ b/control_plane/dokploy/api.py
@@ -282,18 +282,16 @@ def search_dokploy_applications(
     project_id: str = "",
     limit: int = 100,
 ) -> tuple[JsonObject, ...]:
-    query = urlencode(
-        {
-            "name": name,
-            "projectId": project_id,
-            "limit": limit,
-            "offset": 0,
-        }
-    )
+    query: dict[str, str | int] = {"limit": limit, "offset": 0}
+    if name:
+        query["name"] = name
+    if project_id:
+        query["projectId"] = project_id
     payload = dokploy_request(
         host=host,
         token=token,
-        path=f"/api/application.search?{query}",
+        path="/api/application.search",
+        query=query,
     )
     if not isinstance(payload, Mapping):
         raise click.ClickException(
@@ -303,10 +301,12 @@ def search_dokploy_applications(
     total = payload.get("total")
     if not isinstance(raw_items, list) or not isinstance(total, int):
         raise click.ClickException("Dokploy application.search returned malformed search evidence.")
-    if total != len(raw_items):
+    if total > len(raw_items):
         raise click.ClickException(
             "Dokploy application.search result exceeds the bounded inventory."
         )
+    if total < len(raw_items):
+        raise click.ClickException("Dokploy application.search returned an inconsistent total.")
     items: list[JsonObject] = []
     for item in raw_items:
         if not isinstance(item, dict):

--- a/control_plane/dokploy/api.py
+++ b/control_plane/dokploy/api.py
@@ -274,6 +274,49 @@ def fetch_dokploy_projects(*, host: str, token: str) -> tuple[JsonObject, ...]:
     return tuple(projects)
 
 
+def search_dokploy_applications(
+    *,
+    host: str,
+    token: str,
+    name: str = "",
+    project_id: str = "",
+    limit: int = 100,
+) -> tuple[JsonObject, ...]:
+    query = urlencode(
+        {
+            "name": name,
+            "projectId": project_id,
+            "limit": limit,
+            "offset": 0,
+        }
+    )
+    payload = dokploy_request(
+        host=host,
+        token=token,
+        path=f"/api/application.search?{query}",
+    )
+    if not isinstance(payload, Mapping):
+        raise click.ClickException(
+            "Dokploy application.search returned an invalid response payload."
+        )
+    raw_items = payload.get("items")
+    total = payload.get("total")
+    if not isinstance(raw_items, list) or not isinstance(total, int):
+        raise click.ClickException("Dokploy application.search returned malformed search evidence.")
+    if total != len(raw_items):
+        raise click.ClickException(
+            "Dokploy application.search result exceeds the bounded inventory."
+        )
+    items: list[JsonObject] = []
+    for item in raw_items:
+        if not isinstance(item, dict):
+            raise click.ClickException(
+                "Dokploy application.search returned a malformed application."
+            )
+        items.append(item)
+    return tuple(items)
+
+
 def fetch_dokploy_application_domains(
     *, host: str, token: str, application_id: str
 ) -> tuple[JsonObject, ...]:

--- a/tests/test_detached_application_retirement.py
+++ b/tests/test_detached_application_retirement.py
@@ -151,6 +151,11 @@ def _payloads() -> dict[str, dict[str, object]]:
             "projectId": "project-1",
             "environmentId": "environment-testing",
             "applicationStatus": "idle",
+            "environment": {
+                "environmentId": "environment-testing",
+                "name": "testing",
+                "project": {"projectId": "project-1", "name": "example-project"},
+            },
         },
         PROTECTED_IDS[0]: {
             "applicationId": PROTECTED_IDS[0],
@@ -158,6 +163,11 @@ def _payloads() -> dict[str, dict[str, object]]:
             "projectId": "project-1",
             "environmentId": "environment-production",
             "applicationStatus": "running",
+            "environment": {
+                "environmentId": "environment-production",
+                "name": "production",
+                "project": {"projectId": "project-1", "name": "example-project"},
+            },
         },
         PROTECTED_IDS[1]: {
             "applicationId": PROTECTED_IDS[1],
@@ -165,6 +175,11 @@ def _payloads() -> dict[str, dict[str, object]]:
             "projectId": "project-1",
             "environmentId": "environment-testing",
             "applicationStatus": "idle",
+            "environment": {
+                "environmentId": "environment-testing",
+                "name": "testing",
+                "project": {"projectId": "project-1", "name": "example-project"},
+            },
         },
     }
 
@@ -257,6 +272,19 @@ class DetachedApplicationRetirementTests(unittest.TestCase):
             application_id = cast(dict[str, str], kwargs["query"])["applicationId"]
             return (domains or {}).get(application_id, [])
 
+        def search_applications(**kwargs: object) -> tuple[dict[str, object], ...]:
+            name = str(kwargs.get("name") or "")
+            selected = (
+                (CANDIDATE_ID,) if name else (CANDIDATE_ID, PROTECTED_IDS[0], PROTECTED_IDS[1])
+            )
+            return tuple(
+                {
+                    "applicationId": application_id,
+                    "name": payloads[application_id]["name"],
+                }
+                for application_id in selected
+            )
+
         history = dokploy_api.DeploymentHistory(
             state=cast(dokploy_api.DeploymentHistoryState, history_state),
             latest_deployment=None,
@@ -273,6 +301,10 @@ class DetachedApplicationRetirementTests(unittest.TestCase):
             patch(
                 "control_plane.detached_application_retirement.dokploy_api.fetch_dokploy_target_payload",
                 side_effect=fetch_payload,
+            ),
+            patch(
+                "control_plane.detached_application_retirement.dokploy_api.search_dokploy_applications",
+                side_effect=search_applications,
             ),
             patch(
                 "control_plane.detached_application_retirement.dokploy_api.dokploy_request",
@@ -363,6 +395,16 @@ class DetachedApplicationRetirementTests(unittest.TestCase):
             self._discover(projects=malformed)
         with self.assertRaisesRegex(DetachedApplicationRetirementBlockedError, "digest"):
             self._discover(request=_request(candidate_target_sha256="f" * 64))
+
+    def test_discovery_falls_back_to_service_search_when_project_listing_is_inaccessible(
+        self,
+    ) -> None:
+        discovery = self._discover(projects=())
+        self.assertEqual(discovery.candidate.application_id, CANDIDATE_ID)
+        self.assertEqual(
+            tuple(target.target_id_sha256 for target in discovery.protected_targets),
+            _request().expected_protected_target_sha256,
+        )
 
     def test_authority_absence_scans_every_required_source_and_preserves_target_name_distinction(
         self,

--- a/tests/test_detached_application_retirement.py
+++ b/tests/test_detached_application_retirement.py
@@ -260,13 +260,22 @@ class DetachedApplicationRetirementTests(unittest.TestCase):
         domains: Mapping[str, object] | None = None,
         history_state: str = "no_history",
         request: DetachedApplicationRetirementRequest | None = None,
+        absent: bool = False,
     ) -> DetachedApplicationDiscovery:
         payloads = _payloads()
         if payload_updates:
             payloads[CANDIDATE_ID].update(payload_updates)
 
         def fetch_payload(**kwargs: object) -> dict[str, object]:
-            return payloads[cast(str, kwargs["target_id"])]
+            target_id = cast(str, kwargs["target_id"])
+            if absent and target_id == CANDIDATE_ID:
+                raise dokploy_api.DokployRequestFailed(
+                    method="GET",
+                    path="/api/application.one",
+                    detail="not found",
+                    status_code=404,
+                )
+            return payloads[target_id]
 
         def domain_request(**kwargs: object) -> object:
             application_id = cast(dict[str, str], kwargs["query"])["applicationId"]
@@ -275,7 +284,13 @@ class DetachedApplicationRetirementTests(unittest.TestCase):
         def search_applications(**kwargs: object) -> tuple[dict[str, object], ...]:
             name = str(kwargs.get("name") or "")
             selected = (
-                (CANDIDATE_ID,) if name else (CANDIDATE_ID, PROTECTED_IDS[0], PROTECTED_IDS[1])
+                (() if absent else (CANDIDATE_ID,))
+                if name
+                else (
+                    (PROTECTED_IDS[0], PROTECTED_IDS[1])
+                    if absent
+                    else (CANDIDATE_ID, *PROTECTED_IDS)
+                )
             )
             return tuple(
                 {
@@ -319,6 +334,9 @@ class DetachedApplicationRetirementTests(unittest.TestCase):
                 control_plane_root=Path("."),
                 request=request or _request(),
                 observed_at=NOW,
+                absent_application_id=CANDIDATE_ID if absent else "",
+                absent_project_id="project-1" if absent else "",
+                absent_environment_id="environment-testing" if absent else "",
             )
 
     def test_request_requires_sorted_protected_set_and_excludes_candidate(self) -> None:
@@ -405,6 +423,12 @@ class DetachedApplicationRetirementTests(unittest.TestCase):
             tuple(target.target_id_sha256 for target in discovery.protected_targets),
             _request().expected_protected_target_sha256,
         )
+
+    def test_service_search_reconciliation_proves_reviewed_target_absent(self) -> None:
+        discovery = self._discover(projects=(), absent=True)
+        self.assertEqual(discovery.candidate.state, "absent")
+        self.assertEqual(discovery.candidate.project_id, "project-1")
+        self.assertEqual(discovery.candidate.environment_id, "environment-testing")
 
     def test_authority_absence_scans_every_required_source_and_preserves_target_name_distinction(
         self,

--- a/tests/test_dokploy.py
+++ b/tests/test_dokploy.py
@@ -253,6 +253,39 @@ class DokployConfigTests(unittest.TestCase):
             query={"applicationId": "application-one"},
         )
 
+    def test_application_search_uses_bounded_query_and_parses_envelope(self) -> None:
+        response: dokploy_api.JsonValue = {
+            "items": [{"applicationId": "application-one", "name": "example"}],
+            "total": 1,
+        }
+        with patch("control_plane.dokploy.api.dokploy_request", return_value=response) as request:
+            applications = dokploy_api.search_dokploy_applications(
+                host="https://dokploy.example",
+                token="provider-token",
+                name="example",
+                project_id="project-one",
+            )
+
+        self.assertEqual(applications, ({"applicationId": "application-one", "name": "example"},))
+        request.assert_called_once_with(
+            host="https://dokploy.example",
+            token="provider-token",
+            path="/api/application.search",
+            query={"name": "example", "projectId": "project-one", "limit": 100, "offset": 0},
+        )
+
+        with patch("control_plane.dokploy.api.dokploy_request", return_value=response) as request:
+            dokploy_api.search_dokploy_applications(
+                host="https://dokploy.example",
+                token="provider-token",
+            )
+        request.assert_called_once_with(
+            host="https://dokploy.example",
+            token="provider-token",
+            path="/api/application.search",
+            query={"limit": 100, "offset": 0},
+        )
+
     def test_deployment_history_rejects_unsupported_target_type_without_request(self) -> None:
         with patch("control_plane.dokploy.api.dokploy_request") as request:
             with self.assertRaisesRegex(


### PR DESCRIPTION
## Summary

- Fall back from project-level Dokploy inventory to `application.search` when the service identity has application access without project access.
- Preserve exact project/environment/name/digest checks and bounded protected-target enumeration.
- Cover the live access shape that blocked detached-retirement plan run 31482772404.

## Validation

- `python -m unittest tests.test_detached_application_retirement tests.test_dokploy` (126 tests)
- changed-file Ruff and mypy pass

Refs #2100