### PR TITLE
fix: recover blocked merge admission

### DIFF
--- a/.github/actions/launchplane-request/dist/index.js
+++ b/.github/actions/launchplane-request/dist/index.js
@@ -289,6 +289,29 @@ function isExpectedStatus(response, expectedStatuses) {
   return expectedStatuses.has(response.status);
 }
 
+function publicSafeFailureDetail(responseBody) {
+  if (responseBody === null || typeof responseBody !== "object" || Array.isArray(responseBody)) {
+    return "";
+  }
+  const error = responseBody.error;
+  if (error === null || typeof error !== "object" || Array.isArray(error)) {
+    return "";
+  }
+  const code = typeof error.code === "string" ? error.code.trim() : "";
+  const traceId = typeof responseBody.trace_id === "string" ? responseBody.trace_id.trim() : "";
+  if (!code && !traceId) {
+    return "";
+  }
+  const fields = [];
+  if (code) {
+    fields.push(`code=${code}`);
+  }
+  if (traceId) {
+    fields.push(`trace_id=${traceId}`);
+  }
+  return ` (${fields.join(", ")})`;
+}
+
 function readJsonPath(value, path) {
   let cursor = value;
   for (const segment of path.split(".").filter(Boolean)) {
@@ -597,7 +620,9 @@ async function main() {
       responseBodies.push(responseBody);
       if (!isExpectedStatus(response, options.expectedStatuses)) {
         writeResponseOutputFile(responseBodies);
-        const responseDetail = logResponseBody ? `: ${responseText || "empty response"}` : "";
+        const responseDetail = logResponseBody
+          ? `: ${responseText || "empty response"}`
+          : publicSafeFailureDetail(responseBody);
         throw new Error(
           `Launchplane request ${index + 1} failed with ${response.status}${responseDetail}`,
         );
@@ -642,7 +667,9 @@ async function main() {
     process.stdout.write(`${JSON.stringify(responseBody, null, 2)}\n`);
   }
   if (!isExpectedStatus(response, options.expectedStatuses)) {
-    const responseDetail = logResponseBody ? `: ${responseText || "empty response"}` : "";
+    const responseDetail = logResponseBody
+      ? `: ${responseText || "empty response"}`
+      : publicSafeFailureDetail(responseBody);
     throw new Error(
       `Launchplane request failed with ${response.status}${responseDetail}`,
     );

--- a/.github/actions/launchplane-request/dist/index.js
+++ b/.github/actions/launchplane-request/dist/index.js
@@ -294,10 +294,11 @@ function publicSafeFailureDetail(responseBody) {
     return "";
   }
   const error = responseBody.error;
-  if (error === null || typeof error !== "object" || Array.isArray(error)) {
-    return "";
-  }
-  const code = typeof error.code === "string" ? error.code.trim() : "";
+  const code =
+    error !== null && typeof error === "object" && !Array.isArray(error) &&
+    typeof error.code === "string"
+      ? error.code.trim()
+      : "";
   const traceId = typeof responseBody.trace_id === "string" ? responseBody.trace_id.trim() : "";
   if (!code && !traceId) {
     return "";

--- a/control_plane/merge_admission.py
+++ b/control_plane/merge_admission.py
@@ -40,6 +40,17 @@ def _utc_now_timestamp() -> str:
 class MergeAdmissionDeniedError(ValueError):
     """Raised when fresh L2 or structural evidence refuses an effect attempt."""
 
+    def __init__(
+        self,
+        message: str,
+        *,
+        reason_code: str = "merge_admission_denied",
+        readiness: MergeReadinessResult | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.reason_code = reason_code
+        self.readiness = readiness
+
 
 class MergeAdmissionReconciliationRequiredError(RuntimeError):
     """Raised when an earlier attempt remains effect-ambiguous."""
@@ -190,11 +201,14 @@ class GuardedMergeAdmission:
         )
         if evaluation.readiness.state != "ready":
             raise MergeAdmissionDeniedError(
-                "Fresh merge readiness evidence did not admit the provider effect."
+                "Fresh merge readiness evidence did not admit the provider effect.",
+                reason_code="merge_readiness_not_ready",
+                readiness=evaluation.readiness,
             )
         if evaluation.structural_result.status not in {"exact", "recorded_rolling"}:
             raise MergeAdmissionDeniedError(
-                "Fresh structural provenance did not admit the provider effect."
+                "Fresh structural provenance did not admit the provider effect.",
+                reason_code="structural_provenance_not_admitted",
             )
         admitted_at = self.admission_time_provider()
         if self.controller_state_provider is not None:
@@ -203,7 +217,10 @@ class GuardedMergeAdmission:
         candidate = self.candidate_record.candidate
         provenance = candidate.structural_provenance
         if provenance is None:
-            raise MergeAdmissionDeniedError("Merge admission requires structural provenance.")
+            raise MergeAdmissionDeniedError(
+                "Merge admission requires structural provenance.",
+                reason_code="structural_provenance_missing",
+            )
         attempt_id = build_merge_effect_attempt_id(
             controller_key=self.controller_state.controller_key,
             lease_owner=self.controller_state.lease_owner,
@@ -249,7 +266,8 @@ class GuardedMergeAdmission:
             )
         except ValueError as error:
             raise MergeAdmissionDeniedError(
-                "Persisted controller authority changed after live merge evaluation."
+                "Persisted controller authority changed after live merge evaluation.",
+                reason_code="controller_authority_changed",
             ) from error
         try:
             stored, created = self.record_store.create_guarded_merge_admission_record_if_absent(
@@ -257,7 +275,10 @@ class GuardedMergeAdmission:
                 admitted_at=admitted_at,
             )
         except MergeAdmissionFenceRejectedError as error:
-            raise MergeAdmissionDeniedError(str(error)) from error
+            raise MergeAdmissionDeniedError(
+                str(error),
+                reason_code="controller_fence_rejected",
+            ) from error
         if not created:
             raise MergeAdmissionReconciliationRequiredError(
                 "Existing merge admission cannot be reused for another provider effect."

--- a/control_plane/merge_admission_live.py
+++ b/control_plane/merge_admission_live.py
@@ -139,7 +139,8 @@ class LiveMergeAdmissionEvaluator:
             )
         except (LookupError, ValueError, MergeTrainPolicyStoreMissingError) as error:
             raise MergeAdmissionDeniedError(
-                "Active merge-train policy no longer admits the landing-plan lineage."
+                "Active merge-train policy no longer admits the landing-plan lineage.",
+                reason_code="landing_policy_not_admitted",
             ) from error
         expected_queue = tuple(
             (plan_entry.pull_request_number, plan_entry.expected_head_sha)
@@ -153,7 +154,8 @@ class LiveMergeAdmissionEvaluator:
         )
         if snapshot.base_sha != observed_base_sha or live_queue_identity != expected_queue:
             raise MergeAdmissionDeniedError(
-                "Live merge queue or base identity changed from the landing-plan lineage."
+                "Live merge queue or base identity changed from the landing-plan lineage.",
+                reason_code="landing_lineage_changed",
             )
         entry_evidence = tuple(
             self._entry_evidence(

--- a/control_plane/merge_train_controller_run_once.py
+++ b/control_plane/merge_train_controller_run_once.py
@@ -43,6 +43,7 @@ from control_plane.merge_train import (
 )
 from control_plane.merge_admission import (
     GuardedMergeAdmission,
+    MergeAdmissionDeniedError,
     MergeAdmissionEvaluator,
     MergeAdmissionRecordStore,
 )
@@ -845,7 +846,7 @@ def _advance_active_landing_record(
         entry: MergeTrainBatchLandingEntry,
         phase: str,
     ) -> MergeTrainBatchLandingPlanRecord | None:
-        state_phase = "merge_pull_request" if phase == "merge_entry" else "landing_entry_merged"
+        state_phase = "admit_pull_request" if phase == "merge_entry" else "landing_entry_merged"
         lease.checkpoint(
             active_action="land_batch",
             active_phase=state_phase,
@@ -872,13 +873,64 @@ def _advance_active_landing_record(
         landing_store.write_merge_train_batch_landing_plan_record(progress_record)
         return progress_record
 
+    def checkpoint_provider_merge(
+        progress_plan: MergeTrainBatchLandingPlan,
+        entry: MergeTrainBatchLandingEntry,
+    ) -> None:
+        lease.checkpoint(
+            active_action="land_batch",
+            active_phase="merge_pull_request",
+            active_record_id=active_landing_record.record_id,
+            active_pull_request_number=entry.pull_request_number,
+            step_payload={
+                "landing_plan_record_id": active_landing_record.record_id,
+                "landing_plan_id": progress_plan.plan_id,
+                "batch_id": progress_plan.batch_id,
+                "candidate_ref": progress_plan.candidate_ref,
+                "expected_effect_sha": progress_plan.candidate_sha,
+                "completed_entry_count": sum(
+                    progress_entry.status == "merged" for progress_entry in progress_plan.entries
+                ),
+            },
+        )
+
     try:
         landed_plan = github_client.land_batch_candidate(
             landing_plan=active_landing_record.landing_plan,
             admission_guard=admission_guard,
             recorded_at=recorded_at,
+            provider_checkpoint=checkpoint_provider_merge,
             checkpoint=checkpoint_landing_progress,
         )
+    except MergeAdmissionDeniedError as error:
+        readiness = error.readiness
+        blocked_landing_record = admission_guard.landing_plan_record
+        return {
+            "merge_train_batch_landing_plan_record_id": blocked_landing_record.record_id,
+            "repository": blocked_landing_record.landing_plan.repository,
+            "base_branch": blocked_landing_record.landing_plan.base_branch,
+            "mode": "blocked",
+            "controller_action": "block",
+            "blocking_reason": {
+                "code": error.reason_code,
+                "message": str(error),
+            },
+            "merge_readiness": (
+                {
+                    "state": readiness.state,
+                    "reason_codes": list(readiness.reason_codes),
+                    "owner_states": sorted({facet.state for facet in readiness.owner_facets}),
+                    "technical_checks_state": readiness.technical_checks.state,
+                    "engineering_review_state": readiness.engineering_review.state,
+                    "policy_state": readiness.policy.state,
+                    "candidate_state": readiness.candidate.state,
+                    "fence_state": readiness.fence.state,
+                }
+                if readiness is not None
+                else None
+            ),
+            "landing_plan": blocked_landing_record.landing_plan.model_dump(mode="json"),
+        }
     except MergeTrainGitHubStaleHeadError as error:
         stale_plan = stale_merge_train_landing_plan(active_landing_record.landing_plan)
         stale_record = build_merge_train_batch_landing_plan_record(

--- a/control_plane/merge_train_github.py
+++ b/control_plane/merge_train_github.py
@@ -275,6 +275,9 @@ class GitHubMergeTrainClient(MergeTrainStackCollapseBranchClient):
         landing_plan: MergeTrainBatchLandingPlan,
         admission_guard: GuardedMergeAdmission | None = None,
         recorded_at: str = "",
+        provider_checkpoint: (
+            Callable[[MergeTrainBatchLandingPlan, MergeTrainBatchLandingEntry], None] | None
+        ) = None,
         checkpoint: (
             Callable[
                 [MergeTrainBatchLandingPlan, MergeTrainBatchLandingEntry, str],
@@ -489,6 +492,14 @@ class GitHubMergeTrainClient(MergeTrainStackCollapseBranchClient):
                 observed_head_sha=landed_head_sha,
                 observed_head_tree_sha=landed_head_tree_sha,
             )
+            if provider_checkpoint is not None:
+                provider_checkpoint(
+                    _validated_model_update(
+                        landing_plan,
+                        entries=tuple(landed_entries) + landing_plan.entries[entry_index:],
+                    ),
+                    entry,
+                )
             try:
                 merge_commit_sha = self.merge_pull_request(
                     repository=landing_plan.repository,

--- a/docs/merge-admission.md
+++ b/docs/merge-admission.md
@@ -31,6 +31,14 @@ acquisition token, expiry, policy digest, active PR, stable landing-plan ID, and
 expected effect SHA using the actual admission timestamp. Finding the same
 admission again never authorizes replay of the provider mutation.
 
+If fresh readiness or structural evidence refuses admission before the provider
+checkpoint, the controller returns an accepted `block` result with a stable
+reason code and the public-safe readiness facets. It releases the controller
+lease cleanly and leaves the landing plan available for a later pass after the
+missing or stale evidence is corrected. A pre-effect policy refusal is not
+durable effect ambiguity and must not be converted into controller
+reconciliation.
+
 ## Outcome Boundary
 
 Outcomes use only three public states:
@@ -66,6 +74,14 @@ Landing progress records retain one stable `landing_plan_id` while each
 persisted checkpoint receives its own record ID. Admissions bind both values,
 and recovery searches the stable lineage so a restart after a progress
 checkpoint can still find the preceding attempt.
+
+Controller phase evidence distinguishes admission work from the provider effect.
+`admit_pull_request` means Launchplane is re-observing prior outcomes and
+computing or persisting fresh merge admission; GitHub's merge endpoint has not
+yet been called. `merge_pull_request` is checkpointed only after an immutable
+admission exists and immediately before the guarded GitHub merge request. An
+operator must not infer that GitHub rejected a merge from a 409 recorded under
+the admission phase.
 
 On restart, an already-merged exact PR is reconciled against its preceding
 admission and receives a truthful `landed` outcome only after Launchplane reads

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -20,6 +20,24 @@ Contradictory or incomplete evidence remains `reconcile_required` and needs
 operator investigation. Candidate-ref cleanup failures are separate from
 landing truth and may be retried without changing the outcome record.
 
+Use the controller phase when diagnosing a failed landing. An active
+`admit_pull_request` phase means the failure occurred while reconciling or
+evaluating Launchplane admission, before a GitHub merge request. An active
+`merge_pull_request` phase means Launchplane persisted admission and crossed the
+provider-effect checkpoint immediately before the GitHub merge request. Preserve
+the response JSON and trace ID from protected workflow failures; an HTTP 409 by
+itself does not distinguish controller fencing, admission refusal, admission
+reconciliation, or a GitHub state conflict.
+
+A controller response with `controller_action=block` and
+`blocking_reason.code=merge_readiness_not_ready` is a normal fail-closed
+pre-effect result. Read `merge_readiness.reason_codes` and the individual facets,
+repair or record the missing evidence, and call the controller again. Do not
+clear controller state or treat the result as a GitHub merge conflict: no
+provider effect was attempted for the blocked entry and the controller lease is
+released cleanly. Earlier entries in a multi-PR batch may already be merged; the
+returned landing plan identifies their persisted status.
+
 ## Command Groups
 
 Use `uv run launchplane --help` for the complete CLI surface. The current

--- a/scripts/merge_train_controller_feedback.py
+++ b/scripts/merge_train_controller_feedback.py
@@ -167,6 +167,10 @@ def _feedback_message(
 
 
 def _blocking_detail(result: dict[str, Any]) -> str:
+    blocking_reason = _as_dict(result.get("blocking_reason"))
+    blocking_message = _string(blocking_reason.get("message"))
+    if blocking_message:
+        return blocking_message
     dry_run_result = _as_dict(result.get("dry_run_result"))
     detail = _string(dry_run_result.get("next_action_detail"))
     if detail:
@@ -217,10 +221,11 @@ def _landing_plan_complete(landing_plan: dict[str, Any]) -> bool:
 
 def _landing_plan_stale(landing_plan: dict[str, Any]) -> bool:
     entries = _as_list(landing_plan.get("entries"))
-    return bool(entries) and all(
-        _string(_as_dict(entry).get("status")) in {"merged", "stale"}
-        for entry in entries
-    ) and any(_string(_as_dict(entry).get("status")) == "stale" for entry in entries)
+    return (
+        bool(entries)
+        and all(_string(_as_dict(entry).get("status")) in {"merged", "stale"} for entry in entries)
+        and any(_string(_as_dict(entry).get("status")) == "stale" for entry in entries)
+    )
 
 
 def _required_string(value: object, field_name: str) -> str:

--- a/tests/support/merge_train.py
+++ b/tests/support/merge_train.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Callable, cast
+from typing import Callable, Protocol, cast
 
 from control_plane.contracts.merge_train_batch import (
     MergeTrainBatchCandidate,
@@ -9,6 +9,7 @@ from control_plane.contracts.merge_train_batch import (
     MergeTrainBatchEntry,
     MergeTrainBatchLandingEntry,
     MergeTrainBatchLandingPlan,
+    MergeTrainBatchLandingPlanRecord,
     build_merge_train_batch_candidate,
     build_merge_train_batch_candidate_record,
 )
@@ -33,6 +34,7 @@ from control_plane.merge_train import (
     discover_merge_train_stack,
 )
 from control_plane.merge_train_github import MergeTrainGitHubError, MergeTrainGitHubStaleHeadError
+from control_plane.merge_admission import MergeAdmissionDeniedError
 from control_plane.service_auth import GitHubActionsIdentity, LaunchplaneAuthzPolicy
 from control_plane.storage.filesystem import FilesystemRecordStore
 from control_plane.workflows.merge_train_worker import (
@@ -42,6 +44,12 @@ from control_plane.workflows.merge_train_worker import (
 from tests.merge_train_policy_fixtures import build_test_merge_train_policy
 from tests.merge_train_policy_fixtures import build_test_merge_train_policy_record
 from tests.support.auth import _identity
+
+
+class _LandingPlanRecordUpdater(Protocol):
+    def update_landing_plan_record(
+        self, landing_plan_record: MergeTrainBatchLandingPlanRecord
+    ) -> None: ...
 
 
 class _FakeMergeTrainGitHubClient:
@@ -102,10 +110,17 @@ class _FakeMergeTrainGitHubClient:
         self,
         *,
         landing_plan: MergeTrainBatchLandingPlan,
-        admission_guard: object,
+        admission_guard: _LandingPlanRecordUpdater,
         recorded_at: str,
+        provider_checkpoint: (
+            Callable[[MergeTrainBatchLandingPlan, MergeTrainBatchLandingEntry], None] | None
+        ) = None,
         checkpoint: (
-            Callable[[MergeTrainBatchLandingPlan, MergeTrainBatchLandingEntry, str], None] | None
+            Callable[
+                [MergeTrainBatchLandingPlan, MergeTrainBatchLandingEntry, str],
+                MergeTrainBatchLandingPlanRecord | None,
+            ]
+            | None
         ) = None,
     ) -> MergeTrainBatchLandingPlan:
         type(self).land_batch_candidate_calls += 1
@@ -120,6 +135,15 @@ class _FakeMergeTrainGitHubClient:
                     ),
                     entry,
                     "merge_entry",
+                )
+            if provider_checkpoint is not None:
+                provider_checkpoint(
+                    landing_plan.model_copy(
+                        update={
+                            "entries": tuple(merged_entries) + landing_plan.entries[entry_index:]
+                        }
+                    ),
+                    entry,
                 )
             merged_entry = entry.model_copy(
                 update={
@@ -224,8 +248,15 @@ class _StaleLandingMergeTrainGitHubClient(_FakeMergeTrainGitHubClient):
         landing_plan: MergeTrainBatchLandingPlan,
         admission_guard: object,
         recorded_at: str,
+        provider_checkpoint: (
+            Callable[[MergeTrainBatchLandingPlan, MergeTrainBatchLandingEntry], None] | None
+        ) = None,
         checkpoint: (
-            Callable[[MergeTrainBatchLandingPlan, MergeTrainBatchLandingEntry, str], None] | None
+            Callable[
+                [MergeTrainBatchLandingPlan, MergeTrainBatchLandingEntry, str],
+                MergeTrainBatchLandingPlanRecord | None,
+            ]
+            | None
         ) = None,
     ) -> MergeTrainBatchLandingPlan:
         raise MergeTrainGitHubStaleHeadError(
@@ -240,12 +271,82 @@ class _UnavailableLandingMergeTrainGitHubClient(_FakeMergeTrainGitHubClient):
         landing_plan: MergeTrainBatchLandingPlan,
         admission_guard: object,
         recorded_at: str,
+        provider_checkpoint: (
+            Callable[[MergeTrainBatchLandingPlan, MergeTrainBatchLandingEntry], None] | None
+        ) = None,
         checkpoint: (
-            Callable[[MergeTrainBatchLandingPlan, MergeTrainBatchLandingEntry, str], None] | None
+            Callable[
+                [MergeTrainBatchLandingPlan, MergeTrainBatchLandingEntry, str],
+                MergeTrainBatchLandingPlanRecord | None,
+            ]
+            | None
         ) = None,
     ) -> MergeTrainBatchLandingPlan:
         raise MergeTrainGitHubError(
             "GitHub API request failed for /repos/example/repo", status_code=503
+        )
+
+
+class _BlockedAdmissionMergeTrainGitHubClient(_FakeMergeTrainGitHubClient):
+    def land_batch_candidate(
+        self,
+        *,
+        landing_plan: MergeTrainBatchLandingPlan,
+        admission_guard: object,
+        recorded_at: str,
+        provider_checkpoint: (
+            Callable[[MergeTrainBatchLandingPlan, MergeTrainBatchLandingEntry], None] | None
+        ) = None,
+        checkpoint: (
+            Callable[
+                [MergeTrainBatchLandingPlan, MergeTrainBatchLandingEntry, str],
+                MergeTrainBatchLandingPlanRecord | None,
+            ]
+            | None
+        ) = None,
+    ) -> MergeTrainBatchLandingPlan:
+        entry = landing_plan.entries[0]
+        if checkpoint is not None:
+            checkpoint(landing_plan, entry, "merge_entry")
+        raise MergeAdmissionDeniedError(
+            "Fresh merge readiness evidence did not admit the provider effect.",
+            reason_code="merge_readiness_not_ready",
+        )
+
+
+class _ProgressedBlockedAdmissionMergeTrainGitHubClient(_FakeMergeTrainGitHubClient):
+    def land_batch_candidate(
+        self,
+        *,
+        landing_plan: MergeTrainBatchLandingPlan,
+        admission_guard: _LandingPlanRecordUpdater,
+        recorded_at: str,
+        provider_checkpoint: (
+            Callable[[MergeTrainBatchLandingPlan, MergeTrainBatchLandingEntry], None] | None
+        ) = None,
+        checkpoint: (
+            Callable[
+                [MergeTrainBatchLandingPlan, MergeTrainBatchLandingEntry, str],
+                MergeTrainBatchLandingPlanRecord | None,
+            ]
+            | None
+        ) = None,
+    ) -> MergeTrainBatchLandingPlan:
+        entry = landing_plan.entries[0]
+        merged_entry = entry.model_copy(
+            update={
+                "status": "merged",
+                "merge_commit_sha": f"merge-{entry.pull_request_number}",
+            }
+        )
+        progress_plan = landing_plan.model_copy(update={"entries": (merged_entry,)})
+        if checkpoint is not None:
+            progress_record = checkpoint(progress_plan, merged_entry, "entry_merged")
+            if progress_record is not None:
+                admission_guard.update_landing_plan_record(progress_record)
+        raise MergeAdmissionDeniedError(
+            "Fresh merge readiness evidence did not admit the provider effect.",
+            reason_code="merge_readiness_not_ready",
         )
 
 

--- a/tests/test_http_app_merge_train.py
+++ b/tests/test_http_app_merge_train.py
@@ -51,6 +51,7 @@ from tests.http_app_test_support import (
 from tests.merge_train_policy_fixtures import build_test_merge_train_policy_with_codex_skills
 from tests.support.auth import _identity, _local_operator_policy, _StubVerifier
 from tests.support.merge_train import (
+    _BlockedAdmissionMergeTrainGitHubClient,
     _CleanupFailingMergeTrainGitHubClient,
     _FakeCollapsedRootStackedMergeTrainSnapshotReader,
     _FakeExpandedMergeTrainSnapshotReader,
@@ -59,6 +60,7 @@ from tests.support.merge_train import (
     _FakeMergeTrainSnapshotReader,
     _FakeMovedRootStackedMergeTrainSnapshotReader,
     _FakeStackedMergeTrainSnapshotReader,
+    _ProgressedBlockedAdmissionMergeTrainGitHubClient,
     _UnavailableLandingMergeTrainGitHubClient,
     _mark_merge_train_batch_candidate_record_passed,
     _merge_train_policy_table,
@@ -305,7 +307,7 @@ class FastApiMergeTrainBatchLandingRunOnceTests(unittest.IsolatedAsyncioTestCase
                 repository="cbusillo/sellyouroutboard", base_branch="main"
             )
 
-        self.assertEqual(response.status_code, 202)
+        self.assertEqual(response.status_code, 202, response.text)
         self.assertEqual(payload["result"]["mode"], "plan")
         self.assertEqual(payload["result"]["landing_plan"]["entries"][0]["status"], "planned")
         self.assertEqual(
@@ -1821,6 +1823,162 @@ class FastApiMergeTrainControllerRunOnceTests(unittest.IsolatedAsyncioTestCase):
         )
         self.assertEqual(stale_record.landing_plan.entries[0].status, "stale")
         self.assertTrue(stale_record.source.startswith("service:controller:stale-landing:"))
+
+    async def test_admission_block_recovers_stuck_pre_provider_reconciliation(self) -> None:
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict("os.environ", {"GH_TOKEN": "token"}, clear=True),
+        ):
+            state_dir = Path(temporary_directory_name) / "state"
+            _seed_merge_train_policy(state_dir)
+            store = FilesystemRecordStore(state_dir=state_dir)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_merge_train_service_identity()),
+                authz_policy=_merge_train_service_policy(),
+                record_store_factory=lambda: store,
+            )
+            request_payload = {
+                "schema_version": 1,
+                "repository": "cbusillo/sellyouroutboard",
+                "base_branch": "main",
+                "mutate": True,
+            }
+            with (
+                patch(
+                    "control_plane.merge_train_controller_run_once.GitHubMergeTrainSnapshotReader",
+                    _FakeMergeTrainSnapshotReader,
+                ),
+                patch(
+                    "control_plane.merge_train_controller_run_once.GitHubMergeTrainClient",
+                    _FakeMergeTrainGitHubClient,
+                ),
+            ):
+                for _ in range(4):
+                    await _post_merge_train_controller_run_once(app, request_payload)
+
+            current_state = store.list_merge_train_controller_state_records(
+                repository="cbusillo/sellyouroutboard",
+                base_branch="main",
+                limit=1,
+            )[0]
+            landing_record = store.list_merge_train_batch_landing_plan_records(
+                repository="cbusillo/sellyouroutboard",
+                base_branch="main",
+                limit=1,
+            )[0]
+            store.write_merge_train_controller_state_record(
+                current_state.model_copy(
+                    update={
+                        "status": "reconcile_required",
+                        "active_action": "land_batch",
+                        "active_phase": "merge_pull_request",
+                        "active_record_id": landing_record.record_id,
+                        "active_pull_request_number": (
+                            landing_record.landing_plan.entries[0].pull_request_number
+                        ),
+                        "step_payload": {
+                            "landing_plan_record_id": landing_record.record_id,
+                            "landing_plan_id": landing_record.landing_plan.plan_id,
+                            "expected_effect_sha": landing_record.landing_plan.candidate_sha,
+                        },
+                        "reconciliation_status": "required",
+                        "reconciliation_detail": "operator_required:github_request_rejected",
+                    }
+                )
+            )
+            with patch(
+                "control_plane.merge_train_controller_run_once.GitHubMergeTrainClient",
+                _BlockedAdmissionMergeTrainGitHubClient,
+            ):
+                response = await _post_merge_train_controller_run_once(
+                    app,
+                    request_payload,
+                    idempotency_key="controller-admission-block-recovered",
+                )
+            recovered_state = store.list_merge_train_controller_state_records(
+                repository="cbusillo/sellyouroutboard",
+                base_branch="main",
+                limit=1,
+            )[0]
+
+        self.assertEqual(response.status_code, 202)
+        payload = response.json()
+        self.assertEqual(payload["result"]["controller_action"], "block")
+        self.assertEqual(
+            payload["result"]["blocking_reason"]["code"],
+            "merge_readiness_not_ready",
+        )
+        self.assertEqual(recovered_state.status, "idle")
+        self.assertEqual(recovered_state.reconciliation_status, "clean")
+        self.assertEqual(recovered_state.last_phase, "admit_pull_request")
+
+    async def test_admission_block_returns_latest_persisted_landing_progress(self) -> None:
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict("os.environ", {"GH_TOKEN": "token"}, clear=True),
+        ):
+            state_dir = Path(temporary_directory_name) / "state"
+            _seed_merge_train_policy(state_dir)
+            store = FilesystemRecordStore(state_dir=state_dir)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_merge_train_service_identity()),
+                authz_policy=_merge_train_service_policy(),
+                record_store_factory=lambda: store,
+            )
+            request_payload = {
+                "schema_version": 1,
+                "repository": "cbusillo/sellyouroutboard",
+                "base_branch": "main",
+                "mutate": True,
+            }
+            with (
+                patch(
+                    "control_plane.merge_train_controller_run_once.GitHubMergeTrainSnapshotReader",
+                    _FakeMergeTrainSnapshotReader,
+                ),
+                patch(
+                    "control_plane.merge_train_controller_run_once.GitHubMergeTrainClient",
+                    _FakeMergeTrainGitHubClient,
+                ),
+            ):
+                for _ in range(4):
+                    await _post_merge_train_controller_run_once(app, request_payload)
+            with (
+                patch(
+                    "control_plane.merge_train_controller_run_once.GitHubMergeTrainSnapshotReader",
+                    _FakeMergeTrainSnapshotReader,
+                ),
+                patch(
+                    "control_plane.merge_train_controller_run_once.GitHubMergeTrainClient",
+                    _ProgressedBlockedAdmissionMergeTrainGitHubClient,
+                ),
+            ):
+                response = await _post_merge_train_controller_run_once(
+                    app,
+                    request_payload,
+                    idempotency_key="controller-partial-admission-block",
+                )
+            landing_records = store.list_merge_train_batch_landing_plan_records(
+                repository="cbusillo/sellyouroutboard",
+                base_branch="main",
+            )
+
+        self.assertEqual(response.status_code, 202, response.text)
+        result = response.json()["result"]
+        self.assertEqual(result["controller_action"], "block")
+        self.assertEqual(
+            [entry["status"] for entry in result["landing_plan"]["entries"]],
+            ["merged"],
+        )
+        persisted_record = next(
+            record
+            for record in landing_records
+            if record.record_id == result["merge_train_batch_landing_plan_record_id"]
+        )
+        self.assertEqual(
+            [entry.status for entry in persisted_record.landing_plan.entries],
+            ["merged"],
+        )
 
     async def test_reflows_failed_candidate_after_queue_changes(self) -> None:
         with (

--- a/tests/test_launchplane_request_action.py
+++ b/tests/test_launchplane_request_action.py
@@ -71,6 +71,16 @@ global.fetch = async (url, init) => {{
   }}
   const configuredStatuses = String(process.env.TEST_REFRESH_STATUSES || '').split(',').filter(Boolean);
   const refreshStatus = configuredStatuses[launchplaneRequestCount - 1] || process.env.TEST_REFRESH_STATUS || 'pass';
+  if (process.env.TEST_ERROR_CODE) {{
+    return new Response(JSON.stringify({{
+      status: 'rejected',
+      trace_id: process.env.TEST_TRACE_ID || '',
+      error: {{
+        code: process.env.TEST_ERROR_CODE,
+        message: process.env.TEST_ERROR_MESSAGE || 'request rejected'
+      }}
+    }}), {{status: statusCode}});
+  }}
   return new Response(JSON.stringify({{
     ok: true,
     result: {{
@@ -211,6 +221,27 @@ process.on('beforeExit', () => {{
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("Launchplane request failed with 401", result.stderr)
 
+    def test_reports_public_safe_error_code_when_body_logging_is_disabled(self) -> None:
+        result = self.run_action(
+            inputs={
+                "launchplane-url": "https://launchplane.example",
+                "route-path": "/v1/work-graph/merge-train/controller/run-once",
+                "payload": '{"schema_version":1,"repository":"example/repo"}',
+                "log-response-body": "false",
+            },
+            environment={
+                "TEST_STATUS": "409",
+                "TEST_ERROR_CODE": "merge_train_landing_not_admitted",
+                "TEST_ERROR_MESSAGE": "sensitive diagnostic detail",
+                "TEST_TRACE_ID": "launchplane_req_example",
+            },
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("code=merge_train_landing_not_admitted", result.stderr)
+        self.assertIn("trace_id=launchplane_req_example", result.stderr)
+        self.assertNotIn("sensitive diagnostic detail", result.stderr)
+
     def test_rejects_invalid_expected_status_input(self) -> None:
         result = self.run_action(
             inputs={
@@ -256,24 +287,27 @@ process.on('beforeExit', () => {{
             )
 
             self.assertEqual(result.returncode, 0, result.stderr)
-            self.assertEqual(json.loads(response_output_path.read_text(encoding="utf-8")), [
-                {
-                    "ok": True,
-                    "result": {
-                        "refresh_status": "pass",
-                        "error_message": "",
-                        "application_id": "app-123",
+            self.assertEqual(
+                json.loads(response_output_path.read_text(encoding="utf-8")),
+                [
+                    {
+                        "ok": True,
+                        "result": {
+                            "refresh_status": "pass",
+                            "error_message": "",
+                            "application_id": "app-123",
+                        },
                     },
-                },
-                {
-                    "ok": True,
-                    "result": {
-                        "refresh_status": "pass",
-                        "error_message": "",
-                        "application_id": "app-123",
+                    {
+                        "ok": True,
+                        "result": {
+                            "refresh_status": "pass",
+                            "error_message": "",
+                            "application_id": "app-123",
+                        },
                     },
-                },
-            ])
+                ],
+            )
             calls = json.loads(result.stderr.strip().splitlines()[-1])
             launchplane_calls = [
                 call
@@ -441,7 +475,9 @@ process.on('beforeExit', () => {{
             if call["url"] == "https://launchplane.example/v1/service/runtime"
         ]
         self.assertEqual(len(launchplane_calls), 2)
-        self.assertIn("Launchplane result runtime.docker_image_reference is HTTP 503", result.stderr)
+        self.assertIn(
+            "Launchplane result runtime.docker_image_reference is HTTP 503", result.stderr
+        )
 
     def test_poll_until_requires_expected_value(self) -> None:
         result = self.run_action(
@@ -545,16 +581,19 @@ process.on('beforeExit', () => {{
 
             self.assertNotEqual(result.returncode, 0)
             self.assertIn("simulated Launchplane network failure", result.stderr)
-            self.assertEqual(json.loads(response_output_path.read_text(encoding="utf-8")), [
-                {
-                    "ok": True,
-                    "result": {
-                        "refresh_status": "pass",
-                        "error_message": "",
-                        "application_id": "app-123",
-                    },
-                }
-            ])
+            self.assertEqual(
+                json.loads(response_output_path.read_text(encoding="utf-8")),
+                [
+                    {
+                        "ok": True,
+                        "result": {
+                            "refresh_status": "pass",
+                            "error_message": "",
+                            "application_id": "app-123",
+                        },
+                    }
+                ],
+            )
 
     def test_retries_launchplane_request_with_fresh_oidc_token(self) -> None:
         result = self.run_action(

--- a/tests/test_launchplane_request_action.py
+++ b/tests/test_launchplane_request_action.py
@@ -71,6 +71,12 @@ global.fetch = async (url, init) => {{
   }}
   const configuredStatuses = String(process.env.TEST_REFRESH_STATUSES || '').split(',').filter(Boolean);
   const refreshStatus = configuredStatuses[launchplaneRequestCount - 1] || process.env.TEST_REFRESH_STATUS || 'pass';
+  if (process.env.TEST_TRACE_ONLY === 'true') {{
+    return new Response(JSON.stringify({{
+      status: 'rejected',
+      trace_id: process.env.TEST_TRACE_ID || ''
+    }}), {{status: statusCode}});
+  }}
   if (process.env.TEST_ERROR_CODE) {{
     return new Response(JSON.stringify({{
       status: 'rejected',
@@ -241,6 +247,24 @@ process.on('beforeExit', () => {{
         self.assertIn("code=merge_train_landing_not_admitted", result.stderr)
         self.assertIn("trace_id=launchplane_req_example", result.stderr)
         self.assertNotIn("sensitive diagnostic detail", result.stderr)
+
+    def test_reports_trace_id_without_error_wrapper(self) -> None:
+        result = self.run_action(
+            inputs={
+                "launchplane-url": "https://launchplane.example",
+                "route-path": "/v1/work-graph/merge-train/controller/run-once",
+                "payload": '{"schema_version":1,"repository":"example/repo"}',
+                "log-response-body": "false",
+            },
+            environment={
+                "TEST_STATUS": "502",
+                "TEST_TRACE_ONLY": "true",
+                "TEST_TRACE_ID": "launchplane_req_gateway",
+            },
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("trace_id=launchplane_req_gateway", result.stderr)
 
     def test_rejects_invalid_expected_status_input(self) -> None:
         result = self.run_action(

--- a/tests/test_merge_admission_records.py
+++ b/tests/test_merge_admission_records.py
@@ -475,9 +475,11 @@ class GuardedMergeAdmissionScenarioTests(unittest.TestCase):
     def test_scenario_12_policy_drift_refuses_next_admission(self) -> None:
         readiness = self._readiness(policy_fingerprints=_policy_fingerprints(drift="merge_train"))
 
-        with self.assertRaises(MergeAdmissionDeniedError):
+        with self.assertRaises(MergeAdmissionDeniedError) as context:
             self._admit(self._guard(readiness))
 
+        self.assertEqual(context.exception.reason_code, "merge_readiness_not_ready")
+        self.assertEqual(context.exception.readiness, readiness)
         self.assertEqual(self.store.list_merge_admission_records(), ())
 
     def test_scenario_22_lost_lease_refuses_admission(self) -> None:

--- a/tests/test_merge_train_controller_feedback.py
+++ b/tests/test_merge_train_controller_feedback.py
@@ -116,6 +116,29 @@ class MergeTrainControllerFeedbackTests(TestCase):
         self.assertEqual({"stale_policy"}, {payload["event"] for payload in payloads})
         self.assertIn("stale", payloads[0]["message"])
 
+    def test_build_feedback_payloads_reports_admission_block_detail(self) -> None:
+        response: dict[str, Any] = {
+            "result": {
+                "repository": "cbusillo/example",
+                "base_branch": "main",
+                "controller_action": "block",
+                "blocking_reason": {
+                    "code": "merge_readiness_not_ready",
+                    "message": "Fresh merge readiness evidence did not admit the provider effect.",
+                },
+                "landing_plan": {
+                    "entries": [{"pull_request_number": 7, "status": "planned"}],
+                },
+            },
+            "records": {"merge_train_batch_landing_plan_record_id": "landing-plan-123"},
+        }
+
+        payloads = feedback.build_feedback_payloads(response=response)
+
+        self.assertEqual(1, len(payloads))
+        self.assertEqual("blocked", payloads[0]["event"])
+        self.assertIn("Fresh merge readiness evidence", payloads[0]["message"])
+
     def test_build_feedback_payloads_skips_actions_without_pr_numbers(self) -> None:
         response: dict[str, Any] = {
             "result": {

--- a/tests/test_merge_train_github.py
+++ b/tests/test_merge_train_github.py
@@ -66,6 +66,7 @@ class GitHubMergeTrainClientTests(unittest.TestCase):
             landing_plan: MergeTrainBatchLandingPlan,
             admission_guard: object | None = None,
             recorded_at: str = "",
+            provider_checkpoint: object | None = None,
             checkpoint: object | None = None,
         ) -> MergeTrainBatchLandingPlan:
             return original(
@@ -75,6 +76,7 @@ class GitHubMergeTrainClientTests(unittest.TestCase):
                     admission_guard or _PermissiveMergeAdmissionGuard()  # type: ignore[arg-type]
                 ),
                 recorded_at=recorded_at or "2026-08-11T00:00:00Z",
+                provider_checkpoint=provider_checkpoint,  # type: ignore[arg-type]
                 checkpoint=checkpoint,  # type: ignore[arg-type]
             )
 
@@ -848,6 +850,7 @@ class GitHubMergeTrainClientTests(unittest.TestCase):
     def test_land_batch_candidate_merges_original_prs_in_order(self) -> None:
         landing_plan = _landing_plan()
         checkpoints: list[tuple[str, int, int]] = []
+        provider_checkpoints: list[tuple[int, int]] = []
         transport = RecordingMergeTrainGitHubTransport(
             responses=(
                 _github_branch(sha="base-main"),
@@ -863,6 +866,12 @@ class GitHubMergeTrainClientTests(unittest.TestCase):
             checkpoint=lambda progress, entry, phase: checkpoints.append(
                 (
                     phase,
+                    entry.pull_request_number,
+                    sum(item.status == "merged" for item in progress.entries),
+                )
+            ),
+            provider_checkpoint=lambda progress, entry: provider_checkpoints.append(
+                (
                     entry.pull_request_number,
                     sum(item.status == "merged" for item in progress.entries),
                 )
@@ -909,6 +918,7 @@ class GitHubMergeTrainClientTests(unittest.TestCase):
                 ("entry_merged", 2, 2),
             ],
         )
+        self.assertEqual(provider_checkpoints, [(1, 0), (2, 1)])
 
     def test_land_batch_candidate_records_candidate_no_op_as_skipped(self) -> None:
         landing_plan = _landing_plan()


### PR DESCRIPTION
## Summary

- distinguish pre-provider admission from the GitHub merge effect checkpoint
- return accepted, actionable blocks for fresh admission denials instead of sticky reconciliation
- preserve actual ambiguous-effect reconciliation behavior
- expose public-safe error code and trace ID from protected request failures, including trace-only responses
- preserve and report the latest persisted landing progress when a later admission blocks

## Root Cause

The controller checkpointed `merge_pull_request` before guarded admission ran. A normal fail-closed admission denial therefore looked like a GitHub merge conflict and was converted into durable reconciliation even though no provider effect had been attempted.

For the affected `codex-skills#539` landing, GitHub still reported the exact planned base/head and a clean, mergeable PR. The actual pre-effect blocker is guarded Launchplane readiness evidence, not movement of `main` and not a GitHub content merge conflict.

## Recovery Behavior

After deployment, resuming the existing landing plan will re-observe prior outcomes and evaluate guarded admission under the truthful `admit_pull_request` phase. If readiness is still incomplete, Launchplane returns `controller_action=block` with public-safe readiness reason codes and releases the controller state cleanly. Once the missing evidence is recorded, a later pass persists admission, checkpoints `merge_pull_request`, and calls GitHub.

## Validation

- `uv run --extra dev launchplane ci unittest-shard local` — 2,905 targets, 12/12 shards passed
- `uv run --extra dev ruff check .` — passed
- changed-file `uv run --extra dev ruff format --check ...` — passed
- `uv run --extra dev mypy control_plane tests` — 719 files passed
- latest trace-only diagnostic follow-up: action suite 30/30 passed and `node --check` passed
- JetBrains changed-files inspection was attempted but did not produce clean execution proof; no GREEN claim is made
- Opus exact-head review: APPROVED
- Gemini/Antigravity exact-head review: APPROVED after one valid trace-only diagnostic finding was fixed and two type-assumption findings were reconsidered against exact source definitions

Addresses #2135. Keep the issue open until the fix is deployed and the existing `codex-skills#539` landing plan reaches an explicit blocked or landed result.
