### PR TITLE
feat: persist guarded merge admission outcomes

### DIFF
--- a/control_plane/contracts/merge_admission_record.py
+++ b/control_plane/contracts/merge_admission_record.py
@@ -1,0 +1,525 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+import hashlib
+import json
+import re
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from control_plane.contracts.merge_readiness import MergeReadinessResult
+from control_plane.contracts.merge_train_controller_state import (
+    MergeTrainControllerStateRecord,
+)
+from control_plane.contracts.merge_train_policy import MergeTrainMergeMethod
+from control_plane.contracts.merge_train_structural_provenance import (
+    MergeTrainStructuralCandidateResult,
+)
+
+
+MergeLandingOutcomeStatus = Literal["landed", "rejected", "reconcile_required"]
+MergeLandingObservedPullRequestState = Literal["", "open", "closed", "merged"]
+MergeLandingOutcomeReason = Literal[
+    "provider_and_git_confirmed",
+    "provider_rejected",
+    "reconciliation_confirmed_no_effect",
+    "provider_transport_ambiguous",
+    "process_interrupted",
+    "lease_lost_after_admission",
+    "landing_evidence_incomplete",
+    "landing_evidence_contradicted",
+]
+
+_GIT_SHA_PATTERN = re.compile(r"^[0-9a-f]{40}(?:[0-9a-f]{24})?$")
+_SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+
+
+class MergeAdmissionFenceRejectedError(RuntimeError):
+    """Raised when persisted controller authority no longer admits an effect."""
+
+
+def _required_token(value: str, field_name: str) -> str:
+    normalized = value.strip()
+    if not normalized:
+        raise ValueError(f"{field_name} must be non-empty")
+    return normalized
+
+
+def _normalize_repository(value: str) -> str:
+    normalized = _required_token(value, "repository").lower()
+    if normalized.count("/") != 1 or not all(normalized.split("/", 1)):
+        raise ValueError("repository must use owner/name")
+    return normalized
+
+
+def _normalize_git_sha(value: str, field_name: str) -> str:
+    normalized = _required_token(value, field_name).lower()
+    if _GIT_SHA_PATTERN.fullmatch(normalized) is None:
+        raise ValueError(f"{field_name} must be a Git SHA")
+    return normalized
+
+
+def _normalize_optional_git_sha(value: str, field_name: str) -> str:
+    normalized = value.strip().lower()
+    if normalized and _GIT_SHA_PATTERN.fullmatch(normalized) is None:
+        raise ValueError(f"{field_name} must be a Git SHA when present")
+    return normalized
+
+
+def _normalize_sha256(value: str, field_name: str) -> str:
+    normalized = _required_token(value, field_name).lower()
+    if _SHA256_PATTERN.fullmatch(normalized) is None:
+        raise ValueError(f"{field_name} must be a lowercase SHA-256 digest")
+    return normalized
+
+
+def _normalize_timestamp(value: str, field_name: str) -> str:
+    normalized = _required_token(value, field_name)
+    try:
+        parsed = datetime.fromisoformat(normalized.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise ValueError(f"{field_name} must be an ISO-8601 timestamp") from error
+    if parsed.tzinfo is None:
+        raise ValueError(f"{field_name} must include a timezone")
+    return parsed.astimezone(UTC).isoformat(timespec="microseconds").replace("+00:00", "Z")
+
+
+def _canonical_sha256(payload: object) -> str:
+    encoded = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+class MergeAdmissionRecord(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    schema_version: Literal[1] = 1
+    admission_id: str = ""
+    admission_binding_sha256: str = ""
+    attempt_id: str
+    attempt_sequence: int = Field(ge=1)
+    decision: Literal["admitted"] = "admitted"
+    source: str
+    repository: str
+    base_branch: str
+    pull_request_number: int = Field(ge=1)
+    queue_position: int = Field(ge=1)
+    batch_id: str
+    candidate_record_id: str
+    landing_plan_record_id: str
+    landing_plan_id: str
+    merge_method: MergeTrainMergeMethod
+    effective_base_sha: str
+    effective_base_tree_sha: str
+    pull_request_head_sha: str
+    pull_request_head_tree_sha: str
+    candidate_sha: str
+    candidate_tree_sha: str
+    expected_effect_sha: str
+    candidate_sha256: str
+    structural_provenance_sha256: str
+    landing_plan_sha256: str
+    readiness: MergeReadinessResult
+    structural_result: MergeTrainStructuralCandidateResult
+    admission_algorithm_version: str
+    controller_key: str
+    lease_owner: str
+    lease_acquired_at: str
+    lease_expires_at: str
+    created_at: str
+
+    @model_validator(mode="after")
+    def _validate_record(self) -> "MergeAdmissionRecord":
+        object.__setattr__(self, "repository", _normalize_repository(self.repository))
+        for field_name in (
+            "attempt_id",
+            "source",
+            "base_branch",
+            "batch_id",
+            "candidate_record_id",
+            "landing_plan_record_id",
+            "landing_plan_id",
+            "admission_algorithm_version",
+            "controller_key",
+            "lease_owner",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _required_token(str(getattr(self, field_name)), field_name),
+            )
+        for field_name in (
+            "effective_base_sha",
+            "effective_base_tree_sha",
+            "pull_request_head_sha",
+            "pull_request_head_tree_sha",
+            "candidate_sha",
+            "candidate_tree_sha",
+            "expected_effect_sha",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _normalize_git_sha(str(getattr(self, field_name)), field_name),
+            )
+        for field_name in (
+            "candidate_sha256",
+            "structural_provenance_sha256",
+            "landing_plan_sha256",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _normalize_sha256(str(getattr(self, field_name)), field_name),
+            )
+        for field_name in ("lease_acquired_at", "lease_expires_at", "created_at"):
+            object.__setattr__(
+                self,
+                field_name,
+                _normalize_timestamp(str(getattr(self, field_name)), field_name),
+            )
+        if self.readiness.state != "ready":
+            raise ValueError("merge admission requires ready Level 2 evidence")
+        target = self.readiness.target
+        if (
+            target.repository != self.repository
+            or target.base_branch != self.base_branch
+            or target.pull_request_number != self.pull_request_number
+            or target.queue_position != self.queue_position
+            or target.base_sha != self.effective_base_sha
+            or target.pull_request_head_sha != self.pull_request_head_sha
+            or target.pull_request_tree_sha != self.pull_request_head_tree_sha
+            or target.expected_effect_sha != self.expected_effect_sha
+        ):
+            raise ValueError("merge admission identity does not match Level 2 evidence")
+        if self.structural_result.status not in {"exact", "recorded_rolling"}:
+            raise ValueError("merge admission requires exact structural provenance")
+        if (
+            self.structural_result.effective_base_sha != self.effective_base_sha
+            or self.structural_result.effective_base_tree_sha != self.effective_base_tree_sha
+            or self.structural_result.candidate_sha256 != self.candidate_sha256
+            or self.structural_result.landing_plan_sha256 != self.landing_plan_sha256
+            or self.structural_result.provenance_sha256 != self.structural_provenance_sha256
+        ):
+            raise ValueError("merge admission identity does not match structural evidence")
+        if self.readiness.candidate.evidence.candidate_sha != self.candidate_sha:
+            raise ValueError("merge admission candidate SHA does not match Level 2 evidence")
+        if self.readiness.fence.evidence.controller_key != self.controller_key:
+            raise ValueError("merge admission controller key does not match Level 2 evidence")
+        if self.readiness.fence.evidence.observed_lease_owner != self.lease_owner:
+            raise ValueError("merge admission lease owner does not match Level 2 evidence")
+        if self.readiness.fence.evidence.lease_expires_at != self.lease_expires_at:
+            raise ValueError("merge admission lease expiry does not match Level 2 evidence")
+        expected_attempt_id = build_merge_effect_attempt_id(
+            controller_key=self.controller_key,
+            lease_owner=self.lease_owner,
+            lease_acquired_at=self.lease_acquired_at,
+            landing_plan_id=self.landing_plan_id,
+            pull_request_number=self.pull_request_number,
+            queue_position=self.queue_position,
+            attempt_sequence=self.attempt_sequence,
+            expected_effect_sha=self.expected_effect_sha,
+        )
+        if self.attempt_id != expected_attempt_id:
+            raise ValueError("merge admission attempt ID does not match its deterministic identity")
+        expected_binding = merge_admission_binding_sha256(self)
+        binding = self.admission_binding_sha256.strip().lower()
+        if binding and _normalize_sha256(binding, "admission_binding_sha256") != expected_binding:
+            raise ValueError("merge admission binding digest does not match payload")
+        expected_id = f"merge-admission-{expected_binding[:24]}"
+        admission_id = self.admission_id.strip()
+        if admission_id and admission_id != expected_id:
+            raise ValueError("merge admission id does not match payload")
+        object.__setattr__(self, "admission_binding_sha256", expected_binding)
+        object.__setattr__(self, "admission_id", expected_id)
+        return self
+
+
+class MergeLandingOutcomeRecord(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    schema_version: Literal[1] = 1
+    outcome_id: str = ""
+    outcome_binding_sha256: str = ""
+    admission_id: str
+    admission_binding_sha256: str
+    attempt_id: str
+    observation_sequence: int = Field(ge=1)
+    prior_outcome_id: str = ""
+    source: str
+    repository: str
+    base_branch: str
+    pull_request_number: int = Field(ge=1)
+    status: MergeLandingOutcomeStatus
+    reason: MergeLandingOutcomeReason
+    provider_effect_attempted: bool
+    provider_conclusive_rejection: bool = False
+    provider_status_code: int | None = Field(default=None, ge=100, le=599)
+    provider_request_id: str = ""
+    provider_message: str = ""
+    observed_pull_request_state: MergeLandingObservedPullRequestState = ""
+    observed_pull_request_head_sha: str = ""
+    observed_pull_request_head_tree_sha: str = ""
+    observed_base_sha: str = ""
+    observed_base_tree_sha: str = ""
+    merge_commit_sha: str = ""
+    merge_commit_tree_sha: str = ""
+    base_contains_merge_commit: bool | None = None
+    exact_landing_confirmed: bool = False
+    observed_at: str
+
+    @model_validator(mode="after")
+    def _validate_record(self) -> "MergeLandingOutcomeRecord":
+        object.__setattr__(self, "repository", _normalize_repository(self.repository))
+        for field_name in ("admission_id", "attempt_id", "source"):
+            object.__setattr__(
+                self,
+                field_name,
+                _required_token(str(getattr(self, field_name)), field_name),
+            )
+        object.__setattr__(
+            self,
+            "admission_binding_sha256",
+            _normalize_sha256(self.admission_binding_sha256, "admission_binding_sha256"),
+        )
+        object.__setattr__(self, "base_branch", _required_token(self.base_branch, "base_branch"))
+        object.__setattr__(self, "prior_outcome_id", self.prior_outcome_id.strip())
+        object.__setattr__(self, "provider_request_id", self.provider_request_id.strip())
+        object.__setattr__(self, "provider_message", self.provider_message.strip())
+        for field_name in (
+            "observed_pull_request_head_sha",
+            "observed_pull_request_head_tree_sha",
+            "observed_base_sha",
+            "observed_base_tree_sha",
+            "merge_commit_sha",
+            "merge_commit_tree_sha",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _normalize_optional_git_sha(str(getattr(self, field_name)), field_name),
+            )
+        object.__setattr__(
+            self, "observed_at", _normalize_timestamp(self.observed_at, "observed_at")
+        )
+        if self.observation_sequence == 1 and self.prior_outcome_id:
+            raise ValueError("first landing outcome cannot reference a prior outcome")
+        if self.observation_sequence > 1 and not self.prior_outcome_id:
+            raise ValueError("reconciled landing outcome requires a prior outcome")
+        if self.status == "landed":
+            if self.provider_conclusive_rejection:
+                raise ValueError("landed outcome cannot carry provider rejection")
+            if not self.exact_landing_confirmed or self.base_contains_merge_commit is not True:
+                raise ValueError("landed outcome requires exact provider and Git confirmation")
+            if not all(
+                (
+                    self.observed_pull_request_head_sha,
+                    self.observed_pull_request_head_tree_sha,
+                    self.observed_base_sha,
+                    self.observed_base_tree_sha,
+                    self.merge_commit_sha,
+                    self.merge_commit_tree_sha,
+                )
+            ):
+                raise ValueError("landed outcome requires complete Git evidence")
+            if self.reason != "provider_and_git_confirmed":
+                raise ValueError("landed outcome requires provider_and_git_confirmed reason")
+        elif self.status == "rejected":
+            if self.exact_landing_confirmed or self.merge_commit_sha or self.merge_commit_tree_sha:
+                raise ValueError("rejected outcome cannot claim a landing")
+            if self.reason == "provider_rejected":
+                if not self.provider_effect_attempted or not self.provider_conclusive_rejection:
+                    raise ValueError("provider rejection requires conclusive provider refusal")
+                if self.provider_status_code is None:
+                    raise ValueError("provider rejection requires provider status code")
+            elif self.reason == "reconciliation_confirmed_no_effect":
+                if not self.provider_effect_attempted:
+                    raise ValueError(
+                        "no-effect reconciliation requires a preceding provider attempt"
+                    )
+                if self.provider_conclusive_rejection or self.provider_status_code is not None:
+                    raise ValueError("no-effect reconciliation cannot claim provider rejection")
+                if self.observed_pull_request_state != "open" or not all(
+                    (
+                        self.observed_pull_request_head_sha,
+                        self.observed_pull_request_head_tree_sha,
+                        self.observed_base_sha,
+                        self.observed_base_tree_sha,
+                    )
+                ):
+                    raise ValueError(
+                        "no-effect reconciliation requires exact open PR and base evidence"
+                    )
+            else:
+                raise ValueError("rejected outcome requires conclusive no-effect evidence")
+        else:
+            if self.provider_conclusive_rejection:
+                raise ValueError("reconcile-required outcome cannot claim conclusive rejection")
+            if self.exact_landing_confirmed:
+                raise ValueError("reconcile-required outcome cannot claim exact landing")
+            if self.reason in {"provider_and_git_confirmed", "provider_rejected"}:
+                raise ValueError("reconcile-required outcome requires an ambiguity reason")
+        expected_binding = merge_landing_outcome_binding_sha256(self)
+        binding = self.outcome_binding_sha256.strip().lower()
+        if binding and _normalize_sha256(binding, "outcome_binding_sha256") != expected_binding:
+            raise ValueError("landing outcome binding digest does not match payload")
+        expected_id = f"merge-landing-outcome-{expected_binding[:24]}"
+        outcome_id = self.outcome_id.strip()
+        if outcome_id and outcome_id != expected_id:
+            raise ValueError("landing outcome id does not match payload")
+        object.__setattr__(self, "outcome_binding_sha256", expected_binding)
+        object.__setattr__(self, "outcome_id", expected_id)
+        return self
+
+
+def build_merge_effect_attempt_id(
+    *,
+    controller_key: str,
+    lease_owner: str,
+    lease_acquired_at: str,
+    landing_plan_id: str,
+    pull_request_number: int,
+    queue_position: int,
+    attempt_sequence: int,
+    expected_effect_sha: str,
+) -> str:
+    if pull_request_number < 1 or queue_position < 1 or attempt_sequence < 1:
+        raise ValueError("merge effect attempt identity requires positive numeric fields")
+    payload = {
+        "controller_key": _required_token(controller_key, "controller_key"),
+        "lease_owner": _required_token(lease_owner, "lease_owner"),
+        "lease_acquired_at": _normalize_timestamp(lease_acquired_at, "lease_acquired_at"),
+        "landing_plan_id": _required_token(landing_plan_id, "landing_plan_id"),
+        "pull_request_number": pull_request_number,
+        "queue_position": queue_position,
+        "attempt_sequence": attempt_sequence,
+        "expected_effect_sha": _normalize_git_sha(expected_effect_sha, "expected_effect_sha"),
+    }
+    return f"merge-effect-attempt-{_canonical_sha256(payload)[:24]}"
+
+
+def merge_admission_binding_sha256(record: MergeAdmissionRecord) -> str:
+    return _canonical_sha256(
+        record.model_dump(
+            mode="json",
+            exclude={"admission_id", "admission_binding_sha256"},
+        )
+    )
+
+
+def merge_landing_outcome_binding_sha256(record: MergeLandingOutcomeRecord) -> str:
+    return _canonical_sha256(
+        record.model_dump(
+            mode="json",
+            exclude={"outcome_id", "outcome_binding_sha256"},
+        )
+    )
+
+
+def validate_merge_landing_outcome_for_admission(
+    *,
+    admission: MergeAdmissionRecord,
+    outcome: MergeLandingOutcomeRecord,
+) -> None:
+    if (
+        outcome.admission_id != admission.admission_id
+        or outcome.admission_binding_sha256 != admission.admission_binding_sha256
+        or outcome.attempt_id != admission.attempt_id
+        or outcome.repository != admission.repository
+        or outcome.base_branch != admission.base_branch
+        or outcome.pull_request_number != admission.pull_request_number
+    ):
+        raise ValueError("landing outcome does not match its merge admission")
+    if outcome.status == "landed":
+        if (
+            outcome.observed_pull_request_head_sha != admission.pull_request_head_sha
+            or outcome.observed_pull_request_head_tree_sha != admission.pull_request_head_tree_sha
+        ):
+            raise ValueError("landed outcome head identity does not match admission")
+    if outcome.reason == "reconciliation_confirmed_no_effect":
+        if (
+            outcome.observed_pull_request_state != "open"
+            or outcome.observed_pull_request_head_sha != admission.pull_request_head_sha
+            or outcome.observed_pull_request_head_tree_sha != admission.pull_request_head_tree_sha
+            or outcome.observed_base_sha != admission.effective_base_sha
+            or outcome.observed_base_tree_sha != admission.effective_base_tree_sha
+        ):
+            raise ValueError("no-effect reconciliation evidence does not match admission")
+
+
+def validate_merge_landing_outcome_successor(
+    *,
+    prior: MergeLandingOutcomeRecord,
+    successor: MergeLandingOutcomeRecord,
+) -> None:
+    if prior.status != "reconcile_required":
+        raise ValueError("terminal landing outcomes cannot be superseded")
+    if (
+        successor.admission_id != prior.admission_id
+        or successor.admission_binding_sha256 != prior.admission_binding_sha256
+        or successor.attempt_id != prior.attempt_id
+        or successor.observation_sequence != prior.observation_sequence + 1
+        or successor.prior_outcome_id != prior.outcome_id
+    ):
+        raise ValueError("landing outcome reconciliation chain is invalid")
+
+
+def validate_merge_admission_controller_fence(
+    *,
+    admission: MergeAdmissionRecord,
+    controller_state: MergeTrainControllerStateRecord,
+    admitted_at: str,
+) -> None:
+    normalized_admitted_at = _normalize_timestamp(admitted_at, "admitted_at")
+    if normalized_admitted_at != admission.created_at:
+        raise MergeAdmissionFenceRejectedError(
+            "Persisted merge admission time does not match the actual admission time."
+        )
+    if (
+        controller_state.status != "running"
+        or controller_state.controller_key != admission.controller_key
+        or controller_state.repository != admission.repository
+        or controller_state.base_branch != admission.base_branch
+        or controller_state.lease_owner != admission.lease_owner
+        or _normalize_timestamp(controller_state.lease_acquired_at, "lease_acquired_at")
+        != admission.lease_acquired_at
+        or _normalize_timestamp(controller_state.lease_expires_at, "lease_expires_at")
+        != admission.lease_expires_at
+    ):
+        raise MergeAdmissionFenceRejectedError(
+            "Persisted merge controller lease changed before admission creation."
+        )
+    admitted_time = datetime.fromisoformat(normalized_admitted_at.replace("Z", "+00:00"))
+    expires_time = datetime.fromisoformat(
+        _normalize_timestamp(controller_state.lease_expires_at, "lease_expires_at").replace(
+            "Z", "+00:00"
+        )
+    )
+    if admitted_time >= expires_time:
+        raise MergeAdmissionFenceRejectedError(
+            "Persisted merge controller lease expired before admission creation."
+        )
+    merge_train_policy = admission.readiness.policy.fingerprints.merge_train
+    if (
+        merge_train_policy.expected_sha256 != controller_state.policy_sha256
+        or merge_train_policy.current_sha256 != controller_state.policy_sha256
+    ):
+        raise MergeAdmissionFenceRejectedError(
+            "Persisted merge controller policy changed before admission creation."
+        )
+    expected_effect_sha = str(controller_state.step_payload.get("expected_effect_sha") or "")
+    landing_plan_id = str(controller_state.step_payload.get("landing_plan_id") or "")
+    if (
+        controller_state.active_action not in {"land_batch", "batch_landing_run_once"}
+        or controller_state.active_pull_request_number != admission.pull_request_number
+        or expected_effect_sha != admission.expected_effect_sha
+        or landing_plan_id != admission.landing_plan_id
+    ):
+        raise MergeAdmissionFenceRejectedError(
+            "Persisted merge controller effect fence changed before admission creation."
+        )

--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -258,6 +258,12 @@ from control_plane.merge_train_batch_candidate import (
     execute_merge_train_batch_candidate_run_once,
     require_merge_train_batch_candidate_record_store,
 )
+from control_plane.merge_admission import (
+    MergeAdmissionDeniedError,
+    MergeAdmissionReconciliationRequiredError,
+    require_merge_admission_record_store,
+)
+from control_plane.merge_admission_live import LiveMergeAdmissionEvaluator
 from control_plane.contracts.merge_train_controller_state import (
     MergeTrainControllerAdoptionRejectedError,
     MergeTrainControllerLeaseHeldError,
@@ -272,7 +278,11 @@ from control_plane.merge_train_controller_run_once import (
     merge_train_controller_mutation_fence,
     require_merge_train_controller_state_record_store,
 )
-from control_plane.merge_train_github import MergeTrainGitHubError, MergeTrainGitHubStaleHeadError
+from control_plane.merge_train_github import (
+    MergeTrainGitHubError,
+    MergeTrainGitHubStaleHeadError,
+    UrllibMergeTrainGitHubTransport,
+)
 from control_plane.merge_train_pr_feedback import (
     MergeTrainPrFeedbackEnvelope,
     build_merge_train_pr_feedback_record,
@@ -283,6 +293,7 @@ from control_plane.merge_train_run_once import (
     execute_merge_train_run_once,
     require_merge_train_run_record_store,
 )
+from control_plane.tenant_admission_controller import TenantAdmissionControllerGitHubClient
 from control_plane.merge_train_stack_collapse import (
     MergeTrainStackCollapseBatchCandidateStoreMissingError,
     MergeTrainStackCollapsePlanRecordNotFoundError,
@@ -5501,6 +5512,7 @@ def create_launchplane_fastapi_app(
                 record_store
             )
             controller_state_store = require_merge_train_controller_state_record_store(record_store)
+            admission_store = require_merge_admission_record_store(record_store)
         except TypeError as error:
             raise _launchplane_http_error(
                 status_code=503,
@@ -5528,6 +5540,16 @@ def create_launchplane_fastapi_app(
                     response=idempotent_response,
                 )
 
+            admission_evaluator = LiveMergeAdmissionEvaluator(
+                store=record_store,
+                repository_evidence_provider=(resolved_change_impact_repository_evidence_provider),
+                technical_check_client=TenantAdmissionControllerGitHubClient(
+                    transport=UrllibMergeTrainGitHubTransport(
+                        token=token,
+                        api_base_url=controller_request.github_api_base_url,
+                    )
+                ),
+            )
             controller_result = execute_merge_train_controller_run_once(
                 request=controller_request,
                 policy=policy_record.policy,
@@ -5540,12 +5562,28 @@ def create_launchplane_fastapi_app(
                 landing_store=landing_store,
                 stack_collapse_store=stack_collapse_store,
                 controller_state_store=controller_state_store,
+                admission_store=admission_store,
+                admission_evaluator=admission_evaluator,
                 before_release=store_controller_idempotency_before_release,
             )
         except MergeTrainGitHubStaleHeadError as error:
             return merge_train_github_stale_state_response(trace_id=trace_id, error=error)
         except MergeTrainGitHubError as error:
             return merge_train_github_request_failed_response(trace_id=trace_id, error=error)
+        except MergeAdmissionDeniedError as error:
+            raise _launchplane_http_error(
+                status_code=409,
+                trace_id=trace_id,
+                code="merge_train_landing_not_admitted",
+                message=str(error),
+            ) from error
+        except MergeAdmissionReconciliationRequiredError as error:
+            raise _launchplane_http_error(
+                status_code=409,
+                trace_id=trace_id,
+                code="merge_train_landing_reconcile_required",
+                message=str(error),
+            ) from error
         except (
             MergeTrainControllerLeaseHeldError,
             MergeTrainControllerLeaseLostError,
@@ -9277,6 +9315,7 @@ def create_launchplane_fastapi_app(
                 record_store
             )
             controller_state_store = require_merge_train_controller_state_record_store(record_store)
+            admission_store = require_merge_admission_record_store(record_store)
         except TypeError as error:
             raise _launchplane_http_error(
                 status_code=503,
@@ -9303,14 +9342,21 @@ def create_launchplane_fastapi_app(
                 )
 
                 def checkpoint_landing_mutation(
-                    phase: str, pull_request_number: int | None
+                    phase: str,
+                    pull_request_number: int | None,
+                    landing_plan_id: str,
+                    expected_effect_sha: str,
                 ) -> None:
                     lease.checkpoint(
                         active_action="batch_landing_run_once",
                         active_phase=phase,
                         active_record_id=active_record_id,
                         active_pull_request_number=pull_request_number,
-                        step_payload={"mode": landing_request.mode},
+                        step_payload={
+                            "mode": landing_request.mode,
+                            "landing_plan_id": landing_plan_id,
+                            "expected_effect_sha": expected_effect_sha,
+                        },
                     )
 
                 landing_result = execute_merge_train_batch_landing_run_once(
@@ -9323,6 +9369,20 @@ def create_launchplane_fastapi_app(
                     candidate_store=candidate_store,
                     landing_store=landing_store,
                     stack_collapse_store=stack_collapse_store,
+                    admission_store=admission_store,
+                    admission_evaluator=LiveMergeAdmissionEvaluator(
+                        store=record_store,
+                        repository_evidence_provider=(
+                            resolved_change_impact_repository_evidence_provider
+                        ),
+                        technical_check_client=TenantAdmissionControllerGitHubClient(
+                            transport=UrllibMergeTrainGitHubTransport(
+                                token=token,
+                                api_base_url=landing_request.github_api_base_url,
+                            )
+                        ),
+                    ),
+                    controller_state_provider=lease.read_current,
                     mutation_checkpoint=checkpoint_landing_mutation,
                 )
                 response = accepted_evidence_response(
@@ -9343,6 +9403,20 @@ def create_launchplane_fastapi_app(
             return merge_train_github_stale_state_response(trace_id=trace_id, error=error)
         except MergeTrainGitHubError as error:
             return merge_train_github_request_failed_response(trace_id=trace_id, error=error)
+        except MergeAdmissionDeniedError as error:
+            raise _launchplane_http_error(
+                status_code=409,
+                trace_id=trace_id,
+                code="merge_train_landing_not_admitted",
+                message=str(error),
+            ) from error
+        except MergeAdmissionReconciliationRequiredError as error:
+            raise _launchplane_http_error(
+                status_code=409,
+                trace_id=trace_id,
+                code="merge_train_landing_reconcile_required",
+                message=str(error),
+            ) from error
         except (
             MergeTrainControllerLeaseHeldError,
             MergeTrainControllerLeaseLostError,

--- a/control_plane/merge_admission.py
+++ b/control_plane/merge_admission.py
@@ -1,0 +1,503 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Protocol, cast
+
+from control_plane.contracts.merge_admission_record import (
+    MergeAdmissionFenceRejectedError,
+    MergeAdmissionRecord,
+    MergeLandingOutcomeReason,
+    MergeLandingOutcomeRecord,
+    build_merge_effect_attempt_id,
+)
+from control_plane.contracts.merge_readiness import MergeReadinessResult
+from control_plane.contracts.merge_train_batch import (
+    MergeTrainBatchCandidateRecord,
+    MergeTrainBatchLandingEntry,
+    MergeTrainBatchLandingPlan,
+    MergeTrainBatchLandingPlanRecord,
+)
+from control_plane.contracts.merge_train_controller_state import (
+    MergeTrainControllerStateRecord,
+)
+from control_plane.contracts.merge_train_stack_collapse import (
+    MergeTrainStackCollapsePlanRecord,
+)
+from control_plane.contracts.merge_train_structural_provenance import (
+    MergeTrainStructuralCandidateResult,
+)
+
+
+MERGE_ADMISSION_ALGORITHM_VERSION = "merge-admission-v1"
+
+
+def _utc_now_timestamp() -> str:
+    return datetime.now(UTC).isoformat(timespec="microseconds").replace("+00:00", "Z")
+
+
+class MergeAdmissionDeniedError(ValueError):
+    """Raised when fresh L2 or structural evidence refuses an effect attempt."""
+
+
+class MergeAdmissionReconciliationRequiredError(RuntimeError):
+    """Raised when an earlier attempt remains effect-ambiguous."""
+
+
+class MergeAdmissionRecordStore(Protocol):
+    def create_merge_admission_record_if_absent(
+        self, record: MergeAdmissionRecord
+    ) -> tuple[MergeAdmissionRecord, bool]: ...
+
+    def create_guarded_merge_admission_record_if_absent(
+        self,
+        record: MergeAdmissionRecord,
+        *,
+        admitted_at: str,
+    ) -> tuple[MergeAdmissionRecord, bool]: ...
+
+    def read_merge_admission_record(self, admission_id: str) -> MergeAdmissionRecord: ...
+
+    def list_merge_admission_records(
+        self,
+        *,
+        repository: str = "",
+        base_branch: str = "",
+        pull_request_number: int | None = None,
+        landing_plan_record_id: str = "",
+        landing_plan_id: str = "",
+        attempt_id: str = "",
+        limit: int | None = None,
+    ) -> tuple[MergeAdmissionRecord, ...]: ...
+
+    def create_merge_landing_outcome_record_if_absent(
+        self, record: MergeLandingOutcomeRecord
+    ) -> tuple[MergeLandingOutcomeRecord, bool]: ...
+
+    def list_merge_landing_outcome_records(
+        self,
+        *,
+        repository: str = "",
+        base_branch: str = "",
+        pull_request_number: int | None = None,
+        admission_id: str = "",
+        status: str = "",
+        observation_sequence: int | None = None,
+        limit: int | None = None,
+    ) -> tuple[MergeLandingOutcomeRecord, ...]: ...
+
+
+def require_merge_admission_record_store(record_store: object) -> MergeAdmissionRecordStore:
+    required_methods = (
+        "create_merge_admission_record_if_absent",
+        "create_guarded_merge_admission_record_if_absent",
+        "read_merge_admission_record",
+        "list_merge_admission_records",
+        "create_merge_landing_outcome_record_if_absent",
+        "list_merge_landing_outcome_records",
+    )
+    if all(callable(getattr(record_store, method_name, None)) for method_name in required_methods):
+        return cast(MergeAdmissionRecordStore, record_store)
+    raise TypeError("record store does not support guarded merge admission records")
+
+
+@dataclass(frozen=True)
+class MergeAdmissionEvaluation:
+    readiness: MergeReadinessResult
+    structural_result: MergeTrainStructuralCandidateResult
+
+
+class MergeAdmissionEvaluator(Protocol):
+    def evaluate(
+        self,
+        *,
+        candidate_record: MergeTrainBatchCandidateRecord,
+        landing_plan_record: MergeTrainBatchLandingPlanRecord,
+        entry: MergeTrainBatchLandingEntry,
+        observed_base_sha: str,
+        observed_base_tree_sha: str,
+        observed_head_sha: str,
+        observed_head_tree_sha: str,
+        controller_state: MergeTrainControllerStateRecord,
+        stack_collapse_record: MergeTrainStackCollapsePlanRecord | None,
+        evaluated_at: str,
+    ) -> MergeAdmissionEvaluation: ...
+
+
+@dataclass
+class GuardedMergeAdmission:
+    record_store: MergeAdmissionRecordStore
+    evaluator: MergeAdmissionEvaluator
+    candidate_record: MergeTrainBatchCandidateRecord
+    landing_plan_record: MergeTrainBatchLandingPlanRecord
+    controller_state: MergeTrainControllerStateRecord
+    trace_id: str
+    admission_algorithm_version: str = MERGE_ADMISSION_ALGORITHM_VERSION
+    controller_state_provider: Callable[[], MergeTrainControllerStateRecord] | None = None
+    admission_time_provider: Callable[[], str] = _utc_now_timestamp
+    stack_collapse_record: MergeTrainStackCollapsePlanRecord | None = None
+
+    def update_landing_plan_record(
+        self, landing_plan_record: MergeTrainBatchLandingPlanRecord
+    ) -> None:
+        self.landing_plan_record = landing_plan_record
+
+    def update_landing_plan(self, landing_plan: MergeTrainBatchLandingPlan) -> None:
+        self.landing_plan_record = self.landing_plan_record.model_copy(
+            update={"landing_plan": landing_plan}
+        )
+
+    def admit(
+        self,
+        *,
+        entry: MergeTrainBatchLandingEntry,
+        observed_base_sha: str,
+        observed_base_tree_sha: str,
+        observed_head_sha: str,
+        observed_head_tree_sha: str,
+    ) -> MergeAdmissionRecord:
+        if self.controller_state_provider is not None:
+            self.controller_state = self.controller_state_provider()
+        evaluation_started_at = self.admission_time_provider()
+        existing = self.record_store.list_merge_admission_records(
+            repository=self.landing_plan_record.landing_plan.repository,
+            base_branch=self.landing_plan_record.landing_plan.base_branch,
+            pull_request_number=entry.pull_request_number,
+            landing_plan_id=self.landing_plan_record.landing_plan.plan_id,
+        )
+        if existing:
+            latest_outcomes = self.record_store.list_merge_landing_outcome_records(
+                admission_id=existing[0].admission_id,
+                limit=1,
+            )
+            if not latest_outcomes or latest_outcomes[0].status == "reconcile_required":
+                raise MergeAdmissionReconciliationRequiredError(
+                    "A prior merge admission remains effect-ambiguous and must be reconciled."
+                )
+        attempt_sequence = max((record.attempt_sequence for record in existing), default=0) + 1
+        evaluation = self.evaluator.evaluate(
+            candidate_record=self.candidate_record,
+            landing_plan_record=self.landing_plan_record,
+            entry=entry,
+            observed_base_sha=observed_base_sha,
+            observed_base_tree_sha=observed_base_tree_sha,
+            observed_head_sha=observed_head_sha,
+            observed_head_tree_sha=observed_head_tree_sha,
+            controller_state=self.controller_state,
+            stack_collapse_record=self.stack_collapse_record,
+            evaluated_at=evaluation_started_at,
+        )
+        if evaluation.readiness.state != "ready":
+            raise MergeAdmissionDeniedError(
+                "Fresh merge readiness evidence did not admit the provider effect."
+            )
+        if evaluation.structural_result.status not in {"exact", "recorded_rolling"}:
+            raise MergeAdmissionDeniedError(
+                "Fresh structural provenance did not admit the provider effect."
+            )
+        admitted_at = self.admission_time_provider()
+        if self.controller_state_provider is not None:
+            self.controller_state = self.controller_state_provider()
+        landing_plan = self.landing_plan_record.landing_plan
+        candidate = self.candidate_record.candidate
+        provenance = candidate.structural_provenance
+        if provenance is None:
+            raise MergeAdmissionDeniedError("Merge admission requires structural provenance.")
+        attempt_id = build_merge_effect_attempt_id(
+            controller_key=self.controller_state.controller_key,
+            lease_owner=self.controller_state.lease_owner,
+            lease_acquired_at=self.controller_state.lease_acquired_at,
+            landing_plan_id=landing_plan.plan_id,
+            pull_request_number=entry.pull_request_number,
+            queue_position=entry.position,
+            attempt_sequence=attempt_sequence,
+            expected_effect_sha=landing_plan.candidate_sha,
+        )
+        try:
+            admission = MergeAdmissionRecord(
+                attempt_id=attempt_id,
+                attempt_sequence=attempt_sequence,
+                source=f"service:merge-admission:{self.trace_id}",
+                repository=landing_plan.repository,
+                base_branch=landing_plan.base_branch,
+                pull_request_number=entry.pull_request_number,
+                queue_position=entry.position,
+                batch_id=landing_plan.batch_id,
+                candidate_record_id=self.candidate_record.record_id,
+                landing_plan_record_id=self.landing_plan_record.record_id,
+                landing_plan_id=landing_plan.plan_id,
+                merge_method=entry.merge_method,
+                effective_base_sha=observed_base_sha,
+                effective_base_tree_sha=observed_base_tree_sha,
+                pull_request_head_sha=observed_head_sha,
+                pull_request_head_tree_sha=observed_head_tree_sha,
+                candidate_sha=landing_plan.candidate_sha,
+                candidate_tree_sha=landing_plan.candidate_tree_sha,
+                expected_effect_sha=landing_plan.candidate_sha,
+                candidate_sha256=landing_plan.candidate_sha256,
+                structural_provenance_sha256=landing_plan.structural_provenance_sha256,
+                landing_plan_sha256=landing_plan.landing_plan_sha256,
+                readiness=evaluation.readiness,
+                structural_result=evaluation.structural_result,
+                admission_algorithm_version=self.admission_algorithm_version,
+                controller_key=self.controller_state.controller_key,
+                lease_owner=self.controller_state.lease_owner,
+                lease_acquired_at=self.controller_state.lease_acquired_at,
+                lease_expires_at=self.controller_state.lease_expires_at,
+                created_at=admitted_at,
+            )
+        except ValueError as error:
+            raise MergeAdmissionDeniedError(
+                "Persisted controller authority changed after live merge evaluation."
+            ) from error
+        try:
+            stored, created = self.record_store.create_guarded_merge_admission_record_if_absent(
+                admission,
+                admitted_at=admitted_at,
+            )
+        except MergeAdmissionFenceRejectedError as error:
+            raise MergeAdmissionDeniedError(str(error)) from error
+        if not created:
+            raise MergeAdmissionReconciliationRequiredError(
+                "Existing merge admission cannot be reused for another provider effect."
+            )
+        return stored
+
+    def record_landed(
+        self,
+        *,
+        admission: MergeAdmissionRecord,
+        entry: MergeTrainBatchLandingEntry,
+        observed_base_sha: str,
+        observed_base_tree_sha: str,
+        base_contains_merge_commit: bool,
+        provider_effect_attempted: bool,
+        observed_at: str,
+    ) -> MergeLandingOutcomeRecord:
+        outcome = self._outcome(
+            admission=admission,
+            status="landed",
+            reason="provider_and_git_confirmed",
+            provider_effect_attempted=provider_effect_attempted,
+            observed_pull_request_head_sha=entry.landed_head_sha,
+            observed_pull_request_head_tree_sha=entry.landed_head_tree_sha,
+            observed_base_sha=observed_base_sha,
+            observed_base_tree_sha=observed_base_tree_sha,
+            merge_commit_sha=entry.merge_commit_sha,
+            merge_commit_tree_sha=entry.merge_commit_tree_sha,
+            base_contains_merge_commit=base_contains_merge_commit,
+            exact_landing_confirmed=base_contains_merge_commit,
+            observed_at=observed_at,
+        )
+        return self.record_store.create_merge_landing_outcome_record_if_absent(outcome)[0]
+
+    def reconcile_existing_landed(
+        self,
+        *,
+        entry: MergeTrainBatchLandingEntry,
+        observed_base_sha: str,
+        observed_base_tree_sha: str,
+        provider_effect_attempted: bool,
+        observed_at: str,
+    ) -> MergeLandingOutcomeRecord:
+        admissions = self.record_store.list_merge_admission_records(
+            repository=self.landing_plan_record.landing_plan.repository,
+            base_branch=self.landing_plan_record.landing_plan.base_branch,
+            pull_request_number=entry.pull_request_number,
+            landing_plan_id=self.landing_plan_record.landing_plan.plan_id,
+        )
+        if not admissions:
+            raise MergeAdmissionReconciliationRequiredError(
+                "Observed landing has no preceding immutable merge admission."
+            )
+        admission = admissions[0]
+        outcomes = self.record_store.list_merge_landing_outcome_records(
+            admission_id=admission.admission_id,
+            limit=1,
+        )
+        if outcomes and outcomes[0].status == "landed":
+            return outcomes[0]
+        if outcomes and outcomes[0].status == "rejected":
+            raise MergeAdmissionReconciliationRequiredError(
+                "Provider landing evidence contradicts a conclusive rejection outcome."
+            )
+        return self.record_landed(
+            admission=admission,
+            entry=entry,
+            observed_base_sha=observed_base_sha,
+            observed_base_tree_sha=observed_base_tree_sha,
+            base_contains_merge_commit=True,
+            provider_effect_attempted=provider_effect_attempted,
+            observed_at=observed_at,
+        )
+
+    def reconcile_existing_no_effect(
+        self,
+        *,
+        entry: MergeTrainBatchLandingEntry,
+        observed_base_sha: str,
+        observed_base_tree_sha: str,
+        observed_head_sha: str,
+        observed_head_tree_sha: str,
+        observed_pull_request_state: str,
+        observed_at: str,
+    ) -> MergeLandingOutcomeRecord | None:
+        admissions = self.record_store.list_merge_admission_records(
+            repository=self.landing_plan_record.landing_plan.repository,
+            base_branch=self.landing_plan_record.landing_plan.base_branch,
+            pull_request_number=entry.pull_request_number,
+            landing_plan_id=self.landing_plan_record.landing_plan.plan_id,
+        )
+        if not admissions:
+            return None
+        admission = admissions[0]
+        outcomes = self.record_store.list_merge_landing_outcome_records(
+            admission_id=admission.admission_id,
+            limit=1,
+        )
+        if outcomes and outcomes[0].status == "rejected":
+            return outcomes[0]
+        if outcomes and outcomes[0].status == "landed":
+            raise MergeAdmissionReconciliationRequiredError(
+                "Open pull request evidence contradicts a landed outcome."
+            )
+        if not outcomes:
+            interrupted = self._outcome(
+                admission=admission,
+                status="reconcile_required",
+                reason="process_interrupted",
+                provider_effect_attempted=True,
+                provider_message=(
+                    "Admission existed without a terminal provider observation; exact provider "
+                    "and Git evidence was re-read before no-effect reconciliation."
+                ),
+                observed_pull_request_state=observed_pull_request_state,
+                observed_pull_request_head_sha=observed_head_sha,
+                observed_pull_request_head_tree_sha=observed_head_tree_sha,
+                observed_base_sha=observed_base_sha,
+                observed_base_tree_sha=observed_base_tree_sha,
+                observed_at=observed_at,
+            )
+            self.record_store.create_merge_landing_outcome_record_if_absent(interrupted)
+        outcome = self._outcome(
+            admission=admission,
+            status="rejected",
+            reason="reconciliation_confirmed_no_effect",
+            provider_effect_attempted=True,
+            provider_message=(
+                "Fresh provider observation confirmed the exact pull request remains open "
+                "and the expected base has not advanced."
+            ),
+            observed_pull_request_state=observed_pull_request_state,
+            observed_pull_request_head_sha=observed_head_sha,
+            observed_pull_request_head_tree_sha=observed_head_tree_sha,
+            observed_base_sha=observed_base_sha,
+            observed_base_tree_sha=observed_base_tree_sha,
+            observed_at=observed_at,
+        )
+        return self.record_store.create_merge_landing_outcome_record_if_absent(outcome)[0]
+
+    def record_provider_failure(
+        self,
+        *,
+        admission: MergeAdmissionRecord,
+        error: Exception,
+        observed_at: str,
+    ) -> MergeLandingOutcomeRecord:
+        status_code = getattr(error, "status_code", None)
+        conclusive_rejection = (
+            isinstance(status_code, int)
+            and 400 <= status_code < 500
+            and (status_code not in {408, 429})
+        )
+        if conclusive_rejection:
+            status = "rejected"
+            reason: MergeLandingOutcomeReason = "provider_rejected"
+        else:
+            status = "reconcile_required"
+            reason = "provider_transport_ambiguous"
+        outcome = self._outcome(
+            admission=admission,
+            status=status,
+            reason=reason,
+            provider_effect_attempted=True,
+            provider_conclusive_rejection=conclusive_rejection,
+            provider_status_code=status_code if isinstance(status_code, int) else None,
+            provider_message=str(error).strip(),
+            observed_at=observed_at,
+        )
+        return self.record_store.create_merge_landing_outcome_record_if_absent(outcome)[0]
+
+    def record_reconcile_required(
+        self,
+        *,
+        admission: MergeAdmissionRecord,
+        reason: MergeLandingOutcomeReason,
+        message: str,
+        observed_at: str,
+    ) -> MergeLandingOutcomeRecord:
+        outcome = self._outcome(
+            admission=admission,
+            status="reconcile_required",
+            reason=reason,
+            provider_effect_attempted=True,
+            provider_message=message,
+            observed_at=observed_at,
+        )
+        return self.record_store.create_merge_landing_outcome_record_if_absent(outcome)[0]
+
+    def _outcome(
+        self,
+        *,
+        admission: MergeAdmissionRecord,
+        status: str,
+        reason: MergeLandingOutcomeReason,
+        provider_effect_attempted: bool,
+        observed_at: str,
+        provider_conclusive_rejection: bool = False,
+        provider_status_code: int | None = None,
+        provider_message: str = "",
+        observed_pull_request_state: str = "",
+        observed_pull_request_head_sha: str = "",
+        observed_pull_request_head_tree_sha: str = "",
+        observed_base_sha: str = "",
+        observed_base_tree_sha: str = "",
+        merge_commit_sha: str = "",
+        merge_commit_tree_sha: str = "",
+        base_contains_merge_commit: bool | None = None,
+        exact_landing_confirmed: bool = False,
+    ) -> MergeLandingOutcomeRecord:
+        previous = self.record_store.list_merge_landing_outcome_records(
+            admission_id=admission.admission_id,
+            limit=1,
+        )
+        return MergeLandingOutcomeRecord.model_validate(
+            {
+                "admission_id": admission.admission_id,
+                "admission_binding_sha256": admission.admission_binding_sha256,
+                "attempt_id": admission.attempt_id,
+                "observation_sequence": previous[0].observation_sequence + 1 if previous else 1,
+                "prior_outcome_id": previous[0].outcome_id if previous else "",
+                "source": f"service:merge-landing-outcome:{self.trace_id}",
+                "repository": admission.repository,
+                "base_branch": admission.base_branch,
+                "pull_request_number": admission.pull_request_number,
+                "status": status,
+                "reason": reason,
+                "provider_effect_attempted": provider_effect_attempted,
+                "provider_conclusive_rejection": provider_conclusive_rejection,
+                "provider_status_code": provider_status_code,
+                "provider_message": provider_message,
+                "observed_pull_request_state": observed_pull_request_state,
+                "observed_pull_request_head_sha": observed_pull_request_head_sha,
+                "observed_pull_request_head_tree_sha": observed_pull_request_head_tree_sha,
+                "observed_base_sha": observed_base_sha,
+                "observed_base_tree_sha": observed_base_tree_sha,
+                "merge_commit_sha": merge_commit_sha,
+                "merge_commit_tree_sha": merge_commit_tree_sha,
+                "base_contains_merge_commit": base_contains_merge_commit,
+                "exact_landing_confirmed": exact_landing_confirmed,
+                "observed_at": observed_at,
+            }
+        )

--- a/control_plane/merge_admission_live.py
+++ b/control_plane/merge_admission_live.py
@@ -1,0 +1,473 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+import hashlib
+import json
+
+from control_plane.change_impact_service import (
+    ChangeImpactRepositoryEvidenceProvider,
+    evaluate_change_impact,
+    load_change_impact_stored_evidence,
+    require_change_impact_policy_read_store,
+)
+from control_plane.contracts.change_impact import (
+    ChangeImpactEvaluation,
+    ChangeImpactRepositoryEvidence,
+    ChangeImpactTargetReference,
+)
+from control_plane.contracts.merge_readiness import (
+    MERGE_READINESS_POLICY_DIMENSIONS,
+    MergeReadinessPolicyFingerprintEvidence,
+    MergeReadinessPolicyFingerprints,
+    MergeReadinessTarget,
+)
+from control_plane.contracts.merge_train_batch import (
+    MergeTrainBatchCandidateRecord,
+    MergeTrainBatchLandingEntry,
+    MergeTrainBatchLandingPlanRecord,
+)
+from control_plane.contracts.merge_train_controller_state import (
+    MergeTrainControllerStateRecord,
+)
+from control_plane.contracts.merge_train_policy import MergeTrainPolicyRecord
+from control_plane.contracts.merge_train_stack_collapse import (
+    MergeTrainStackCollapsePlanRecord,
+)
+from control_plane.contracts.merge_train_structural_provenance import (
+    MergeTrainCombinedCandidateOwnerReview,
+    MergeTrainOwnerEvidenceBinding,
+    MergeTrainStructuralDeltaFingerprint,
+    MergeTrainStructuralEntryObservation,
+    MergeTrainStructuralEvaluationInput,
+    MergeTrainStructuralSubject,
+)
+from control_plane.contracts.owner_acceptance import OwnerAcceptanceDecision
+from control_plane.durable_operation_authorization import read_active_authz_policy_record
+from control_plane.engineering_review_decision_service import (
+    require_engineering_review_decision_store,
+)
+from control_plane.merge_admission import (
+    MERGE_ADMISSION_ALGORITHM_VERSION,
+    MergeAdmissionDeniedError,
+    MergeAdmissionEvaluation,
+)
+from control_plane.merge_readiness import evaluate_merge_readiness_from_live_evidence
+from control_plane.merge_train import (
+    MergeTrainSnapshotReader,
+    build_merge_train_dry_run_result,
+)
+from control_plane.merge_train_github import GitHubMergeTrainSnapshotReader
+from control_plane.merge_train_policy_source import (
+    MergeTrainPolicyStoreMissingError,
+    resolve_merge_train_policy_record,
+)
+from control_plane.merge_train_structural_provenance import (
+    evaluate_merge_train_structural_candidate,
+)
+from control_plane.owner_acceptance import evaluate_owner_acceptance
+from control_plane.tenant_admission_controller import (
+    TenantAdmissionControllerGitHubClient,
+    TenantAdmissionTechnicalChecks,
+)
+
+
+_MISSING_POLICY_SHA256 = hashlib.sha256(b"launchplane-policy-unavailable").hexdigest()
+MERGE_ADMISSION_ALGORITHM_SHA256 = hashlib.sha256(
+    MERGE_ADMISSION_ALGORITHM_VERSION.encode("utf-8")
+).hexdigest()
+
+
+def _canonical_sha256(payload: object) -> str:
+    return hashlib.sha256(
+        json.dumps(
+            payload,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+        ).encode("utf-8")
+    ).hexdigest()
+
+
+@dataclass(frozen=True)
+class _EntryEvidence:
+    repository_evidence: ChangeImpactRepositoryEvidence
+    impact: ChangeImpactEvaluation
+    owner_decision: OwnerAcceptanceDecision
+    observation: MergeTrainStructuralEntryObservation
+
+
+@dataclass(frozen=True)
+class LiveMergeAdmissionEvaluator:
+    store: object
+    repository_evidence_provider: ChangeImpactRepositoryEvidenceProvider
+    technical_check_client: TenantAdmissionControllerGitHubClient
+    policy_record_provider: Callable[[], MergeTrainPolicyRecord] | None = None
+    snapshot_reader: MergeTrainSnapshotReader | None = None
+
+    def evaluate(
+        self,
+        *,
+        candidate_record: MergeTrainBatchCandidateRecord,
+        landing_plan_record: MergeTrainBatchLandingPlanRecord,
+        entry: MergeTrainBatchLandingEntry,
+        observed_base_sha: str,
+        observed_base_tree_sha: str,
+        observed_head_sha: str,
+        observed_head_tree_sha: str,
+        controller_state: MergeTrainControllerStateRecord,
+        stack_collapse_record: MergeTrainStackCollapsePlanRecord | None,
+        evaluated_at: str,
+    ) -> MergeAdmissionEvaluation:
+        landing_plan = landing_plan_record.landing_plan
+        snapshot_reader = self.snapshot_reader or GitHubMergeTrainSnapshotReader(
+            transport=self.technical_check_client.transport
+        )
+        try:
+            policy_record = (
+                self.policy_record_provider()
+                if self.policy_record_provider is not None
+                else resolve_merge_train_policy_record(self.store)
+            )
+            snapshot = snapshot_reader.read_merge_train_snapshot(
+                repository=landing_plan.repository,
+                base_branch=landing_plan.base_branch,
+            )
+            live_queue = build_merge_train_dry_run_result(
+                policy=policy_record.policy,
+                snapshot=snapshot,
+            )
+        except (LookupError, ValueError, MergeTrainPolicyStoreMissingError) as error:
+            raise MergeAdmissionDeniedError(
+                "Active merge-train policy no longer admits the landing-plan lineage."
+            ) from error
+        expected_queue = tuple(
+            (plan_entry.pull_request_number, plan_entry.expected_head_sha)
+            for plan_entry in landing_plan.entries
+            if plan_entry.status not in {"merged", "skipped"}
+        )
+        live_queue_by_number = {queue_entry.number: queue_entry for queue_entry in live_queue.queue}
+        live_queue_identity = tuple(
+            (pull_request_number, live_queue_by_number[pull_request_number].head_sha)
+            for pull_request_number in live_queue.queue_order
+        )
+        if snapshot.base_sha != observed_base_sha or live_queue_identity != expected_queue:
+            raise MergeAdmissionDeniedError(
+                "Live merge queue or base identity changed from the landing-plan lineage."
+            )
+        entry_evidence = tuple(
+            self._entry_evidence(
+                repository=landing_plan.repository,
+                pull_request_number=candidate_entry.pull_request_number,
+                evaluated_at=evaluated_at,
+                position=candidate_entry.position,
+            )
+            for candidate_entry in candidate_record.candidate.entries
+        )
+        observations = tuple(item.observation for item in entry_evidence)
+        combined_owner_review = self._combined_owner_review(
+            landing_plan_record=landing_plan_record,
+            entry_evidence=entry_evidence,
+        )
+        structural_result = evaluate_merge_train_structural_candidate(
+            evaluation=MergeTrainStructuralEvaluationInput(
+                repository=landing_plan.repository,
+                base_branch=landing_plan.base_branch,
+                target_pull_request_number=entry.pull_request_number,
+                target_queue_position=entry.position,
+                observed_base_sha=observed_base_sha,
+                observed_base_tree_sha=observed_base_tree_sha,
+                policy_key=landing_plan.policy_key,
+                policy_sha256=landing_plan.policy_sha256,
+                active_candidate_sha256=landing_plan.candidate_sha256,
+                active_landing_plan_sha256=landing_plan.landing_plan_sha256,
+                entries=observations,
+                combined_owner_review=combined_owner_review,
+            ),
+            candidate_record=candidate_record,
+            landing_plan_record=landing_plan_record,
+            stack_collapse_record=stack_collapse_record,
+        )
+        target_evidence = next(
+            item
+            for item in entry_evidence
+            if item.repository_evidence.target.pull_request_number == entry.pull_request_number
+        )
+        engineering_store = require_engineering_review_decision_store(self.store)
+        decisions = engineering_store.list_engineering_review_decision_records(
+            repository=landing_plan.repository,
+            pull_request_number=entry.pull_request_number,
+            head_sha=observed_head_sha,
+            limit=25,
+        )
+        engineering_decision = decisions[0] if decisions else None
+        engineering_runs = (
+            engineering_store.list_engineering_review_run_records(
+                repository=landing_plan.repository,
+                pr_number=entry.pull_request_number,
+                head_sha=observed_head_sha,
+                work_request_id=engineering_decision.work_request_id,
+                limit=50,
+            )
+            if engineering_decision is not None
+            else ()
+        )
+        authorities = engineering_store.list_engineering_review_authority_records(
+            repository=landing_plan.repository,
+            status="active",
+            limit=2,
+        )
+        active_authority = authorities[0] if len(authorities) == 1 else None
+        technical_checks = self.technical_check_client.read_technical_checks(
+            repository=landing_plan.repository,
+            base_branch=landing_plan.base_branch,
+            base_sha=observed_base_sha,
+            head_sha=landing_plan.candidate_sha,
+            evaluated_at=evaluated_at,
+        )
+        policy_fingerprints = self._policy_fingerprints(
+            impact=target_evidence.impact,
+            owner_decision=target_evidence.owner_decision,
+            engineering_decision=engineering_decision,
+            engineering_authority_digest=(
+                active_authority.authority_digest if active_authority is not None else None
+            ),
+            technical_checks=technical_checks,
+            landing_policy_sha256=landing_plan.policy_sha256,
+            current_merge_train_policy_sha256=policy_record.policy_sha256,
+        )
+        readiness = evaluate_merge_readiness_from_live_evidence(
+            target=MergeReadinessTarget(
+                repository=landing_plan.repository,
+                pull_request_number=entry.pull_request_number,
+                base_branch=landing_plan.base_branch,
+                base_sha=observed_base_sha,
+                pull_request_head_sha=observed_head_sha,
+                pull_request_tree_sha=observed_head_tree_sha,
+                expected_effect_sha=landing_plan.candidate_sha,
+                queue_position=entry.position,
+            ),
+            owner_decision=target_evidence.owner_decision,
+            engineering_decision=engineering_decision,
+            engineering_runs=engineering_runs,
+            technical_checks=technical_checks,
+            policy_fingerprints=policy_fingerprints,
+            candidate_record=candidate_record,
+            structural_candidate_status=structural_result.status,
+            controller_state=controller_state,
+            expected_lease_owner=controller_state.lease_owner,
+            observed_effect_sha=landing_plan.candidate_sha,
+            evaluated_at=evaluated_at,
+        )
+        return MergeAdmissionEvaluation(
+            readiness=readiness,
+            structural_result=structural_result,
+        )
+
+    def _entry_evidence(
+        self,
+        *,
+        repository: str,
+        pull_request_number: int,
+        evaluated_at: str,
+        position: int,
+    ) -> _EntryEvidence:
+        target_reference = ChangeImpactTargetReference(
+            repository=repository,
+            pull_request_number=pull_request_number,
+        )
+        repository_evidence = self.repository_evidence_provider.resolve(target_reference)
+        policy_store = require_change_impact_policy_read_store(self.store)
+        impact = evaluate_change_impact(
+            repository_evidence=repository_evidence,
+            policies=policy_store.list_change_impact_policy_records(
+                repository_id=repository_evidence.target.repository_id,
+            ),
+            stored_evidence=load_change_impact_stored_evidence(
+                store=self.store,
+                target=repository_evidence.target,
+            ),
+            evaluated_at=evaluated_at,
+        )
+        owner_decision = evaluate_owner_acceptance(
+            store=self.store,
+            repository_evidence_provider=self.repository_evidence_provider,
+            target=target_reference,
+            evaluated_at=evaluated_at,
+        )
+        current_delta = self._current_delta(
+            repository_evidence=repository_evidence,
+            impact=impact,
+        )
+        reviewed_delta = (
+            current_delta
+            if self._owner_evidence_matches_current(
+                decision=owner_decision,
+                repository_evidence=repository_evidence,
+            )
+            else None
+        )
+        observation = MergeTrainStructuralEntryObservation(
+            position=position,
+            pull_request_number=pull_request_number,
+            head_sha=repository_evidence.target.head_sha,
+            head_tree_sha=repository_evidence.target.tree_sha,
+            reviewed_delta=reviewed_delta,
+            current_delta=current_delta,
+        )
+        return _EntryEvidence(
+            repository_evidence=repository_evidence,
+            impact=impact,
+            owner_decision=owner_decision,
+            observation=observation,
+        )
+
+    def _current_delta(
+        self,
+        *,
+        repository_evidence: ChangeImpactRepositoryEvidence,
+        impact: ChangeImpactEvaluation,
+    ) -> MergeTrainStructuralDeltaFingerprint | None:
+        if impact.status != "success":
+            return None
+        return MergeTrainStructuralDeltaFingerprint(
+            head_sha=repository_evidence.target.head_sha,
+            head_tree_sha=repository_evidence.target.tree_sha,
+            changed_paths=tuple(item.path for item in repository_evidence.changed_files),
+            affected_subjects=tuple(
+                MergeTrainStructuralSubject(product=item.product, system=item.system)
+                for item in impact.affected_products
+            ),
+        )
+
+    def _owner_evidence_matches_current(
+        self,
+        *,
+        decision: OwnerAcceptanceDecision,
+        repository_evidence: ChangeImpactRepositoryEvidence,
+    ) -> bool:
+        if decision.status == "not_required":
+            return True
+        if decision.status != "accepted" or not decision.admissible or not decision.products:
+            return False
+        return all(
+            product.status == "accepted"
+            and product.admissible
+            and product.binding is not None
+            and product.current_event is not None
+            and product.binding.head_sha == repository_evidence.target.head_sha
+            and product.binding.tree_sha == repository_evidence.target.tree_sha
+            for product in decision.products
+        )
+
+    def _combined_owner_review(
+        self,
+        *,
+        landing_plan_record: MergeTrainBatchLandingPlanRecord,
+        entry_evidence: tuple[_EntryEvidence, ...],
+    ) -> MergeTrainCombinedCandidateOwnerReview | None:
+        observations = tuple(item.observation for item in entry_evidence)
+        if any(
+            observation.reviewed_delta is None or observation.current_delta is None
+            for observation in observations
+        ):
+            return None
+        bindings = {
+            (product.current_event.event_id, product.binding.binding_sha256)
+            for item in entry_evidence
+            for product in item.owner_decision.products
+            if product.status == "accepted"
+            and product.admissible
+            and product.current_event is not None
+            and product.binding is not None
+        }
+        if not bindings:
+            return None
+        landing_plan = landing_plan_record.landing_plan
+        return MergeTrainCombinedCandidateOwnerReview(
+            evidence_bindings=tuple(
+                MergeTrainOwnerEvidenceBinding(
+                    event_id=event_id,
+                    binding_sha256=binding_sha256,
+                )
+                for event_id, binding_sha256 in sorted(bindings)
+            ),
+            candidate_sha256=landing_plan.candidate_sha256,
+            landing_plan_sha256=landing_plan.landing_plan_sha256,
+            policy_key=landing_plan.policy_key,
+            policy_sha256=landing_plan.policy_sha256,
+            entries=observations,
+        )
+
+    def _policy_fingerprints(
+        self,
+        *,
+        impact: ChangeImpactEvaluation,
+        owner_decision: OwnerAcceptanceDecision,
+        engineering_decision: object | None,
+        engineering_authority_digest: str | None,
+        technical_checks: TenantAdmissionTechnicalChecks,
+        landing_policy_sha256: str,
+        current_merge_train_policy_sha256: str,
+    ) -> MergeReadinessPolicyFingerprints:
+        technical_policy_sha256 = _canonical_sha256(
+            {
+                "strict": technical_checks.strict,
+                "required_checks": [
+                    check.model_dump(mode="json") for check in technical_checks.required_checks
+                ],
+                "excluded_contexts": list(technical_checks.excluded_contexts),
+            }
+        )
+        expected_impact_digests = {
+            product.binding.change_impact_policy_digest
+            for product in owner_decision.products
+            if product.binding is not None
+        }
+        decision_impact_digest = str(
+            getattr(engineering_decision, "change_impact_policy_digest", "")
+        ).strip()
+        if decision_impact_digest:
+            expected_impact_digests.add(decision_impact_digest)
+        expected_impact = (
+            next(iter(expected_impact_digests))
+            if len(expected_impact_digests) == 1
+            else _MISSING_POLICY_SHA256
+        )
+        expected_engineering = (
+            str(getattr(engineering_decision, "authority_digest", "")).strip()
+            or _MISSING_POLICY_SHA256
+        )
+        try:
+            authorization_sha256 = read_active_authz_policy_record(self.store).policy_sha256
+        except (LookupError, TypeError, ValueError):
+            authorization_sha256 = None
+
+        values: dict[str, tuple[str, str | None]] = {
+            "impact": (expected_impact, impact.policy_digest or None),
+            "technical_checks": (technical_policy_sha256, technical_policy_sha256),
+            "engineering_review": (expected_engineering, engineering_authority_digest),
+            "ruleset": (technical_policy_sha256, technical_policy_sha256),
+            "merge_train": (
+                landing_policy_sha256,
+                current_merge_train_policy_sha256,
+            ),
+            "authorization": (
+                authorization_sha256 or _MISSING_POLICY_SHA256,
+                authorization_sha256,
+            ),
+            "admission_algorithm": (
+                MERGE_ADMISSION_ALGORITHM_SHA256,
+                MERGE_ADMISSION_ALGORITHM_SHA256,
+            ),
+        }
+        return MergeReadinessPolicyFingerprints.model_validate(
+            {
+                dimension: MergeReadinessPolicyFingerprintEvidence(
+                    dimension=dimension,
+                    expected_sha256=values[dimension][0],
+                    current_sha256=values[dimension][1],
+                )
+                for dimension in MERGE_READINESS_POLICY_DIMENSIONS
+            }
+        )

--- a/control_plane/merge_train_batch_landing.py
+++ b/control_plane/merge_train_batch_landing.py
@@ -5,10 +5,14 @@ from typing import Callable, Literal, Protocol, cast
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from control_plane.contracts.merge_train_batch import (
+    MergeTrainBatchLandingEntry,
     MergeTrainBatchLandingPlan,
     MergeTrainBatchLandingPlanRecord,
     build_merge_train_batch_landing_plan,
     build_merge_train_batch_landing_plan_record,
+)
+from control_plane.contracts.merge_train_controller_state import (
+    MergeTrainControllerStateRecord,
 )
 from control_plane.contracts.merge_train_policy import MergeTrainRepositoryPolicy
 from control_plane.contracts.merge_train_stack_collapse import (
@@ -21,6 +25,11 @@ from control_plane.merge_train_batch_candidate import (
     MergeTrainBatchCandidateRecordStore,
     read_merge_train_batch_candidate_record,
 )
+from control_plane.merge_admission import (
+    GuardedMergeAdmission,
+    MergeAdmissionEvaluator,
+    MergeAdmissionRecordStore,
+)
 from control_plane.merge_train_github import (
     GitHubMergeTrainClient,
     MergeTrainGitHubError,
@@ -31,6 +40,9 @@ from control_plane.merge_train_stack_collapse import (
     MergeTrainStackCollapsePlanRecordStore,
     read_merge_train_stack_collapse_plan_record,
     stack_collapse_expected_root_head_sha,
+)
+from control_plane.workflows.merge_train_controller import (
+    latest_merge_train_batch_candidate_progress_record,
 )
 
 
@@ -116,7 +128,10 @@ def execute_merge_train_batch_landing_run_once(
     candidate_store: MergeTrainBatchCandidateRecordStore,
     landing_store: MergeTrainBatchLandingPlanRecordStore,
     stack_collapse_store: MergeTrainStackCollapsePlanRecordStore,
-    mutation_checkpoint: Callable[[str, int | None], None] | None = None,
+    admission_store: MergeAdmissionRecordStore,
+    admission_evaluator: MergeAdmissionEvaluator,
+    controller_state_provider: Callable[[], MergeTrainControllerStateRecord],
+    mutation_checkpoint: Callable[[str, int | None, str, str], None] | None = None,
 ) -> MergeTrainBatchLandingRunOnceResult:
     if request.mode == "plan":
         return _execute_plan_mode(
@@ -136,6 +151,10 @@ def execute_merge_train_batch_landing_run_once(
         recorded_at=recorded_at,
         landing_store=landing_store,
         stack_collapse_store=stack_collapse_store,
+        candidate_store=candidate_store,
+        admission_store=admission_store,
+        admission_evaluator=admission_evaluator,
+        controller_state_provider=controller_state_provider,
         mutation_checkpoint=mutation_checkpoint,
     )
 
@@ -234,9 +253,13 @@ def _execute_land_mode(
     token: str,
     trace_id: str,
     recorded_at: str,
+    candidate_store: MergeTrainBatchCandidateRecordStore,
     landing_store: MergeTrainBatchLandingPlanRecordStore,
     stack_collapse_store: MergeTrainStackCollapsePlanRecordStore,
-    mutation_checkpoint: Callable[[str, int | None], None] | None,
+    admission_store: MergeAdmissionRecordStore,
+    admission_evaluator: MergeAdmissionEvaluator,
+    controller_state_provider: Callable[[], MergeTrainControllerStateRecord],
+    mutation_checkpoint: Callable[[str, int | None, str, str], None] | None,
 ) -> MergeTrainBatchLandingRunOnceResult:
     landing_record = read_merge_train_batch_landing_plan_record(
         record_store=landing_store,
@@ -251,25 +274,66 @@ def _execute_land_mode(
         landing_plan=landing_record.landing_plan,
         stack_collapse_store=stack_collapse_store,
     )
+    candidate_matches = tuple(
+        record
+        for record in candidate_store.list_merge_train_batch_candidate_records(
+            repository=request.repository,
+            base_branch=request.base_branch,
+            status="active",
+            limit=100,
+        )
+        if record.candidate.batch_id == landing_record.landing_plan.batch_id
+        and record.candidate.candidate_sha == landing_record.landing_plan.candidate_sha
+        and record.candidate.candidate_sha256 == landing_record.landing_plan.candidate_sha256
+    )
+    candidate_record = latest_merge_train_batch_candidate_progress_record(candidate_matches)
+    if candidate_record is None:
+        raise ValueError("merge train landing requires its exact active candidate record")
     github_client = GitHubMergeTrainClient(
         transport=UrllibMergeTrainGitHubTransport(
             token=token,
             api_base_url=request.github_api_base_url,
         )
     )
+    admission_guard = GuardedMergeAdmission(
+        record_store=admission_store,
+        evaluator=admission_evaluator,
+        candidate_record=candidate_record,
+        landing_plan_record=landing_record,
+        controller_state=controller_state_provider(),
+        controller_state_provider=controller_state_provider,
+        stack_collapse_record=collapse_existing_record,
+        trace_id=trace_id,
+    )
+
+    def checkpoint_landing_progress(
+        progress_plan: MergeTrainBatchLandingPlan,
+        entry: MergeTrainBatchLandingEntry,
+        phase: str,
+    ) -> MergeTrainBatchLandingPlanRecord | None:
+        if mutation_checkpoint is not None:
+            mutation_checkpoint(
+                phase,
+                entry.pull_request_number,
+                progress_plan.plan_id,
+                progress_plan.candidate_sha,
+            )
+        if phase not in {"entry_merged", "entry_skipped"}:
+            return None
+        progress_record = build_merge_train_batch_landing_plan_record(
+            landing_plan=progress_plan,
+            source=f"service:{request.mode}:landing-progress:{trace_id}",
+            updated_at=recorded_at,
+        )
+        landing_store.write_merge_train_batch_landing_plan_record(progress_record)
+        return progress_record
+
     try:
         landing_plan = github_client.land_batch_candidate(
             landing_plan=landing_record.landing_plan,
-            checkpoint=(
-                lambda progress_plan, entry, phase: (
-                    mutation_checkpoint(
-                        phase,
-                        entry.pull_request_number,
-                    )
-                    if mutation_checkpoint is not None
-                    else None
-                )
-            ),
+            admission_guard=admission_guard,
+            recorded_at=recorded_at,
+            checkpoint=checkpoint_landing_progress,
         )
     except MergeTrainGitHubStaleHeadError:
         stale_plan = _stale_merge_train_landing_plan(landing_record.landing_plan)
@@ -287,7 +351,12 @@ def _execute_land_mode(
     )
     landing_store.write_merge_train_batch_landing_plan_record(landing_record)
     if mutation_checkpoint is not None:
-        mutation_checkpoint("cleanup_candidate_ref", None)
+        mutation_checkpoint(
+            "cleanup_candidate_ref",
+            None,
+            landing_plan.plan_id,
+            landing_plan.candidate_sha,
+        )
     candidate_ref_cleanup_result = _cleanup_merge_train_batch_candidate_ref(
         github_client=github_client,
         landing_plan=landing_plan,
@@ -311,6 +380,8 @@ def _execute_land_mode(
             mutation_checkpoint(
                 "reconcile_stack_children",
                 collapse_existing_record.plan.root_pull_request_number,
+                landing_plan.plan_id,
+                landing_plan.candidate_sha,
             )
         reconciled_collapse_plan = reconcile_merge_train_stack_children_after_root_landing(
             plan=collapse_existing_record.plan,
@@ -330,6 +401,8 @@ def _execute_land_mode(
                             ),
                             None,
                         ),
+                        landing_plan.plan_id,
+                        landing_plan.candidate_sha,
                     )
                     if mutation_checkpoint is not None
                     else None

--- a/control_plane/merge_train_controller_run_once.py
+++ b/control_plane/merge_train_controller_run_once.py
@@ -41,6 +41,11 @@ from control_plane.merge_train import (
     build_merge_train_dry_run_result,
     discover_merge_train_stack,
 )
+from control_plane.merge_admission import (
+    GuardedMergeAdmission,
+    MergeAdmissionEvaluator,
+    MergeAdmissionRecordStore,
+)
 from control_plane.merge_train_batch_candidate import (
     MergeTrainBatchCandidateRecordStore,
     merge_train_snapshot_has_stack_topology,
@@ -180,6 +185,20 @@ class MergeTrainControllerLeaseContext:
         )
         return self.record
 
+    def read_current(self) -> MergeTrainControllerStateRecord:
+        if self.record_store is None:
+            return self.record
+        records = self.record_store.list_merge_train_controller_state_records(
+            repository=self.record.repository,
+            base_branch=self.record.base_branch,
+            limit=1,
+        )
+        if not records:
+            raise MergeTrainControllerLeaseLostError(
+                "Persisted merge train controller state is missing."
+            )
+        return records[0]
+
     def release(
         self,
         *,
@@ -286,6 +305,8 @@ def execute_merge_train_controller_run_once(
     landing_store: MergeTrainBatchLandingPlanRecordStore,
     stack_collapse_store: MergeTrainStackCollapsePlanRecordStore,
     controller_state_store: MergeTrainControllerStateRecordStore,
+    admission_store: MergeAdmissionRecordStore,
+    admission_evaluator: MergeAdmissionEvaluator,
     before_release: Callable[[MergeTrainControllerRunOnceResult], None] | None = None,
 ) -> MergeTrainControllerRunOnceResult:
     transport = UrllibMergeTrainGitHubTransport(
@@ -350,8 +371,11 @@ def execute_merge_train_controller_run_once(
                     trace_id=trace_id,
                     recorded_at=recorded_at,
                     github_client=github_client,
+                    candidate_store=candidate_store,
                     landing_store=landing_store,
                     stack_collapse_store=stack_collapse_store,
+                    admission_store=admission_store,
+                    admission_evaluator=admission_evaluator,
                     active_landing_record=active_landing_record,
                     lease=lease,
                 )
@@ -597,6 +621,26 @@ def latest_passed_merge_train_batch_candidate_record(
     return latest_record
 
 
+def _candidate_record_for_landing_plan(
+    *,
+    record_store: MergeTrainBatchCandidateRecordStore,
+    landing_plan: MergeTrainBatchLandingPlan,
+) -> MergeTrainBatchCandidateRecord | None:
+    matches = tuple(
+        record
+        for record in record_store.list_merge_train_batch_candidate_records(
+            repository=landing_plan.repository,
+            base_branch=landing_plan.base_branch,
+            status="active",
+            limit=100,
+        )
+        if record.candidate.batch_id == landing_plan.batch_id
+        and record.candidate.candidate_sha == landing_plan.candidate_sha
+        and record.candidate.candidate_sha256 == landing_plan.candidate_sha256
+    )
+    return latest_merge_train_batch_candidate_progress_record(matches)
+
+
 def latest_merge_train_batch_landing_plan_record(
     *,
     record_store: MergeTrainBatchLandingPlanRecordStore,
@@ -718,8 +762,11 @@ def _advance_active_landing_record(
     trace_id: str,
     recorded_at: str,
     github_client: GitHubMergeTrainClient,
+    candidate_store: MergeTrainBatchCandidateRecordStore,
     landing_store: MergeTrainBatchLandingPlanRecordStore,
     stack_collapse_store: MergeTrainStackCollapsePlanRecordStore,
+    admission_store: MergeAdmissionRecordStore,
+    admission_evaluator: MergeAdmissionEvaluator,
     active_landing_record: MergeTrainBatchLandingPlanRecord,
     lease: MergeTrainControllerLeaseContext,
 ) -> dict[str, object]:
@@ -751,6 +798,24 @@ def _advance_active_landing_record(
             raise ValueError(
                 "merge train stack child disposition requires stack_child_disposition_label policy"
             )
+    candidate_record = _candidate_record_for_landing_plan(
+        record_store=candidate_store,
+        landing_plan=active_landing_record.landing_plan,
+    )
+    if candidate_record is None:
+        raise MergeTrainControllerRequestError(
+            "merge train landing requires its exact active candidate record"
+        )
+    admission_guard = GuardedMergeAdmission(
+        record_store=admission_store,
+        evaluator=admission_evaluator,
+        candidate_record=candidate_record,
+        landing_plan_record=active_landing_record,
+        controller_state=lease.record,
+        controller_state_provider=lease.read_current,
+        stack_collapse_record=collapse_record,
+        trace_id=trace_id,
+    )
     if not request.mutate:
         result: dict[str, object] = {
             "repository": request.repository,
@@ -768,14 +833,18 @@ def _advance_active_landing_record(
         active_phase="merge_batch_entries",
         active_record_id=active_landing_record.record_id,
         active_pull_request_number=None,
-        step_payload={"landing_plan_record_id": active_landing_record.record_id},
+        step_payload={
+            "landing_plan_record_id": active_landing_record.record_id,
+            "landing_plan_id": active_landing_record.landing_plan.plan_id,
+            "expected_effect_sha": active_landing_record.landing_plan.candidate_sha,
+        },
     )
 
     def checkpoint_landing_progress(
         progress_plan: MergeTrainBatchLandingPlan,
         entry: MergeTrainBatchLandingEntry,
         phase: str,
-    ) -> None:
+    ) -> MergeTrainBatchLandingPlanRecord | None:
         state_phase = "merge_pull_request" if phase == "merge_entry" else "landing_entry_merged"
         lease.checkpoint(
             active_action="land_batch",
@@ -784,25 +853,30 @@ def _advance_active_landing_record(
             active_pull_request_number=entry.pull_request_number,
             step_payload={
                 "landing_plan_record_id": active_landing_record.record_id,
+                "landing_plan_id": progress_plan.plan_id,
                 "batch_id": progress_plan.batch_id,
                 "candidate_ref": progress_plan.candidate_ref,
+                "expected_effect_sha": progress_plan.candidate_sha,
                 "completed_entry_count": sum(
                     progress_entry.status == "merged" for progress_entry in progress_plan.entries
                 ),
             },
         )
-        if phase != "entry_merged":
-            return
+        if phase not in {"entry_merged", "entry_skipped"}:
+            return None
         progress_record = build_merge_train_batch_landing_plan_record(
             landing_plan=progress_plan,
             source=f"service:controller:landing-progress:{trace_id}",
             updated_at=lease.record.updated_at,
         )
         landing_store.write_merge_train_batch_landing_plan_record(progress_record)
+        return progress_record
 
     try:
         landed_plan = github_client.land_batch_candidate(
             landing_plan=active_landing_record.landing_plan,
+            admission_guard=admission_guard,
+            recorded_at=recorded_at,
             checkpoint=checkpoint_landing_progress,
         )
     except MergeTrainGitHubStaleHeadError as error:

--- a/control_plane/merge_train_github.py
+++ b/control_plane/merge_train_github.py
@@ -11,6 +11,7 @@ from control_plane.contracts.merge_train_batch import MergeTrainBatchCandidate
 from control_plane.contracts.merge_train_batch import MergeTrainBatchEntry
 from control_plane.contracts.merge_train_batch import MergeTrainBatchLandingEntry
 from control_plane.contracts.merge_train_batch import MergeTrainBatchLandingPlan
+from control_plane.contracts.merge_train_batch import MergeTrainBatchLandingPlanRecord
 from control_plane.contracts.merge_train_stack_collapse import MergeTrainStackCollapseBranchClient
 from control_plane.contracts.merge_train_policy import MergeTrainMergeMethod
 from control_plane.contracts.merge_train_structural_provenance import (
@@ -26,6 +27,7 @@ from control_plane.merge_train import MergeTrainDryRunSnapshot
 from control_plane.merge_train import MergeTrainMergeableState
 from control_plane.merge_train import MergeTrainPullRequestSnapshot
 from control_plane.merge_train import MergeTrainPullRequestState
+from control_plane.merge_admission import GuardedMergeAdmission, MergeAdmissionDeniedError
 
 
 class MergeTrainGitHubError(RuntimeError):
@@ -271,14 +273,40 @@ class GitHubMergeTrainClient(MergeTrainStackCollapseBranchClient):
         self,
         *,
         landing_plan: MergeTrainBatchLandingPlan,
+        admission_guard: GuardedMergeAdmission | None = None,
+        recorded_at: str = "",
         checkpoint: (
-            Callable[[MergeTrainBatchLandingPlan, MergeTrainBatchLandingEntry, str], None] | None
+            Callable[
+                [MergeTrainBatchLandingPlan, MergeTrainBatchLandingEntry, str],
+                MergeTrainBatchLandingPlanRecord | None,
+            ]
+            | None
         ) = None,
     ) -> MergeTrainBatchLandingPlan:
+        if admission_guard is None:
+            raise MergeAdmissionDeniedError(
+                "Batch landing requires the guarded merge admission boundary."
+            )
+        if not recorded_at.strip():
+            raise ValueError("Batch landing admission requires recorded_at.")
         repository_path = _repository_path(landing_plan.repository)
         expected_base_sha = landing_plan.entries[0].expected_base_sha
         expected_base_tree_sha = landing_plan.entries[0].recorded_candidate_parent_tree_sha
         landed_entries: list[MergeTrainBatchLandingEntry] = []
+
+        def update_progress(
+            progress_plan: MergeTrainBatchLandingPlan,
+            progress_entry: MergeTrainBatchLandingEntry,
+            phase: str,
+        ) -> None:
+            persisted_record = (
+                checkpoint(progress_plan, progress_entry, phase) if checkpoint is not None else None
+            )
+            if persisted_record is not None:
+                admission_guard.update_landing_plan_record(persisted_record)
+            else:
+                admission_guard.update_landing_plan(progress_plan)
+
         for entry_index, entry in enumerate(landing_plan.entries):
             current_base_sha, current_base_tree_sha = _base_branch_identity(
                 transport=self.transport,
@@ -324,10 +352,31 @@ class GitHubMergeTrainClient(MergeTrainStackCollapseBranchClient):
                         status_code=409,
                     )
                 landed_entries.append(recovered_entry)
+                admission_guard.reconcile_existing_landed(
+                    entry=recovered_entry,
+                    observed_base_sha=current_base_sha,
+                    observed_base_tree_sha=current_base_tree_sha,
+                    provider_effect_attempted=True,
+                    observed_at=recorded_at,
+                )
                 expected_base_sha = recovered_entry.merge_commit_sha
                 expected_base_tree_sha = recovered_entry.merge_commit_tree_sha
+                progress_plan = _validated_model_update(
+                    landing_plan,
+                    entries=tuple(landed_entries) + landing_plan.entries[entry_index + 1 :],
+                )
+                update_progress(progress_plan, recovered_entry, "entry_merged")
                 continue
             if _recorded_candidate_step_is_no_op(entry):
+                if checkpoint is not None:
+                    checkpoint(
+                        _validated_model_update(
+                            landing_plan,
+                            entries=tuple(landed_entries) + landing_plan.entries[entry_index:],
+                        ),
+                        entry,
+                        "merge_entry",
+                    )
                 skipped_entry = self._recover_no_op_landing_entry(
                     repository=landing_plan.repository,
                     repository_path=repository_path,
@@ -336,16 +385,28 @@ class GitHubMergeTrainClient(MergeTrainStackCollapseBranchClient):
                     expected_rolling_base_sha=expected_base_sha,
                     expected_rolling_base_tree_sha=expected_base_tree_sha,
                 )
+                no_op_admission = admission_guard.admit(
+                    entry=entry,
+                    observed_base_sha=current_base_sha,
+                    observed_base_tree_sha=current_base_tree_sha,
+                    observed_head_sha=entry.expected_head_sha,
+                    observed_head_tree_sha=entry.expected_head_tree_sha,
+                )
+                admission_guard.record_landed(
+                    admission=no_op_admission,
+                    entry=skipped_entry,
+                    observed_base_sha=current_base_sha,
+                    observed_base_tree_sha=current_base_tree_sha,
+                    base_contains_merge_commit=True,
+                    provider_effect_attempted=False,
+                    observed_at=recorded_at,
+                )
                 landed_entries.append(skipped_entry)
-                if checkpoint is not None:
-                    checkpoint(
-                        _validated_model_update(
-                            landing_plan,
-                            entries=tuple(landed_entries) + landing_plan.entries[entry_index + 1 :],
-                        ),
-                        skipped_entry,
-                        "entry_skipped",
-                    )
+                progress_plan = _validated_model_update(
+                    landing_plan,
+                    entries=tuple(landed_entries) + landing_plan.entries[entry_index + 1 :],
+                )
+                update_progress(progress_plan, skipped_entry, "entry_skipped")
                 continue
             if current_base_sha != expected_base_sha:
                 already_merged_entry = self._already_merged_landing_entry(
@@ -369,17 +430,20 @@ class GitHubMergeTrainClient(MergeTrainStackCollapseBranchClient):
                         status_code=409,
                     )
                 landed_entries.append(already_merged_entry)
+                admission_guard.reconcile_existing_landed(
+                    entry=already_merged_entry,
+                    observed_base_sha=current_base_sha,
+                    observed_base_tree_sha=current_base_tree_sha,
+                    provider_effect_attempted=True,
+                    observed_at=recorded_at,
+                )
                 expected_base_sha = already_merged_entry.merge_commit_sha
                 expected_base_tree_sha = already_merged_entry.merge_commit_tree_sha
-                if checkpoint is not None:
-                    checkpoint(
-                        _validated_model_update(
-                            landing_plan,
-                            entries=tuple(landed_entries) + landing_plan.entries[entry_index + 1 :],
-                        ),
-                        already_merged_entry,
-                        "entry_merged",
-                    )
+                progress_plan = _validated_model_update(
+                    landing_plan,
+                    entries=tuple(landed_entries) + landing_plan.entries[entry_index + 1 :],
+                )
+                update_progress(progress_plan, already_merged_entry, "entry_merged")
                 continue
             landed_head_sha, landed_head_tree_sha = _git_commit_identity(
                 transport=self.transport,
@@ -400,6 +464,15 @@ class GitHubMergeTrainClient(MergeTrainStackCollapseBranchClient):
                 expected_base_ref=landing_plan.base_branch,
                 expected_base_sha=expected_base_sha,
             )
+            admission_guard.reconcile_existing_no_effect(
+                entry=entry,
+                observed_base_sha=current_base_sha,
+                observed_base_tree_sha=current_base_tree_sha,
+                observed_head_sha=landed_head_sha,
+                observed_head_tree_sha=landed_head_tree_sha,
+                observed_pull_request_state="open",
+                observed_at=recorded_at,
+            )
             if checkpoint is not None:
                 checkpoint(
                     _validated_model_update(
@@ -409,20 +482,65 @@ class GitHubMergeTrainClient(MergeTrainStackCollapseBranchClient):
                     entry,
                     "merge_entry",
                 )
-            merge_commit_sha = self.merge_pull_request(
-                repository=landing_plan.repository,
-                pull_request_number=entry.pull_request_number,
-                head_sha=entry.expected_head_sha,
-                merge_method=entry.merge_method,
+            admission = admission_guard.admit(
+                entry=entry,
+                observed_base_sha=current_base_sha,
+                observed_base_tree_sha=current_base_tree_sha,
+                observed_head_sha=landed_head_sha,
+                observed_head_tree_sha=landed_head_tree_sha,
             )
-            merge_commit_sha, merge_commit_tree_sha = _validated_landing_commit_identity(
-                transport=self.transport,
-                repository_path=repository_path,
-                commit_sha=merge_commit_sha,
-                expected_parent_sha=current_base_sha,
-                expected_head_sha=landed_head_sha,
-                merge_method=entry.merge_method,
+            try:
+                merge_commit_sha = self.merge_pull_request(
+                    repository=landing_plan.repository,
+                    pull_request_number=entry.pull_request_number,
+                    head_sha=entry.expected_head_sha,
+                    merge_method=entry.merge_method,
+                )
+            except Exception as error:
+                admission_guard.record_provider_failure(
+                    admission=admission,
+                    error=error,
+                    observed_at=recorded_at,
+                )
+                raise
+            try:
+                merge_commit_sha, merge_commit_tree_sha = _validated_landing_commit_identity(
+                    transport=self.transport,
+                    repository_path=repository_path,
+                    commit_sha=merge_commit_sha,
+                    expected_parent_sha=current_base_sha,
+                    expected_head_sha=landed_head_sha,
+                    merge_method=entry.merge_method,
+                )
+                observed_base_sha, observed_base_tree_sha = _base_branch_identity(
+                    transport=self.transport,
+                    repository_path=repository_path,
+                    base_branch=landing_plan.base_branch,
+                )
+            except Exception as error:
+                admission_guard.record_reconcile_required(
+                    admission=admission,
+                    reason="landing_evidence_incomplete",
+                    message=str(error).strip(),
+                    observed_at=recorded_at,
+                )
+                raise
+            base_contains_merge_commit = observed_base_sha == merge_commit_sha or (
+                self.branch_contains_commit(
+                    repository=landing_plan.repository,
+                    branch_ref=landing_plan.base_branch,
+                    commit_sha=merge_commit_sha,
+                )
             )
+            if not base_contains_merge_commit:
+                message = "Target base branch does not contain the provider merge commit."
+                admission_guard.record_reconcile_required(
+                    admission=admission,
+                    reason="landing_evidence_contradicted",
+                    message=message,
+                    observed_at=recorded_at,
+                )
+                raise MergeTrainGitHubStaleHeadError(message, status_code=409)
             merged_entry = _validated_model_update(
                 entry,
                 status="merged",
@@ -434,17 +552,22 @@ class GitHubMergeTrainClient(MergeTrainStackCollapseBranchClient):
                 merge_commit_tree_sha=merge_commit_tree_sha,
             )
             landed_entries.append(merged_entry)
+            admission_guard.record_landed(
+                admission=admission,
+                entry=merged_entry,
+                observed_base_sha=observed_base_sha,
+                observed_base_tree_sha=observed_base_tree_sha,
+                base_contains_merge_commit=base_contains_merge_commit,
+                provider_effect_attempted=True,
+                observed_at=recorded_at,
+            )
             expected_base_sha = merge_commit_sha
             expected_base_tree_sha = merge_commit_tree_sha
-            if checkpoint is not None:
-                checkpoint(
-                    _validated_model_update(
-                        landing_plan,
-                        entries=tuple(landed_entries) + landing_plan.entries[entry_index + 1 :],
-                    ),
-                    merged_entry,
-                    "entry_merged",
-                )
+            progress_plan = _validated_model_update(
+                landing_plan,
+                entries=tuple(landed_entries) + landing_plan.entries[entry_index + 1 :],
+            )
+            update_progress(progress_plan, merged_entry, "entry_merged")
         current_base_sha = _base_branch_sha(
             transport=self.transport,
             repository_path=repository_path,

--- a/control_plane/storage/filesystem.py
+++ b/control_plane/storage/filesystem.py
@@ -46,6 +46,14 @@ from control_plane.contracts.manager_preview_approval import (
     ManagerPreviewApprovalEventRecord,
     ManagerPreviewApprovalEventWriteStatus,
 )
+from control_plane.contracts.merge_admission_record import (
+    MergeAdmissionFenceRejectedError,
+    MergeAdmissionRecord,
+    MergeLandingOutcomeRecord,
+    validate_merge_admission_controller_fence,
+    validate_merge_landing_outcome_for_admission,
+    validate_merge_landing_outcome_successor,
+)
 from control_plane.contracts.owner_acceptance import (
     OwnerAcceptanceEventRecord,
     OwnerAcceptanceEventWriteStatus,
@@ -1985,6 +1993,209 @@ class FilesystemRecordStore:
             and (not status or record.status == status)
         ]
         records.sort(key=lambda record: (record.updated_at, record.record_id), reverse=True)
+        if limit is not None:
+            records = records[:limit]
+        return tuple(records)
+
+    def create_merge_admission_record_if_absent(
+        self, record: MergeAdmissionRecord
+    ) -> tuple[MergeAdmissionRecord, bool]:
+        record_type = "launchplane_merge_admissions"
+        with self._exclusive_record_lock(record_type, record.attempt_id):
+            existing_attempts = self.list_merge_admission_records(
+                attempt_id=record.attempt_id,
+                limit=2,
+            )
+            if existing_attempts:
+                existing = existing_attempts[0]
+                if existing != record:
+                    raise ValueError("Merge admission attempts are append-only.")
+                return existing, False
+            created = self._create_model_if_absent(record_type, record.admission_id, record)
+            if created:
+                return record, True
+            existing = self.read_merge_admission_record(record.admission_id)
+            if existing != record:
+                raise ValueError("Merge admission records are append-only.")
+            return existing, False
+
+    def create_guarded_merge_admission_record_if_absent(
+        self,
+        record: MergeAdmissionRecord,
+        *,
+        admitted_at: str,
+    ) -> tuple[MergeAdmissionRecord, bool]:
+        controller_record_type = "launchplane_merge_train_controller_states"
+        controller_storage_id = _merge_train_controller_storage_id(record.controller_key)
+        with self._exclusive_record_lock(controller_record_type, record.controller_key):
+            controller_path = self._record_path(
+                controller_record_type,
+                controller_storage_id,
+            )
+            if not controller_path.exists():
+                raise MergeAdmissionFenceRejectedError(
+                    "Persisted merge controller state is missing at admission creation."
+                )
+            controller_state = self._read_model_locked(
+                MergeTrainControllerStateRecord,
+                controller_record_type,
+                controller_storage_id,
+            )
+            validate_merge_admission_controller_fence(
+                admission=record,
+                controller_state=controller_state,
+                admitted_at=admitted_at,
+            )
+            return self.create_merge_admission_record_if_absent(record)
+
+    def read_merge_admission_record(self, admission_id: str) -> MergeAdmissionRecord:
+        return self._read_model(
+            MergeAdmissionRecord,
+            "launchplane_merge_admissions",
+            admission_id,
+        )
+
+    def list_merge_admission_records(
+        self,
+        *,
+        repository: str = "",
+        base_branch: str = "",
+        pull_request_number: int | None = None,
+        landing_plan_record_id: str = "",
+        landing_plan_id: str = "",
+        attempt_id: str = "",
+        limit: int | None = None,
+    ) -> tuple[MergeAdmissionRecord, ...]:
+        records = [
+            record
+            for record in self._list_models(
+                MergeAdmissionRecord,
+                "launchplane_merge_admissions",
+            )
+            if (not repository or record.repository == repository.strip().lower())
+            and (not base_branch or record.base_branch == base_branch)
+            and (pull_request_number is None or record.pull_request_number == pull_request_number)
+            and (
+                not landing_plan_record_id
+                or record.landing_plan_record_id == landing_plan_record_id
+            )
+            and (not landing_plan_id or record.landing_plan_id == landing_plan_id)
+            and (not attempt_id or record.attempt_id == attempt_id)
+        ]
+        records.sort(key=lambda item: (item.created_at, item.admission_id), reverse=True)
+        if limit is not None:
+            records = records[:limit]
+        return tuple(records)
+
+    def create_merge_landing_outcome_record_if_absent(
+        self, record: MergeLandingOutcomeRecord
+    ) -> tuple[MergeLandingOutcomeRecord, bool]:
+        record_type = "launchplane_merge_landing_outcomes"
+        with self._exclusive_record_lock(record_type, record.admission_id):
+            admission = self.read_merge_admission_record(record.admission_id)
+            validate_merge_landing_outcome_for_admission(
+                admission=admission,
+                outcome=record,
+            )
+            existing_sequence = self.list_merge_landing_outcome_records(
+                admission_id=record.admission_id,
+                observation_sequence=record.observation_sequence,
+                limit=2,
+            )
+            if existing_sequence:
+                existing = existing_sequence[0]
+                if existing != record:
+                    raise ValueError("Merge landing outcome observations are append-only.")
+                return existing, False
+            prior_records = self.list_merge_landing_outcome_records(
+                admission_id=record.admission_id,
+                limit=1,
+            )
+            if prior_records:
+                validate_merge_landing_outcome_successor(
+                    prior=prior_records[0],
+                    successor=record,
+                )
+            elif record.observation_sequence != 1:
+                raise ValueError("Merge landing outcome reconciliation is missing its predecessor.")
+            created = self._create_model_if_absent(record_type, record.outcome_id, record)
+            if created:
+                return record, True
+            existing = self.read_merge_landing_outcome_record(record.outcome_id)
+            if existing != record:
+                raise ValueError("Merge landing outcome records are append-only.")
+            return existing, False
+
+    def read_merge_landing_outcome_record(self, outcome_id: str) -> MergeLandingOutcomeRecord:
+        return self._read_model(
+            MergeLandingOutcomeRecord,
+            "launchplane_merge_landing_outcomes",
+            outcome_id,
+        )
+
+    def list_merge_landing_outcome_records(
+        self,
+        *,
+        repository: str = "",
+        base_branch: str = "",
+        pull_request_number: int | None = None,
+        admission_id: str = "",
+        status: str = "",
+        observation_sequence: int | None = None,
+        limit: int | None = None,
+    ) -> tuple[MergeLandingOutcomeRecord, ...]:
+        records = [
+            record
+            for record in self._list_models(
+                MergeLandingOutcomeRecord,
+                "launchplane_merge_landing_outcomes",
+            )
+            if (not repository or record.repository == repository.strip().lower())
+            and (not base_branch or record.base_branch == base_branch)
+            and (pull_request_number is None or record.pull_request_number == pull_request_number)
+            and (not admission_id or record.admission_id == admission_id)
+            and (not status or record.status == status)
+            and (
+                observation_sequence is None or record.observation_sequence == observation_sequence
+            )
+        ]
+        records.sort(
+            key=lambda item: (
+                item.admission_id,
+                item.observation_sequence,
+                item.observed_at,
+                item.outcome_id,
+            ),
+            reverse=True,
+        )
+        if limit is not None:
+            records = records[:limit]
+        return tuple(records)
+
+    def list_unresolved_merge_admission_records(
+        self,
+        *,
+        repository: str = "",
+        base_branch: str = "",
+        limit: int | None = None,
+    ) -> tuple[MergeAdmissionRecord, ...]:
+        outcomes_by_admission: dict[str, MergeLandingOutcomeRecord] = {}
+        for outcome in self.list_merge_landing_outcome_records(
+            repository=repository,
+            base_branch=base_branch,
+        ):
+            outcomes_by_admission.setdefault(outcome.admission_id, outcome)
+        records = [
+            admission
+            for admission in self.list_merge_admission_records(
+                repository=repository,
+                base_branch=base_branch,
+            )
+            if (
+                admission.admission_id not in outcomes_by_admission
+                or outcomes_by_admission[admission.admission_id].status == "reconcile_required"
+            )
+        ]
         if limit is not None:
             records = records[:limit]
         return tuple(records)

--- a/control_plane/storage/migrations/versions/e9b1d3f5a7c0_add_merge_admission_outcomes.py
+++ b/control_plane/storage/migrations/versions/e9b1d3f5a7c0_add_merge_admission_outcomes.py
@@ -1,0 +1,172 @@
+"""Add guarded merge admission and landing outcome records.
+
+Revision ID: e9b1d3f5a7c0
+Revises: d8a0c2e4f6b8
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.sql.elements import ColumnElement, TextClause
+
+
+revision: str = "e9b1d3f5a7c0"
+down_revision: str | None = "d8a0c2e4f6b8"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_ADMISSIONS_TABLE = "launchplane_merge_admissions"
+_OUTCOMES_TABLE = "launchplane_merge_landing_outcomes"
+
+
+def _table_exists(table_name: str) -> bool:
+    return table_name in set(sa.inspect(op.get_bind()).get_table_names())
+
+
+def _index_exists(table_name: str, index_name: str) -> bool:
+    if not _table_exists(table_name):
+        return False
+    return index_name in {
+        str(index["name"]) for index in sa.inspect(op.get_bind()).get_indexes(table_name)
+    }
+
+
+def upgrade() -> None:
+    if not _table_exists(_ADMISSIONS_TABLE):
+        op.create_table(
+            _ADMISSIONS_TABLE,
+            sa.Column("admission_id", sa.String(), nullable=False),
+            sa.Column("admission_binding_sha256", sa.String(length=64), nullable=False),
+            sa.Column("attempt_id", sa.String(), nullable=False),
+            sa.Column("attempt_sequence", sa.Integer(), nullable=False),
+            sa.Column("decision", sa.String(), nullable=False),
+            sa.Column("repository", sa.String(), nullable=False),
+            sa.Column("base_branch", sa.String(), nullable=False),
+            sa.Column("pull_request_number", sa.Integer(), nullable=False),
+            sa.Column("queue_position", sa.Integer(), nullable=False),
+            sa.Column("landing_plan_record_id", sa.String(), nullable=False),
+            sa.Column("landing_plan_id", sa.String(), nullable=False),
+            sa.Column("created_at", sa.String(), nullable=False),
+            sa.Column(
+                "payload",
+                sa.JSON().with_variant(
+                    postgresql.JSONB(astext_type=sa.Text()),
+                    "postgresql",
+                ),
+                nullable=False,
+            ),
+            sa.CheckConstraint(
+                "pull_request_number > 0 AND queue_position > 0 AND attempt_sequence > 0",
+                name="launchplane_merge_admissions_positive_values_check",
+            ),
+            sa.CheckConstraint(
+                "decision = 'admitted'",
+                name="launchplane_merge_admissions_decision_check",
+            ),
+            sa.PrimaryKeyConstraint("admission_id"),
+        )
+    admission_indexes: tuple[
+        tuple[str, Sequence[str | TextClause | ColumnElement[object]], bool], ...
+    ] = (
+        (
+            "launchplane_merge_admissions_attempt_uidx",
+            ["attempt_id"],
+            True,
+        ),
+        (
+            "launchplane_merge_admissions_binding_uidx",
+            ["admission_binding_sha256"],
+            True,
+        ),
+        (
+            "launchplane_merge_admissions_target_idx",
+            ["repository", "base_branch", "pull_request_number", sa.text("created_at DESC")],
+            False,
+        ),
+        (
+            "launchplane_merge_admissions_plan_idx",
+            ["landing_plan_id", "queue_position", sa.text("created_at DESC")],
+            False,
+        ),
+    )
+    for index_name, columns, unique in admission_indexes:
+        if not _index_exists(_ADMISSIONS_TABLE, index_name):
+            op.create_index(
+                index_name,
+                _ADMISSIONS_TABLE,
+                columns,
+                unique=unique,
+            )
+
+    if not _table_exists(_OUTCOMES_TABLE):
+        op.create_table(
+            _OUTCOMES_TABLE,
+            sa.Column("outcome_id", sa.String(), nullable=False),
+            sa.Column("outcome_binding_sha256", sa.String(length=64), nullable=False),
+            sa.Column("admission_id", sa.String(), nullable=False),
+            sa.Column("attempt_id", sa.String(), nullable=False),
+            sa.Column("observation_sequence", sa.Integer(), nullable=False),
+            sa.Column("status", sa.String(), nullable=False),
+            sa.Column("repository", sa.String(), nullable=False),
+            sa.Column("base_branch", sa.String(), nullable=False),
+            sa.Column("pull_request_number", sa.Integer(), nullable=False),
+            sa.Column("observed_at", sa.String(), nullable=False),
+            sa.Column(
+                "payload",
+                sa.JSON().with_variant(
+                    postgresql.JSONB(astext_type=sa.Text()),
+                    "postgresql",
+                ),
+                nullable=False,
+            ),
+            sa.CheckConstraint(
+                "pull_request_number > 0 AND observation_sequence > 0",
+                name="launchplane_merge_landing_outcomes_positive_values_check",
+            ),
+            sa.CheckConstraint(
+                "status IN ('landed', 'rejected', 'reconcile_required')",
+                name="launchplane_merge_landing_outcomes_status_check",
+            ),
+            sa.PrimaryKeyConstraint("outcome_id"),
+        )
+    outcome_indexes: tuple[
+        tuple[str, Sequence[str | TextClause | ColumnElement[object]], bool], ...
+    ] = (
+        (
+            "launchplane_merge_landing_outcomes_observation_uidx",
+            ["admission_id", "observation_sequence"],
+            True,
+        ),
+        (
+            "launchplane_merge_landing_outcomes_binding_uidx",
+            ["outcome_binding_sha256"],
+            True,
+        ),
+        (
+            "launchplane_merge_landing_outcomes_target_idx",
+            ["repository", "base_branch", "pull_request_number", sa.text("observed_at DESC")],
+            False,
+        ),
+        (
+            "launchplane_merge_landing_outcomes_status_idx",
+            ["status", sa.text("observed_at DESC")],
+            False,
+        ),
+    )
+    for index_name, columns, unique in outcome_indexes:
+        if not _index_exists(_OUTCOMES_TABLE, index_name):
+            op.create_index(
+                index_name,
+                _OUTCOMES_TABLE,
+                columns,
+                unique=unique,
+            )
+
+
+def downgrade() -> None:
+    if _table_exists(_OUTCOMES_TABLE):
+        op.drop_table(_OUTCOMES_TABLE)
+    if _table_exists(_ADMISSIONS_TABLE):
+        op.drop_table(_ADMISSIONS_TABLE)

--- a/control_plane/storage/postgres.py
+++ b/control_plane/storage/postgres.py
@@ -94,6 +94,14 @@ from control_plane.contracts.manager_preview_approval import (
     ManagerPreviewApprovalEventRecord,
     ManagerPreviewApprovalEventWriteStatus,
 )
+from control_plane.contracts.merge_admission_record import (
+    MergeAdmissionFenceRejectedError,
+    MergeAdmissionRecord,
+    MergeLandingOutcomeRecord,
+    validate_merge_admission_controller_fence,
+    validate_merge_landing_outcome_for_admission,
+    validate_merge_landing_outcome_successor,
+)
 from control_plane.contracts.owner_acceptance import (
     OwnerAcceptanceEventRecord,
     OwnerAcceptanceEventWriteStatus,
@@ -2777,6 +2785,106 @@ class LaunchplaneMergeTrainBatchLandingPlanRow(Base):
     base_branch: Mapped[str] = mapped_column(String, nullable=False)
     batch_id: Mapped[str] = mapped_column(String, nullable=False)
     plan_id: Mapped[str] = mapped_column(String, nullable=False)
+    payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
+
+
+class LaunchplaneMergeAdmissionRow(Base):
+    __tablename__ = "launchplane_merge_admissions"
+    __table_args__ = (
+        CheckConstraint(
+            "pull_request_number > 0 AND queue_position > 0 AND attempt_sequence > 0",
+            name="launchplane_merge_admissions_positive_values_check",
+        ),
+        CheckConstraint(
+            "decision = 'admitted'",
+            name="launchplane_merge_admissions_decision_check",
+        ),
+        Index(
+            "launchplane_merge_admissions_attempt_uidx",
+            "attempt_id",
+            unique=True,
+        ),
+        Index(
+            "launchplane_merge_admissions_binding_uidx",
+            "admission_binding_sha256",
+            unique=True,
+        ),
+        Index(
+            "launchplane_merge_admissions_target_idx",
+            "repository",
+            "base_branch",
+            "pull_request_number",
+            desc("created_at"),
+        ),
+        Index(
+            "launchplane_merge_admissions_plan_idx",
+            "landing_plan_id",
+            "queue_position",
+            desc("created_at"),
+        ),
+    )
+
+    admission_id: Mapped[str] = mapped_column(String, primary_key=True)
+    admission_binding_sha256: Mapped[str] = mapped_column(String, nullable=False)
+    attempt_id: Mapped[str] = mapped_column(String, nullable=False)
+    attempt_sequence: Mapped[int] = mapped_column(Integer, nullable=False)
+    decision: Mapped[str] = mapped_column(String, nullable=False)
+    repository: Mapped[str] = mapped_column(String, nullable=False)
+    base_branch: Mapped[str] = mapped_column(String, nullable=False)
+    pull_request_number: Mapped[int] = mapped_column(Integer, nullable=False)
+    queue_position: Mapped[int] = mapped_column(Integer, nullable=False)
+    landing_plan_record_id: Mapped[str] = mapped_column(String, nullable=False)
+    landing_plan_id: Mapped[str] = mapped_column(String, nullable=False)
+    created_at: Mapped[str] = mapped_column(String, nullable=False)
+    payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
+
+
+class LaunchplaneMergeLandingOutcomeRow(Base):
+    __tablename__ = "launchplane_merge_landing_outcomes"
+    __table_args__ = (
+        CheckConstraint(
+            "pull_request_number > 0 AND observation_sequence > 0",
+            name="launchplane_merge_landing_outcomes_positive_values_check",
+        ),
+        CheckConstraint(
+            "status IN ('landed', 'rejected', 'reconcile_required')",
+            name="launchplane_merge_landing_outcomes_status_check",
+        ),
+        Index(
+            "launchplane_merge_landing_outcomes_observation_uidx",
+            "admission_id",
+            "observation_sequence",
+            unique=True,
+        ),
+        Index(
+            "launchplane_merge_landing_outcomes_binding_uidx",
+            "outcome_binding_sha256",
+            unique=True,
+        ),
+        Index(
+            "launchplane_merge_landing_outcomes_target_idx",
+            "repository",
+            "base_branch",
+            "pull_request_number",
+            desc("observed_at"),
+        ),
+        Index(
+            "launchplane_merge_landing_outcomes_status_idx",
+            "status",
+            desc("observed_at"),
+        ),
+    )
+
+    outcome_id: Mapped[str] = mapped_column(String, primary_key=True)
+    outcome_binding_sha256: Mapped[str] = mapped_column(String, nullable=False)
+    admission_id: Mapped[str] = mapped_column(String, nullable=False)
+    attempt_id: Mapped[str] = mapped_column(String, nullable=False)
+    observation_sequence: Mapped[int] = mapped_column(Integer, nullable=False)
+    status: Mapped[str] = mapped_column(String, nullable=False)
+    repository: Mapped[str] = mapped_column(String, nullable=False)
+    base_branch: Mapped[str] = mapped_column(String, nullable=False)
+    pull_request_number: Mapped[int] = mapped_column(Integer, nullable=False)
+    observed_at: Mapped[str] = mapped_column(String, nullable=False)
     payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
 
 
@@ -12293,6 +12401,313 @@ class PostgresRecordStore(HumanSessionStore):
             limit=limit,
         )
 
+    def create_merge_admission_record_if_absent(
+        self, record: MergeAdmissionRecord
+    ) -> tuple[MergeAdmissionRecord, bool]:
+        with self._session_factory() as session:
+            existing_row = session.scalar(
+                select(LaunchplaneMergeAdmissionRow).where(
+                    LaunchplaneMergeAdmissionRow.attempt_id == record.attempt_id
+                )
+            )
+            if existing_row is not None:
+                existing = MergeAdmissionRecord.model_validate(existing_row.payload)
+                if existing != record:
+                    raise ValueError("Merge admission attempts are append-only.")
+                return existing, False
+            session.add(
+                LaunchplaneMergeAdmissionRow(
+                    admission_id=record.admission_id,
+                    admission_binding_sha256=record.admission_binding_sha256,
+                    attempt_id=record.attempt_id,
+                    attempt_sequence=record.attempt_sequence,
+                    decision=record.decision,
+                    repository=record.repository,
+                    base_branch=record.base_branch,
+                    pull_request_number=record.pull_request_number,
+                    queue_position=record.queue_position,
+                    landing_plan_record_id=record.landing_plan_record_id,
+                    landing_plan_id=record.landing_plan_id,
+                    created_at=record.created_at,
+                    payload=self._payload_dict(record),
+                )
+            )
+            try:
+                session.commit()
+            except IntegrityError:
+                session.rollback()
+                existing_row = session.scalar(
+                    select(LaunchplaneMergeAdmissionRow).where(
+                        or_(
+                            LaunchplaneMergeAdmissionRow.attempt_id == record.attempt_id,
+                            LaunchplaneMergeAdmissionRow.admission_id == record.admission_id,
+                            LaunchplaneMergeAdmissionRow.admission_binding_sha256
+                            == record.admission_binding_sha256,
+                        )
+                    )
+                )
+                if existing_row is None:
+                    raise
+                existing = MergeAdmissionRecord.model_validate(existing_row.payload)
+                if existing != record:
+                    raise ValueError("Merge admission records are append-only.") from None
+                return existing, False
+        return record, True
+
+    def create_guarded_merge_admission_record_if_absent(
+        self,
+        record: MergeAdmissionRecord,
+        *,
+        admitted_at: str,
+    ) -> tuple[MergeAdmissionRecord, bool]:
+        with self._session_factory() as session:
+            self._advisory_lock_merge_train_controller(session, record.controller_key)
+            controller_row = session.scalar(
+                select(LaunchplaneMergeTrainControllerStateRow)
+                .where(
+                    LaunchplaneMergeTrainControllerStateRow.controller_key == record.controller_key
+                )
+                .with_for_update()
+            )
+            if controller_row is None:
+                raise MergeAdmissionFenceRejectedError(
+                    "Persisted merge controller state is missing at admission creation."
+                )
+            controller_state = MergeTrainControllerStateRecord.model_validate(
+                controller_row.payload
+            )
+            validate_merge_admission_controller_fence(
+                admission=record,
+                controller_state=controller_state,
+                admitted_at=admitted_at,
+            )
+            existing_row = session.scalar(
+                select(LaunchplaneMergeAdmissionRow).where(
+                    LaunchplaneMergeAdmissionRow.attempt_id == record.attempt_id
+                )
+            )
+            if existing_row is not None:
+                existing = MergeAdmissionRecord.model_validate(existing_row.payload)
+                if existing != record:
+                    raise ValueError("Merge admission attempts are append-only.")
+                return existing, False
+            session.add(
+                LaunchplaneMergeAdmissionRow(
+                    admission_id=record.admission_id,
+                    admission_binding_sha256=record.admission_binding_sha256,
+                    attempt_id=record.attempt_id,
+                    attempt_sequence=record.attempt_sequence,
+                    decision=record.decision,
+                    repository=record.repository,
+                    base_branch=record.base_branch,
+                    pull_request_number=record.pull_request_number,
+                    queue_position=record.queue_position,
+                    landing_plan_record_id=record.landing_plan_record_id,
+                    landing_plan_id=record.landing_plan_id,
+                    created_at=record.created_at,
+                    payload=self._payload_dict(record),
+                )
+            )
+            try:
+                session.commit()
+            except IntegrityError:
+                session.rollback()
+                existing_row = session.scalar(
+                    select(LaunchplaneMergeAdmissionRow).where(
+                        or_(
+                            LaunchplaneMergeAdmissionRow.attempt_id == record.attempt_id,
+                            LaunchplaneMergeAdmissionRow.admission_id == record.admission_id,
+                            LaunchplaneMergeAdmissionRow.admission_binding_sha256
+                            == record.admission_binding_sha256,
+                        )
+                    )
+                )
+                if existing_row is None:
+                    raise
+                existing = MergeAdmissionRecord.model_validate(existing_row.payload)
+                if existing != record:
+                    raise ValueError("Merge admission records are append-only.") from None
+                return existing, False
+        return record, True
+
+    def read_merge_admission_record(self, admission_id: str) -> MergeAdmissionRecord:
+        return self._read_model(
+            model_type=MergeAdmissionRecord,
+            orm_model=LaunchplaneMergeAdmissionRow,
+            filters=(LaunchplaneMergeAdmissionRow.admission_id == admission_id,),
+        )
+
+    def list_merge_admission_records(
+        self,
+        *,
+        repository: str = "",
+        base_branch: str = "",
+        pull_request_number: int | None = None,
+        landing_plan_record_id: str = "",
+        landing_plan_id: str = "",
+        attempt_id: str = "",
+        limit: int | None = None,
+    ) -> tuple[MergeAdmissionRecord, ...]:
+        filters: list[object] = []
+        if repository:
+            filters.append(LaunchplaneMergeAdmissionRow.repository == repository.strip().lower())
+        if base_branch:
+            filters.append(LaunchplaneMergeAdmissionRow.base_branch == base_branch)
+        if pull_request_number is not None:
+            filters.append(LaunchplaneMergeAdmissionRow.pull_request_number == pull_request_number)
+        if landing_plan_record_id:
+            filters.append(
+                LaunchplaneMergeAdmissionRow.landing_plan_record_id == landing_plan_record_id
+            )
+        if landing_plan_id:
+            filters.append(LaunchplaneMergeAdmissionRow.landing_plan_id == landing_plan_id)
+        if attempt_id:
+            filters.append(LaunchplaneMergeAdmissionRow.attempt_id == attempt_id)
+        return self._list_models(
+            model_type=MergeAdmissionRecord,
+            orm_model=LaunchplaneMergeAdmissionRow,
+            filters=filters,
+            order_by=(
+                LaunchplaneMergeAdmissionRow.created_at.desc(),
+                LaunchplaneMergeAdmissionRow.admission_id.desc(),
+            ),
+            limit=limit,
+        )
+
+    def create_merge_landing_outcome_record_if_absent(
+        self, record: MergeLandingOutcomeRecord
+    ) -> tuple[MergeLandingOutcomeRecord, bool]:
+        admission = self.read_merge_admission_record(record.admission_id)
+        validate_merge_landing_outcome_for_admission(admission=admission, outcome=record)
+        prior_records = self.list_merge_landing_outcome_records(
+            admission_id=record.admission_id,
+            limit=1,
+        )
+        if prior_records:
+            prior = prior_records[0]
+            if prior.observation_sequence == record.observation_sequence:
+                if prior != record:
+                    raise ValueError("Merge landing outcome observations are append-only.")
+                return prior, False
+            validate_merge_landing_outcome_successor(prior=prior, successor=record)
+        elif record.observation_sequence != 1:
+            raise ValueError("Merge landing outcome reconciliation is missing its predecessor.")
+        with self._session_factory() as session:
+            session.add(
+                LaunchplaneMergeLandingOutcomeRow(
+                    outcome_id=record.outcome_id,
+                    outcome_binding_sha256=record.outcome_binding_sha256,
+                    admission_id=record.admission_id,
+                    attempt_id=record.attempt_id,
+                    observation_sequence=record.observation_sequence,
+                    status=record.status,
+                    repository=record.repository,
+                    base_branch=record.base_branch,
+                    pull_request_number=record.pull_request_number,
+                    observed_at=record.observed_at,
+                    payload=self._payload_dict(record),
+                )
+            )
+            try:
+                session.commit()
+            except IntegrityError:
+                session.rollback()
+                existing_row = session.scalar(
+                    select(LaunchplaneMergeLandingOutcomeRow).where(
+                        or_(
+                            LaunchplaneMergeLandingOutcomeRow.outcome_id == record.outcome_id,
+                            (LaunchplaneMergeLandingOutcomeRow.admission_id == record.admission_id)
+                            & (
+                                LaunchplaneMergeLandingOutcomeRow.observation_sequence
+                                == record.observation_sequence
+                            ),
+                        )
+                    )
+                )
+                if existing_row is None:
+                    raise
+                existing = MergeLandingOutcomeRecord.model_validate(existing_row.payload)
+                if existing != record:
+                    raise ValueError("Merge landing outcome records are append-only.") from None
+                return existing, False
+        return record, True
+
+    def read_merge_landing_outcome_record(self, outcome_id: str) -> MergeLandingOutcomeRecord:
+        return self._read_model(
+            model_type=MergeLandingOutcomeRecord,
+            orm_model=LaunchplaneMergeLandingOutcomeRow,
+            filters=(LaunchplaneMergeLandingOutcomeRow.outcome_id == outcome_id,),
+        )
+
+    def list_merge_landing_outcome_records(
+        self,
+        *,
+        repository: str = "",
+        base_branch: str = "",
+        pull_request_number: int | None = None,
+        admission_id: str = "",
+        status: str = "",
+        observation_sequence: int | None = None,
+        limit: int | None = None,
+    ) -> tuple[MergeLandingOutcomeRecord, ...]:
+        filters: list[object] = []
+        if repository:
+            filters.append(
+                LaunchplaneMergeLandingOutcomeRow.repository == repository.strip().lower()
+            )
+        if base_branch:
+            filters.append(LaunchplaneMergeLandingOutcomeRow.base_branch == base_branch)
+        if pull_request_number is not None:
+            filters.append(
+                LaunchplaneMergeLandingOutcomeRow.pull_request_number == pull_request_number
+            )
+        if admission_id:
+            filters.append(LaunchplaneMergeLandingOutcomeRow.admission_id == admission_id)
+        if status:
+            filters.append(LaunchplaneMergeLandingOutcomeRow.status == status)
+        if observation_sequence is not None:
+            filters.append(
+                LaunchplaneMergeLandingOutcomeRow.observation_sequence == observation_sequence
+            )
+        return self._list_models(
+            model_type=MergeLandingOutcomeRecord,
+            orm_model=LaunchplaneMergeLandingOutcomeRow,
+            filters=filters,
+            order_by=(
+                LaunchplaneMergeLandingOutcomeRow.admission_id.desc(),
+                LaunchplaneMergeLandingOutcomeRow.observation_sequence.desc(),
+                LaunchplaneMergeLandingOutcomeRow.observed_at.desc(),
+                LaunchplaneMergeLandingOutcomeRow.outcome_id.desc(),
+            ),
+            limit=limit,
+        )
+
+    def list_unresolved_merge_admission_records(
+        self,
+        *,
+        repository: str = "",
+        base_branch: str = "",
+        limit: int | None = None,
+    ) -> tuple[MergeAdmissionRecord, ...]:
+        admissions = self.list_merge_admission_records(
+            repository=repository,
+            base_branch=base_branch,
+        )
+        unresolved = tuple(
+            admission
+            for admission in admissions
+            if (
+                not (
+                    outcomes := self.list_merge_landing_outcome_records(
+                        admission_id=admission.admission_id,
+                        limit=1,
+                    )
+                )
+                or outcomes[0].status == "reconcile_required"
+            )
+        )
+        return unresolved[:limit] if limit is not None else unresolved
+
     def write_merge_train_stack_collapse_plan_record(
         self, record: MergeTrainStackCollapsePlanRecord
     ) -> None:
@@ -15966,6 +16381,8 @@ class PostgresRecordStore(HumanSessionStore):
             "merge_train_batch_candidates": 0,
             "merge_train_controller_states": 0,
             "merge_train_batch_landing_plans": 0,
+            "merge_admissions": 0,
+            "merge_landing_outcomes": 0,
             "merge_train_stack_collapse_plans": 0,
             "merge_train_policies": 0,
             "merge_train_runs": 0,
@@ -16134,6 +16551,25 @@ class PostgresRecordStore(HumanSessionStore):
             for plan_record in filesystem_store.list_merge_train_batch_landing_plan_records():
                 self.write_merge_train_batch_landing_plan_record(plan_record)
                 counts["merge_train_batch_landing_plans"] += 1
+        if hasattr(filesystem_store, "list_merge_admission_records"):
+            for admission_record in sorted(
+                filesystem_store.list_merge_admission_records(),
+                key=lambda record: (record.created_at, record.admission_id),
+            ):
+                self.create_merge_admission_record_if_absent(admission_record)
+                counts["merge_admissions"] += 1
+        if hasattr(filesystem_store, "list_merge_landing_outcome_records"):
+            for outcome_record in sorted(
+                filesystem_store.list_merge_landing_outcome_records(),
+                key=lambda record: (
+                    record.admission_id,
+                    record.observation_sequence,
+                    record.observed_at,
+                    record.outcome_id,
+                ),
+            ):
+                self.create_merge_landing_outcome_record_if_absent(outcome_record)
+                counts["merge_landing_outcomes"] += 1
         if hasattr(filesystem_store, "list_merge_train_stack_collapse_plan_records"):
             for collapse_record in filesystem_store.list_merge_train_stack_collapse_plan_records():
                 self.write_merge_train_stack_collapse_plan_record(collapse_record)

--- a/control_plane/storage/schema_invariants.py
+++ b/control_plane/storage/schema_invariants.py
@@ -10,7 +10,7 @@ from sqlalchemy.engine import Engine
 from sqlalchemy.exc import SQLAlchemyError
 
 AUTHZ_COMPATIBILITY_FLOOR_REVISION = "f3b5d7e9a1c2"
-EXPECTED_ALEMBIC_HEAD_REVISION = "d8a0c2e4f6b8"
+EXPECTED_ALEMBIC_HEAD_REVISION = "e9b1d3f5a7c0"
 RUNTIME_COMPATIBLE_ALEMBIC_REVISIONS = (EXPECTED_ALEMBIC_HEAD_REVISION,)
 _AUTHZ_POLICY_TABLE = "launchplane_authz_policies"
 _AUTHZ_POLICY_WRITE_FENCE_TRIGGER = "launchplane_authz_policy_write_fence"
@@ -52,6 +52,26 @@ class CriticalPrimaryKey:
 
 
 CRITICAL_POSTGRES_COLUMN_TYPES: tuple[CriticalColumnType, ...] = (
+    CriticalColumnType(
+        "launchplane_merge_admissions",
+        "payload",
+        ("jsonb",),
+    ),
+    CriticalColumnType(
+        "launchplane_merge_admissions",
+        "attempt_sequence",
+        ("integer", "int4"),
+    ),
+    CriticalColumnType(
+        "launchplane_merge_landing_outcomes",
+        "payload",
+        ("jsonb",),
+    ),
+    CriticalColumnType(
+        "launchplane_merge_landing_outcomes",
+        "observation_sequence",
+        ("integer", "int4"),
+    ),
     CriticalColumnType(
         "launchplane_detached_application_retirements",
         "payload",
@@ -403,6 +423,30 @@ _ODOO_STABLE_ACTIVE_OPERATION_PREDICATE_TOKENS = (
 )
 
 CRITICAL_SCHEMA_INDEXES: tuple[CriticalIndex, ...] = (
+    CriticalIndex(
+        "launchplane_merge_admissions",
+        "launchplane_merge_admissions_attempt_uidx",
+        ("attempt_id",),
+        unique=True,
+    ),
+    CriticalIndex(
+        "launchplane_merge_admissions",
+        "launchplane_merge_admissions_binding_uidx",
+        ("admission_binding_sha256",),
+        unique=True,
+    ),
+    CriticalIndex(
+        "launchplane_merge_landing_outcomes",
+        "launchplane_merge_landing_outcomes_observation_uidx",
+        ("admission_id", "observation_sequence"),
+        unique=True,
+    ),
+    CriticalIndex(
+        "launchplane_merge_landing_outcomes",
+        "launchplane_merge_landing_outcomes_binding_uidx",
+        ("outcome_binding_sha256",),
+        unique=True,
+    ),
     CriticalIndex(
         "launchplane_detached_application_retirements",
         "launchplane_detached_app_retirements_plan_idempotency_unique",
@@ -839,6 +883,14 @@ CRITICAL_SCHEMA_INDEXES: tuple[CriticalIndex, ...] = (
 )
 
 CRITICAL_PRIMARY_KEYS: tuple[CriticalPrimaryKey, ...] = (
+    CriticalPrimaryKey(
+        "launchplane_merge_admissions",
+        ("admission_id",),
+    ),
+    CriticalPrimaryKey(
+        "launchplane_merge_landing_outcomes",
+        ("outcome_id",),
+    ),
     CriticalPrimaryKey(
         "launchplane_detached_application_retirements",
         ("record_id",),

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,6 +37,8 @@ Use these docs as the source of truth for `launchplane`.
 - [merge-train-structural-provenance.md](merge-train-structural-provenance.md) —
   deterministic candidate, rolling-base, impact-subject, and landing-plan
   provenance consumed by merge readiness.
+- [merge-admission.md](merge-admission.md) — immutable per-attempt Level 3
+  admission, truthful landing outcomes, and append-only reconciliation.
 - [runner-lane-baseline.md](runner-lane-baseline.md) — self-hosted runner lane
   baseline, Docker credential isolation, and readiness contract.
 - [runner-host-hygiene.md](runner-host-hygiene.md) — report-only shared runner

--- a/docs/merge-admission.md
+++ b/docs/merge-admission.md
@@ -1,0 +1,96 @@
+---
+title: Guarded Merge Admission And Landing Outcomes
+---
+
+# Guarded Merge Admission And Landing Outcomes
+
+Launchplane treats merge readiness, merge authorization, and landing truth as
+separate layers. Level 2 readiness remains ephemeral and non-authoritative. A
+provider merge effect is allowed only after Launchplane persists one immutable
+Level 3 `MergeAdmissionRecord` for the exact attempt. Launchplane then appends a
+separate `MergeLandingOutcomeRecord` that reports what can truthfully be proven
+after the effect boundary.
+
+## Admission Boundary
+
+Each batch entry is re-evaluated under the current repository/base controller
+lease immediately before its provider merge. The live adapter resolves current
+Owner acceptance, change impact, engineering decision and run evidence,
+required technical checks, policy fingerprints, structural candidate
+provenance, queue position, rolling base, exact head/tree, candidate identity,
+and the expected effect SHA. It re-reads the active merge-train policy record
+and GitHub queue for every entry rather than treating request-start policy or
+stored candidate order as live evidence.
+
+Only `ready` Level 2 evidence plus `exact` or `recorded_rolling` structural
+evidence may produce an admission. The admission binds the complete L2 and
+structural results, candidate and landing-plan digests, current lease identity,
+algorithm version, attempt sequence, and exact Git identities. Storage creation
+is insert-only. The storage transaction re-reads the persisted controller lease,
+acquisition token, expiry, policy digest, active PR, stable landing-plan ID, and
+expected effect SHA using the actual admission timestamp. Finding the same
+admission again never authorizes replay of the provider mutation.
+
+## Outcome Boundary
+
+Outcomes use only three public states:
+
+- `landed`: provider response and exact Git commit/tree evidence confirm the
+  intended landing.
+- `rejected`: provider evidence, or later exact observation, conclusively proves
+  that the attempt produced no landing.
+- `reconcile_required`: transport, process, lease, or observation evidence
+  cannot distinguish landed from not landed.
+
+An admission without an outcome is effect-unknown. A `reconcile_required`
+outcome is also effect-unknown. Neither state permits another provider attempt.
+Reconciliation observes GitHub first and appends a successor outcome; it never
+rewrites history or repeats an ambiguous mutation.
+
+A conclusive provider refusal and a conclusive observed no-effect result are
+different evidence. No-effect reconciliation records the exact open PR state,
+head/tree, and unchanged base SHA/tree without claiming a provider rejection.
+If an admission had no outcome, reconciliation first appends the truthful
+`process_interrupted` observation and then appends the proven no-effect
+successor.
+
+## Batch And Recovery
+
+The controller and direct batch-landing endpoint share the same guarded
+boundary. Each constituent PR receives independent evidence and fresh
+revalidation against the actual rolling base. Queue, head, policy, Owner,
+technical-check, structural, lease, or expected-SHA drift refuses the next
+admission before mutation.
+
+Landing progress records retain one stable `landing_plan_id` while each
+persisted checkpoint receives its own record ID. Admissions bind both values,
+and recovery searches the stable lineage so a restart after a progress
+checkpoint can still find the preceding attempt.
+
+On restart, an already-merged exact PR is reconciled against its preceding
+admission and receives a truthful `landed` outcome only after Launchplane reads
+the actual base ref SHA/tree and proves that base contains the merge commit. If
+the exact PR remains open
+and the expected base did not advance, Launchplane appends conclusive no-effect
+evidence and may create a fresh admission only after complete L2 recomputation.
+Candidate-ref cleanup happens after landing evidence, so cleanup failure cannot
+erase or downgrade a truthful outcome.
+
+## Persistence
+
+Filesystem rehearsal stores records under:
+
+- `state/launchplane_merge_admissions/`
+- `state/launchplane_merge_landing_outcomes/`
+
+Shared-service PostgreSQL stores them under:
+
+- `launchplane_merge_admissions`
+- `launchplane_merge_landing_outcomes`
+
+Attempt identity is deterministically validated from stable landing-plan
+lineage, lease acquisition, PR, queue position, sequence, and expected effect;
+attempt and admission bindings are unique. Landing observations are unique and
+ordered authoritatively by admission plus observation sequence, with timestamps
+retained only as metadata. Exact replay is idempotent; conflicting replay fails
+closed.

--- a/docs/merge-readiness.md
+++ b/docs/merge-readiness.md
@@ -133,3 +133,7 @@ each later L3 attempt. A lost, missing, expired, or wrong-owner lease; controlle
 scope mismatch; expected-SHA mismatch; current-head drift; queue movement;
 policy drift; or evidence loss produces a non-ready result. A previous L2 result
 is never reusable authority.
+
+The production guarded landing adapter follows this rule for every constituent
+PR and persists the complete result only inside the subsequent immutable L3
+admission. See [merge-admission.md](merge-admission.md).

--- a/docs/merge-train-policy.md
+++ b/docs/merge-train-policy.md
@@ -629,6 +629,23 @@ persisted landing result, but the controller remains `reconcile_required` with
 the cleanup phase and candidate ref intact. The next owner resumes that exact
 phase before planning new train work.
 
+### Guarded Level 3 landing
+
+Controller landing and direct batch landing use the same per-entry guarded
+boundary documented in [merge-admission.md](merge-admission.md). Immediately
+before each provider merge, Launchplane re-resolves current Owner,
+change-impact, engineering-review, technical-check, policy, candidate, queue,
+rolling-base, head/tree, lease, and expected-effect evidence. It persists one
+immutable admission before mutation and a separate truthful landing outcome
+afterward.
+
+An existing admission is never a retry token. Missing outcomes and latest
+`reconcile_required` outcomes block another provider effect until GitHub is
+observed and append-only reconciliation establishes either exact landing or
+conclusive no effect. A provider rejection requires a fresh L2 evaluation and a
+new admission. Candidate-ref cleanup remains downstream of landing evidence and
+cannot downgrade it.
+
 Scheduler admission is a deterministic decision over the latest stored
 `launchplane_merge_train_runs` record for the repository/base branch. Dry-run
 records do not throttle the scheduler. Mutation records with `reread_required`

--- a/docs/merge-train-structural-provenance.md
+++ b/docs/merge-train-structural-provenance.md
@@ -44,11 +44,12 @@ evidence must carry non-empty exact L1 Owner event IDs and their immutable
 binding digests. It is explicitly non-authoritative, authorizes no merge or
 other effect, and cannot be replaced by a free-text evidence ID.
 
-#2085 is the first production caller and adapter for this pure boundary. It must
-derive reviewed/current deltas and combined-candidate evidence from the current
-Owner and change-impact services. #2084 supplies only the pure evaluator,
-durable Git provenance, and additive record payloads. It adds no HTTP or UI
-surface, no L3 admission authority, and no table or record family.
+The guarded merge-admission adapter is the first production caller of this pure
+boundary. It derives reviewed/current deltas and combined-candidate evidence
+from current Owner and change-impact services immediately before each batch
+entry. The structural module itself remains non-authoritative and adds no HTTP
+or UI surface; [merge-admission.md](merge-admission.md) owns the L3 record and
+provider-effect boundary.
 
 Candidate construction reads immutable GitHub commit objects for the recorded
 base and each PR head. For every non-no-op merge it resolves the result commit

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -2,6 +2,24 @@
 title: Operations
 ---
 
+## Merge Admission Recovery
+
+Treat a merge admission without a terminal outcome as effect-unknown. Do not
+rerun the merge mutation manually and do not infer success from checks,
+candidate status, landing-plan progress, or a sent GitHub request. Re-run the
+Launchplane controller so it observes the exact PR head, target base, merge
+commit/tree, and branch containment through the guarded recovery path.
+
+If the exact PR is already merged, Launchplane appends a `landed` observation.
+If the exact PR remains open and the expected base did not advance, Launchplane
+first appends `process_interrupted` when the attempt lacked an outcome, then
+appends conclusive no-effect evidence with exact open PR, head/tree, and
+base/tree observations; this evidence does not claim that GitHub rejected the
+request. Only then may Launchplane recompute L2 for a fresh admission.
+Contradictory or incomplete evidence remains `reconcile_required` and needs
+operator investigation. Candidate-ref cleanup failures are separate from
+landing truth and may be retried without changing the outcome record.
+
 ## Command Groups
 
 Use `uv run launchplane --help` for the complete CLI surface. The current
@@ -2567,22 +2585,26 @@ job_workflow_ref=cbusillo/launchplane/.github/workflows/reusable-product-retirem
 
 ## Detached Application Retirement
 
-**Reusable Detached Application Retirement** is the `workflow_call` worker.
-The thin **Detached Application Retirement** `workflow_dispatch` wrapper is
-pinned to the exact worker SHA below. The wrapper only defines manual inputs,
+Phase one provides **Reusable Detached Application Retirement** as a
+`workflow_call`-only worker. Phase two adds the thin
+**Detached Application Retirement** `workflow_dispatch` wrapper, pinned to the
+exact merged worker SHA below. The wrapper only defines the manual inputs,
 forwards them unchanged, and grants `contents: read` plus `id-token: write`; it
-does not define a runner, environment, steps, or concurrency. The worker uses
-the protected `launchplane-authz-admin` environment, OIDC, target-digest
-concurrency, exact input validation, and redacted evidence.
+does not define a runner, environment, steps, or concurrency. Do not configure
+the live authz managed-set secret, deploy this branch, or attempt a provider
+mutation as part of this code phase. The worker uses the protected
+`launchplane-authz-admin` environment, OIDC, target-digest concurrency, exact
+input validation, and redacted evidence.
 
-Any temporary authorization must bind this exact identity pair:
+The protected identity pair to configure only after this wrapper is merged and
+deployed is:
 
 ```text
 workflow_ref=cbusillo/launchplane/.github/workflows/detached-application-retirement.yml@refs/heads/main
 job_workflow_ref=cbusillo/launchplane/.github/workflows/reusable-detached-application-retirement.yml@11d53d2840a6f1898785d7c8f1553c202caa3fbf
 ```
 
-The operator sequence is plan then apply. Inputs are exact Dokploy
+The future operator sequence is plan then apply. Inputs are exact Dokploy
 project/environment/application names, the candidate target SHA-256, a sorted
 non-empty JSON array of every other accessible application target SHA-256 whose
 provider payload has the same exact project name, including duplicate physical
@@ -2600,27 +2622,18 @@ either the candidate provider target ID is present or the deployment record
 lacks consistent application-typed target evidence and still names the
 candidate. Provider-target records use the same target-ID binding. Do not
 rewrite append-only deployment history or adopted target authority to bypass
-either gate. Apply repeats all proofs under a durable provider-operation lease
-before checkpointing the sole `application.delete`. Reconciliation and
-already-absent retries reuse the same apply idempotency key. Completion requires
-candidate absence, unchanged protected fingerprints, and zero authority writes.
+either gate.
+Apply repeats all proofs under a durable provider-operation lease before checkpointing the sole
+`application.delete`. Reconciliation and already-absent retries reuse the same
+apply idempotency key. Completion requires candidate absence, unchanged
+protected fingerprints, and zero authority writes.
 
 Managed authz routing is reserved through the
 `detached-application-retirement` selector, managed-set ID
 `operator.detached-application-retirement`, and secret name
-`LAUNCHPLANE_AUTHZ_DETACHED_APPLICATION_RETIREMENT_MANAGED_SET_JSON`. The normal
-resting state is dormant: the managed set has no rules and the repository secret
-is absent. In that state the selector remains reusable but fails closed before
-reconciliation or retirement can mint authority.
-
-To re-arm for a reviewed one-shot operation, first verify the wrapper's current
-immutable worker pin, then provision a schema-v2 managed-set secret containing
-only the exact caller and that worker rule. Run managed authz dry-run then apply,
-and verify the active rule before retirement planning. After the retirement
-apply and independent provider verification, replace the secret payload with an
-empty desired policy, run authz dry-run then exact-plan apply, confirm a second
-dry run is unchanged with zero managed rules, and only then delete the secret.
-Verify live policy and secret state at every transition; this documentation is
-procedure, not runtime authority. Never substitute a different caller workflow
-ref, a mutable worker ref, a checked-in target value, or a local CLI live-target
-fallback.
+`LAUNCHPLANE_AUTHZ_DETACHED_APPLICATION_RETIREMENT_MANAGED_SET_JSON`. Neither
+phase creates or populates that secret or reconciles a live rule. The remaining
+sequence is: merge and deploy this wrapper, configure the exact caller and
+worker authz pair through the managed authz path, then run the reviewed plan and
+apply sequence. Never substitute a mutable ref, a checked-in target value, or a
+local CLI live-target fallback.

--- a/docs/records.md
+++ b/docs/records.md
@@ -2519,3 +2519,37 @@ phases, whether the sole application-delete effect was attempted/performed,
 candidate absence verification, protected-target stability, and the literal
 zero authority-write count. There are no profile lifecycle, authority deletion,
 secret mutation, target rewrite, or runtime mutation fields.
+
+## Merge admission and landing outcome records
+
+Guarded merge authorization is persisted separately from mutable batch landing
+progress. `MergeAdmissionRecord` is append-only evidence written immediately
+before one exact provider merge attempt. It binds the current L2 readiness
+result and digest, structural result and provenance digest, Owner and
+engineering evidence carried by L2, all seven policy fingerprints, repository,
+base branch, PR and queue position, candidate and landing-plan identity,
+rolling base/head/tree identity, algorithm version, controller lease, expected
+effect SHA, attempt sequence, and actual creation time. Each admission carries
+the stable landing-plan lineage ID plus the exact persisted progress-record ID.
+Its deterministic attempt ID is contract-validated, and guarded creation
+atomically rechecks persisted lease acquisition/expiry, policy, active PR, plan,
+and expected effect fences.
+
+`MergeLandingOutcomeRecord` is a separate append-only observation for that
+admission. Its status is `landed`, `rejected`, or `reconcile_required`.
+Admissions without outcomes and latest `reconcile_required` observations remain
+effect-unknown and block provider replay. Reconciliation appends a successor
+observation after fresh GitHub reads; terminal `landed` and `rejected` outcomes
+cannot be superseded. `landed` requires the actual observed base SHA/tree and
+containment proof. Observed no-effect reconciliation records exact open PR,
+head/tree, and unchanged base evidence without setting provider-rejection
+fields. Observation sequence, not wall-clock timestamp, is chain authority for
+listing and filesystem import.
+
+Filesystem rehearsal uses `launchplane_merge_admissions/` and
+`launchplane_merge_landing_outcomes/`. PostgreSQL uses
+`launchplane_merge_admissions` and `launchplane_merge_landing_outcomes` with
+unique attempt, binding, and per-admission observation-sequence indexes.
+Migration `e9b1d3f5a7c0` creates both tables after the detached application
+retirement migration. Historical landing plans are not backfilled into L3
+authority.

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -1007,6 +1007,15 @@ response `result.controller_action` is the helper contract for retry/stop
 behavior; see [merge-train-policy.md](merge-train-policy.md) for the action
 matrix and public-safe reporting fields.
 
+Mutating landing phases are guarded by immutable per-attempt Level 3 admission.
+The service recomputes current Level 2 and structural evidence under the live
+controller lease immediately before each constituent PR effect, persists the
+admission before GitHub mutation, and appends `landed`, `rejected`, or
+`reconcile_required` evidence afterward. A blocked admission returns
+`merge_train_landing_not_admitted`; unresolved effect evidence returns
+`merge_train_landing_reconcile_required`. Neither response permits provider
+replay.
+
 Every retained write-capable merge-train route acquires that same
 repository/base fence for its full mutation window. Phase-specific and legacy
 mutation calls therefore return the same lease-held or reconciliation-required
@@ -1058,6 +1067,11 @@ the route validates the linked
 stack-collapse record before the root merge and then writes stack-child
 disposition evidence after the landing record is persisted. Accepted calls
 support optional `Idempotency-Key` replay/conflict handling.
+
+Land mode is not a second authority path. It requires the same guarded
+admission store, live evidence adapter, controller lease, and append-only
+landing outcome behavior as controller mode. If those dependencies are
+unavailable, the route fails closed before GitHub mutation.
 
 `.github/workflows/merge-train-runner.yml` is the first external scheduler for
 this route. It mints a GitHub Actions OIDC token for the Launchplane service,

--- a/tests/support/merge_train.py
+++ b/tests/support/merge_train.py
@@ -102,6 +102,8 @@ class _FakeMergeTrainGitHubClient:
         self,
         *,
         landing_plan: MergeTrainBatchLandingPlan,
+        admission_guard: object,
+        recorded_at: str,
         checkpoint: (
             Callable[[MergeTrainBatchLandingPlan, MergeTrainBatchLandingEntry, str], None] | None
         ) = None,
@@ -220,6 +222,8 @@ class _StaleLandingMergeTrainGitHubClient(_FakeMergeTrainGitHubClient):
         self,
         *,
         landing_plan: MergeTrainBatchLandingPlan,
+        admission_guard: object,
+        recorded_at: str,
         checkpoint: (
             Callable[[MergeTrainBatchLandingPlan, MergeTrainBatchLandingEntry, str], None] | None
         ) = None,
@@ -234,6 +238,8 @@ class _UnavailableLandingMergeTrainGitHubClient(_FakeMergeTrainGitHubClient):
         self,
         *,
         landing_plan: MergeTrainBatchLandingPlan,
+        admission_guard: object,
+        recorded_at: str,
         checkpoint: (
             Callable[[MergeTrainBatchLandingPlan, MergeTrainBatchLandingEntry, str], None] | None
         ) = None,

--- a/tests/test_merge_admission_live.py
+++ b/tests/test_merge_admission_live.py
@@ -1,0 +1,161 @@
+import unittest
+
+from control_plane.merge_admission import MergeAdmissionDeniedError
+from control_plane.merge_admission_live import LiveMergeAdmissionEvaluator
+from control_plane.merge_train import (
+    MergeTrainDryRunSnapshot,
+    MergeTrainPullRequestSnapshot,
+)
+from control_plane.merge_train_github import RecordingMergeTrainGitHubTransport
+from control_plane.tenant_admission_controller import TenantAdmissionControllerGitHubClient
+from tests.merge_train_policy_fixtures import build_test_merge_train_policy_record
+from tests.test_merge_admission_records import _guard_records
+from tests.test_merge_readiness import BASE_SHA, HEAD_SHA, REPOSITORY
+
+
+class _StaticSnapshotReader:
+    def __init__(self, snapshot: MergeTrainDryRunSnapshot) -> None:
+        self.snapshot = snapshot
+        self.read_count = 0
+
+    def read_merge_train_snapshot(
+        self,
+        *,
+        repository: str,
+        base_branch: str,
+    ) -> MergeTrainDryRunSnapshot:
+        self.read_count += 1
+        if repository != self.snapshot.repository or base_branch != self.snapshot.base_branch:
+            raise AssertionError("unexpected merge queue scope")
+        return self.snapshot
+
+
+class _UnusedRepositoryEvidenceProvider:
+    def resolve(self, target: object) -> object:
+        raise AssertionError(f"queue drift should fail before repository evidence: {target}")
+
+
+def _queued_pull_request(
+    *,
+    number: int,
+    head_sha: str,
+    created_at: str,
+) -> MergeTrainPullRequestSnapshot:
+    return MergeTrainPullRequestSnapshot(
+        number=number,
+        created_at=created_at,
+        labels=("ready-to-merge",),
+        actor_role="repo_owner",
+        head_sha=head_sha,
+        base_sha=BASE_SHA,
+        base_ref="main",
+        mergeable="mergeable",
+        required_checks_status="pass",
+    )
+
+
+class LiveMergeAdmissionEvaluatorTests(unittest.TestCase):
+    def test_live_queue_is_rediscovered_and_inserted_pr_refuses_admission(self) -> None:
+        candidate_record, landing_record, controller_state, _ = _guard_records()
+        snapshot_reader = _StaticSnapshotReader(
+            MergeTrainDryRunSnapshot(
+                repository=REPOSITORY,
+                base_branch="main",
+                base_sha=BASE_SHA,
+                pull_requests=(
+                    _queued_pull_request(
+                        number=2082,
+                        head_sha="d" * 40,
+                        created_at="2026-08-11T02:59:00Z",
+                    ),
+                    _queued_pull_request(
+                        number=2083,
+                        head_sha=HEAD_SHA,
+                        created_at="2026-08-11T03:00:00Z",
+                    ),
+                ),
+            )
+        )
+        policy_reads = 0
+
+        def read_policy():  # type: ignore[no-untyped-def]
+            nonlocal policy_reads
+            policy_reads += 1
+            return build_test_merge_train_policy_record(repository=REPOSITORY)
+
+        evaluator = LiveMergeAdmissionEvaluator(
+            store=object(),
+            repository_evidence_provider=_UnusedRepositoryEvidenceProvider(),  # type: ignore[arg-type]
+            technical_check_client=TenantAdmissionControllerGitHubClient(
+                transport=RecordingMergeTrainGitHubTransport()
+            ),
+            policy_record_provider=read_policy,
+            snapshot_reader=snapshot_reader,
+        )
+        entry = landing_record.landing_plan.entries[0]
+
+        for _ in range(2):
+            with self.assertRaisesRegex(MergeAdmissionDeniedError, "Live merge queue"):
+                evaluator.evaluate(
+                    candidate_record=candidate_record,
+                    landing_plan_record=landing_record,
+                    entry=entry,
+                    observed_base_sha=BASE_SHA,
+                    observed_base_tree_sha="4" * 40,
+                    observed_head_sha=HEAD_SHA,
+                    observed_head_tree_sha="2" * 40,
+                    controller_state=controller_state,
+                    stack_collapse_record=None,
+                    evaluated_at="2026-08-11T03:01:00Z",
+                )
+
+        self.assertEqual(policy_reads, 2)
+        self.assertEqual(snapshot_reader.read_count, 2)
+
+    def test_active_policy_removal_is_rediscovered_and_refuses_admission(self) -> None:
+        candidate_record, landing_record, controller_state, _ = _guard_records()
+        snapshot_reader = _StaticSnapshotReader(
+            MergeTrainDryRunSnapshot(
+                repository=REPOSITORY,
+                base_branch="main",
+                base_sha=BASE_SHA,
+                pull_requests=(
+                    _queued_pull_request(
+                        number=2083,
+                        head_sha=HEAD_SHA,
+                        created_at="2026-08-11T03:00:00Z",
+                    ),
+                ),
+            )
+        )
+        evaluator = LiveMergeAdmissionEvaluator(
+            store=object(),
+            repository_evidence_provider=_UnusedRepositoryEvidenceProvider(),  # type: ignore[arg-type]
+            technical_check_client=TenantAdmissionControllerGitHubClient(
+                transport=RecordingMergeTrainGitHubTransport()
+            ),
+            policy_record_provider=lambda: build_test_merge_train_policy_record(
+                repository="example/other-repository"
+            ),
+            snapshot_reader=snapshot_reader,
+        )
+
+        with self.assertRaisesRegex(MergeAdmissionDeniedError, "Active merge-train policy"):
+            evaluator.evaluate(
+                candidate_record=candidate_record,
+                landing_plan_record=landing_record,
+                entry=landing_record.landing_plan.entries[0],
+                observed_base_sha=BASE_SHA,
+                observed_base_tree_sha="4" * 40,
+                observed_head_sha=HEAD_SHA,
+                observed_head_tree_sha="2" * 40,
+                controller_state=controller_state,
+                stack_collapse_record=None,
+                evaluated_at="2026-08-11T03:01:00Z",
+            )
+
+        self.assertEqual(snapshot_reader.read_count, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_merge_admission_records.py
+++ b/tests/test_merge_admission_records.py
@@ -1,0 +1,563 @@
+from collections.abc import Callable
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import cast
+import unittest
+
+from control_plane.contracts.merge_admission_record import MergeLandingOutcomeRecord
+from control_plane.contracts.merge_readiness import (
+    MergeReadinessCandidateEvidence,
+    MergeReadinessResult,
+)
+from control_plane.contracts.merge_train_batch import (
+    MergeTrainBatchCandidate,
+    MergeTrainBatchCandidateRecord,
+    MergeTrainBatchEntry,
+    MergeTrainBatchLandingPlanRecord,
+    build_merge_train_batch_candidate_ref,
+    build_merge_train_batch_id,
+    build_merge_train_batch_landing_plan,
+)
+from control_plane.contracts.merge_train_controller_state import (
+    MergeTrainControllerStateRecord,
+    build_merge_train_controller_key,
+)
+from control_plane.contracts.merge_train_structural_provenance import (
+    MergeTrainRollingStep,
+    MergeTrainStructuralCandidateResult,
+    MergeTrainStructuralEntryBinding,
+    MergeTrainStructuralProvenance,
+)
+from control_plane.merge_admission import (
+    GuardedMergeAdmission,
+    MergeAdmissionDeniedError,
+    MergeAdmissionEvaluation,
+    MergeAdmissionEvaluator,
+    MergeAdmissionReconciliationRequiredError,
+)
+from control_plane.storage.filesystem import FilesystemRecordStore
+from control_plane.storage.postgres import PostgresRecordStore
+from tests.test_merge_readiness import (
+    BASE_SHA,
+    CANDIDATE_SHA,
+    HEAD_SHA,
+    OTHER_SHA,
+    POLICY_SHA,
+    REPOSITORY,
+    TREE_SHA,
+    _candidate,
+    _evaluate,
+    _fence,
+    _merge_admission,
+    _policy_fingerprints,
+    _target,
+)
+
+
+def _ambiguous_outcome(
+    *,
+    observation_sequence: int = 1,
+    prior_outcome_id: str = "",
+    observed_at: str = "",
+) -> MergeLandingOutcomeRecord:
+    admission = _merge_admission()
+    return MergeLandingOutcomeRecord(
+        admission_id=admission.admission_id,
+        admission_binding_sha256=admission.admission_binding_sha256,
+        attempt_id=admission.attempt_id,
+        observation_sequence=observation_sequence,
+        prior_outcome_id=prior_outcome_id,
+        source="test:ambiguous",
+        repository=admission.repository,
+        base_branch=admission.base_branch,
+        pull_request_number=admission.pull_request_number,
+        status="reconcile_required",
+        reason="provider_transport_ambiguous",
+        provider_effect_attempted=True,
+        provider_message="connection reset after request send",
+        observed_at=observed_at or f"2026-08-11T03:0{observation_sequence + 1}:00Z",
+    )
+
+
+def _landed_outcome(
+    *,
+    observation_sequence: int,
+    prior_outcome_id: str,
+) -> MergeLandingOutcomeRecord:
+    admission = _merge_admission()
+    return MergeLandingOutcomeRecord(
+        admission_id=admission.admission_id,
+        admission_binding_sha256=admission.admission_binding_sha256,
+        attempt_id=admission.attempt_id,
+        observation_sequence=observation_sequence,
+        prior_outcome_id=prior_outcome_id,
+        source="test:reconciled-landed",
+        repository=admission.repository,
+        base_branch=admission.base_branch,
+        pull_request_number=admission.pull_request_number,
+        status="landed",
+        reason="provider_and_git_confirmed",
+        provider_effect_attempted=True,
+        observed_pull_request_head_sha=admission.pull_request_head_sha,
+        observed_pull_request_head_tree_sha=admission.pull_request_head_tree_sha,
+        observed_base_sha="7" * 40,
+        observed_base_tree_sha="8" * 40,
+        merge_commit_sha="9" * 40,
+        merge_commit_tree_sha="a" * 40,
+        base_contains_merge_commit=True,
+        exact_landing_confirmed=True,
+        observed_at="2026-08-11T03:04:00Z",
+    )
+
+
+def _guard_records() -> tuple[
+    MergeTrainBatchCandidateRecord,
+    MergeTrainBatchLandingPlanRecord,
+    MergeTrainControllerStateRecord,
+    MergeTrainStructuralCandidateResult,
+]:
+    entry = MergeTrainBatchEntry(
+        pull_request_number=2083,
+        position=2,
+        head_sha=HEAD_SHA,
+        head_tree_sha=TREE_SHA,
+        impact_status="known",
+    )
+    provenance = MergeTrainStructuralProvenance(
+        repository=REPOSITORY,
+        base_branch="main",
+        base_sha=BASE_SHA,
+        base_tree_sha=OTHER_SHA,
+        policy_key=f"{REPOSITORY}:main",
+        policy_sha256=POLICY_SHA,
+        entries=(
+            MergeTrainStructuralEntryBinding(
+                position=1,
+                pull_request_number=entry.pull_request_number,
+                head_sha=entry.head_sha,
+                head_tree_sha=entry.head_tree_sha,
+                impact_status="known",
+            ),
+        ),
+        steps=(
+            MergeTrainRollingStep(
+                position=1,
+                pull_request_number=entry.pull_request_number,
+                parent_sha=BASE_SHA,
+                parent_tree_sha=OTHER_SHA,
+                head_sha=entry.head_sha,
+                head_tree_sha=entry.head_tree_sha,
+                result_sha=CANDIDATE_SHA,
+                result_tree_sha="6" * 40,
+                kind="merge_commit",
+            ),
+        ),
+        candidate_sha=CANDIDATE_SHA,
+        candidate_tree_sha="6" * 40,
+    )
+    normalized_entry = entry.model_copy(update={"position": 1})
+    batch_id = build_merge_train_batch_id(
+        repository=REPOSITORY,
+        base_branch="main",
+        base_sha=BASE_SHA,
+        entry_head_shas=(HEAD_SHA,),
+    )
+    candidate = MergeTrainBatchCandidate(
+        batch_id=batch_id,
+        repository=REPOSITORY,
+        base_branch="main",
+        base_sha=BASE_SHA,
+        policy_key=f"{REPOSITORY}:main",
+        policy_sha256=POLICY_SHA,
+        candidate_ref=build_merge_train_batch_candidate_ref(
+            repository=REPOSITORY,
+            base_branch="main",
+            batch_id=batch_id,
+        ),
+        candidate_sha=CANDIDATE_SHA,
+        candidate_tree_sha="6" * 40,
+        status="passed",
+        entries=(normalized_entry,),
+        structural_provenance=provenance,
+        required_checks_status="pass",
+        created_at="2026-08-11T03:00:00Z",
+        updated_at="2026-08-11T03:00:00Z",
+    )
+    candidate_record = MergeTrainBatchCandidateRecord(
+        record_id="candidate-record-1",
+        source="test",
+        updated_at="2026-08-11T03:00:00Z",
+        candidate=candidate,
+    )
+    landing_plan = build_merge_train_batch_landing_plan(
+        candidate=candidate,
+        merge_method="merge",
+        created_at="2026-08-11T03:00:30Z",
+    )
+    landing_record = MergeTrainBatchLandingPlanRecord(
+        record_id="landing-record-1",
+        source="test",
+        updated_at="2026-08-11T03:00:30Z",
+        landing_plan=landing_plan,
+    )
+    controller_state = MergeTrainControllerStateRecord(
+        controller_key=build_merge_train_controller_key(
+            repository=REPOSITORY,
+            base_branch="main",
+        ),
+        repository=REPOSITORY,
+        base_branch="main",
+        policy_key=f"{REPOSITORY}:main",
+        policy_sha256=POLICY_SHA,
+        status="running",
+        updated_at="2026-08-11T03:00:00Z",
+        lease_owner="controller-run-1",
+        lease_acquired_at="2026-08-11T03:00:00Z",
+        lease_expires_at="2026-08-11T03:10:00.000000Z",
+        heartbeat_at="2026-08-11T03:00:00Z",
+        active_action="land_batch",
+        active_phase="merge_batch_entries",
+        active_pull_request_number=2083,
+        step_payload={
+            "landing_plan_id": landing_plan.plan_id,
+            "expected_effect_sha": landing_plan.candidate_sha,
+        },
+    )
+    structural_result = MergeTrainStructuralCandidateResult(
+        status="exact",
+        reason_codes=("structural_single_entry_exact",),
+        effective_base_sha=BASE_SHA,
+        effective_base_tree_sha=OTHER_SHA,
+        candidate_sha256=candidate.candidate_sha256,
+        landing_plan_sha256=landing_plan.landing_plan_sha256,
+        provenance_sha256=provenance.provenance_sha256,
+    )
+    return candidate_record, landing_record, controller_state, structural_result
+
+
+class _StaticEvaluator:
+    def __init__(self, evaluation: MergeAdmissionEvaluation) -> None:
+        self.evaluation = evaluation
+
+    def evaluate(self, **_: object) -> MergeAdmissionEvaluation:
+        return self.evaluation
+
+
+class _ProviderError(RuntimeError):
+    def __init__(self, status_code: int) -> None:
+        super().__init__(f"provider rejected with {status_code}")
+        self.status_code = status_code
+
+
+class MergeAdmissionStoreContract:
+    store: FilesystemRecordStore | PostgresRecordStore
+
+    def test_admission_create_is_append_only_and_idempotent(self) -> None:
+        test_case = cast(unittest.TestCase, self)
+        admission = _merge_admission()
+
+        stored, created = self.store.create_merge_admission_record_if_absent(admission)
+        replayed, replay_created = self.store.create_merge_admission_record_if_absent(admission)
+
+        test_case.assertTrue(created)
+        test_case.assertFalse(replay_created)
+        test_case.assertEqual(stored, admission)
+        test_case.assertEqual(replayed, admission)
+        test_case.assertEqual(
+            self.store.read_merge_admission_record(admission.admission_id),
+            admission,
+        )
+        test_case.assertEqual(
+            self.store.list_unresolved_merge_admission_records(),
+            (admission,),
+        )
+
+        conflicting = admission.model_copy(
+            update={
+                "admission_id": "",
+                "admission_binding_sha256": "",
+                "source": "test:conflict",
+            }
+        )
+        conflicting = type(admission).model_validate(conflicting.model_dump(mode="json"))
+        with test_case.assertRaisesRegex(ValueError, "append-only"):
+            self.store.create_merge_admission_record_if_absent(conflicting)
+
+    def test_ambiguous_outcome_reconciles_append_only_to_landed(self) -> None:
+        test_case = cast(unittest.TestCase, self)
+        admission = _merge_admission()
+        self.store.create_merge_admission_record_if_absent(admission)
+        ambiguous = _ambiguous_outcome(observed_at="2026-08-11T03:09:00Z")
+
+        stored, created = self.store.create_merge_landing_outcome_record_if_absent(ambiguous)
+        replayed, replay_created = self.store.create_merge_landing_outcome_record_if_absent(
+            ambiguous
+        )
+
+        test_case.assertTrue(created)
+        test_case.assertFalse(replay_created)
+        test_case.assertEqual(stored, replayed)
+        test_case.assertEqual(
+            self.store.list_unresolved_merge_admission_records(),
+            (admission,),
+        )
+
+        landed = _landed_outcome(
+            observation_sequence=2,
+            prior_outcome_id=ambiguous.outcome_id,
+        )
+        self.store.create_merge_landing_outcome_record_if_absent(landed)
+
+        test_case.assertEqual(self.store.list_unresolved_merge_admission_records(), ())
+        test_case.assertEqual(
+            tuple(
+                outcome.status
+                for outcome in reversed(
+                    self.store.list_merge_landing_outcome_records(
+                        admission_id=admission.admission_id
+                    )
+                )
+            ),
+            ("reconcile_required", "landed"),
+        )
+
+
+class FilesystemMergeAdmissionStoreTests(MergeAdmissionStoreContract, unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary_directory = TemporaryDirectory()
+        self.addCleanup(self.temporary_directory.cleanup)
+        self.store = FilesystemRecordStore(Path(self.temporary_directory.name))
+
+
+class PostgresMergeAdmissionStoreTests(MergeAdmissionStoreContract, unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary_directory = TemporaryDirectory()
+        self.addCleanup(self.temporary_directory.cleanup)
+        database_path = Path(self.temporary_directory.name) / "launchplane.sqlite3"
+        self.store = PostgresRecordStore(database_url=f"sqlite+pysqlite:///{database_path}")
+        self.store.ensure_schema()
+        self.addCleanup(self.store.close)
+
+    def test_filesystem_import_uses_outcome_sequence_not_observation_time(self) -> None:
+        filesystem_store = FilesystemRecordStore(
+            Path(self.temporary_directory.name) / "filesystem-state"
+        )
+        admission = _merge_admission()
+        filesystem_store.create_merge_admission_record_if_absent(admission)
+        ambiguous = _ambiguous_outcome(observed_at="2026-08-11T03:09:00Z")
+        filesystem_store.create_merge_landing_outcome_record_if_absent(ambiguous)
+        filesystem_store.create_merge_landing_outcome_record_if_absent(
+            _landed_outcome(
+                observation_sequence=2,
+                prior_outcome_id=ambiguous.outcome_id,
+            )
+        )
+
+        counts = cast(PostgresRecordStore, self.store).import_core_records_from_filesystem(
+            filesystem_store
+        )
+
+        self.assertEqual(counts["merge_landing_outcomes"], 2)
+        outcomes = self.store.list_merge_landing_outcome_records(
+            admission_id=admission.admission_id
+        )
+        self.assertEqual(tuple(outcome.observation_sequence for outcome in outcomes), (2, 1))
+
+
+class GuardedMergeAdmissionScenarioTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary_directory = TemporaryDirectory()
+        self.addCleanup(self.temporary_directory.cleanup)
+        self.store = FilesystemRecordStore(Path(self.temporary_directory.name))
+        (
+            self.candidate_record,
+            self.landing_record,
+            self.controller_state,
+            self.structural_result,
+        ) = _guard_records()
+        self.store.write_merge_train_controller_state_record(self.controller_state)
+
+    def _readiness(self, **updates: object):  # type: ignore[no-untyped-def]
+        payload: dict[str, object] = {
+            "target": _target(queue_position=1),
+            "candidate_evidence": MergeReadinessCandidateEvidence.model_validate(
+                {
+                    **_candidate().model_dump(mode="json"),
+                    "queue_position": 1,
+                    "record_id": self.candidate_record.record_id,
+                }
+            ),
+        }
+        payload.update(updates)
+        return _evaluate(**payload)
+
+    def _guard(
+        self,
+        readiness: MergeReadinessResult | None = None,
+        *,
+        evaluator: MergeAdmissionEvaluator | None = None,
+        admission_time_provider: Callable[[], str] | None = None,
+    ) -> GuardedMergeAdmission:
+        return GuardedMergeAdmission(
+            record_store=self.store,
+            evaluator=evaluator
+            or _StaticEvaluator(
+                MergeAdmissionEvaluation(
+                    readiness=readiness or self._readiness(),
+                    structural_result=self.structural_result,
+                )
+            ),
+            candidate_record=self.candidate_record,
+            landing_plan_record=self.landing_record,
+            controller_state=self.controller_state,
+            controller_state_provider=lambda: self.store.list_merge_train_controller_state_records(
+                repository=REPOSITORY,
+                base_branch="main",
+                limit=1,
+            )[0],
+            admission_time_provider=admission_time_provider or (lambda: "2026-08-11T03:01:00Z"),
+            trace_id="scenario-test",
+        )
+
+    def _admit(self, guard: GuardedMergeAdmission):  # type: ignore[no-untyped-def]
+        entry = self.landing_record.landing_plan.entries[0]
+        return guard.admit(
+            entry=entry,
+            observed_base_sha=BASE_SHA,
+            observed_base_tree_sha=OTHER_SHA,
+            observed_head_sha=HEAD_SHA,
+            observed_head_tree_sha=TREE_SHA,
+        )
+
+    def test_scenario_2_persists_exact_admission_before_effect(self) -> None:
+        admission = self._admit(self._guard())
+
+        self.assertEqual(
+            self.store.read_merge_admission_record(admission.admission_id),
+            admission,
+        )
+        self.assertEqual(admission.readiness.state, "ready")
+
+    def test_scenario_11_missing_outcome_blocks_provider_retry(self) -> None:
+        guard = self._guard()
+        self._admit(guard)
+
+        with self.assertRaises(MergeAdmissionReconciliationRequiredError):
+            self._admit(guard)
+
+    def test_scenario_11_open_exact_pr_reconciliation_allows_fresh_attempt(self) -> None:
+        guard = self._guard()
+        first = self._admit(guard)
+        entry = self.landing_record.landing_plan.entries[0]
+
+        reconciled = guard.reconcile_existing_no_effect(
+            entry=entry,
+            observed_base_sha=BASE_SHA,
+            observed_base_tree_sha=OTHER_SHA,
+            observed_head_sha=HEAD_SHA,
+            observed_head_tree_sha=TREE_SHA,
+            observed_pull_request_state="open",
+            observed_at="2026-08-11T03:02:00Z",
+        )
+        second = self._admit(guard)
+
+        self.assertIsNotNone(reconciled)
+        assert reconciled is not None
+        self.assertEqual(reconciled.status, "rejected")
+        self.assertEqual(reconciled.reason, "reconciliation_confirmed_no_effect")
+        self.assertFalse(reconciled.provider_conclusive_rejection)
+        self.assertIsNone(reconciled.provider_status_code)
+        outcomes = self.store.list_merge_landing_outcome_records(admission_id=first.admission_id)
+        self.assertEqual(tuple(outcome.observation_sequence for outcome in outcomes), (2, 1))
+        self.assertEqual(outcomes[1].status, "reconcile_required")
+        self.assertNotEqual(first.admission_id, second.admission_id)
+
+    def test_scenario_12_policy_drift_refuses_next_admission(self) -> None:
+        readiness = self._readiness(policy_fingerprints=_policy_fingerprints(drift="merge_train"))
+
+        with self.assertRaises(MergeAdmissionDeniedError):
+            self._admit(self._guard(readiness))
+
+        self.assertEqual(self.store.list_merge_admission_records(), ())
+
+    def test_scenario_22_lost_lease_refuses_admission(self) -> None:
+        readiness = self._readiness(
+            fence_evidence=_fence(
+                observed_lease_owner="another-controller",
+            )
+        )
+
+        with self.assertRaises(MergeAdmissionDeniedError):
+            self._admit(self._guard(readiness))
+
+        self.assertEqual(self.store.list_merge_admission_records(), ())
+
+    def test_lease_stolen_after_evaluation_creates_no_admission(self) -> None:
+        evaluation = MergeAdmissionEvaluation(
+            readiness=self._readiness(),
+            structural_result=self.structural_result,
+        )
+        test_case = self
+
+        class LeaseStealingEvaluator:
+            def evaluate(self, **_: object) -> MergeAdmissionEvaluation:
+                stolen = test_case.controller_state.model_copy(
+                    update={
+                        "lease_owner": "controller-run-2",
+                        "lease_acquired_at": "2026-08-11T03:00:30Z",
+                    }
+                )
+                test_case.store.write_merge_train_controller_state_record(stolen)
+                return evaluation
+
+        with self.assertRaises(MergeAdmissionDeniedError):
+            self._admit(self._guard(evaluator=LeaseStealingEvaluator()))
+
+        self.assertEqual(self.store.list_merge_admission_records(), ())
+
+    def test_lease_expiry_is_rechecked_at_actual_admission_time(self) -> None:
+        times = iter(("2026-08-11T03:09:59Z", "2026-08-11T03:10:00Z"))
+
+        with self.assertRaises(MergeAdmissionDeniedError):
+            self._admit(self._guard(admission_time_provider=lambda: next(times)))
+
+        self.assertEqual(self.store.list_merge_admission_records(), ())
+
+    def test_progress_record_uses_stable_landing_plan_lineage(self) -> None:
+        guard = self._guard()
+        first = self._admit(guard)
+        guard.record_provider_failure(
+            admission=first,
+            error=_ProviderError(405),
+            observed_at="2026-08-11T03:02:00Z",
+        )
+        progress_record = self.landing_record.model_copy(
+            update={"record_id": "landing-record-progress-2"}
+        )
+        guard.update_landing_plan_record(progress_record)
+
+        second = self._admit(guard)
+
+        self.assertEqual(second.attempt_sequence, 2)
+        self.assertEqual(second.landing_plan_id, first.landing_plan_id)
+        self.assertEqual(second.landing_plan_record_id, progress_record.record_id)
+        self.assertNotEqual(second.attempt_id, first.attempt_id)
+
+    def test_scenario_23_rejection_requires_fresh_admission_for_retry(self) -> None:
+        guard = self._guard()
+        first = self._admit(guard)
+        rejected = guard.record_provider_failure(
+            admission=first,
+            error=_ProviderError(405),
+            observed_at="2026-08-11T03:02:00Z",
+        )
+
+        second = self._admit(guard)
+
+        self.assertEqual(rejected.status, "rejected")
+        self.assertNotEqual(first.admission_id, second.admission_id)
+        self.assertEqual(second.attempt_sequence, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_merge_readiness.py
+++ b/tests/test_merge_readiness.py
@@ -7,6 +7,12 @@ from pydantic import ValidationError
 from control_plane.contracts.change_impact import ChangeImpactTarget
 from control_plane.contracts.engineering_review_decision import EngineeringReviewDecisionRecord
 from control_plane.contracts.engineering_review_run import EngineeringReviewRunRecord
+from control_plane.contracts.merge_admission_record import (
+    MergeAdmissionRecord,
+    MergeLandingOutcomeRecord,
+    build_merge_effect_attempt_id,
+    validate_merge_landing_outcome_for_admission,
+)
 from control_plane.contracts.merge_readiness import (
     MERGE_READINESS_POLICY_DIMENSIONS,
     MergeReadinessAdvisoryObservation,
@@ -27,6 +33,9 @@ from control_plane.contracts.merge_train_batch import (
 from control_plane.contracts.merge_train_controller_state import (
     MergeTrainControllerStateRecord,
     build_merge_train_controller_key,
+)
+from control_plane.contracts.merge_train_structural_provenance import (
+    MergeTrainStructuralCandidateResult,
 )
 from control_plane.contracts.owner_acceptance import (
     OwnerAcceptanceBinding,
@@ -300,6 +309,62 @@ def _evaluate(**updates: object) -> MergeReadinessResult:
     }
     payload.update(updates)
     return evaluate_merge_readiness(**payload)  # type: ignore[arg-type]
+
+
+def _merge_admission(**updates: object) -> MergeAdmissionRecord:
+    readiness = _evaluate()
+    attempt_id = build_merge_effect_attempt_id(
+        controller_key=readiness.fence.evidence.controller_key,
+        lease_owner=readiness.fence.evidence.observed_lease_owner,
+        lease_acquired_at="2026-08-11T03:00:00Z",
+        landing_plan_id="landing-plan-1",
+        pull_request_number=2083,
+        queue_position=2,
+        attempt_sequence=1,
+        expected_effect_sha=CANDIDATE_SHA,
+    )
+    payload: dict[str, object] = {
+        "attempt_id": attempt_id,
+        "attempt_sequence": 1,
+        "source": "test:merge-admission",
+        "repository": REPOSITORY,
+        "base_branch": "main",
+        "pull_request_number": 2083,
+        "queue_position": 2,
+        "batch_id": "batch-1",
+        "candidate_record_id": "candidate-record-1",
+        "landing_plan_record_id": "landing-record-1",
+        "landing_plan_id": "landing-plan-1",
+        "merge_method": "merge",
+        "effective_base_sha": BASE_SHA,
+        "effective_base_tree_sha": OTHER_SHA,
+        "pull_request_head_sha": HEAD_SHA,
+        "pull_request_head_tree_sha": TREE_SHA,
+        "candidate_sha": CANDIDATE_SHA,
+        "candidate_tree_sha": "6" * 40,
+        "expected_effect_sha": CANDIDATE_SHA,
+        "candidate_sha256": POLICY_SHA,
+        "structural_provenance_sha256": EVIDENCE_SHA,
+        "landing_plan_sha256": OTHER_POLICY_SHA,
+        "readiness": readiness,
+        "structural_result": MergeTrainStructuralCandidateResult(
+            status="exact",
+            reason_codes=("structural_single_entry_exact",),
+            effective_base_sha=BASE_SHA,
+            effective_base_tree_sha=OTHER_SHA,
+            candidate_sha256=POLICY_SHA,
+            landing_plan_sha256=OTHER_POLICY_SHA,
+            provenance_sha256=EVIDENCE_SHA,
+        ),
+        "admission_algorithm_version": "merge-admission-v1",
+        "controller_key": readiness.fence.evidence.controller_key,
+        "lease_owner": readiness.fence.evidence.observed_lease_owner,
+        "lease_acquired_at": "2026-08-11T03:00:00Z",
+        "lease_expires_at": readiness.fence.evidence.lease_expires_at,
+        "created_at": "2026-08-11T03:01:00Z",
+    }
+    payload.update(updates)
+    return MergeAdmissionRecord.model_validate(payload)
 
 
 class MergeReadinessScenarioTests(unittest.TestCase):
@@ -812,6 +877,87 @@ class MergeReadinessModelValidationTests(unittest.TestCase):
         payload["unexpected"] = True
         with self.assertRaises(ValidationError):
             MergeReadinessResult.model_validate(payload)
+
+
+class MergeAdmissionRecordTests(unittest.TestCase):
+    def test_ready_evidence_builds_deterministic_admission(self) -> None:
+        first = _merge_admission()
+        second = _merge_admission()
+
+        self.assertEqual(first, second)
+        self.assertTrue(first.admission_id.startswith("merge-admission-"))
+        self.assertEqual(len(first.admission_binding_sha256), 64)
+        self.assertEqual(first.readiness.state, "ready")
+
+    def test_admission_contract_rejects_non_deterministic_attempt_id(self) -> None:
+        admission = _merge_admission()
+        payload = admission.model_dump(mode="json")
+        payload.update(
+            {
+                "admission_id": "",
+                "admission_binding_sha256": "",
+                "attempt_id": "merge-effect-attempt-not-deterministic",
+            }
+        )
+
+        with self.assertRaisesRegex(ValidationError, "deterministic identity"):
+            MergeAdmissionRecord.model_validate(payload)
+
+    def test_non_ready_evidence_cannot_be_admitted(self) -> None:
+        with self.assertRaises(ValidationError):
+            _merge_admission(readiness=_evaluate(technical_checks=_checks(status="pending")))
+
+    def test_landed_outcome_requires_exact_matching_git_evidence(self) -> None:
+        admission = _merge_admission()
+        outcome = MergeLandingOutcomeRecord(
+            admission_id=admission.admission_id,
+            admission_binding_sha256=admission.admission_binding_sha256,
+            attempt_id=admission.attempt_id,
+            observation_sequence=1,
+            source="test:landed",
+            repository=admission.repository,
+            base_branch=admission.base_branch,
+            pull_request_number=admission.pull_request_number,
+            status="landed",
+            reason="provider_and_git_confirmed",
+            provider_effect_attempted=True,
+            observed_pull_request_head_sha=admission.pull_request_head_sha,
+            observed_pull_request_head_tree_sha=admission.pull_request_head_tree_sha,
+            observed_base_sha="7" * 40,
+            observed_base_tree_sha="8" * 40,
+            merge_commit_sha="9" * 40,
+            merge_commit_tree_sha="a" * 40,
+            base_contains_merge_commit=True,
+            exact_landing_confirmed=True,
+            observed_at="2026-08-11T03:02:00Z",
+        )
+
+        validate_merge_landing_outcome_for_admission(
+            admission=admission,
+            outcome=outcome,
+        )
+        self.assertEqual(outcome.status, "landed")
+
+    def test_ambiguous_transport_is_never_rejected(self) -> None:
+        admission = _merge_admission()
+        outcome = MergeLandingOutcomeRecord(
+            admission_id=admission.admission_id,
+            admission_binding_sha256=admission.admission_binding_sha256,
+            attempt_id=admission.attempt_id,
+            observation_sequence=1,
+            source="test:ambiguous",
+            repository=admission.repository,
+            base_branch=admission.base_branch,
+            pull_request_number=admission.pull_request_number,
+            status="reconcile_required",
+            reason="provider_transport_ambiguous",
+            provider_effect_attempted=True,
+            provider_message="connection reset after request send",
+            observed_at="2026-08-11T03:02:00Z",
+        )
+
+        self.assertFalse(outcome.provider_conclusive_rejection)
+        self.assertFalse(outcome.exact_landing_confirmed)
 
     def test_contract_rejects_authority_state_reason_and_digest_forgery(self) -> None:
         result = _evaluate()

--- a/tests/test_merge_train_github.py
+++ b/tests/test_merge_train_github.py
@@ -27,7 +27,65 @@ from control_plane.merge_train_structural_provenance import (
 )
 
 
+class _PermissiveMergeAdmissionGuard:
+    def __init__(self) -> None:
+        self.admit_calls: list[dict[str, object]] = []
+        self.landed_calls: list[dict[str, object]] = []
+        self.reconcile_required_calls: list[dict[str, object]] = []
+
+    def admit(self, **kwargs: object) -> object:
+        self.admit_calls.append(kwargs)
+        return object()
+
+    def record_landed(self, **kwargs: object) -> None:
+        self.landed_calls.append(kwargs)
+
+    def record_provider_failure(self, **_: object) -> None:
+        return None
+
+    def record_reconcile_required(self, **kwargs: object) -> None:
+        self.reconcile_required_calls.append(kwargs)
+
+    def reconcile_existing_landed(self, **_: object) -> None:
+        return None
+
+    def reconcile_existing_no_effect(self, **_: object) -> None:
+        return None
+
+    def update_landing_plan(self, _: MergeTrainBatchLandingPlan) -> None:
+        return None
+
+
 class GitHubMergeTrainClientTests(unittest.TestCase):
+    def setUp(self) -> None:
+        original = GitHubMergeTrainClient.land_batch_candidate
+
+        def guarded_land_batch_candidate(
+            client: GitHubMergeTrainClient,
+            *,
+            landing_plan: MergeTrainBatchLandingPlan,
+            admission_guard: object | None = None,
+            recorded_at: str = "",
+            checkpoint: object | None = None,
+        ) -> MergeTrainBatchLandingPlan:
+            return original(
+                client,
+                landing_plan=landing_plan,
+                admission_guard=(
+                    admission_guard or _PermissiveMergeAdmissionGuard()  # type: ignore[arg-type]
+                ),
+                recorded_at=recorded_at or "2026-08-11T00:00:00Z",
+                checkpoint=checkpoint,  # type: ignore[arg-type]
+            )
+
+        patcher = patch.object(
+            GitHubMergeTrainClient,
+            "land_batch_candidate",
+            new=guarded_land_batch_candidate,
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
     def test_add_pull_request_label_uses_issue_labels_endpoint(self) -> None:
         transport = RecordingMergeTrainGitHubTransport()
         client = GitHubMergeTrainClient(transport=transport)
@@ -793,23 +851,9 @@ class GitHubMergeTrainClientTests(unittest.TestCase):
         transport = RecordingMergeTrainGitHubTransport(
             responses=(
                 _github_branch(sha="base-main"),
-                _git_commit("head-1", "tree-head-1"),
-                _landing_pull_request(1, base_sha="base-main"),
-                {"sha": "merge-sha-1"},
-                _git_commit(
-                    "merge-sha-1",
-                    "tree-candidate-1",
-                    parents=("base-main", "head-1"),
-                ),
+                *_normal_landing_responses(1, "base-main", "merge-sha-1"),
                 _github_branch(sha="merge-sha-1"),
-                _git_commit("head-2", "tree-head-2"),
-                _landing_pull_request(2, base_sha="merge-sha-1"),
-                {"sha": "merge-sha-2"},
-                _git_commit(
-                    "merge-sha-2",
-                    "tree-candidate-2",
-                    parents=("merge-sha-1", "head-2"),
-                ),
+                *_normal_landing_responses(2, "merge-sha-1", "merge-sha-2"),
                 _github_branch(sha="merge-sha-2"),
             )
         )
@@ -843,6 +887,7 @@ class GitHubMergeTrainClientTests(unittest.TestCase):
                 ),
                 ("GET", "/repos/example/merge-train-repo/git/commits/merge-sha-1", None),
                 ("GET", "/repos/example/merge-train-repo/branches/main", None),
+                ("GET", "/repos/example/merge-train-repo/branches/main", None),
                 ("GET", "/repos/example/merge-train-repo/git/commits/head-2", None),
                 ("GET", "/repos/example/merge-train-repo/pulls/2", None),
                 (
@@ -851,6 +896,7 @@ class GitHubMergeTrainClientTests(unittest.TestCase):
                     {"sha": "head-2", "merge_method": "merge"},
                 ),
                 ("GET", "/repos/example/merge-train-repo/git/commits/merge-sha-2", None),
+                ("GET", "/repos/example/merge-train-repo/branches/main", None),
                 ("GET", "/repos/example/merge-train-repo/branches/main", None),
             ],
         )
@@ -903,6 +949,45 @@ class GitHubMergeTrainClientTests(unittest.TestCase):
             "/pulls/1/merge",
             "\n".join(request.path for request in transport.requests),
         )
+
+    def test_failed_no_op_recovery_does_not_persist_admission(self) -> None:
+        landing_plan = _landing_plan()
+        first = type(landing_plan.entries[0]).model_validate(
+            {
+                **landing_plan.entries[0].model_dump(mode="python"),
+                "recorded_candidate_parent_sha": "base-main",
+                "recorded_candidate_parent_tree_sha": "tree-base",
+                "recorded_candidate_result_sha": "base-main",
+                "recorded_candidate_result_tree_sha": "tree-base",
+            }
+        )
+        landing_plan = MergeTrainBatchLandingPlan.model_validate(
+            {
+                **landing_plan.model_dump(mode="python"),
+                "entries": (first, landing_plan.entries[1]),
+                "landing_plan_sha256": "",
+            }
+        )
+        guard = _PermissiveMergeAdmissionGuard()
+        client = GitHubMergeTrainClient(
+            transport=RecordingMergeTrainGitHubTransport(
+                responses=(_github_branch(sha="base-main"),)
+            )
+        )
+
+        with patch.object(
+            client,
+            "_recover_no_op_landing_entry",
+            side_effect=MergeTrainGitHubStaleHeadError("no-op evidence drifted"),
+        ):
+            with self.assertRaises(MergeTrainGitHubStaleHeadError):
+                client.land_batch_candidate(
+                    landing_plan=landing_plan,
+                    admission_guard=guard,
+                    recorded_at="2026-08-11T03:01:00Z",
+                )
+
+        self.assertEqual(guard.admit_calls, [])
 
     def test_land_batch_candidate_recovers_planned_no_op_after_later_merge(self) -> None:
         landing_plan = _landing_plan()
@@ -1112,23 +1197,9 @@ class GitHubMergeTrainClientTests(unittest.TestCase):
         transport = RecordingMergeTrainGitHubTransport(
             responses=(
                 _github_branch(sha="base-main"),
-                _git_commit("head-1", "tree-head-1"),
-                _landing_pull_request(1, base_sha="base-main"),
-                {"sha": "merge-sha-1"},
-                _git_commit(
-                    "merge-sha-1",
-                    "tree-candidate-1",
-                    parents=("base-main", "head-1"),
-                ),
+                *_normal_landing_responses(1, "base-main", "merge-sha-1"),
                 _github_branch(sha="merge-sha-1"),
-                _git_commit("head-2", "tree-head-2"),
-                _landing_pull_request(2, base_sha="merge-sha-1"),
-                {"sha": "merge-sha-2"},
-                _git_commit(
-                    "merge-sha-2",
-                    "tree-candidate-2",
-                    parents=("merge-sha-1", "head-2"),
-                ),
+                *_normal_landing_responses(2, "merge-sha-1", "merge-sha-2"),
                 _github_branch(sha="later-base-sha"),
                 {"status": "ahead"},
             )
@@ -1144,8 +1215,16 @@ class GitHubMergeTrainClientTests(unittest.TestCase):
             "/repos/example/merge-train-repo/compare/merge-sha-2...main",
         )
 
-    def test_land_batch_candidate_rejects_divergence_after_final_merge(self) -> None:
-        landing_plan = _landing_plan()
+    def test_landed_outcome_uses_actual_base_identity_and_containment_proof(self) -> None:
+        original_plan = _landing_plan()
+        landing_plan = MergeTrainBatchLandingPlan.model_validate(
+            {
+                **original_plan.model_dump(mode="python"),
+                "entries": (original_plan.entries[0],),
+                "landing_plan_sha256": "",
+            }
+        )
+        guard = _PermissiveMergeAdmissionGuard()
         transport = RecordingMergeTrainGitHubTransport(
             responses=(
                 _github_branch(sha="base-main"),
@@ -1157,15 +1236,73 @@ class GitHubMergeTrainClientTests(unittest.TestCase):
                     "tree-candidate-1",
                     parents=("base-main", "head-1"),
                 ),
-                _github_branch(sha="merge-sha-1"),
-                _git_commit("head-2", "tree-head-2"),
-                _landing_pull_request(2, base_sha="merge-sha-1"),
-                {"sha": "merge-sha-2"},
+                _github_branch(sha="later-base-sha"),
+                {"status": "ahead"},
+                _github_branch(sha="later-base-sha"),
+                {"status": "ahead"},
+            )
+        )
+
+        GitHubMergeTrainClient(transport=transport).land_batch_candidate(
+            landing_plan=landing_plan,
+            admission_guard=guard,  # type: ignore[arg-type]
+            recorded_at="2026-08-11T03:01:00Z",
+        )
+
+        self.assertEqual(len(guard.landed_calls), 1)
+        landed_call = guard.landed_calls[0]
+        self.assertEqual(landed_call["observed_base_sha"], "later-base-sha")
+        self.assertEqual(landed_call["observed_base_tree_sha"], "tree-later-base-sha")
+        self.assertIs(landed_call["base_contains_merge_commit"], True)
+
+    def test_missing_post_merge_containment_requires_reconciliation(self) -> None:
+        original_plan = _landing_plan()
+        landing_plan = MergeTrainBatchLandingPlan.model_validate(
+            {
+                **original_plan.model_dump(mode="python"),
+                "entries": (original_plan.entries[0],),
+                "landing_plan_sha256": "",
+            }
+        )
+        guard = _PermissiveMergeAdmissionGuard()
+        transport = RecordingMergeTrainGitHubTransport(
+            responses=(
+                _github_branch(sha="base-main"),
+                _git_commit("head-1", "tree-head-1"),
+                _landing_pull_request(1, base_sha="base-main"),
+                {"sha": "merge-sha-1"},
                 _git_commit(
-                    "merge-sha-2",
-                    "tree-candidate-2",
-                    parents=("merge-sha-1", "head-2"),
+                    "merge-sha-1",
+                    "tree-candidate-1",
+                    parents=("base-main", "head-1"),
                 ),
+                _github_branch(sha="rewritten-base-sha"),
+                {"status": "diverged"},
+            )
+        )
+
+        with self.assertRaisesRegex(MergeTrainGitHubStaleHeadError, "does not contain"):
+            GitHubMergeTrainClient(transport=transport).land_batch_candidate(
+                landing_plan=landing_plan,
+                admission_guard=guard,  # type: ignore[arg-type]
+                recorded_at="2026-08-11T03:01:00Z",
+            )
+
+        self.assertEqual(guard.landed_calls, [])
+        self.assertEqual(len(guard.reconcile_required_calls), 1)
+        self.assertEqual(
+            guard.reconcile_required_calls[0]["reason"],
+            "landing_evidence_contradicted",
+        )
+
+    def test_land_batch_candidate_rejects_divergence_after_final_merge(self) -> None:
+        landing_plan = _landing_plan()
+        transport = RecordingMergeTrainGitHubTransport(
+            responses=(
+                _github_branch(sha="base-main"),
+                *_normal_landing_responses(1, "base-main", "merge-sha-1"),
+                _github_branch(sha="merge-sha-1"),
+                *_normal_landing_responses(2, "merge-sha-1", "merge-sha-2"),
                 _github_branch(sha="rewritten-base-sha"),
                 {"status": "diverged"},
             )
@@ -1258,6 +1395,7 @@ class GitHubMergeTrainClientTests(unittest.TestCase):
                     "tree-candidate-2",
                     parents=("merge-sha-1", "head-2"),
                 ),
+                _github_branch(sha="merge-sha-2"),
                 _github_branch(sha="merge-sha-2"),
             )
         )
@@ -1496,7 +1634,7 @@ class GitHubMergeTrainClientTests(unittest.TestCase):
 
         self.assertEqual(
             [request.method for request in transport.requests],
-            ["GET", "GET", "GET", "PUT", "GET", "GET", "GET"],
+            ["GET", "GET", "GET", "PUT", "GET", "GET", "GET", "GET"],
         )
         self.assertNotIn("DELETE", [request.method for request in transport.requests])
 
@@ -1864,6 +2002,7 @@ def _normal_landing_responses(number: int, parent_sha: str, merge_sha: str) -> t
             f"tree-candidate-{number}",
             parents=(parent_sha, f"head-{number}"),
         ),
+        _github_branch(sha=merge_sha),
     )
 
 

--- a/tests/test_merge_train_github.py
+++ b/tests/test_merge_train_github.py
@@ -983,7 +983,7 @@ class GitHubMergeTrainClientTests(unittest.TestCase):
             with self.assertRaises(MergeTrainGitHubStaleHeadError):
                 client.land_batch_candidate(
                     landing_plan=landing_plan,
-                    admission_guard=guard,
+                    admission_guard=guard,  # type: ignore[arg-type]
                     recorded_at="2026-08-11T03:01:00Z",
                 )
 

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -8008,6 +8008,8 @@ env_var = "GH_TOKEN"
                     "odoo_prod_backup_restore_operations": 0,
                     "odoo_prod_retained_volume_backup_import_operations": 0,
                     "merge_train_batch_landing_plans": 1,
+                    "merge_admissions": 0,
+                    "merge_landing_outcomes": 0,
                     "merge_train_stack_collapse_plans": 1,
                     "merge_train_policies": 1,
                     "merge_train_runs": 1,

--- a/tests/test_schema_migration.py
+++ b/tests/test_schema_migration.py
@@ -1293,7 +1293,36 @@ class SchemaMigrationTests(unittest.TestCase):
             for primary_key in CRITICAL_PRIMARY_KEYS
         }
 
-        self.assertEqual(EXPECTED_ALEMBIC_HEAD_REVISION, "d8a0c2e4f6b8")
+        self.assertEqual(EXPECTED_ALEMBIC_HEAD_REVISION, "e9b1d3f5a7c0")
+        self.assertEqual(
+            column_types[("launchplane_merge_admissions", "payload")],
+            ("jsonb",),
+        )
+        self.assertEqual(
+            column_types[("launchplane_merge_landing_outcomes", "payload")],
+            ("jsonb",),
+        )
+        self.assertTrue(
+            indexes[
+                (
+                    "launchplane_merge_admissions",
+                    "launchplane_merge_admissions_attempt_uidx",
+                )
+            ].unique
+        )
+        self.assertTrue(
+            indexes[
+                (
+                    "launchplane_merge_landing_outcomes",
+                    "launchplane_merge_landing_outcomes_observation_uidx",
+                )
+            ].unique
+        )
+        self.assertEqual(primary_keys["launchplane_merge_admissions"], ("admission_id",))
+        self.assertEqual(
+            primary_keys["launchplane_merge_landing_outcomes"],
+            ("outcome_id",),
+        )
         self.assertEqual(
             column_types[("launchplane_detached_application_retirements", "payload")],
             ("jsonb",),


### PR DESCRIPTION
## Summary
- persist immutable per-attempt Level 3 merge admissions before provider effects
- append truthful landed, rejected, or reconcile-required outcomes with exact Git evidence
- revalidate live queue, policy, Owner, checks, structural provenance, lease, SHA, and rolling-base evidence for every batch entry
- route controller and direct batch landing through the same guarded boundary
- add filesystem/Postgres storage, Alembic migration, reconciliation, tests, and operating docs

## Validation
- 2,890 unittest targets across 12 shards passed
- focused merge-admission and landing tests passed
- Ruff check passed
- Mypy passed for 716 source files
- changed-file Ruff format check passed
- frontend validate and browser suites passed
- config-authority audit passed
- independent review findings resolved, including stale-lease races, live queue/policy drift, plan lineage, exact containment proof, no-effect truthfulness, deterministic attempts, outcome sequencing, and failed no-op recovery

Refs #2085