### PR TITLE
feat: add generic web testing ingress authz set

### DIFF
--- a/.github/workflows/authz-policy-reconcile.yml
+++ b/.github/workflows/authz-policy-reconcile.yml
@@ -29,6 +29,7 @@ name: Manage Launchplane Authorization
           - detached-application-retirement
           - preview-feedback-remediation
           - generic-web-route-binding
+          - generic-web-testing-ingress-route
           - odoo-route-binding
           - odoo-external-route-binding
           - odoo-testing-ingress-route
@@ -186,6 +187,18 @@ jobs:
       related_issue: ${{ inputs.related_issue }}
     secrets:
       managed_set_json: ${{ secrets.LAUNCHPLANE_AUTHZ_GENERIC_WEB_ROUTE_BINDING_MANAGED_SET_JSON }}
+
+  reconcile-generic-web-testing-ingress-route:
+    if: ${{ inputs.managed_set == 'generic-web-testing-ingress-route' }}
+    uses: cbusillo/launchplane/.github/workflows/reusable-authz-policy-reconcile.yml@39aecc250d6dee91204e24673725bd1ea1ca6bda # main
+    with:
+      mode: ${{ inputs.mode }}
+      expected_managed_set_id: operator.generic-web-testing-ingress-route
+      reviewed_plan_sha256: ${{ inputs.reviewed_plan_sha256 }}
+      reason: ${{ inputs.reason }}
+      related_issue: ${{ inputs.related_issue }}
+    secrets:
+      managed_set_json: ${{ secrets.LAUNCHPLANE_AUTHZ_GENERIC_WEB_TESTING_INGRESS_ROUTE_MANAGED_SET_JSON }}
 
   reconcile-odoo-route-binding:
     if: ${{ inputs.managed_set == 'odoo-route-binding' }}

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -503,6 +503,12 @@ Product Health Monitoring wrapper's exact immutable worker grant;
 exact-instance route-binding read/apply grants for generic-web stable lanes and
 must declare `operator.generic-web-route-binding`. Keep real products, contexts,
 instances, and immutable workflow identities only in that protected secret;
+`LAUNCHPLANE_AUTHZ_GENERIC_WEB_TESTING_INGRESS_ROUTE_MANAGED_SET_JSON` owns the
+separate exact-instance `ingress_route.plan` and `ingress_route.apply` grants
+for generic-web testing lanes and must declare
+`operator.generic-web-testing-ingress-route`; keep it independent from the
+route-binding set so ingress provider access is never implied by record-only
+route-binding authority;
 `LAUNCHPLANE_AUTHZ_ODOO_ROUTE_BINDING_MANAGED_SET_JSON` owns the independent
 Odoo stable managed route-binding set.
 `LAUNCHPLANE_AUTHZ_PREVIEW_FEEDBACK_REMEDIATION_MANAGED_SET_JSON` owns the

--- a/tests/test_authz_operator_workflow.py
+++ b/tests/test_authz_operator_workflow.py
@@ -41,6 +41,7 @@ class AuthzOperatorWorkflowTests(unittest.TestCase):
                 "detached-application-retirement",
                 "preview-feedback-remediation",
                 "generic-web-route-binding",
+                "generic-web-testing-ingress-route",
                 "odoo-route-binding",
                 "odoo-external-route-binding",
                 "odoo-testing-ingress-route",
@@ -97,6 +98,10 @@ class AuthzOperatorWorkflowTests(unittest.TestCase):
             "reconcile-generic-web-route-binding": (
                 "${{ inputs.managed_set == 'generic-web-route-binding' }}",
                 "${{ secrets.LAUNCHPLANE_AUTHZ_GENERIC_WEB_ROUTE_BINDING_MANAGED_SET_JSON }}",
+            ),
+            "reconcile-generic-web-testing-ingress-route": (
+                "${{ inputs.managed_set == 'generic-web-testing-ingress-route' }}",
+                "${{ secrets.LAUNCHPLANE_AUTHZ_GENERIC_WEB_TESTING_INGRESS_ROUTE_MANAGED_SET_JSON }}",
             ),
             "reconcile-odoo-route-binding": (
                 "${{ inputs.managed_set == 'odoo-route-binding' }}",
@@ -171,6 +176,9 @@ class AuthzOperatorWorkflowTests(unittest.TestCase):
                     ),
                     "reconcile-generic-web-route-binding": (
                         "operator.generic-web-route-binding"
+                    ),
+                    "reconcile-generic-web-testing-ingress-route": (
+                        "operator.generic-web-testing-ingress-route"
                     ),
                 }
                 if job_name in expected_managed_set_ids:


### PR DESCRIPTION
## Summary
- add a protected `generic-web-testing-ingress-route` managed-set entrypoint
- keep exact-instance ingress plan/apply grants separate from record-only generic-web route-binding grants
- document protected secret ownership and add workflow contract coverage

## Live motivation
- canonical SYO route-binding reconciliation now reaches `ingress_audit_missing`
- ingress dry-run `31634963880` is denied before provider access because no exact-instance generic-web ingress grant exists
- existing `generic-web-route-binding` dry-run `31635092098` is active and unchanged, confirming it should not be broadened

## Validation
- `uv run --extra dev python -m unittest tests.test_authz_operator_workflow`
- scoped Ruff check
- `git diff --check`

Related: #2116
