### PR TITLE
chore: prepare Python worktrees for IDE inspection

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -72,6 +72,16 @@
     "inspection": {
       "tool": "jetbrains",
       "ide": "PyCharm",
+      "prepare": {
+        "python": {
+          "version": "3.13",
+          "moduleName": "launchplane",
+          "testRoots": ["tests"],
+          "sync": true,
+          "extras": ["dev"],
+          "requiredGeneratedState": [".venv", ".idea"]
+        }
+      },
       "scopePreference": ["changed_files", "directory", "whole_project"]
     },
     "docsRequiredWhen": [


### PR DESCRIPTION
## Summary
- configure structured JetBrains Python worktree preparation
- create a Python 3.13 `.venv` and minimal `.idea` model per linked worktree
- install the `dev` extra using locked `uv sync`
- require `.venv` and `.idea` before inspection begins or a receipt is reused

## Dependency
- requires merged `cbusillo/codex-skills#535`
- the active runtime skills checkout has been reconciled to its merge commit `0c870e01fdd9dfcdb5dfcb998598decbf9e02756`

## Validation
- landed helper created/reused the Launchplane SDK and project model
- locked dependency sync succeeded
- preparation produced zero tracked or untracked Git mutations
- the prior `language_sdk_missing` failure is resolved
- the remaining local PyCharm issue is independently classified as `already_opening_stuck` with an explicit IDE-session recovery action