### PR TITLE
fix: disambiguate duplicate Dokploy projects

### DIFF
--- a/control_plane/detached_application_retirement.py
+++ b/control_plane/detached_application_retirement.py
@@ -344,11 +344,7 @@ def discover_detached_application(
         for project_id, project_name in parsed.projects
         if project_name == request.project_name
     }
-    if len(matching_projects) > 1:
-        raise DetachedApplicationRetirementBlockedError(
-            "Detached application retirement requires exactly one project name match."
-        )
-    if not matching_projects:
+    if len(matching_projects) != 1:
         return _discover_detached_application_with_service_search(
             host=host,
             token=token,

--- a/tests/test_detached_application_retirement.py
+++ b/tests/test_detached_application_retirement.py
@@ -424,6 +424,25 @@ class DetachedApplicationRetirementTests(unittest.TestCase):
             _request().expected_protected_target_sha256,
         )
 
+    def test_discovery_uses_candidate_payload_to_disambiguate_duplicate_project_names(self) -> None:
+        duplicate_projects = (
+            *_projects(),
+            {
+                "projectId": "project-2",
+                "name": "example-project",
+                "environments": [
+                    {
+                        "environmentId": "environment-other",
+                        "name": "production",
+                        "applications": [],
+                    }
+                ],
+            },
+        )
+        discovery = self._discover(projects=duplicate_projects)
+        self.assertEqual(discovery.candidate.application_id, CANDIDATE_ID)
+        self.assertEqual(discovery.candidate.project_id, "project-1")
+
     def test_service_search_reconciliation_proves_reviewed_target_absent(self) -> None:
         discovery = self._discover(projects=(), absent=True)
         self.assertEqual(discovery.candidate.state, "absent")


### PR DESCRIPTION
## Summary

- Route duplicate project-name inventories through the already reviewed service-scoped application search.
- Bind the selected candidate to its own target payload project ID instead of trusting ambiguous project names.
- Cover the exact live shape that blocked plan run 31485455846.

## Validation

- `python -m unittest tests.test_detached_application_retirement` (15 tests)

Refs #2100