### PR TITLE
fix: avoid PyCharm module name collision

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -75,7 +75,7 @@
       "prepare": {
         "python": {
           "version": "3.13",
-          "moduleName": "launchplane",
+          "moduleName": "launchplane-inspection",
           "testRoots": ["tests"],
           "sync": true,
           "extras": ["dev"],


### PR DESCRIPTION
## Summary
- use a collision-free generated inspection module name
- prevent PyCharm's `pyproject.toml` importer from replacing the SDK-bound project module

## Restart smoke evidence
- fresh PyCharm session opened the exact worktree successfully
- Python 3.13 SDK and locked dev dependencies prepared with zero Git mutations
- generated `launchplane-inspection.iml` retained the `.venv` SDK and `tests` source root after PyCharm import
- the remaining `extractor_failure` occurs after inspection execution and is a separate inspection-plugin defect, not an SDK/module configuration failure