### PR TITLE
Add bounded product lane context repair

### DIFF
--- a/.github/workflows/product-context-cutover.yml
+++ b/.github/workflows/product-context-cutover.yml
@@ -4,25 +4,48 @@ name: Product Context Cutover
 "on":
   workflow_dispatch:
     inputs:
+      operation:
+        description: Context migration operation to run.
+        required: true
+        default: context-cutover
+        type: choice
+        options:
+          - context-cutover
+          - lane-context-repair
       product:
-        description: Product profile key to cut over.
+        description: Product profile key to operate on.
         required: true
         type: string
       source_context:
-        description: Legacy context to copy current-authority records from.
+        description: Legacy context expected on the source lane.
         required: true
         type: string
       target_context:
-        description: >-
-          Canonical product context to copy current-authority records to.
+        description: Canonical product context.
         required: true
         type: string
       display_name:
-        description: Product display name to write with the profile cutover.
-        required: true
+        description: Product display name required for context-cutover.
+        required: false
+        type: string
+      instance:
+        description: Lane instance required for lane-context-repair.
+        required: false
+        type: string
+      expected_profile_sha256:
+        description: Reviewed profile digest required for lane repair apply.
+        required: false
+        type: string
+      reviewed_plan_sha256:
+        description: Dry-run plan digest required for lane repair apply.
+        required: false
+        type: string
+      reason:
+        description: Operator reason required for lane-context-repair.
+        required: false
         type: string
       dry_run:
-        description: Plan only when true; write records and profile when false.
+        description: Plan only when true; write profile authority when false.
         required: true
         default: true
         type: boolean
@@ -36,17 +59,23 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  cutover:
+  context-operation:
     runs-on: ubuntu-latest
+    environment: launchplane-authz-admin
     env:
       LAUNCHPLANE_URL: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}
+      OPERATION: ${{ inputs.operation }}
       PRODUCT: ${{ inputs.product }}
       SOURCE_CONTEXT: ${{ inputs.source_context }}
       TARGET_CONTEXT: ${{ inputs.target_context }}
       DISPLAY_NAME: ${{ inputs.display_name }}
+      INSTANCE: ${{ inputs.instance }}
+      EXPECTED_PROFILE_SHA256: ${{ inputs.expected_profile_sha256 }}
+      REVIEWED_PLAN_SHA256: ${{ inputs.reviewed_plan_sha256 }}
+      REASON: ${{ inputs.reason }}
       DRY_RUN: ${{ inputs.dry_run }}
     steps:
-      - name: Request product context cutover
+      - name: Build context operation request
         id: request
         shell: bash
         run: |
@@ -55,78 +84,134 @@ jobs:
           : "${PRODUCT:?Missing product input}"
           : "${SOURCE_CONTEXT:?Missing source_context input}"
           : "${TARGET_CONTEXT:?Missing target_context input}"
-          : "${DISPLAY_NAME:?Missing display_name input}"
 
           mode="apply"
           if [ "$DRY_RUN" = "true" ]; then
             mode="dry-run"
           fi
 
-          jq -n \
-            --arg product "$PRODUCT" \
-            --arg source_context "$SOURCE_CONTEXT" \
-            --arg target_context "$TARGET_CONTEXT" \
-            --arg display_name "$DISPLAY_NAME" \
-            --arg mode "$mode" \
-            '{
-              product: $product,
-              source_context: $source_context,
-              target_context: $target_context,
-              display_name: $display_name,
-              mode: $mode,
-              source_label: "workflow:product-context-cutover"
-            }' > launchplane-product-context-cutover-payload.json
-          idempotency_key="product-context-cutover:${PRODUCT}:${SOURCE_CONTEXT}:${TARGET_CONTEXT}:${mode}:${GITHUB_RUN_ID}"
-          printf 'idempotency_key=%s\n' "$idempotency_key" >> "$GITHUB_OUTPUT"
+          case "$OPERATION" in
+            context-cutover)
+              : "${DISPLAY_NAME:?Missing display_name input for context-cutover}"
+              route_path="/v1/product-profiles/context-cutover/apply"
+              jq -n \
+                --arg product "$PRODUCT" \
+                --arg source_context "$SOURCE_CONTEXT" \
+                --arg target_context "$TARGET_CONTEXT" \
+                --arg display_name "$DISPLAY_NAME" \
+                --arg mode "$mode" \
+                '{
+                  product: $product,
+                  source_context: $source_context,
+                  target_context: $target_context,
+                  display_name: $display_name,
+                  mode: $mode,
+                  source_label: "workflow:product-context-cutover"
+                }' > launchplane-product-context-operation-payload.json
+              ;;
+            lane-context-repair)
+              : "${INSTANCE:?Missing instance input for lane-context-repair}"
+              : "${REASON:?Missing reason input for lane-context-repair}"
+              if [ "$mode" = "dry-run" ] && [ -n "$REVIEWED_PLAN_SHA256" ]; then
+                echo "Dry-run lane repair rejects reviewed_plan_sha256." >&2
+                exit 1
+              fi
+              if [ "$mode" = "apply" ]; then
+                : "${EXPECTED_PROFILE_SHA256:?Missing expected_profile_sha256 for lane repair apply}"
+                : "${REVIEWED_PLAN_SHA256:?Missing reviewed_plan_sha256 for lane repair apply}"
+              fi
+              route_path="/v1/product-profiles/lane-context-repair/apply"
+              jq -n \
+                --arg product "$PRODUCT" \
+                --arg instance "$INSTANCE" \
+                --arg expected_current_context "$SOURCE_CONTEXT" \
+                --arg requested_context "$TARGET_CONTEXT" \
+                --arg expected_profile_sha256 "$EXPECTED_PROFILE_SHA256" \
+                --arg reviewed_plan_sha256 "$REVIEWED_PLAN_SHA256" \
+                --arg reason "$REASON" \
+                --arg mode "$mode" \
+                '{
+                  schema_version: 1,
+                  product: $product,
+                  instance: $instance,
+                  expected_current_context: $expected_current_context,
+                  requested_context: $requested_context,
+                  expected_profile_sha256: $expected_profile_sha256,
+                  mode: $mode,
+                  reason: $reason,
+                  reviewed_plan_sha256: $reviewed_plan_sha256
+                }' > launchplane-product-context-operation-payload.json
+              ;;
+            *)
+              echo "Unsupported context operation: ${OPERATION}" >&2
+              exit 1
+              ;;
+          esac
 
-      - name: Request Launchplane product context cutover
-        id: cutover_request
+          idempotency_key="product-context-operation:${OPERATION}:${PRODUCT}:${SOURCE_CONTEXT}:${TARGET_CONTEXT}:${INSTANCE}:${mode}:${GITHUB_RUN_ID}"
+          printf 'idempotency_key=%s\n' "$idempotency_key" >> "$GITHUB_OUTPUT"
+          printf 'route_path=%s\n' "$route_path" >> "$GITHUB_OUTPUT"
+
+      - name: Request Launchplane context operation
+        id: context_request
         uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
         with:
           launchplane-url: ${{ env.LAUNCHPLANE_URL }}
-          route-path: /v1/product-profiles/context-cutover/apply
-          payload-file: launchplane-product-context-cutover-payload.json
+          route-path: ${{ steps.request.outputs.route_path }}
+          payload-file: launchplane-product-context-operation-payload.json
           idempotency-key: ${{ steps.request.outputs.idempotency_key }}
-          response-output-file: launchplane-product-context-cutover.json
+          response-output-file: launchplane-product-context-operation.json
 
-      - name: Check cutover response
+      - name: Check context operation response
         shell: bash
         env:
-          CUTOVER_STATUS_CODE: ${{ steps.cutover_request.outputs.status-code }}
+          CONTEXT_STATUS_CODE: ${{ steps.context_request.outputs.status-code }}
         run: |
           set -euo pipefail
-          response_file="launchplane-product-context-cutover.json"
-          if [ "$CUTOVER_STATUS_CODE" != "202" ]; then
+          response_file="launchplane-product-context-operation.json"
+          if [ "$CONTEXT_STATUS_CODE" != "202" ]; then
             cat "$response_file" >&2
-            echo "Launchplane product context cutover failed with HTTP ${CUTOVER_STATUS_CODE}." >&2
+            echo "Launchplane context operation failed with HTTP ${CONTEXT_STATUS_CODE}." >&2
             exit 1
           fi
           jq . "$response_file"
 
-      - name: Upload cutover artifact
+      - name: Upload context operation artifact
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: launchplane-product-context-cutover-${{ inputs.product }}
-          path: launchplane-product-context-cutover.json
+          name: launchplane-product-context-operation-${{ inputs.product }}
+          path: launchplane-product-context-operation.json
           if-no-files-found: error
 
-      - name: Summarize cutover
+      - name: Summarize context operation
         shell: bash
         run: |
           set -euo pipefail
+          result_file="launchplane-product-context-operation.json"
           {
-            echo '## Launchplane product context cutover'
+            echo '## Launchplane product context operation'
             echo
+            echo "- Operation: ${OPERATION}"
             echo "- Product: ${PRODUCT}"
             echo "- Source context: ${SOURCE_CONTEXT}"
             echo "- Target context: ${TARGET_CONTEXT}"
+            echo "- Instance: ${INSTANCE:-n/a}"
             echo "- Dry run: ${DRY_RUN}"
-            echo "- Display name: ${DISPLAY_NAME}"
-            echo "- Runtime records: $(jq -c '.result.counts.runtime_environment_records' launchplane-product-context-cutover.json)"
-            echo "- Managed secrets: $(jq -c '.result.counts.managed_secret_records' launchplane-product-context-cutover.json)"
-            echo "- Provider targets: $(jq -c '.result.counts.provider_targets' launchplane-product-context-cutover.json)"
-            echo "- Provider target IDs: $(jq -c '.result.counts.provider_target_ids' launchplane-product-context-cutover.json)"
-            echo "- Inventory records: $(jq -c '.result.counts.inventory_records' launchplane-product-context-cutover.json)"
-            echo "- Release tuples: $(jq -c '.result.counts.release_tuple_records' launchplane-product-context-cutover.json)"
+            if [ "$OPERATION" = "lane-context-repair" ]; then
+              echo "- Profile digest: $(jq -r '.result.profile_sha256_before' "$result_file")"
+              echo "- Plan digest: $(jq -r '.result.plan_sha256' "$result_file")"
+              echo "- Physical target match: $(jq -r '.result.same_physical_target' "$result_file")"
+              echo "- Source target digest: $(jq -r '.result.source_target.record_sha256' "$result_file")"
+              echo "- Target target digest: $(jq -r '.result.target_target.record_sha256' "$result_file")"
+              echo "- Preview context: $(jq -r '.result.preserved_preview_context' "$result_file")"
+            else
+              echo "- Display name: ${DISPLAY_NAME}"
+              echo "- Runtime records: $(jq -c '.result.counts.runtime_environment_records' "$result_file")"
+              echo "- Managed secrets: $(jq -c '.result.counts.managed_secret_records' "$result_file")"
+              echo "- Provider targets: $(jq -c '.result.counts.provider_targets' "$result_file")"
+              echo "- Provider target IDs: $(jq -c '.result.counts.provider_target_ids' "$result_file")"
+              echo "- Inventory records: $(jq -c '.result.counts.inventory_records' "$result_file")"
+              echo "- Release tuples: $(jq -c '.result.counts.release_tuple_records' "$result_file")"
+            fi
           } >> "$GITHUB_STEP_SUMMARY"

--- a/control_plane/config_authority_audit.py
+++ b/control_plane/config_authority_audit.py
@@ -333,6 +333,7 @@ WORKFLOW_INPUT_MECHANIC_DEFAULT_PATH_VALUES = {
     },
     ".github/workflows/product-context-cutover.yml": {
         "inputs.dry_run.default": frozenset(("true",)),
+        "inputs.operation.default": frozenset(("context-cutover",)),
     },
     ".github/workflows/product-environment-evidence.yml": {
         "inputs.routes_json.default": frozenset(("[]",)),
@@ -691,6 +692,11 @@ WORKFLOW_OPERATOR_INPUT_REFERENCE_PATH_VALUES = {
         "REQUESTED_BASE_BRANCH": frozenset(("${{ inputs.base_branch }}",)),
     },
     ".github/workflows/product-context-cutover.yml": {
+        "EXPECTED_PROFILE_SHA256": frozenset(("${{ inputs.expected_profile_sha256 }}",)),
+        "INSTANCE": frozenset(("${{ inputs.instance }}",)),
+        "OPERATION": frozenset(("${{ inputs.operation }}",)),
+        "REASON": frozenset(("${{ inputs.reason }}",)),
+        "REVIEWED_PLAN_SHA256": frozenset(("${{ inputs.reviewed_plan_sha256 }}",)),
         "SOURCE_CONTEXT": frozenset(("${{ inputs.source_context }}",)),
         "TARGET_CONTEXT": frozenset(("${{ inputs.target_context }}",)),
     },
@@ -1094,7 +1100,8 @@ WORKFLOW_THIN_CONNECTOR_PATH_VALUES = {
     },
     ".github/workflows/product-context-cutover.yml": {
         "idempotency-key": frozenset(("${{ steps.request.outputs.idempotency_key }}",)),
-        "payload-file": frozenset(("launchplane-product-context-cutover-payload.json",)),
+        "payload-file": frozenset(("launchplane-product-context-operation-payload.json",)),
+        "route-path": frozenset(("${{ steps.request.outputs.route_path }}",)),
     },
     ".github/workflows/product-legacy-context-cleanup.yml": {
         "idempotency-key": frozenset(("${{ steps.request.outputs.idempotency_key }}",)),

--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -37,6 +37,9 @@ from control_plane import product_config as control_plane_product_config
 from control_plane import product_config_service as control_plane_product_config_service
 from control_plane import product_context_cutover as control_plane_product_context_cutover
 from control_plane import product_health_monitoring as control_plane_product_health_monitoring
+from control_plane import (
+    product_lane_context_repair as control_plane_product_lane_context_repair,
+)
 from control_plane import product_onboarding_service as control_plane_product_onboarding_service
 from control_plane.generic_web_onboarding import (
     GenericWebOnboardingIntent,
@@ -576,6 +579,7 @@ from control_plane.contracts.product_profile_record import (
     ProductLaneProfile,
     ProductRuntimeConfigRequirement,
     ProductSecretConfigRequirement,
+    product_profile_record_sha256,
     validate_product_profile_history_transition,
 )
 from control_plane.contracts.product_retirement import (
@@ -977,6 +981,7 @@ _PRODUCT_PREVIEW_TLS_APPLY_ROUTE = "/v1/product-profiles/preview-tls/apply"
 _PRODUCT_RETIREMENT_ROUTE = "/v1/product-retirement"
 _DETACHED_APPLICATION_RETIREMENT_ROUTE = "/v1/detached-application-retirement"
 _PRODUCT_CONTEXT_CUTOVER_APPLY_ROUTE = "/v1/product-profiles/context-cutover/apply"
+_PRODUCT_LANE_CONTEXT_REPAIR_APPLY_ROUTE = "/v1/product-profiles/lane-context-repair/apply"
 _PRODUCT_LEGACY_CONTEXT_CLEANUP_APPLY_ROUTE = "/v1/product-profiles/legacy-context-cleanup/apply"
 _PRODUCT_ONBOARDING_APPLY_ROUTE = "/v1/product-onboarding/apply"
 _MERGE_TRAIN_POLICY_IMPORT_ROUTE = "/v1/merge-train/policies/import"
@@ -14480,6 +14485,261 @@ def create_launchplane_fastapi_app(
             )
         return response
 
+    async def apply_product_lane_context_repair(
+        request: Request,
+        identity: Annotated[LaunchplaneIdentity, Depends(read_write_identity)],
+        record_store: Annotated[object, Depends(get_record_store)],
+        idempotency_key: Annotated[str, Header(alias="Idempotency-Key")] = "",
+    ) -> AcceptedEvidenceResponse:
+        trace_id = next_trace_id()
+        try:
+            raw_payload = await request.json()
+        except ValueError as error:
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_request",
+                message="Product lane context repair request failed validation.",
+            ) from error
+        if not isinstance(raw_payload, dict):
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_request",
+                message="Product lane context repair request failed validation.",
+            )
+        try:
+            repair_request = control_plane_product_lane_context_repair.ProductLaneContextRepairRequest.model_validate(
+                raw_payload
+            )
+        except ValidationError as error:
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_request",
+                message="Product lane context repair request failed validation.",
+            ) from error
+        if not resolved_authz_policy_runtime.policy.allows(
+            identity=identity,
+            action="product_profile.write",
+            product=repair_request.product,
+            context=_LAUNCHPLANE_SERVICE_CONTEXT,
+        ):
+            raise _launchplane_http_error(
+                status_code=403,
+                trace_id=trace_id,
+                code="authorization_denied",
+                message="Workflow cannot repair the requested product lane context.",
+            )
+        normalized_idempotency_key = idempotency_key.strip()
+        if repair_request.mode == "apply" and not normalized_idempotency_key:
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="idempotency_key_required",
+                message="Product lane context repair apply requires an Idempotency-Key header.",
+            )
+        database_store = require_product_context_apply_database_store(
+            record_store=record_store,
+            trace_id=trace_id,
+            label="Product lane context repair",
+        )
+        payload_fingerprint = ""
+
+        def prepare_product_lane_context_repair_mutation() -> AcceptedEvidenceResponse | None:
+            preflight = database_store.prepare_db_only_mutation(
+                scope=idempotency_scope(identity),
+                route_path=_PRODUCT_LANE_CONTEXT_REPAIR_APPLY_ROUTE,
+                idempotency_key=normalized_idempotency_key,
+                request_fingerprint=payload_fingerprint,
+            )
+            if preflight.status in {"missing", "released"}:
+                return None
+            if preflight.record is None:
+                raise RuntimeError(
+                    "Product lane context repair mutation preflight requires evidence."
+                )
+            if preflight.status == "replayed":
+                return replay_idempotent_response(
+                    trace_id=trace_id,
+                    stored_record=preflight.record,
+                    route_path=_PRODUCT_LANE_CONTEXT_REPAIR_APPLY_ROUTE,
+                )
+            if preflight.status == "conflict":
+                raise _launchplane_http_error(
+                    status_code=409,
+                    trace_id=trace_id,
+                    code="idempotency_key_reused",
+                    message=(
+                        "Idempotency-Key was already used for a different Launchplane request "
+                        "payload on this route."
+                    ),
+                )
+            if preflight.status == "in_progress":
+                raise _launchplane_http_error(
+                    status_code=409,
+                    trace_id=trace_id,
+                    code="mutation_in_progress",
+                    message=(
+                        "A matching product lane context repair is already running. Retry with "
+                        "the same Idempotency-Key."
+                    ),
+                )
+            if preflight.status == "reconcile_required":
+                raise _launchplane_http_error(
+                    status_code=409,
+                    trace_id=trace_id,
+                    code="mutation_reconciliation_required",
+                    message=(
+                        "The product lane context repair requires reconciliation before retry."
+                    ),
+                )
+            raise RuntimeError(
+                "Unsupported product lane context repair mutation preflight status: "
+                f"{preflight.status}"
+            )
+
+        if repair_request.mode == "apply":
+            payload_fingerprint = idempotency_request_fingerprint(
+                route_path=_PRODUCT_LANE_CONTEXT_REPAIR_APPLY_ROUTE,
+                payload=cast(dict[str, object], raw_payload),
+            )
+            replay_response = prepare_product_lane_context_repair_mutation()
+            if replay_response is not None:
+                return replay_response
+        try:
+            plan, profile, replacement_profile, source_target, target_target = (
+                control_plane_product_lane_context_repair.build_product_lane_context_repair_plan(
+                    record_store=database_store,
+                    request=repair_request,
+                )
+            )
+        except FileNotFoundError as error:
+            raise _launchplane_http_error(
+                status_code=404,
+                trace_id=trace_id,
+                code="not_found",
+                message=str(error),
+            ) from error
+        except (
+            control_plane_product_lane_context_repair.ProductLaneContextRepairBoundaryError
+        ) as error:
+            raise _launchplane_http_error(
+                status_code=409,
+                trace_id=trace_id,
+                code="lane_context_repair_blocked",
+                message=str(error),
+            ) from error
+        except (ValueError, ValidationError) as error:
+            raise _launchplane_http_error(
+                status_code=409,
+                trace_id=trace_id,
+                code="lane_context_repair_blocked",
+                message="Product lane context repair cannot produce a valid profile transition.",
+            ) from error
+        if (
+            repair_request.mode == "apply"
+            and repair_request.reviewed_plan_sha256 != plan.plan_sha256
+        ):
+            replay_response = prepare_product_lane_context_repair_mutation()
+            if replay_response is not None:
+                return replay_response
+            raise _launchplane_http_error(
+                status_code=409,
+                trace_id=trace_id,
+                code="stale",
+                message="Reviewed product lane context repair plan no longer matches authority.",
+            )
+        if repair_request.mode == "dry-run":
+            return accepted_evidence_response(
+                trace_id=trace_id,
+                records={
+                    "product_profile": repair_request.product,
+                    "context": repair_request.expected_current_context,
+                    "instance": repair_request.instance,
+                },
+                result=plan.model_dump(mode="json"),
+            )
+        updated_profile = (
+            control_plane_product_lane_context_repair.updated_product_lane_context_repair_profile(
+                replacement_profile=replacement_profile,
+                updated_at=utc_now_timestamp(),
+            )
+        )
+        applied_plan = plan.model_copy(
+            update={
+                "applied": True,
+                "profile_sha256_after": product_profile_record_sha256(updated_profile),
+                "profile_updated_at_after": updated_profile.updated_at,
+            }
+        )
+        response = accepted_evidence_response(
+            trace_id=trace_id,
+            records={
+                "product_profile": repair_request.product,
+                "context": repair_request.requested_context,
+                "instance": repair_request.instance,
+            },
+            result=applied_plan.model_dump(mode="json"),
+        )
+        write_result = database_store.compare_and_write_product_profile_record(
+            expected_record=profile,
+            replacement_record=updated_profile,
+            mutation=DbOnlyMutationRequest(
+                scope=idempotency_scope(identity),
+                route_path=_PRODUCT_LANE_CONTEXT_REPAIR_APPLY_ROUTE,
+                idempotency_key=normalized_idempotency_key,
+                request_fingerprint=payload_fingerprint,
+                lease_owner=trace_id,
+                response_status_code=202,
+                response_trace_id=trace_id,
+                response_payload=response.model_dump(mode="json", exclude_none=True),
+                lease_seconds=int(_DB_ONLY_MUTATION_LEASE.total_seconds()),
+            ),
+            expected_provider_targets=(source_target, target_target),
+        )
+        if write_result.status == "written":
+            return response
+        if write_result.status == "replayed":
+            if write_result.idempotency_record is None:
+                raise RuntimeError("Replayed product lane context repair requires evidence.")
+            return replay_idempotent_response(
+                trace_id=trace_id,
+                stored_record=write_result.idempotency_record,
+                route_path=_PRODUCT_LANE_CONTEXT_REPAIR_APPLY_ROUTE,
+            )
+        status_errors = {
+            "idempotency_conflict": (
+                "idempotency_key_reused",
+                "Idempotency-Key was already used for a different Launchplane request payload "
+                "on this route.",
+            ),
+            "missing": (
+                "not_found",
+                "Product profile disappeared before the lane context repair could be applied.",
+            ),
+            "changed": (
+                "stale",
+                "Product profile changed while applying the reviewed lane context repair plan.",
+            ),
+            "reservation_in_progress": (
+                "mutation_in_progress",
+                "A matching product lane context repair is already running. Retry with the same "
+                "Idempotency-Key.",
+            ),
+            "reconciliation_required": (
+                "mutation_reconciliation_required",
+                "The product lane context repair requires reconciliation before retry.",
+            ),
+        }
+        error_code, error_message = status_errors[write_result.status]
+        raise _launchplane_http_error(
+            status_code=404 if write_result.status == "missing" else 409,
+            trace_id=trace_id,
+            code=error_code,
+            message=error_message,
+        )
+
     async def apply_product_legacy_context_cleanup(
         request: Request,
         identity: Annotated[LaunchplaneIdentity, Depends(read_write_identity)],
@@ -21981,6 +22241,37 @@ def create_launchplane_fastapi_app(
         },
         operation_id="apply_product_context_cutover",
         summary="Plan or apply product context cutover",
+        responses={
+            400: {"model": LaunchplaneErrorResponse},
+            401: {"model": LaunchplaneErrorResponse},
+            403: {"model": LaunchplaneErrorResponse},
+            404: {"model": LaunchplaneErrorResponse},
+            409: {"model": LaunchplaneErrorResponse},
+            503: {"model": LaunchplaneErrorResponse},
+        },
+    )
+
+    app.add_api_route(
+        _PRODUCT_LANE_CONTEXT_REPAIR_APPLY_ROUTE,
+        apply_product_lane_context_repair,
+        methods=["POST"],
+        status_code=202,
+        response_model=AcceptedEvidenceResponse,
+        response_model_exclude_none=True,
+        openapi_extra={
+            "requestBody": {
+                "required": True,
+                "content": {
+                    "application/json": {
+                        "schema": _openapi_model_schema(
+                            control_plane_product_lane_context_repair.ProductLaneContextRepairRequest
+                        )
+                    }
+                },
+            }
+        },
+        operation_id="apply_product_lane_context_repair",
+        summary="Plan or apply a bounded product lane context repair",
         responses={
             400: {"model": LaunchplaneErrorResponse},
             401: {"model": LaunchplaneErrorResponse},

--- a/control_plane/product_lane_context_repair.py
+++ b/control_plane/product_lane_context_repair.py
@@ -1,0 +1,310 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from typing import Literal, Protocol
+
+from pydantic import BaseModel, ConfigDict, model_validator
+
+from control_plane.contracts.deploy_target import ProviderTargetRecord
+from control_plane.contracts.product_profile_record import (
+    LaunchplaneProductProfileRecord,
+    product_profile_record_sha256,
+    validate_product_profile_history_transition,
+)
+
+
+ProductLaneContextRepairMode = Literal["dry-run", "apply"]
+PRODUCT_LANE_CONTEXT_REPAIR_SOURCE: Literal["service:product-lane-context-repair"] = (
+    "service:product-lane-context-repair"
+)
+
+
+class ProductLaneContextRepairBoundaryError(ValueError):
+    pass
+
+
+class ProductLaneContextRepairReadStore(Protocol):
+    def read_product_profile_record(self, product: str) -> LaunchplaneProductProfileRecord: ...
+
+    def list_physical_provider_target_records(self) -> tuple[ProviderTargetRecord, ...]: ...
+
+
+class ProductLaneContextRepairRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: Literal[1] = 1
+    product: str
+    instance: str
+    expected_current_context: str
+    requested_context: str
+    expected_profile_sha256: str = ""
+    mode: ProductLaneContextRepairMode = "dry-run"
+    reason: str
+    reviewed_plan_sha256: str = ""
+
+    @model_validator(mode="after")
+    def _validate_request(self) -> ProductLaneContextRepairRequest:
+        self.product = self.product.strip()
+        self.instance = self.instance.strip()
+        self.expected_current_context = self.expected_current_context.strip()
+        self.requested_context = self.requested_context.strip()
+        self.expected_profile_sha256 = self.expected_profile_sha256.strip().lower()
+        self.reason = self.reason.strip()
+        self.reviewed_plan_sha256 = self.reviewed_plan_sha256.strip().lower()
+        for field_name in (
+            "product",
+            "instance",
+            "expected_current_context",
+            "requested_context",
+            "reason",
+        ):
+            if not getattr(self, field_name):
+                raise ValueError(f"Product lane context repair requires {field_name}.")
+        if self.expected_current_context == self.requested_context:
+            raise ValueError("Product lane context repair requires distinct contexts.")
+        if self.expected_profile_sha256 and not re.fullmatch(
+            r"[0-9a-f]{64}", self.expected_profile_sha256
+        ):
+            raise ValueError(
+                "Product lane context repair expected_profile_sha256 must be a 64-character "
+                "SHA-256."
+            )
+        if self.mode == "dry-run" and self.reviewed_plan_sha256:
+            raise ValueError("Product lane context repair dry-run rejects reviewed_plan_sha256.")
+        if self.mode == "apply":
+            if not self.expected_profile_sha256:
+                raise ValueError(
+                    "Product lane context repair apply requires expected_profile_sha256."
+                )
+            if not re.fullmatch(r"[0-9a-f]{64}", self.reviewed_plan_sha256):
+                raise ValueError(
+                    "Product lane context repair apply requires a reviewed 64-character plan "
+                    "SHA-256."
+                )
+        return self
+
+
+class ProductLaneContextRepairTargetEvidence(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    context: str
+    instance: str
+    provider_id: str
+    target_category: str
+    provider_target_type: str
+    target_id: str
+    record_sha256: str
+
+
+class ProductLaneContextRepairPlan(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["ok"] = "ok"
+    mode: ProductLaneContextRepairMode
+    product: str
+    instance: str
+    current_context: str
+    requested_context: str
+    changed: bool
+    applied: bool = False
+    same_physical_target: Literal[True] = True
+    source_target: ProductLaneContextRepairTargetEvidence
+    target_target: ProductLaneContextRepairTargetEvidence
+    preserved_historical_contexts: tuple[str, ...]
+    preserved_preview_context: str
+    reason: str
+    source_label: Literal["service:product-lane-context-repair"] = (
+        PRODUCT_LANE_CONTEXT_REPAIR_SOURCE
+    )
+    profile_sha256_before: str
+    profile_sha256_after: str = ""
+    profile_updated_at_before: str
+    profile_updated_at_after: str = ""
+    plan_sha256: str
+
+
+def _record_sha256(record: ProviderTargetRecord) -> str:
+    payload = json.dumps(
+        record.model_dump(mode="json"),
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _target_evidence(record: ProviderTargetRecord) -> ProductLaneContextRepairTargetEvidence:
+    return ProductLaneContextRepairTargetEvidence(
+        context=record.context,
+        instance=record.instance,
+        provider_id=record.provider_id,
+        target_category=record.target_category,
+        provider_target_type=record.provider_target_type,
+        target_id=record.target_id,
+        record_sha256=_record_sha256(record),
+    )
+
+
+def _route_target(
+    records: tuple[ProviderTargetRecord, ...], *, context: str, instance: str
+) -> ProviderTargetRecord:
+    matches = tuple(
+        record for record in records if record.context == context and record.instance == instance
+    )
+    if len(matches) != 1:
+        raise ProductLaneContextRepairBoundaryError(
+            "Product lane context repair requires exactly one provider target for each route."
+        )
+    return matches[0]
+
+
+def build_product_lane_context_repair_plan(
+    *,
+    record_store: ProductLaneContextRepairReadStore,
+    request: ProductLaneContextRepairRequest,
+) -> tuple[
+    ProductLaneContextRepairPlan,
+    LaunchplaneProductProfileRecord,
+    LaunchplaneProductProfileRecord,
+    ProviderTargetRecord,
+    ProviderTargetRecord,
+]:
+    profile = record_store.read_product_profile_record(request.product)
+    profile_sha256_before = product_profile_record_sha256(profile)
+    if request.expected_profile_sha256 and request.expected_profile_sha256 != profile_sha256_before:
+        raise ProductLaneContextRepairBoundaryError(
+            "Product lane context repair expected profile digest does not match stored authority."
+        )
+    if request.requested_context != profile.product:
+        raise ProductLaneContextRepairBoundaryError(
+            "Product lane context repair requested_context must be the canonical product context."
+        )
+    if request.expected_current_context not in profile.historical_contexts:
+        raise ProductLaneContextRepairBoundaryError(
+            "Product lane context repair source context must already be preserved as history."
+        )
+    if request.requested_context in profile.historical_contexts:
+        raise ProductLaneContextRepairBoundaryError(
+            "Product lane context repair cannot restore a historical context as current authority."
+        )
+    matching_lane_indexes = tuple(
+        index
+        for index, lane in enumerate(profile.lanes)
+        if lane.instance == request.instance and lane.context == request.expected_current_context
+    )
+    if len(matching_lane_indexes) != 1:
+        raise ProductLaneContextRepairBoundaryError(
+            "Product lane context repair requires exactly one matching current lane."
+        )
+    provider_targets = record_store.list_physical_provider_target_records()
+    source_target = _route_target(
+        provider_targets,
+        context=request.expected_current_context,
+        instance=request.instance,
+    )
+    target_target = _route_target(
+        provider_targets,
+        context=request.requested_context,
+        instance=request.instance,
+    )
+    if (
+        source_target.provider_id,
+        source_target.target_category,
+        source_target.target_id,
+    ) != (
+        target_target.provider_id,
+        target_target.target_category,
+        target_target.target_id,
+    ):
+        raise ProductLaneContextRepairBoundaryError(
+            "Product lane context repair routes do not resolve to the same physical target."
+        )
+    allowed_routes = {
+        (request.expected_current_context, request.instance),
+        (request.requested_context, request.instance),
+    }
+    conflicting_routes = sorted(
+        (record.context, record.instance)
+        for record in provider_targets
+        if (record.provider_id, record.target_category, record.target_id)
+        == (
+            target_target.provider_id,
+            target_target.target_category,
+            target_target.target_id,
+        )
+        and (record.context, record.instance) not in allowed_routes
+    )
+    if conflicting_routes:
+        raise ProductLaneContextRepairBoundaryError(
+            "Product lane context repair physical target is claimed by an unexpected route."
+        )
+    lane_index = matching_lane_indexes[0]
+    updated_lanes = list(profile.lanes)
+    updated_lanes[lane_index] = updated_lanes[lane_index].model_copy(
+        update={"context": request.requested_context}
+    )
+    replacement_profile = LaunchplaneProductProfileRecord.model_validate(
+        profile.model_copy(
+            update={
+                "lanes": tuple(updated_lanes),
+                "source": PRODUCT_LANE_CONTEXT_REPAIR_SOURCE,
+            }
+        ).model_dump(mode="json")
+    )
+    validate_product_profile_history_transition(
+        existing_profile=profile,
+        replacement_profile=replacement_profile,
+    )
+    source_evidence = _target_evidence(source_target)
+    target_evidence = _target_evidence(target_target)
+    plan_evidence = {
+        "schema_version": 1,
+        "product": request.product,
+        "instance": request.instance,
+        "current_context": request.expected_current_context,
+        "requested_context": request.requested_context,
+        "profile_sha256_before": profile_sha256_before,
+        "source_target": source_evidence.model_dump(mode="json"),
+        "target_target": target_evidence.model_dump(mode="json"),
+        "preserved_historical_contexts": list(profile.historical_contexts),
+        "preserved_preview_context": profile.preview.context,
+        "source_label": PRODUCT_LANE_CONTEXT_REPAIR_SOURCE,
+        "reason": request.reason,
+    }
+    plan_sha256 = hashlib.sha256(
+        json.dumps(plan_evidence, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+    return (
+        ProductLaneContextRepairPlan(
+            mode=request.mode,
+            product=request.product,
+            instance=request.instance,
+            current_context=request.expected_current_context,
+            requested_context=request.requested_context,
+            changed=True,
+            source_target=source_evidence,
+            target_target=target_evidence,
+            preserved_historical_contexts=profile.historical_contexts,
+            preserved_preview_context=profile.preview.context,
+            reason=request.reason,
+            profile_sha256_before=profile_sha256_before,
+            profile_updated_at_before=profile.updated_at,
+            plan_sha256=plan_sha256,
+        ),
+        profile,
+        replacement_profile,
+        source_target,
+        target_target,
+    )
+
+
+def updated_product_lane_context_repair_profile(
+    *,
+    replacement_profile: LaunchplaneProductProfileRecord,
+    updated_at: str,
+) -> LaunchplaneProductProfileRecord:
+    return LaunchplaneProductProfileRecord.model_validate(
+        replacement_profile.model_copy(update={"updated_at": updated_at}).model_dump(mode="json")
+    )

--- a/control_plane/storage/postgres.py
+++ b/control_plane/storage/postgres.py
@@ -13679,6 +13679,7 @@ class PostgresRecordStore(HumanSessionStore):
         expected_record: LaunchplaneProductProfileRecord,
         replacement_record: LaunchplaneProductProfileRecord,
         mutation: DbOnlyMutationRequest | None = None,
+        expected_provider_targets: tuple[ProviderTargetRecord, ...] = (),
     ) -> ProductProfileCompareWriteResult:
         if expected_record.product != replacement_record.product:
             raise ValueError("Product profile compare-and-write requires matching products.")
@@ -13702,6 +13703,7 @@ class PostgresRecordStore(HumanSessionStore):
                     statement=statement,
                     expected_record=expected_record,
                     replacement_record=replacement_record,
+                    expected_provider_targets=expected_provider_targets,
                 )
 
         reservation_insert_error: IntegrityError | None = None
@@ -13736,6 +13738,7 @@ class PostgresRecordStore(HumanSessionStore):
                     reservation_row=reservation_row,
                     mutation_reservation=stored_reservation,
                     mutation=mutation,
+                    expected_provider_targets=expected_provider_targets,
                 )
 
         with self._session_factory() as session:
@@ -13817,6 +13820,7 @@ class PostgresRecordStore(HumanSessionStore):
                 reservation_row=reservation_row,
                 mutation_reservation=reclaimed_reservation,
                 mutation=mutation,
+                expected_provider_targets=expected_provider_targets,
             )
 
     def _compare_and_write_product_profile_locked(
@@ -13829,7 +13833,18 @@ class PostgresRecordStore(HumanSessionStore):
         reservation_row: LaunchplaneIdempotencyRow | None = None,
         mutation_reservation: LaunchplaneIdempotencyRecord | None = None,
         mutation: DbOnlyMutationRequest | None = None,
+        expected_provider_targets: tuple[ProviderTargetRecord, ...] = (),
     ) -> ProductProfileCompareWriteResult:
+        if expected_provider_targets:
+            self._lock_product_authority_bundle_write(session)
+            if not self._provider_target_expectations_match(
+                session=session,
+                expected_records=expected_provider_targets,
+            ):
+                if reservation_row is not None:
+                    session.delete(reservation_row)
+                    session.commit()
+                return ProductProfileCompareWriteResult(status="changed")
         row = session.scalar(statement)
         if row is None:
             if reservation_row is not None:
@@ -13865,6 +13880,54 @@ class PostgresRecordStore(HumanSessionStore):
             status="written",
             idempotency_record=stored_completion,
         )
+
+    def _provider_target_expectations_match(
+        self,
+        *,
+        session: Any,
+        expected_records: tuple[ProviderTargetRecord, ...],
+    ) -> bool:
+        expected_routes = {(record.context, record.instance): record for record in expected_records}
+        if len(expected_routes) != len(expected_records):
+            raise ValueError("Provider target expectations must identify unique routes.")
+        expected_identities = {
+            (record.provider_id, record.target_category, record.target_id)
+            for record in expected_records
+        }
+        if len(expected_identities) != 1:
+            raise ValueError("Provider target expectations must share one physical identity.")
+        for route, expected_record in expected_routes.items():
+            statement = (
+                select(LaunchplaneProviderTargetRow)
+                .where(
+                    LaunchplaneProviderTargetRow.context == route[0],
+                    LaunchplaneProviderTargetRow.instance == route[1],
+                )
+                .limit(1)
+            )
+            if not self.database_url.startswith("sqlite"):
+                statement = statement.with_for_update()
+            row = session.scalar(statement)
+            if row is None:
+                return False
+            current_record = self._read_payload(
+                model_type=ProviderTargetRecord,
+                payload=row.payload,
+            )
+            if self._payload_dict(current_record) != self._payload_dict(expected_record):
+                return False
+        provider_id, target_category, target_id = next(iter(expected_identities))
+        identity_statement = select(LaunchplaneProviderTargetRow).where(
+            LaunchplaneProviderTargetRow.provider_id == provider_id,
+            LaunchplaneProviderTargetRow.target_category == target_category,
+            LaunchplaneProviderTargetRow.target_id == target_id,
+        )
+        if not self.database_url.startswith("sqlite"):
+            identity_statement = identity_statement.with_for_update()
+        claimed_routes = {
+            (row.context, row.instance) for row in session.scalars(identity_statement)
+        }
+        return claimed_routes == set(expected_routes)
 
     def _read_product_profile_payload(
         self, payload: PayloadDict

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1126,6 +1126,21 @@ secrets, Dokploy targets, target IDs, inventories, release tuples, and the
 product profile lane contexts. The workflow intentionally leaves append-only deployments,
 promotions, backup gates, and preview history on their original contexts.
 
+The same protected workflow temporarily exposes `operation=lane-context-repair`
+for the final migration-only repair tracked by #2114. This operation changes
+exactly one named lane from an expected historical context to the canonical
+product context. It fails closed unless both context routes still resolve to
+the same provider, target category, and physical target ID; no third route may
+claim that identity. Run a dry-run first and review the profile, plan, source-
+target, and target-target SHA-256 values. Apply requires the unchanged profile
+digest, reviewed plan digest, operator reason, and a unique idempotency key.
+The service atomically compares the profile and both provider-target records
+before writing only the profile lane pointer, source label, and timestamp. It
+does not mutate provider, runtime, secret, inventory, release, deployment,
+promotion, backup-gate, or preview authority. Remove this temporary operation
+with the migration-only context subsystem after #2114 completes, as tracked by
+#2115.
+
 After a cutover has been applied and the product profile no longer references
 the legacy context, run the manual Product Legacy Context Cleanup workflow with
 `dry_run=true`. The artifact reports mutable source records that can be cleaned:

--- a/frontend/generated/openapi-canonical.json
+++ b/frontend/generated/openapi-canonical.json
@@ -60855,6 +60855,172 @@
         "summary": "Plan or apply product health monitoring policy"
       }
     },
+    "/v1/product-profiles/lane-context-repair/apply": {
+      "post": {
+        "operationId": "apply_product_lane_context_repair",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Idempotency-Key",
+            "required": false,
+            "schema": {
+              "default": "",
+              "title": "Idempotency-Key",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "Authorization",
+            "required": false,
+            "schema": {
+              "default": "",
+              "title": "Authorization",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "expected_current_context": {
+                    "title": "Expected Current Context",
+                    "type": "string"
+                  },
+                  "expected_profile_sha256": {
+                    "default": "",
+                    "title": "Expected Profile Sha256",
+                    "type": "string"
+                  },
+                  "instance": {
+                    "title": "Instance",
+                    "type": "string"
+                  },
+                  "mode": {
+                    "default": "dry-run",
+                    "enum": [
+                      "dry-run",
+                      "apply"
+                    ],
+                    "title": "Mode",
+                    "type": "string"
+                  },
+                  "product": {
+                    "title": "Product",
+                    "type": "string"
+                  },
+                  "reason": {
+                    "title": "Reason",
+                    "type": "string"
+                  },
+                  "requested_context": {
+                    "title": "Requested Context",
+                    "type": "string"
+                  },
+                  "reviewed_plan_sha256": {
+                    "default": "",
+                    "title": "Reviewed Plan Sha256",
+                    "type": "string"
+                  },
+                  "schema_version": {
+                    "const": 1,
+                    "default": 1,
+                    "title": "Schema Version",
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "product",
+                  "instance",
+                  "expected_current_context",
+                  "requested_context",
+                  "reason"
+                ],
+                "title": "ProductLaneContextRepairRequest",
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AcceptedEvidenceResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "summary": "Plan or apply a bounded product lane context repair"
+      }
+    },
     "/v1/product-profiles/legacy-context-cleanup/apply": {
       "post": {
         "operationId": "apply_product_legacy_context_cleanup",

--- a/tests/test_config_authority_audit.py
+++ b/tests/test_config_authority_audit.py
@@ -3910,7 +3910,7 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
         path = ".github/workflows/product-context-cutover.yml"
         for key, value in (
             ("idempotency-key", "${{ steps.request.outputs.idempotency_key }}"),
-            ("payload-file", "launchplane-product-context-cutover-payload.json"),
+            ("payload-file", "launchplane-product-context-operation-payload.json"),
         ):
             with self.subTest(key=key, value=value):
                 self.assertEqual(

--- a/tests/test_http_app_policy_apply.py
+++ b/tests/test_http_app_policy_apply.py
@@ -9,7 +9,11 @@ from typing import (
 from unittest.mock import patch
 
 from control_plane import secrets as control_plane_secrets
-from control_plane.contracts.product_profile_record import LaunchplaneProductProfileRecord
+from control_plane.contracts.deploy_target import ProviderTargetRecord
+from control_plane.contracts.product_profile_record import (
+    LaunchplaneProductProfileRecord,
+    product_profile_record_sha256,
+)
 from control_plane.contracts.runtime_environment_record import RuntimeEnvironmentRecord
 from control_plane.contracts.runtime_key_safety_policy import RuntimeSecretSafetyRule
 from control_plane.http_app import (
@@ -30,7 +34,12 @@ from control_plane.service_human_auth import (
 )
 from control_plane.storage.filesystem import FilesystemRecordStore
 from control_plane.storage.postgres import PostgresRecordStore
-from control_plane.storage.product_authority_bundle import ProductAuthorityBundle
+from control_plane.storage.postgres import DbOnlyMutationRequest
+from control_plane.storage.postgres import ProductProfileCompareWriteResult
+from control_plane.storage.product_authority_bundle import (
+    ProductAuthorityBundle,
+    ProviderTargetWrite,
+)
 from tests.http_app_test_support import (
     _AGENT_WRITE_INTENT_SOURCE_URL,
     _agent_write_intent_payload,
@@ -3319,6 +3328,275 @@ class FastApiProductConfigApplyTests(unittest.IsolatedAsyncioTestCase):
 
 
 class FastApiProductContextCutoverTests(unittest.IsolatedAsyncioTestCase):
+    async def test_lane_context_repair_returns_stale_when_provider_authority_changes(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+
+            class _DriftingStore(PostgresRecordStore):
+                def compare_and_write_product_profile_record(
+                    self,
+                    *,
+                    expected_record: LaunchplaneProductProfileRecord,
+                    replacement_record: LaunchplaneProductProfileRecord,
+                    mutation: DbOnlyMutationRequest | None = None,
+                    expected_provider_targets: tuple[ProviderTargetRecord, ...] = (),
+                ) -> ProductProfileCompareWriteResult:
+                    expected_targets = expected_provider_targets
+                    target = expected_targets[1]
+                    self.write_product_authority_bundle(
+                        ProductAuthorityBundle(
+                            provider_target_writes=(
+                                ProviderTargetWrite(
+                                    record=target.model_copy(
+                                        update={"updated_at": "2026-08-12T12:00:00Z"}
+                                    ),
+                                    expected_record=target,
+                                    allowed_conflicting_routes=(
+                                        (
+                                            expected_targets[0].context,
+                                            expected_targets[0].instance,
+                                        ),
+                                    ),
+                                ),
+                            )
+                        )
+                    )
+                    return super().compare_and_write_product_profile_record(
+                        expected_record=expected_record,
+                        replacement_record=replacement_record,
+                        mutation=mutation,
+                        expected_provider_targets=expected_provider_targets,
+                    )
+
+            app_store = _DriftingStore(database_url=database_url)
+            app_store.ensure_schema()
+            profile = LaunchplaneProductProfileRecord.model_validate(
+                {
+                    "product": "sellyouroutboard",
+                    "display_name": "SellYourOutboard",
+                    "repository": "cbusillo/sellyouroutboard",
+                    "driver_id": "generic-web",
+                    "image": {"repository": "ghcr.io/cbusillo/sellyouroutboard"},
+                    "runtime_port": 3000,
+                    "health_path": "/api/health",
+                    "lanes": [
+                        {
+                            "instance": "testing",
+                            "context": "sellyouroutboard-testing",
+                        }
+                    ],
+                    "historical_contexts": ["sellyouroutboard-testing"],
+                    "updated_at": "2026-08-05T17:01:06Z",
+                    "source": "service:generic-web-onboarding",
+                }
+            )
+            source_target = ProviderTargetRecord(
+                context="sellyouroutboard-testing",
+                instance="testing",
+                provider_id="dokploy",
+                target_category="application",
+                target_id="shared-testing-target",
+                display_name="sellyouroutboard-testing",
+                provider_target_type="application",
+                updated_at="2026-08-05T17:47:15Z",
+                source_label="test",
+            )
+            target_target = source_target.model_copy(
+                update={
+                    "context": "sellyouroutboard",
+                    "display_name": "syo-testing-app",
+                }
+            )
+            app_store.write_product_profile_record(profile)
+            app_store.write_provider_target_record(source_target)
+            app_store.write_product_authority_bundle(
+                ProductAuthorityBundle(
+                    provider_target_writes=(
+                        ProviderTargetWrite(
+                            record=target_target,
+                            expected_absent=True,
+                            allowed_conflicting_routes=(
+                                (source_target.context, source_target.instance),
+                            ),
+                        ),
+                    )
+                )
+            )
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_product_profile_write_policy(product="sellyouroutboard"),
+                record_store_factory=lambda: app_store,
+            )
+            dry_run_payload: dict[str, object] = {
+                "schema_version": 1,
+                "product": "sellyouroutboard",
+                "instance": "testing",
+                "expected_current_context": "sellyouroutboard-testing",
+                "requested_context": "sellyouroutboard",
+                "mode": "dry-run",
+                "reason": "Repair the legacy testing lane pointer.",
+            }
+            dry_run_response = await _asgi_request(
+                app,
+                "POST",
+                "/v1/product-profiles/lane-context-repair/apply",
+                headers={"Authorization": "Bearer valid-token"},
+                payload=dry_run_payload,
+            )
+            apply_payload = {
+                **dry_run_payload,
+                "mode": "apply",
+                "expected_profile_sha256": product_profile_record_sha256(profile),
+                "reviewed_plan_sha256": dry_run_response.json()["result"]["plan_sha256"],
+            }
+
+            response = await _asgi_request(
+                app,
+                "POST",
+                "/v1/product-profiles/lane-context-repair/apply",
+                headers={
+                    "Authorization": "Bearer valid-token",
+                    "Idempotency-Key": "lane-context-repair-drift",
+                },
+                payload=apply_payload,
+            )
+            stored_profile = app_store.read_product_profile_record("sellyouroutboard")
+            app_store.close()
+
+        self.assertEqual(response.status_code, 409)
+        self.assertEqual(response.json()["error"]["code"], "stale")
+        self.assertEqual(stored_profile, profile)
+
+    async def test_lane_context_repair_applies_reviewed_single_lane_plan(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            app_store = PostgresRecordStore(database_url=database_url)
+            app_store.ensure_schema()
+            profile = LaunchplaneProductProfileRecord.model_validate(
+                {
+                    "product": "sellyouroutboard",
+                    "display_name": "SellYourOutboard",
+                    "repository": "cbusillo/sellyouroutboard",
+                    "driver_id": "generic-web",
+                    "image": {"repository": "ghcr.io/cbusillo/sellyouroutboard"},
+                    "runtime_port": 3000,
+                    "health_path": "/api/health",
+                    "lanes": [
+                        {
+                            "instance": "testing",
+                            "context": "sellyouroutboard-testing",
+                        }
+                    ],
+                    "historical_contexts": ["sellyouroutboard-testing"],
+                    "preview": {
+                        "enabled": True,
+                        "context": "sellyouroutboard-preview",
+                    },
+                    "updated_at": "2026-08-05T17:01:06Z",
+                    "source": "service:generic-web-onboarding",
+                }
+            )
+            source_target = ProviderTargetRecord(
+                context="sellyouroutboard-testing",
+                instance="testing",
+                provider_id="dokploy",
+                target_category="application",
+                target_id="shared-testing-target",
+                display_name="sellyouroutboard-testing",
+                provider_target_type="application",
+                updated_at="2026-08-05T17:47:15Z",
+                source_label="test",
+            )
+            target_target = source_target.model_copy(
+                update={
+                    "context": "sellyouroutboard",
+                    "display_name": "syo-testing-app",
+                }
+            )
+            app_store.write_product_profile_record(profile)
+            app_store.write_provider_target_record(source_target)
+            app_store.write_product_authority_bundle(
+                ProductAuthorityBundle(
+                    provider_target_writes=(
+                        ProviderTargetWrite(
+                            record=target_target,
+                            expected_absent=True,
+                            allowed_conflicting_routes=(
+                                (source_target.context, source_target.instance),
+                            ),
+                        ),
+                    )
+                )
+            )
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_product_profile_write_policy(product="sellyouroutboard"),
+                record_store_factory=lambda: app_store,
+            )
+            request_payload: dict[str, object] = {
+                "schema_version": 1,
+                "product": "sellyouroutboard",
+                "instance": "testing",
+                "expected_current_context": "sellyouroutboard-testing",
+                "requested_context": "sellyouroutboard",
+                "mode": "dry-run",
+                "reason": "Repair the legacy testing lane pointer.",
+            }
+
+            dry_run_response = await _asgi_request(
+                app,
+                "POST",
+                "/v1/product-profiles/lane-context-repair/apply",
+                headers={"Authorization": "Bearer valid-token"},
+                payload=request_payload,
+            )
+            dry_run_result = dry_run_response.json()["result"]
+            apply_payload = {
+                **request_payload,
+                "mode": "apply",
+                "expected_profile_sha256": product_profile_record_sha256(profile),
+                "reviewed_plan_sha256": dry_run_result["plan_sha256"],
+            }
+            apply_response = await _asgi_request(
+                app,
+                "POST",
+                "/v1/product-profiles/lane-context-repair/apply",
+                headers={
+                    "Authorization": "Bearer valid-token",
+                    "Idempotency-Key": "lane-context-repair",
+                },
+                payload=apply_payload,
+            )
+            replay_response = await _asgi_request(
+                app,
+                "POST",
+                "/v1/product-profiles/lane-context-repair/apply",
+                headers={
+                    "Authorization": "Bearer valid-token",
+                    "Idempotency-Key": "lane-context-repair",
+                },
+                payload=apply_payload,
+            )
+            stored_profile = app_store.read_product_profile_record("sellyouroutboard")
+            stored_targets = app_store.list_physical_provider_target_records()
+            app_store.close()
+
+        self.assertEqual(dry_run_response.status_code, 202)
+        self.assertTrue(dry_run_result["same_physical_target"])
+        self.assertEqual(apply_response.status_code, 202)
+        self.assertEqual(replay_response.status_code, 202)
+        self.assertEqual(replay_response.json()["records"], apply_response.json()["records"])
+        self.assertEqual(replay_response.json()["result"], apply_response.json()["result"])
+        self.assertTrue(apply_response.json()["result"]["applied"])
+        self.assertEqual(stored_profile.lanes[0].context, "sellyouroutboard")
+        self.assertEqual(stored_profile.preview.context, "sellyouroutboard-preview")
+        self.assertEqual(stored_profile.historical_contexts, ("sellyouroutboard-testing",))
+        self.assertEqual(stored_targets, (target_target, source_target))
+
     async def test_context_cutover_apply_updates_profile_for_authorized_workflow(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)
@@ -3604,10 +3882,15 @@ class FastApiProductContextCutoverTests(unittest.IsolatedAsyncioTestCase):
         cleanup_route = openapi["paths"]["/v1/product-profiles/legacy-context-cleanup/apply"][
             "post"
         ]
+        repair_route = openapi["paths"]["/v1/product-profiles/lane-context-repair/apply"]["post"]
         self.assertEqual(cutover_route["operationId"], "apply_product_context_cutover")
         self.assertEqual(
             cleanup_route["operationId"],
             "apply_product_legacy_context_cleanup",
+        )
+        self.assertEqual(
+            repair_route["operationId"],
+            "apply_product_lane_context_repair",
         )
         self.assertEqual(
             cutover_route["requestBody"]["content"]["application/json"]["schema"]["title"],
@@ -3617,7 +3900,11 @@ class FastApiProductContextCutoverTests(unittest.IsolatedAsyncioTestCase):
             cleanup_route["requestBody"]["content"]["application/json"]["schema"]["title"],
             "LegacyContextCleanupRequest",
         )
-        for route in (cutover_route, cleanup_route):
+        self.assertEqual(
+            repair_route["requestBody"]["content"]["application/json"]["schema"]["title"],
+            "ProductLaneContextRepairRequest",
+        )
+        for route in (cutover_route, cleanup_route, repair_route):
             self.assertEqual(
                 route["responses"]["202"]["content"]["application/json"]["schema"]["$ref"],
                 "#/components/schemas/AcceptedEvidenceResponse",

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -230,6 +230,10 @@ from control_plane.storage.postgres import (
     OutboxWithIdempotencyRequest,
     PostgresRecordStore,
 )
+from control_plane.storage.product_authority_bundle import (
+    ProductAuthorityBundle,
+    ProviderTargetWrite,
+)
 from control_plane.trusted_maintenance import (
     TrustedMaintenanceEvidenceConflictError,
     TrustedMaintenancePolicyConflictError,
@@ -6557,6 +6561,139 @@ env_var = "GH_TOKEN"
 
         self.assertEqual(result.status, "changed")
         self.assertEqual(loaded_record, concurrent_record)
+
+    def test_product_profile_compare_and_write_rejects_changed_provider_authority(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(
+                    Path(temporary_directory_name) / "launchplane.sqlite3"
+                )
+            )
+            store.ensure_schema()
+            expected_profile = _product_profile_record()
+            replacement_profile = expected_profile.model_copy(
+                update={
+                    "updated_at": "2026-07-12T02:00:00Z",
+                    "source": "service:test-compare-write",
+                }
+            )
+            source_target = _provider_target_record(
+                context="sellyouroutboard-testing",
+                instance="testing",
+                target_id="shared-target",
+            )
+            target_target = _provider_target_record(
+                context="sellyouroutboard",
+                instance="testing",
+                target_id="shared-target",
+            )
+            changed_target = target_target.model_copy(update={"updated_at": "2026-07-12T01:30:00Z"})
+            store.write_product_profile_record(expected_profile)
+            store.write_provider_target_record(source_target)
+            store.write_product_authority_bundle(
+                ProductAuthorityBundle(
+                    provider_target_writes=(
+                        ProviderTargetWrite(
+                            record=target_target,
+                            expected_absent=True,
+                            allowed_conflicting_routes=(
+                                (source_target.context, source_target.instance),
+                            ),
+                        ),
+                    )
+                )
+            )
+            store.write_product_authority_bundle(
+                ProductAuthorityBundle(
+                    provider_target_writes=(
+                        ProviderTargetWrite(
+                            record=changed_target,
+                            expected_record=target_target,
+                            allowed_conflicting_routes=(
+                                (source_target.context, source_target.instance),
+                            ),
+                        ),
+                    )
+                )
+            )
+
+            result = store.compare_and_write_product_profile_record(
+                expected_record=expected_profile,
+                replacement_record=replacement_profile,
+                expected_provider_targets=(source_target, target_target),
+            )
+            loaded_profile = store.read_product_profile_record(expected_profile.product)
+            store.close()
+
+        self.assertEqual(result.status, "changed")
+        self.assertEqual(loaded_profile, expected_profile)
+
+    def test_product_profile_compare_and_write_rejects_new_provider_route_claim(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(
+                    Path(temporary_directory_name) / "launchplane.sqlite3"
+                )
+            )
+            store.ensure_schema()
+            expected_profile = _product_profile_record()
+            replacement_profile = expected_profile.model_copy(
+                update={
+                    "updated_at": "2026-07-12T02:00:00Z",
+                    "source": "service:test-compare-write",
+                }
+            )
+            source_target = _provider_target_record(
+                context="sellyouroutboard-testing",
+                instance="testing",
+                target_id="shared-target",
+            )
+            target_target = _provider_target_record(
+                context="sellyouroutboard",
+                instance="testing",
+                target_id="shared-target",
+            )
+            unexpected_target = _provider_target_record(
+                context="other-context",
+                instance="testing",
+                target_id="shared-target",
+            )
+            store.write_product_profile_record(expected_profile)
+            store.write_provider_target_record(source_target)
+            store.write_product_authority_bundle(
+                ProductAuthorityBundle(
+                    provider_target_writes=(
+                        ProviderTargetWrite(
+                            record=target_target,
+                            expected_absent=True,
+                            allowed_conflicting_routes=(
+                                (source_target.context, source_target.instance),
+                            ),
+                        ),
+                        ProviderTargetWrite(
+                            record=unexpected_target,
+                            expected_absent=True,
+                            allowed_conflicting_routes=(
+                                (source_target.context, source_target.instance),
+                                (target_target.context, target_target.instance),
+                            ),
+                        ),
+                    )
+                )
+            )
+
+            result = store.compare_and_write_product_profile_record(
+                expected_record=expected_profile,
+                replacement_record=replacement_profile,
+                expected_provider_targets=(source_target, target_target),
+            )
+            loaded_profile = store.read_product_profile_record(expected_profile.product)
+            store.close()
+
+        self.assertEqual(result.status, "changed")
+        self.assertEqual(loaded_profile, expected_profile)
 
     def test_product_profile_compare_and_write_serializes_sqlite_writers(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:

--- a/tests/test_product_lane_context_repair.py
+++ b/tests/test_product_lane_context_repair.py
@@ -1,0 +1,271 @@
+import unittest
+
+from control_plane.contracts.deploy_target import ProviderTargetRecord
+from control_plane.contracts.product_profile_record import (
+    LaunchplaneProductProfileRecord,
+    ProductImageProfile,
+    ProductLaneProfile,
+    ProductPreviewProfile,
+    product_profile_record_sha256,
+)
+from control_plane.product_lane_context_repair import (
+    ProductLaneContextRepairBoundaryError,
+    ProductLaneContextRepairRequest,
+    build_product_lane_context_repair_plan,
+    updated_product_lane_context_repair_profile,
+)
+
+
+def _profile() -> LaunchplaneProductProfileRecord:
+    return LaunchplaneProductProfileRecord(
+        product="sellyouroutboard",
+        display_name="SellYourOutboard",
+        repository="cbusillo/sellyouroutboard",
+        driver_id="generic-web",
+        image=ProductImageProfile(repository="ghcr.io/cbusillo/sellyouroutboard"),
+        runtime_port=3000,
+        health_path="/api/health",
+        lanes=(
+            ProductLaneProfile(
+                instance="testing",
+                context="sellyouroutboard-testing",
+            ),
+        ),
+        historical_contexts=("sellyouroutboard-testing",),
+        preview=ProductPreviewProfile(
+            enabled=True,
+            context="sellyouroutboard-preview",
+        ),
+        updated_at="2026-08-05T17:01:06Z",
+        source="service:generic-web-onboarding",
+    )
+
+
+def _provider_target(*, context: str, target_id: str = "target-testing") -> ProviderTargetRecord:
+    return ProviderTargetRecord(
+        context=context,
+        instance="testing",
+        provider_id="dokploy",
+        target_category="application",
+        target_id=target_id,
+        display_name=f"{context}-testing",
+        provider_target_type="application",
+        updated_at="2026-08-05T17:47:15Z",
+        source_label="test",
+    )
+
+
+class _Store:
+    def __init__(
+        self,
+        *,
+        profile: LaunchplaneProductProfileRecord | None = None,
+        provider_targets: tuple[ProviderTargetRecord, ...] | None = None,
+    ) -> None:
+        self.profile = profile or _profile()
+        self.provider_targets = provider_targets or (
+            _provider_target(context="sellyouroutboard-testing"),
+            _provider_target(context="sellyouroutboard"),
+        )
+
+    def read_product_profile_record(self, product: str) -> LaunchplaneProductProfileRecord:
+        if product != self.profile.product:
+            raise FileNotFoundError(product)
+        return self.profile
+
+    def list_physical_provider_target_records(self) -> tuple[ProviderTargetRecord, ...]:
+        return self.provider_targets
+
+
+def _request(**updates: object) -> ProductLaneContextRepairRequest:
+    payload: dict[str, object] = {
+        "product": "sellyouroutboard",
+        "instance": "testing",
+        "expected_current_context": "sellyouroutboard-testing",
+        "requested_context": "sellyouroutboard",
+        "reason": "Repair the legacy testing lane pointer.",
+    }
+    payload.update(updates)
+    return ProductLaneContextRepairRequest.model_validate(payload)
+
+
+class ProductLaneContextRepairTests(unittest.TestCase):
+    def test_plan_changes_only_matching_lane_and_source(self) -> None:
+        store = _Store()
+
+        plan, original, replacement, _, _ = build_product_lane_context_repair_plan(
+            record_store=store,
+            request=_request(),
+        )
+
+        self.assertEqual(plan.current_context, "sellyouroutboard-testing")
+        self.assertEqual(plan.requested_context, "sellyouroutboard")
+        self.assertEqual(plan.source_target.target_id, plan.target_target.target_id)
+        self.assertEqual(plan.preserved_preview_context, "sellyouroutboard-preview")
+        self.assertEqual(replacement.lanes[0].context, "sellyouroutboard")
+        self.assertEqual(replacement.preview, original.preview)
+        self.assertEqual(replacement.historical_contexts, original.historical_contexts)
+        self.assertEqual(replacement.updated_at, original.updated_at)
+        self.assertEqual(replacement.source, "service:product-lane-context-repair")
+        original_payload = original.model_dump(mode="json")
+        replacement_payload = replacement.model_dump(mode="json")
+        original_payload["lanes"][0]["context"] = "sellyouroutboard"
+        original_payload["source"] = "service:product-lane-context-repair"
+        self.assertEqual(replacement_payload, original_payload)
+
+    def test_plan_digest_changes_with_provider_target_evidence(self) -> None:
+        first_plan, _, _, _, _ = build_product_lane_context_repair_plan(
+            record_store=_Store(),
+            request=_request(),
+        )
+        changed_target = _provider_target(context="sellyouroutboard").model_copy(
+            update={"updated_at": "2026-08-05T17:47:16Z"}
+        )
+
+        second_plan, _, _, _, _ = build_product_lane_context_repair_plan(
+            record_store=_Store(
+                provider_targets=(
+                    _provider_target(context="sellyouroutboard-testing"),
+                    changed_target,
+                )
+            ),
+            request=_request(),
+        )
+
+        self.assertNotEqual(first_plan.plan_sha256, second_plan.plan_sha256)
+
+    def test_apply_request_requires_reviewed_plan_and_profile_digests(self) -> None:
+        with self.assertRaisesRegex(ValueError, "expected_profile_sha256"):
+            _request(mode="apply", reviewed_plan_sha256="a" * 64)
+        with self.assertRaisesRegex(ValueError, "reviewed 64-character"):
+            _request(
+                mode="apply",
+                expected_profile_sha256=product_profile_record_sha256(_profile()),
+            )
+
+    def test_dry_run_rejects_reviewed_plan_digest(self) -> None:
+        with self.assertRaisesRegex(ValueError, "dry-run rejects"):
+            _request(reviewed_plan_sha256="a" * 64)
+
+    def test_plan_rejects_profile_digest_drift(self) -> None:
+        with self.assertRaisesRegex(
+            ProductLaneContextRepairBoundaryError,
+            "expected profile digest",
+        ):
+            build_product_lane_context_repair_plan(
+                record_store=_Store(),
+                request=_request(expected_profile_sha256="a" * 64),
+            )
+
+    def test_plan_rejects_mismatched_physical_targets(self) -> None:
+        with self.assertRaisesRegex(
+            ProductLaneContextRepairBoundaryError,
+            "same physical target",
+        ):
+            build_product_lane_context_repair_plan(
+                record_store=_Store(
+                    provider_targets=(
+                        _provider_target(context="sellyouroutboard-testing"),
+                        _provider_target(
+                            context="sellyouroutboard",
+                            target_id="different-target",
+                        ),
+                    )
+                ),
+                request=_request(),
+            )
+
+    def test_plan_requires_canonical_requested_context(self) -> None:
+        with self.assertRaisesRegex(
+            ProductLaneContextRepairBoundaryError,
+            "canonical product context",
+        ):
+            build_product_lane_context_repair_plan(
+                record_store=_Store(),
+                request=_request(requested_context="different-context"),
+            )
+
+    def test_plan_requires_source_context_in_history(self) -> None:
+        profile = _profile().model_copy(update={"historical_contexts": ()})
+        with self.assertRaisesRegex(
+            ProductLaneContextRepairBoundaryError,
+            "preserved as history",
+        ):
+            build_product_lane_context_repair_plan(
+                record_store=_Store(profile=profile),
+                request=_request(),
+            )
+
+    def test_plan_rejects_historical_canonical_context(self) -> None:
+        profile = _profile().model_copy(
+            update={
+                "historical_contexts": (
+                    "sellyouroutboard-testing",
+                    "sellyouroutboard",
+                )
+            }
+        )
+        with self.assertRaisesRegex(
+            ProductLaneContextRepairBoundaryError,
+            "restore a historical context",
+        ):
+            build_product_lane_context_repair_plan(
+                record_store=_Store(profile=profile),
+                request=_request(),
+            )
+
+    def test_plan_requires_exact_matching_lane(self) -> None:
+        with self.assertRaisesRegex(
+            ProductLaneContextRepairBoundaryError,
+            "exactly one matching current lane",
+        ):
+            build_product_lane_context_repair_plan(
+                record_store=_Store(),
+                request=_request(instance="prod"),
+            )
+
+    def test_plan_requires_both_provider_target_routes(self) -> None:
+        with self.assertRaisesRegex(
+            ProductLaneContextRepairBoundaryError,
+            "exactly one provider target",
+        ):
+            build_product_lane_context_repair_plan(
+                record_store=_Store(
+                    provider_targets=(_provider_target(context="sellyouroutboard-testing"),)
+                ),
+                request=_request(),
+            )
+
+    def test_plan_rejects_unexpected_third_route_claim(self) -> None:
+        with self.assertRaisesRegex(
+            ProductLaneContextRepairBoundaryError,
+            "unexpected route",
+        ):
+            build_product_lane_context_repair_plan(
+                record_store=_Store(
+                    provider_targets=(
+                        _provider_target(context="sellyouroutboard-testing"),
+                        _provider_target(context="sellyouroutboard"),
+                        _provider_target(context="other-context"),
+                    )
+                ),
+                request=_request(),
+            )
+
+    def test_updated_profile_sets_only_timestamp_after_plan(self) -> None:
+        _, _, replacement, _, _ = build_product_lane_context_repair_plan(
+            record_store=_Store(),
+            request=_request(),
+        )
+
+        updated = updated_product_lane_context_repair_profile(
+            replacement_profile=replacement,
+            updated_at="2026-08-12T12:00:00Z",
+        )
+
+        self.assertEqual(updated.updated_at, "2026-08-12T12:00:00Z")
+        self.assertEqual(updated.lanes[0].context, "sellyouroutboard")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -1532,16 +1532,18 @@ class ProductOnboardingTests(unittest.TestCase):
         )
 
         self.assertIn("runs-on: ubuntu-latest", workflow_text)
+        self.assertIn("environment: launchplane-authz-admin", workflow_text)
         self.assertIn(
             "uses: cbusillo/launchplane/.github/actions/launchplane-request@",
             workflow_text,
         )
+        self.assertIn('route_path="/v1/product-profiles/context-cutover/apply"', workflow_text)
         self.assertIn(
-            "route-path: /v1/product-profiles/context-cutover/apply",
+            'route_path="/v1/product-profiles/lane-context-repair/apply"',
             workflow_text,
         )
         self.assertIn(
-            "payload-file: launchplane-product-context-cutover-payload.json",
+            "payload-file: launchplane-product-context-operation-payload.json",
             workflow_text,
         )
         self.assertIn(
@@ -1549,7 +1551,7 @@ class ProductOnboardingTests(unittest.TestCase):
             workflow_text,
         )
         self.assertIn(
-            "response-output-file: launchplane-product-context-cutover.json",
+            "response-output-file: launchplane-product-context-operation.json",
             workflow_text,
         )
         self.assertIn('mode="apply"', workflow_text)
@@ -1558,19 +1560,25 @@ class ProductOnboardingTests(unittest.TestCase):
         self.assertIn('--arg source_context "$SOURCE_CONTEXT"', workflow_text)
         self.assertIn('--arg target_context "$TARGET_CONTEXT"', workflow_text)
         self.assertIn('--arg display_name "$DISPLAY_NAME"', workflow_text)
+        self.assertIn('--arg instance "$INSTANCE"', workflow_text)
+        self.assertIn('--arg expected_profile_sha256 "$EXPECTED_PROFILE_SHA256"', workflow_text)
+        self.assertIn('--arg reviewed_plan_sha256 "$REVIEWED_PLAN_SHA256"', workflow_text)
         self.assertIn('--arg mode "$mode"', workflow_text)
         self.assertIn("product: $product", workflow_text)
         self.assertIn("source_context: $source_context", workflow_text)
         self.assertIn("target_context: $target_context", workflow_text)
         self.assertIn("display_name: $display_name", workflow_text)
+        self.assertIn("expected_current_context: $expected_current_context", workflow_text)
+        self.assertIn("requested_context: $requested_context", workflow_text)
+        self.assertIn("reviewed_plan_sha256: $reviewed_plan_sha256", workflow_text)
         self.assertIn("mode: $mode", workflow_text)
         self.assertIn('source_label: "workflow:product-context-cutover"', workflow_text)
         self.assertIn("if: always()", workflow_text)
         self.assertIn(
-            "CUTOVER_STATUS_CODE: ${{ steps.cutover_request.outputs.status-code }}",
+            "CONTEXT_STATUS_CODE: ${{ steps.context_request.outputs.status-code }}",
             workflow_text,
         )
-        self.assertIn('if [ "$CUTOVER_STATUS_CODE" != "202" ]; then', workflow_text)
+        self.assertIn('if [ "$CONTEXT_STATUS_CODE" != "202" ]; then', workflow_text)
         self.assertNotIn("ACTIONS_ID_TOKEN_REQUEST_URL", workflow_text)
         self.assertNotIn("ACTIONS_ID_TOKEN_REQUEST_TOKEN", workflow_text)
         self.assertNotIn("Authorization: Bearer", workflow_text)


### PR DESCRIPTION
## Summary
- add a temporary fail-closed lane-context repair endpoint for #2114
- atomically verify the profile and both provider-target aliases before changing only one lane pointer
- expose the repair through the existing protected context workflow with reviewed plan/profile digests
- document removal with the migration-only subsystem in #2115

## Safety
- no provider API or lifecycle mutation
- canonical and legacy routes must share provider, target category, and target ID
- no third route may claim the physical target
- preview and historical contexts are preserved
- apply requires protected environment approval, idempotency, expected profile digest, and reviewed plan digest

## Validation
- `uv run --extra dev launchplane ci unittest-shard local`
- `uv run --extra dev mypy control_plane tests`
- `uv run --extra dev ruff check ...changed Python files...`
- `pnpm --dir frontend validate`
- `uv run launchplane service audit-config-authority --control-plane-root .`
- Opus final review approved after requested hardening
- Gemini core and surface final reviews approved

Closes no issue; #2114 remains open through live repair and verification.