### PR TITLE
Enforce content-current first-party action pins

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,8 @@ version: 2
 
 updates:
   - package-ecosystem: github-actions
-    # Inline release-tag provenance comments keep full-SHA action pin updates
-    # reviewable.
+    # Covers third-party Actions. Same-repository first-party action pins are
+    # enforced and updated through `launchplane action-pins` instead.
     directory: "/"
     open-pull-requests-limit: 5
     schedule:

--- a/.github/workflows/deploy-launchplane.yml
+++ b/.github/workflows/deploy-launchplane.yml
@@ -326,7 +326,7 @@ jobs:
       - name: Read previous Launchplane runtime
         id: previous_runtime
         continue-on-error: true
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: ${{ steps.service.outputs.service_url }}
           audience: ${{ steps.service.outputs.service_audience }}
@@ -544,7 +544,7 @@ jobs:
       - name: Request Launchplane self deploy
         id: self_deploy_request
         continue-on-error: true
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: ${{ steps.service.outputs.service_url }}
           audience: ${{ steps.service.outputs.service_audience }}
@@ -593,7 +593,7 @@ jobs:
           } >>"$GITHUB_OUTPUT"
 
       - name: Wait for deployed Launchplane runtime image
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: ${{ steps.service.outputs.service_url }}
           audience: ${{ steps.service.outputs.service_audience }}
@@ -667,7 +667,7 @@ jobs:
           exit 1
 
       - name: Verify deployed Launchplane runtime image after health
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: ${{ steps.service.outputs.service_url }}
           audience: ${{ steps.service.outputs.service_audience }}
@@ -718,7 +718,7 @@ jobs:
           && steps.rollback_request.outputs.previous_image_reference != ''
         id: rollback_request_action
         continue-on-error: true
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: ${{ steps.service.outputs.service_url }}
           audience: ${{ steps.service.outputs.service_audience }}
@@ -796,7 +796,7 @@ jobs:
           && steps.rollback_request_action.outcome == 'success'
         id: rollback_runtime
         continue-on-error: true
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: ${{ steps.service.outputs.service_url }}
           audience: ${{ steps.service.outputs.service_audience }}
@@ -935,7 +935,7 @@ jobs:
           && steps.rollback_request_action.outcome == 'success'
           && steps.rollback_runtime.outcome == 'success'
           && steps.rollback_health.outcome == 'success'
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: ${{ steps.service.outputs.service_url }}
           audience: ${{ steps.service.outputs.service_audience }}
@@ -960,7 +960,7 @@ jobs:
 
       - name: Ensure runtime key-safety policy
         if: steps.runtime_key_safety.outputs.has_runtime_key_safety_policy == 'true'
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: ${{ steps.service.outputs.service_url }}
           audience: ${{ steps.service.outputs.service_audience }}
@@ -973,7 +973,7 @@ jobs:
       - name: Read deployed Launchplane runtime
         id: deployed_runtime
         continue-on-error: true
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: ${{ steps.service.outputs.service_url }}
           audience: ${{ steps.service.outputs.service_audience }}

--- a/.github/workflows/dokploy-target-inspect.yml
+++ b/.github/workflows/dokploy-target-inspect.yml
@@ -97,7 +97,7 @@ jobs:
 
       - name: Inspect target
         id: inspect_request
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}
           audience: ${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}

--- a/.github/workflows/dokploy-target-setup.yml
+++ b/.github/workflows/dokploy-target-setup.yml
@@ -337,7 +337,7 @@ jobs:
 
       - name: Request Launchplane target setup
         id: target_setup_request
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: ${{ env.LAUNCHPLANE_URL }}
           audience: ${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}

--- a/.github/workflows/generic-web-preview-authorization.yml
+++ b/.github/workflows/generic-web-preview-authorization.yml
@@ -216,7 +216,7 @@ jobs:
             > authz-plan-request.json
 
       - name: Plan preview authorization
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: ${{ env.LAUNCHPLANE_URL }}
           audience: ${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}

--- a/.github/workflows/ingress-route-audit-read.yml
+++ b/.github/workflows/ingress-route-audit-read.yml
@@ -112,7 +112,7 @@ jobs:
 
       - name: Request redacted audit records
         id: audit_read_request
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}
           audience: ${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}

--- a/.github/workflows/ingress-route-canary-apply.yml
+++ b/.github/workflows/ingress-route-canary-apply.yml
@@ -92,7 +92,7 @@ jobs:
 
       - name: Request ingress route canary apply
         id: launchplane
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: ${{ env.LAUNCHPLANE_URL }}
           method: POST

--- a/.github/workflows/live-target-runtime.yml
+++ b/.github/workflows/live-target-runtime.yml
@@ -102,7 +102,7 @@ jobs:
 
       - name: Apply live target runtime sync
         id: live_target_runtime_request
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}
           audience: ${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}

--- a/.github/workflows/merge-train-policy-import.yml
+++ b/.github/workflows/merge-train-policy-import.yml
@@ -233,7 +233,7 @@ jobs:
 
       - name: Request policy import dry-run
         id: dry_run
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: ${{ env.LAUNCHPLANE_URL }}
           audience: ${{ steps.service.outputs.audience }}
@@ -279,7 +279,7 @@ jobs:
 
       - name: Apply policy import
         if: env.APPLY_POLICY == 'true'
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: ${{ env.LAUNCHPLANE_URL }}
           audience: ${{ steps.service.outputs.audience }}

--- a/.github/workflows/merge-train-runner.yml
+++ b/.github/workflows/merge-train-runner.yml
@@ -201,7 +201,7 @@ jobs:
       - name: Read scheduled merge-train targets
         if: github.event_name == 'schedule'
         id: scheduled_target_read
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: ${{ env.LAUNCHPLANE_URL }}
           audience: ${{ steps.scheduled_target_request.outputs.service_audience }}
@@ -324,7 +324,7 @@ jobs:
       - name: Read merge-train admission
         if: steps.admission_request.outputs.should_request == 'true'
         id: admission_read
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: ${{ env.LAUNCHPLANE_URL }}
           audience: ${{ steps.admission_request.outputs.service_audience }}
@@ -446,7 +446,7 @@ jobs:
       - name: Send merge-train run-once request
         if: steps.level1_request.outputs.should_request == 'true'
         id: level1_run
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: ${{ env.LAUNCHPLANE_URL }}
           audience: ${{ steps.admission.outputs.service_audience }}
@@ -558,7 +558,7 @@ jobs:
           steps.admission.outputs.admission_status == 'admitted' &&
           env.MERGE_TRAIN_RUNNER_MODE == 'controller'
         id: controller_run
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: ${{ env.LAUNCHPLANE_URL }}
           audience: ${{ steps.admission.outputs.service_audience }}
@@ -638,7 +638,7 @@ jobs:
           steps.admission.outputs.admission_status == 'admitted' &&
           env.MERGE_TRAIN_RUNNER_MODE == 'controller' &&
           steps.controller_summary.outputs.feedback_count != '0'
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: ${{ env.LAUNCHPLANE_URL }}
           audience: ${{ steps.admission.outputs.service_audience }}
@@ -705,7 +705,7 @@ jobs:
           steps.admission.outputs.admission_status == 'admitted' &&
           env.MERGE_TRAIN_BATCH_CANDIDATE_MODE != 'none'
         id: batch_candidate_run
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: ${{ env.LAUNCHPLANE_URL }}
           audience: ${{ steps.admission.outputs.service_audience }}
@@ -814,7 +814,7 @@ jobs:
           steps.admission.outputs.admission_status == 'admitted' &&
           env.MERGE_TRAIN_STACK_COLLAPSE_MODE != 'none'
         id: stack_collapse_run
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: ${{ env.LAUNCHPLANE_URL }}
           audience: ${{ steps.admission.outputs.service_audience }}
@@ -936,7 +936,7 @@ jobs:
           steps.admission.outputs.admission_status == 'admitted' &&
           env.MERGE_TRAIN_BATCH_LANDING_MODE != 'none'
         id: batch_landing_run
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: ${{ env.LAUNCHPLANE_URL }}
           audience: ${{ steps.admission.outputs.service_audience }}
@@ -1052,7 +1052,7 @@ jobs:
           steps.admission.outputs.admission_status == 'admitted' &&
           env.MERGE_TRAIN_RUNNER_MODE == 'level1' &&
           steps.manual_phase_feedback.outputs.feedback_count != '0'
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: ${{ env.LAUNCHPLANE_URL }}
           audience: ${{ steps.admission.outputs.service_audience }}

--- a/.github/workflows/odoo-config-parameter-override.yml
+++ b/.github/workflows/odoo-config-parameter-override.yml
@@ -102,7 +102,7 @@ jobs:
 
       - name: Write config parameter override
         id: launchplane
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}
           audience: ${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}

--- a/.github/workflows/odoo-driver-route-smoke.yml
+++ b/.github/workflows/odoo-driver-route-smoke.yml
@@ -168,7 +168,7 @@ jobs:
 
       - name: Resolve Odoo artifact publish inputs through GitHub OIDC
         id: publish_inputs
-        uses: ./.github/actions/launchplane-request
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: ${{ env.LAUNCHPLANE_URL }}
           audience: ${{ env.LAUNCHPLANE_AUDIENCE }}
@@ -288,7 +288,7 @@ jobs:
       - name: Probe Odoo preview apply inputs route
         id: preview_apply_inputs_probe
         continue-on-error: true
-        uses: ./.github/actions/launchplane-request
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: ${{ env.LAUNCHPLANE_URL }}
           audience: ${{ env.LAUNCHPLANE_AUDIENCE }}
@@ -305,7 +305,7 @@ jobs:
       - name: Probe Odoo preview apply route
         id: preview_apply_probe
         continue-on-error: true
-        uses: ./.github/actions/launchplane-request
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: ${{ env.LAUNCHPLANE_URL }}
           audience: ${{ env.LAUNCHPLANE_AUDIENCE }}
@@ -322,7 +322,7 @@ jobs:
       - name: Probe preview PR feedback route
         id: preview_pr_feedback_probe
         continue-on-error: true
-        uses: ./.github/actions/launchplane-request
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: ${{ env.LAUNCHPLANE_URL }}
           audience: ${{ env.LAUNCHPLANE_AUDIENCE }}

--- a/.github/workflows/odoo-stable-bootstrap.yml
+++ b/.github/workflows/odoo-stable-bootstrap.yml
@@ -155,7 +155,7 @@ jobs:
 
       - name: Create bootstrap operation
         id: create_bootstrap
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}
           audience: ${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}
@@ -205,7 +205,7 @@ jobs:
 
       - name: Poll bootstrap operation
         id: poll_bootstrap
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}
           audience: ${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}

--- a/.github/workflows/preview-lifecycle.yml
+++ b/.github/workflows/preview-lifecycle.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Run Launchplane-owned preview lifecycle
         id: preview_lifecycle_request
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: ${{ env.LAUNCHPLANE_URL }}
           audience: ${{ env.LAUNCHPLANE_AUDIENCE }}

--- a/.github/workflows/product-environment-evidence.yml
+++ b/.github/workflows/product-environment-evidence.yml
@@ -134,7 +134,7 @@ jobs:
 
       - name: Read product environment evidence
         id: environment_request
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: ${{ env.LAUNCHPLANE_URL }}
           audience: ${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}
@@ -204,7 +204,7 @@ jobs:
 
       - name: Read product environment config status
         id: config_status_request
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: ${{ env.LAUNCHPLANE_URL }}
           audience: ${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}

--- a/.github/workflows/product-onboarding-manifest.yml
+++ b/.github/workflows/product-onboarding-manifest.yml
@@ -89,7 +89,7 @@ jobs:
 
       - name: Request product onboarding apply
         id: onboarding_request
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: ${{ env.LAUNCHPLANE_URL }}
           audience: ${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}

--- a/.github/workflows/product-onboarding.yml
+++ b/.github/workflows/product-onboarding.yml
@@ -353,7 +353,7 @@ jobs:
 
       - name: Plan Dokploy application target
         id: target-plan
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: ${{ env.LAUNCHPLANE_URL }}
           audience: ${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}
@@ -365,7 +365,7 @@ jobs:
 
       - name: Plan product records
         id: onboarding-plan
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: ${{ env.LAUNCHPLANE_URL }}
           audience: ${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}
@@ -377,7 +377,7 @@ jobs:
 
       - name: Plan preview authorization
         id: authz-plan
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: ${{ env.LAUNCHPLANE_URL }}
           audience: ${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}

--- a/.github/workflows/product-preview-tls.yml
+++ b/.github/workflows/product-preview-tls.yml
@@ -115,7 +115,7 @@ jobs:
 
       - name: Request product preview TLS operation
         id: preview_tls_request
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: ${{ env.LAUNCHPLANE_URL }}
           audience: ${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}

--- a/.github/workflows/provider-target-operations.yml
+++ b/.github/workflows/provider-target-operations.yml
@@ -200,7 +200,7 @@ jobs:
 
       - name: Request provider-target operation
         id: provider_target_request
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: ${{ env.LAUNCHPLANE_URL }}
           audience: ${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}

--- a/.github/workflows/reusable-authz-policy-reconcile.yml
+++ b/.github/workflows/reusable-authz-policy-reconcile.yml
@@ -220,7 +220,7 @@ jobs:
 
       - name: Reconcile managed authz policy
         id: reconcile
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: ${{ env.LAUNCHPLANE_PUBLIC_URL }}
           audience: ${{ env.LAUNCHPLANE_SERVICE_AUDIENCE }}

--- a/.github/workflows/reusable-detached-application-retirement.yml
+++ b/.github/workflows/reusable-detached-application-retirement.yml
@@ -174,7 +174,7 @@ jobs:
 
       - name: Request audited detached application retirement
         id: request
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@3f063c09bab63836d2b1c880ecb995786f045893 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: ${{ env.LAUNCHPLANE_URL }}
           route-path: /v1/detached-application-retirement

--- a/.github/workflows/reusable-external-route-binding-reconcile.yml
+++ b/.github/workflows/reusable-external-route-binding-reconcile.yml
@@ -88,7 +88,7 @@ jobs:
 
       - name: Read current route binding
         id: current
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: ${{ env.LAUNCHPLANE_URL }}
           audience: ${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}
@@ -175,7 +175,7 @@ jobs:
 
       - name: Request external route-binding reconcile
         id: reconcile
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: ${{ env.LAUNCHPLANE_URL }}
           audience: ${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}

--- a/.github/workflows/reusable-generic-web-onboarding-apply.yml
+++ b/.github/workflows/reusable-generic-web-onboarding-apply.yml
@@ -88,7 +88,7 @@ jobs:
 
       - name: Create Dokploy application target
         id: target-apply
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: ${{ env.LAUNCHPLANE_URL }}
           audience: ${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}
@@ -121,7 +121,7 @@ jobs:
 
       - name: Apply product records
         id: onboarding-apply
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: ${{ env.LAUNCHPLANE_URL }}
           audience: ${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}
@@ -136,7 +136,7 @@ jobs:
 
       - name: Apply preview authorization
         id: authz-apply
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: ${{ env.LAUNCHPLANE_URL }}
           audience: ${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}

--- a/.github/workflows/reusable-generic-web-preview-authz-apply.yml
+++ b/.github/workflows/reusable-generic-web-preview-authz-apply.yml
@@ -53,7 +53,7 @@ jobs:
             authz-reconcile-request.json > authz-apply-request.json
 
       - name: Apply preview authorization
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: ${{ env.LAUNCHPLANE_URL }}
           audience: ${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}

--- a/.github/workflows/reusable-generic-web-preview-lifecycle.yml
+++ b/.github/workflows/reusable-generic-web-preview-lifecycle.yml
@@ -221,7 +221,7 @@ jobs:
     steps:
       - name: Request Launchplane generic-web preview refresh
         id: lp
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: >-
             ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}
@@ -257,7 +257,7 @@ jobs:
 
       - name: Diagnose preview refresh authorization
         if: ${{ steps.lp.outputs.status-code == '403' }}
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: >-
             ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}
@@ -303,7 +303,7 @@ jobs:
     steps:
       - name: Request Launchplane generic-web preview destroy
         id: lp
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: >-
             ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}
@@ -349,7 +349,7 @@ jobs:
     steps:
       - name: Request Launchplane unsupported preview feedback
         id: lp
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: >-
             ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}

--- a/.github/workflows/reusable-generic-web-preview-verification.yml
+++ b/.github/workflows/reusable-generic-web-preview-verification.yml
@@ -214,7 +214,7 @@ jobs:
 
       - name: Request Launchplane generic-web preview verification
         id: lp
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: >-
             ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}

--- a/.github/workflows/reusable-generic-web-prod-promotion.yml
+++ b/.github/workflows/reusable-generic-web-prod-promotion.yml
@@ -285,7 +285,7 @@ jobs:
 
       - name: Request Launchplane generic-web prod promotion
         id: lp
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: >-
             ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}

--- a/.github/workflows/reusable-generic-web-prod-rollback.yml
+++ b/.github/workflows/reusable-generic-web-prod-rollback.yml
@@ -189,7 +189,7 @@ jobs:
 
       - name: Request Launchplane generic-web prod rollback
         id: lp
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: >-
             ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}

--- a/.github/workflows/reusable-generic-web-stable-deploy.yml
+++ b/.github/workflows/reusable-generic-web-stable-deploy.yml
@@ -110,7 +110,7 @@ jobs:
 
       - name: Request Launchplane generic-web stable deploy
         id: lp
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: >-
             ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}

--- a/.github/workflows/reusable-generic-web-stable-verification.yml
+++ b/.github/workflows/reusable-generic-web-stable-verification.yml
@@ -229,7 +229,7 @@ jobs:
 
       - name: Request Launchplane generic-web stable verification
         id: lp
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: >-
             ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}

--- a/.github/workflows/reusable-ingress-route-apply.yml
+++ b/.github/workflows/reusable-ingress-route-apply.yml
@@ -135,7 +135,7 @@ jobs:
 
       - name: Request ingress route apply
         id: launchplane
-        uses: ./.github/actions/launchplane-request
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: ${{ env.LAUNCHPLANE_URL }}
           method: POST

--- a/.github/workflows/reusable-ingress-route-dry-run.yml
+++ b/.github/workflows/reusable-ingress-route-dry-run.yml
@@ -231,7 +231,7 @@ jobs:
 
       - name: Request ingress route dry run
         id: launchplane
-        uses: ./.github/actions/launchplane-request
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: ${{ env.LAUNCHPLANE_URL }}
           method: POST

--- a/.github/workflows/reusable-odoo-artifact-publish.yml
+++ b/.github/workflows/reusable-odoo-artifact-publish.yml
@@ -201,7 +201,7 @@ jobs:
 
       - name: Resolve Launchplane publish inputs
         id: publish_inputs
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: >-
             ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}
@@ -343,7 +343,7 @@ jobs:
 
       - name: Record artifact in Launchplane
         id: launchplane
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: >-
             ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}

--- a/.github/workflows/reusable-odoo-preview.yml
+++ b/.github/workflows/reusable-odoo-preview.yml
@@ -338,7 +338,7 @@ jobs:
 
       - name: Resolve Launchplane publish inputs
         id: publish_inputs
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: >-
             ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}
@@ -463,7 +463,7 @@ jobs:
 
       - name: Request Launchplane isolated preview apply inputs
         id: dry_run
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: >-
             ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}
@@ -501,7 +501,7 @@ jobs:
 
       - name: Request Launchplane isolated preview apply
         id: launchplane
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: >-
             ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}
@@ -667,7 +667,7 @@ jobs:
 
       - name: Request Launchplane isolated preview destroy inputs
         id: dry_run
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: >-
             ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}
@@ -704,7 +704,7 @@ jobs:
 
       - name: Request Launchplane isolated preview destroy
         id: launchplane
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: >-
             ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}

--- a/.github/workflows/reusable-odoo-prod-backup-restore-apply.yml
+++ b/.github/workflows/reusable-odoo-prod-backup-restore-apply.yml
@@ -182,7 +182,7 @@ jobs:
 
       - name: Create destructive restore operation
         id: create_restore
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: >-
             ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}
@@ -221,7 +221,7 @@ jobs:
 
       - name: Poll destructive restore operation
         id: poll_restore
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: >-
             ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}

--- a/.github/workflows/reusable-odoo-prod-backup-restore-plan.yml
+++ b/.github/workflows/reusable-odoo-prod-backup-restore-plan.yml
@@ -124,7 +124,7 @@ jobs:
 
       - name: Build reviewed restore plan
         id: launchplane
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: >-
             ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}

--- a/.github/workflows/reusable-odoo-prod-backup-verification.yml
+++ b/.github/workflows/reusable-odoo-prod-backup-verification.yml
@@ -127,7 +127,7 @@ jobs:
       - name: Request Launchplane backup verification
         id: launchplane
         # yamllint disable-line rule:line-length
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850  # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: >-
             ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}

--- a/.github/workflows/reusable-odoo-prod-retained-volume-backup-import-apply.yml
+++ b/.github/workflows/reusable-odoo-prod-retained-volume-backup-import-apply.yml
@@ -135,7 +135,7 @@ jobs:
 
       - name: Re-read reviewed retained-volume plan
         id: reviewed_plan
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: >-
             ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}
@@ -225,7 +225,7 @@ jobs:
 
       - name: Create retained-volume backup import operation
         id: create_import
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: >-
             ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}
@@ -242,7 +242,7 @@ jobs:
 
       - name: Poll retained-volume backup import operation
         id: poll_import
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: >-
             ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}

--- a/.github/workflows/reusable-odoo-prod-retained-volume-backup-import-plan.yml
+++ b/.github/workflows/reusable-odoo-prod-retained-volume-backup-import-plan.yml
@@ -163,7 +163,7 @@ jobs:
 
       - name: Create durable retained-volume plan operation
         id: create_plan
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: >-
             ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}
@@ -180,7 +180,7 @@ jobs:
 
       - name: Poll retained-volume plan operation
         id: poll_plan
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: >-
             ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}

--- a/.github/workflows/reusable-odoo-target-replacement-apply.yml
+++ b/.github/workflows/reusable-odoo-target-replacement-apply.yml
@@ -185,7 +185,7 @@ jobs:
 
       - name: Read product environment authority
         id: environment
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: >-
             ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}
@@ -303,7 +303,7 @@ jobs:
 
       - name: Read target replacement readiness
         id: readiness
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: >-
             ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}
@@ -457,7 +457,7 @@ jobs:
 
       - name: Create replacement operation
         id: create_replacement
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: >-
             ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}
@@ -521,7 +521,7 @@ jobs:
 
       - name: Poll replacement operation
         id: poll_replacement
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: >-
             ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}

--- a/.github/workflows/reusable-odoo-target-replacement-plan.yml
+++ b/.github/workflows/reusable-odoo-target-replacement-plan.yml
@@ -121,7 +121,7 @@ jobs:
 
       - name: Read product environment authority
         id: environment
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: >-
             ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}
@@ -233,7 +233,7 @@ jobs:
 
       - name: Read target replacement readiness
         id: readiness
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: >-
             ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}
@@ -367,7 +367,7 @@ jobs:
 
       - name: Build replacement plan
         id: launchplane
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: >-
             ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}

--- a/.github/workflows/reusable-odoo-testing-route-binding-refresh.yml
+++ b/.github/workflows/reusable-odoo-testing-route-binding-refresh.yml
@@ -73,7 +73,7 @@ jobs:
             > odoo-testing-route-binding-refresh-request.json
 
       - name: Run Odoo testing route-binding refresh
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: ${{ env.LAUNCHPLANE_URL }}
           audience: ${{ env.LAUNCHPLANE_AUDIENCE }}

--- a/.github/workflows/reusable-odoo-website-bootstrap-override.yml
+++ b/.github/workflows/reusable-odoo-website-bootstrap-override.yml
@@ -183,7 +183,7 @@ jobs:
       - name: Write website bootstrap override
         id: launchplane
         continue-on-error: true
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: ${{ env.LAUNCHPLANE_SERVICE_URL }}
           audience: ${{ env.LAUNCHPLANE_SERVICE_AUDIENCE }}

--- a/.github/workflows/reusable-preview-pr-feedback.yml
+++ b/.github/workflows/reusable-preview-pr-feedback.yml
@@ -154,7 +154,7 @@ jobs:
 
       - name: Request Launchplane preview PR feedback
         id: lp
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: >-
             ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}

--- a/.github/workflows/reusable-product-driver-app-maintenance.yml
+++ b/.github/workflows/reusable-product-driver-app-maintenance.yml
@@ -199,7 +199,7 @@ jobs:
 
       - name: Request Launchplane app maintenance
         id: lp
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: >-
             ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}

--- a/.github/workflows/reusable-product-driver-post-deploy.yml
+++ b/.github/workflows/reusable-product-driver-post-deploy.yml
@@ -120,7 +120,7 @@ jobs:
 
       - name: Request Launchplane post-deploy driver
         id: lp
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: >-
             ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}

--- a/.github/workflows/reusable-product-driver-prod-backup-gate.yml
+++ b/.github/workflows/reusable-product-driver-prod-backup-gate.yml
@@ -127,7 +127,7 @@ jobs:
 
       - name: Request Launchplane prod backup gate
         id: lp
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: >-
             ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}

--- a/.github/workflows/reusable-product-driver-prod-promotion.yml
+++ b/.github/workflows/reusable-product-driver-prod-promotion.yml
@@ -237,7 +237,7 @@ jobs:
       - name: Request Launchplane VeriReel prod promotion
         id: lp_verireel
         if: ${{ steps.request.outputs.driver == 'verireel' }}
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: >-
             ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}
@@ -287,7 +287,7 @@ jobs:
       - name: Request Launchplane Odoo prod promotion
         id: lp_odoo
         if: ${{ steps.request.outputs.driver == 'odoo' }}
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: >-
             ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}

--- a/.github/workflows/reusable-product-driver-prod-rollback.yml
+++ b/.github/workflows/reusable-product-driver-prod-rollback.yml
@@ -208,7 +208,7 @@ jobs:
       - name: Request Launchplane VeriReel prod rollback
         id: lp_verireel
         if: ${{ steps.request.outputs.driver == 'verireel' }}
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: >-
             ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}
@@ -247,7 +247,7 @@ jobs:
       - name: Request Launchplane Odoo prod rollback
         id: lp_odoo
         if: ${{ steps.request.outputs.driver == 'odoo' }}
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: >-
             ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}

--- a/.github/workflows/reusable-product-driver-runtime-verification.yml
+++ b/.github/workflows/reusable-product-driver-runtime-verification.yml
@@ -132,7 +132,7 @@ jobs:
 
       - name: Request Launchplane runtime verification
         id: lp
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: >-
             ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}

--- a/.github/workflows/reusable-product-driver-stable-deploy.yml
+++ b/.github/workflows/reusable-product-driver-stable-deploy.yml
@@ -148,7 +148,7 @@ jobs:
 
       - name: Request Launchplane stable deploy
         id: lp
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: >-
             ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}

--- a/.github/workflows/reusable-product-driver-stable-environment.yml
+++ b/.github/workflows/reusable-product-driver-stable-environment.yml
@@ -116,7 +116,7 @@ jobs:
 
       - name: Request Launchplane stable environment
         id: lp
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: >-
             ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}

--- a/.github/workflows/reusable-product-driver-testing-deploy.yml
+++ b/.github/workflows/reusable-product-driver-testing-deploy.yml
@@ -177,7 +177,7 @@ jobs:
 
       - name: Request Launchplane Odoo target replacement apply
         id: lp
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: >-
             ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}
@@ -252,7 +252,7 @@ jobs:
 
       - name: Poll target replacement operation result
         id: poll_result
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: >-
             ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}

--- a/.github/workflows/reusable-product-driver-testing-verification.yml
+++ b/.github/workflows/reusable-product-driver-testing-verification.yml
@@ -128,7 +128,7 @@ jobs:
 
       - name: Request Launchplane testing verification
         id: lp
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: >-
             ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}

--- a/.github/workflows/reusable-product-health-monitoring.yml
+++ b/.github/workflows/reusable-product-health-monitoring.yml
@@ -209,7 +209,7 @@ jobs:
 
       - name: Request product health monitoring operation
         id: health_monitoring_request
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: ${{ env.LAUNCHPLANE_URL }}
           audience: ${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}

--- a/.github/workflows/reusable-product-prelaunch-rebuild-policy.yml
+++ b/.github/workflows/reusable-product-prelaunch-rebuild-policy.yml
@@ -228,7 +228,7 @@ jobs:
 
       - name: Request product prelaunch rebuild policy operation
         id: prelaunch_rebuild_policy_request
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: ${{ env.LAUNCHPLANE_URL }}
           audience: ${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}

--- a/.github/workflows/reusable-product-retirement.yml
+++ b/.github/workflows/reusable-product-retirement.yml
@@ -139,7 +139,7 @@ jobs:
 
       - name: Request audited product retirement
         id: request
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@3f063c09bab63836d2b1c880ecb995786f045893 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: ${{ env.LAUNCHPLANE_URL }}
           route-path: /v1/product-retirement

--- a/.github/workflows/reusable-route-binding-reconcile.yml
+++ b/.github/workflows/reusable-route-binding-reconcile.yml
@@ -83,7 +83,7 @@ jobs:
 
       - name: Read current route binding
         id: current
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: ${{ env.LAUNCHPLANE_URL }}
           audience: ${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}
@@ -167,7 +167,7 @@ jobs:
 
       - name: Request route-binding reconcile
         id: reconcile
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: ${{ env.LAUNCHPLANE_URL }}
           audience: ${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}

--- a/.github/workflows/reusable-tracked-target-logs.yml
+++ b/.github/workflows/reusable-tracked-target-logs.yml
@@ -162,7 +162,7 @@ jobs:
       - name: Read tracked target logs
         id: request
         continue-on-error: true
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: ${{ env.LAUNCHPLANE_SERVICE_URL }}
           route-path: ${{ steps.route.outputs.route_path }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
 
       - name: Install uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
@@ -58,6 +60,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
 
       - name: Install uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0

--- a/.github/workflows/work-graph-snapshot-validate.yml
+++ b/.github/workflows/work-graph-snapshot-validate.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Request work graph snapshot
         id: snapshot_request
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
         with:
           launchplane-url: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}
           audience: ${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}

--- a/control_plane/cli.py
+++ b/control_plane/cli.py
@@ -48,6 +48,7 @@ from control_plane.cli_dokploy_targets import (
     target_id_map,
 )
 from control_plane.cli_ci import register_ci_commands
+from control_plane.cli_action_pins import register_action_pin_commands
 from control_plane.cli_dependency_health import register_dependency_health_commands
 from control_plane.cli_shared import DATABASE_URL_ENV_KEYS as _DATABASE_URL_ENV_KEYS
 from control_plane.cli_every_code import register_every_code_commands
@@ -3580,6 +3581,7 @@ register_runner_lane_commands(cast(click.Group, work_graph))  # type: ignore[red
 register_preview_workflow_commands(cast(click.Group, work_graph))  # type: ignore[redundant-cast]
 register_work_graph_core_commands(cast(click.Group, work_graph))  # type: ignore[redundant-cast]
 register_ci_commands(cast(click.Group, main))  # type: ignore[redundant-cast]
+register_action_pin_commands(cast(click.Group, main))  # type: ignore[redundant-cast]
 register_dependency_health_commands(cast(click.Group, main))  # type: ignore[redundant-cast]
 register_every_code_commands(cast(click.Group, main), store_factory=_store)  # type: ignore[redundant-cast]
 register_ingress_commands(

--- a/control_plane/cli_action_pins.py
+++ b/control_plane/cli_action_pins.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import click
+
+from control_plane.first_party_action_pins import (
+    ActionPinError,
+    ActionPinReport,
+    build_action_pin_report,
+    update_action_pins,
+)
+
+
+def register_action_pin_commands(main: click.Group) -> None:
+    main.add_command(action_pins)
+
+
+@click.group("action-pins")
+def action_pins() -> None:
+    """Check and update first-party GitHub Action pins."""
+
+
+@action_pins.command("check")
+@click.option("--repo-root", type=click.Path(path_type=Path, file_okay=False), default=Path("."))
+def check_action_pins(repo_root: Path) -> None:
+    """Fail when ordinary first-party action pins are stale or unverifiable."""
+    report = _load_report(repo_root)
+    click.echo(json.dumps(report.as_summary_dict(), indent=2, sort_keys=True))
+    if report.violations:
+        raise click.exceptions.Exit(1)
+
+
+@action_pins.command("report")
+@click.option("--repo-root", type=click.Path(path_type=Path, file_okay=False), default=Path("."))
+def report_action_pins(repo_root: Path) -> None:
+    """Emit deterministic first-party action pin evidence."""
+    report = _load_report(repo_root)
+    click.echo(json.dumps(report.as_dict(), indent=2, sort_keys=True))
+
+
+@action_pins.command("update")
+@click.option("--repo-root", type=click.Path(path_type=Path, file_okay=False), default=Path("."))
+@click.option("--release-sha", required=True)
+@click.option("--dry-run", is_flag=True)
+def update_action_pin_references(repo_root: Path, release_sha: str, dry_run: bool) -> None:
+    """Rewrite ordinary consumers to one content-equivalent release SHA."""
+    try:
+        changed_paths = update_action_pins(
+            repo_root,
+            release_sha=release_sha,
+            dry_run=dry_run,
+        )
+    except ActionPinError as error:
+        raise click.ClickException(str(error)) from error
+    click.echo(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "status": "dry-run" if dry_run else "updated",
+                "release_sha": release_sha,
+                "changed_files": [path.as_posix() for path in changed_paths],
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+
+
+def _load_report(repo_root: Path) -> ActionPinReport:
+    try:
+        return build_action_pin_report(repo_root)
+    except ActionPinError as error:
+        raise click.ClickException(str(error)) from error

--- a/control_plane/first_party_action_pins.py
+++ b/control_plane/first_party_action_pins.py
@@ -1,0 +1,439 @@
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+
+LAUNCHPLANE_REQUEST_ACTION_PATH = Path(".github/actions/launchplane-request")
+FIRST_PARTY_ACTION_PROVENANCE = "launchplane-request"
+FULL_SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
+GITHUB_REPOSITORY_PATTERN = re.compile(
+    r"^(?P<owner>[A-Za-z0-9_.-]+)/(?P<repository>[A-Za-z0-9_.-]+)$"
+)
+GITHUB_REMOTE_PATTERNS = (
+    re.compile(r"^git@github\.com:(?P<repository>[^/\s]+/[^/\s]+?)(?:\.git)?$"),
+    re.compile(
+        r"^(?:ssh://git@|https://)github\.com/(?P<repository>[^/\s]+/[^/\s]+?)(?:\.git)?/?$"
+    ),
+)
+
+
+class ActionPinError(ValueError):
+    """Raised when first-party action pin verification cannot proceed safely."""
+
+
+class PrivilegedReferenceRefused(ActionPinError):
+    """Raised when action-pin tooling is pointed at an authorization trust anchor."""
+
+
+@dataclass(frozen=True)
+class ActionPinSite:
+    path: Path
+    line_number: int
+    revision: str
+    provenance: str | None
+
+    @property
+    def location(self) -> str:
+        return f"{self.path}:{self.line_number}"
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "path": self.path.as_posix(),
+            "line_number": self.line_number,
+            "revision": self.revision,
+            "provenance": self.provenance,
+        }
+
+
+@dataclass(frozen=True)
+class ActionPinViolation:
+    code: str
+    message: str
+    path: Path | None = None
+    line_number: int | None = None
+
+    @property
+    def location(self) -> str:
+        if self.path is None:
+            return "repository"
+        if self.line_number is None:
+            return self.path.as_posix()
+        return f"{self.path}:{self.line_number}"
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "code": self.code,
+            "location": self.location,
+            "message": self.message,
+        }
+
+
+@dataclass(frozen=True)
+class ActionPinReport:
+    action_source: str
+    head_sha: str
+    head_action_tree: str
+    references: tuple[ActionPinSite, ...]
+    violations: tuple[ActionPinViolation, ...]
+
+    @property
+    def status(self) -> str:
+        return "pass" if not self.violations else "fail"
+
+    def as_dict(self) -> dict[str, object]:
+        revisions = sorted({reference.revision for reference in self.references})
+        return {
+            "schema_version": 1,
+            "status": self.status,
+            "action_source": self.action_source,
+            "action_path": LAUNCHPLANE_REQUEST_ACTION_PATH.as_posix(),
+            "head_sha": self.head_sha,
+            "head_action_tree": self.head_action_tree,
+            "reference_count": len(self.references),
+            "revisions": revisions,
+            "references": [reference.as_dict() for reference in self.references],
+            "violations": [violation.as_dict() for violation in self.violations],
+        }
+
+    def as_summary_dict(self) -> dict[str, object]:
+        return {key: value for key, value in self.as_dict().items() if key != "references"}
+
+
+def discover_action_pin_sites(repo_root: Path) -> tuple[ActionPinSite, ...]:
+    action_source = launchplane_request_action_source(repo_root)
+    pin_line_pattern = _pin_line_pattern(action_source)
+    workflow_root = repo_root / ".github" / "workflows"
+    workflow_paths = sorted((*workflow_root.glob("*.yml"), *workflow_root.glob("*.yaml")))
+    sites: list[ActionPinSite] = []
+    for path in workflow_paths:
+        relative_path = path.relative_to(repo_root)
+        for line_number, line in enumerate(
+            path.read_text(encoding="utf-8").split("\n"),
+            start=1,
+        ):
+            match = pin_line_pattern.match(line)
+            if match is None:
+                continue
+            sites.append(
+                ActionPinSite(
+                    path=relative_path,
+                    line_number=line_number,
+                    revision=match.group("revision"),
+                    provenance=match.group("provenance"),
+                )
+            )
+    return tuple(sites)
+
+
+def build_action_pin_report(
+    repo_root: Path,
+    *,
+    target_revision: str = "HEAD",
+) -> ActionPinReport:
+    root = repo_root.resolve()
+    action_source = launchplane_request_action_source(root)
+    head_sha = _resolve_commit(root, target_revision)
+    head_action_tree = _subtree_oid(root, head_sha, LAUNCHPLANE_REQUEST_ACTION_PATH)
+    references = discover_action_pin_sites(root)
+    violations: list[ActionPinViolation] = []
+
+    if _path_is_dirty(root, LAUNCHPLANE_REQUEST_ACTION_PATH):
+        violations.append(
+            ActionPinViolation(
+                code="action_worktree_dirty",
+                message=(
+                    "Commit the launchplane-request action change before checking or updating "
+                    "consumer pins."
+                ),
+                path=LAUNCHPLANE_REQUEST_ACTION_PATH,
+            )
+        )
+    if not references:
+        violations.append(
+            ActionPinViolation(
+                code="action_pin_missing",
+                message="No remote launchplane-request action references were found.",
+            )
+        )
+
+    revisions: set[str] = set()
+    revision_evidence: dict[str, tuple[str | None, bool | None, str | None]] = {}
+    for reference in references:
+        if FULL_SHA_PATTERN.fullmatch(reference.revision) is None:
+            violations.append(
+                _site_violation(
+                    reference,
+                    code="action_pin_invalid_revision",
+                    message="launchplane-request must use a lowercase 40-character commit SHA.",
+                )
+            )
+            continue
+        revisions.add(reference.revision)
+        if reference.provenance != FIRST_PARTY_ACTION_PROVENANCE:
+            violations.append(
+                _site_violation(
+                    reference,
+                    code="action_pin_invalid_provenance",
+                    message=(
+                        f"launchplane-request provenance must be {FIRST_PARTY_ACTION_PROVENANCE!r}."
+                    ),
+                )
+            )
+        if reference.revision not in revision_evidence:
+            try:
+                pinned_tree = _subtree_oid(
+                    root,
+                    reference.revision,
+                    LAUNCHPLANE_REQUEST_ACTION_PATH,
+                )
+                reachable = _is_ancestor(root, reference.revision, head_sha)
+            except ActionPinError as error:
+                revision_evidence[reference.revision] = (None, None, str(error))
+            else:
+                revision_evidence[reference.revision] = (pinned_tree, reachable, None)
+        evidence_tree, evidence_reachable, evidence_error = revision_evidence[reference.revision]
+        if evidence_error is not None:
+            violations.append(
+                _site_violation(
+                    reference,
+                    code="action_pin_object_unavailable",
+                    message=evidence_error,
+                )
+            )
+            continue
+        assert evidence_tree is not None
+        assert evidence_reachable is not None
+        if evidence_tree != head_action_tree:
+            violations.append(
+                _site_violation(
+                    reference,
+                    code="action_pin_content_stale",
+                    message=(
+                        f"Pinned action tree {evidence_tree} does not match current action tree "
+                        f"{head_action_tree}."
+                    ),
+                )
+            )
+        if not evidence_reachable:
+            violations.append(
+                _site_violation(
+                    reference,
+                    code="action_pin_unreachable",
+                    message=(
+                        f"Pinned commit {reference.revision} is not an ancestor of {head_sha}; "
+                        "squash, rebase, or force-push would leave the action reference dangling."
+                    ),
+                )
+            )
+
+    if len(revisions) > 1:
+        violations.append(
+            ActionPinViolation(
+                code="action_pin_mixed_revisions",
+                message=(
+                    "Ordinary launchplane-request consumers must share one immutable release SHA; "
+                    f"found {', '.join(sorted(revisions))}."
+                ),
+            )
+        )
+
+    return ActionPinReport(
+        action_source=action_source,
+        head_sha=head_sha,
+        head_action_tree=head_action_tree,
+        references=references,
+        violations=tuple(violations),
+    )
+
+
+def update_action_pins(
+    repo_root: Path,
+    *,
+    release_sha: str,
+    source: str | None = None,
+    dry_run: bool = False,
+) -> tuple[Path, ...]:
+    root = repo_root.resolve()
+    action_source = launchplane_request_action_source(root)
+    update_source = action_source if source is None else source
+    _validate_update_source(update_source, expected_source=action_source)
+    if FULL_SHA_PATTERN.fullmatch(release_sha) is None:
+        raise ActionPinError("release_sha must be a lowercase 40-character commit SHA.")
+    if _path_is_dirty(root, LAUNCHPLANE_REQUEST_ACTION_PATH):
+        raise ActionPinError(
+            "Commit the launchplane-request action change before sweeping consumer pins."
+        )
+    head_sha = _resolve_commit(root, "HEAD")
+    release_tree = _subtree_oid(root, release_sha, LAUNCHPLANE_REQUEST_ACTION_PATH)
+    head_tree = _subtree_oid(root, head_sha, LAUNCHPLANE_REQUEST_ACTION_PATH)
+    if release_tree != head_tree:
+        raise ActionPinError(
+            f"Release action tree {release_tree} does not match current action tree {head_tree}."
+        )
+    if not _is_ancestor(root, release_sha, head_sha):
+        raise ActionPinError(
+            f"Release commit {release_sha} must be an ancestor of current HEAD {head_sha}."
+        )
+
+    workflow_root = root / ".github" / "workflows"
+    workflow_paths = sorted((*workflow_root.glob("*.yml"), *workflow_root.glob("*.yaml")))
+    pin_line_pattern = _pin_line_pattern(action_source)
+    replacements: dict[Path, str] = {}
+    observed_count = 0
+    for path in workflow_paths:
+        original = path.read_text(encoding="utf-8")
+        if "\r" in original:
+            raise ActionPinError(f"Refusing to normalize CRLF workflow file: {path}")
+        lines = original.split("\n")
+        changed = False
+        for index, line in enumerate(lines):
+            match = pin_line_pattern.match(line)
+            if match is None:
+                continue
+            observed_count += 1
+            replacement = (
+                f"{match.group('prefix')}{update_source}@{release_sha} "
+                f"# {FIRST_PARTY_ACTION_PROVENANCE}"
+            )
+            if replacement != line:
+                lines[index] = replacement
+                changed = True
+        if changed:
+            replacements[path] = "\n".join(lines)
+    if observed_count == 0:
+        raise ActionPinError("No remote launchplane-request action references were found.")
+
+    changed_paths = tuple(path.relative_to(root) for path in sorted(replacements))
+    if not dry_run:
+        for path, content in replacements.items():
+            temporary_path = path.with_suffix(f"{path.suffix}.tmp")
+            temporary_path.write_text(content, encoding="utf-8")
+            temporary_path.replace(path)
+    return changed_paths
+
+
+def launchplane_request_action_source(repo_root: Path) -> str:
+    root = repo_root.resolve()
+    repository = os.environ.get("GITHUB_REPOSITORY", "").strip()
+    if GITHUB_REPOSITORY_PATTERN.fullmatch(repository) is not None:
+        return f"{repository}/{LAUNCHPLANE_REQUEST_ACTION_PATH.as_posix()}"
+
+    remote_result = _git(root, "remote", "get-url", "origin")
+    if remote_result.returncode == 0:
+        remote_repository = _repository_from_remote(remote_result.stdout.strip())
+        if remote_repository is not None:
+            return f"{remote_repository}/{LAUNCHPLANE_REQUEST_ACTION_PATH.as_posix()}"
+    raise ActionPinError(
+        "Could not resolve the current GitHub repository from origin or GITHUB_REPOSITORY."
+    )
+
+
+def _repository_from_remote(remote_url: str) -> str | None:
+    for pattern in GITHUB_REMOTE_PATTERNS:
+        match = pattern.fullmatch(remote_url)
+        if match is not None:
+            repository = match.group("repository")
+            if GITHUB_REPOSITORY_PATTERN.fullmatch(repository) is not None:
+                return repository
+    return None
+
+
+def _pin_line_pattern(action_source: str) -> re.Pattern[str]:
+    return re.compile(
+        r"^(?P<prefix>\s*(?:-\s+)?uses:\s*)"
+        rf"(?P<source>{re.escape(action_source)})@"
+        r"(?P<revision>[^#\s]+)"
+        r"(?:\s+#\s*(?P<provenance>.*?))?\s*$"
+    )
+
+
+def _validate_update_source(source: str, *, expected_source: str) -> None:
+    if "/.github/workflows/" in source:
+        raise PrivilegedReferenceRefused(
+            "Privileged reusable-workflow pins are authorization trust anchors and require "
+            "their documented two-landing rollout."
+        )
+    if source != expected_source:
+        raise ActionPinError(f"Unsupported first-party action source: {source!r}")
+
+
+def _site_violation(
+    reference: ActionPinSite,
+    *,
+    code: str,
+    message: str,
+) -> ActionPinViolation:
+    return ActionPinViolation(
+        code=code,
+        message=message,
+        path=reference.path,
+        line_number=reference.line_number,
+    )
+
+
+def _git(repo_root: Path, *arguments: str) -> subprocess.CompletedProcess[str]:
+    environment = os.environ | {
+        "GIT_CONFIG_GLOBAL": "/dev/null",
+        "GIT_CONFIG_SYSTEM": "/dev/null",
+        "GIT_NO_LAZY_FETCH": "1",
+        "GIT_OPTIONAL_LOCKS": "0",
+        "GIT_TERMINAL_PROMPT": "0",
+    }
+    return subprocess.run(
+        ("git", *arguments),
+        cwd=repo_root,
+        check=False,
+        capture_output=True,
+        text=True,
+        env=environment,
+    )
+
+
+def _resolve_commit(repo_root: Path, revision: str) -> str:
+    result = _git(repo_root, "rev-parse", "--verify", f"{revision}^{{commit}}")
+    resolved = result.stdout.strip()
+    if result.returncode != 0 or FULL_SHA_PATTERN.fullmatch(resolved) is None:
+        raise ActionPinError(
+            f"Git commit {revision!r} is unavailable locally; fetch full history before checking pins."
+        )
+    return resolved
+
+
+def _subtree_oid(repo_root: Path, revision: str, path: Path) -> str:
+    commit_sha = _resolve_commit(repo_root, revision)
+    result = _git(repo_root, "rev-parse", f"{commit_sha}:{path.as_posix()}")
+    object_id = result.stdout.strip()
+    if result.returncode != 0 or not object_id:
+        raise ActionPinError(
+            f"Action subtree {path} is unavailable at commit {commit_sha}; fetch full history."
+        )
+    return object_id
+
+
+def _is_ancestor(repo_root: Path, ancestor: str, descendant: str) -> bool:
+    result = _git(repo_root, "merge-base", "--is-ancestor", ancestor, descendant)
+    if result.returncode == 0:
+        return True
+    if result.returncode == 1:
+        return False
+    raise ActionPinError(
+        f"Could not verify reachability from {ancestor} to {descendant}; fetch full history."
+    )
+
+
+def _path_is_dirty(repo_root: Path, path: Path) -> bool:
+    result = _git(
+        repo_root,
+        "status",
+        "--porcelain",
+        "--untracked-files=all",
+        "--",
+        path.as_posix(),
+    )
+    if result.returncode != 0:
+        raise ActionPinError(f"Could not inspect worktree state for {path}.")
+    return bool(result.stdout.strip())

--- a/docs/github-actions-security.md
+++ b/docs/github-actions-security.md
@@ -20,7 +20,7 @@ an immutable `sha256` manifest digest.
 | Same-repository privileged reusable worker        | First-party immutable trust anchor | Authz administration, route-authority reconciliation, or exact-instance reviewed product-policy mutation | Repository-qualified path at a full reviewed SHA, limited to the approved dispatch wrappers |
 | GitHub-maintained action                          | GitHub-maintained                  | Checkout, artifacts, cache, runtime setup, GitHub API, CodeQL                                            | Full SHA plus a release-tag provenance comment                                              |
 | Third-party publisher                             | Third-party publisher              | Python bootstrap, registry authentication, image build and publication                                   | Full SHA plus a release-tag provenance comment                                              |
-| First-party cross-repository Launchplane action   | First-party cross-repository       | OIDC-authenticated Launchplane requests and preview-client setup                                         | Full SHA plus `# main` provenance                                                           |
+| First-party cross-repository Launchplane action   | First-party cross-repository       | OIDC-authenticated Launchplane requests and preview-client setup                                         | Content-current full SHA plus action-name provenance                                        |
 | Static workflow container image                   | Official or third-party publisher  | Workflow linting, secret/vulnerability scanning, integration services                                    | Release tag plus `@sha256:<manifest-digest>`                                                |
 
 <!-- markdownlint-enable MD013 -->
@@ -62,8 +62,8 @@ written to the workflow log by the upstream implementation.
 - A remote action must use a full 40-character lowercase commit SHA; tags,
   branches, short SHAs, and expressions are rejected.
 - Every remote pin must retain its provenance comment: an exact release tag for
-  public actions or `main` for the first-party cross-repository composite
-  actions.
+  public actions, `launchplane-request` for that first-party composite action,
+  or `main` for approved pinned reusable-workflow trust anchors.
 - The mutable remote-reference allowlist is explicitly represented by
   `MUTABLE_REFERENCE_ALLOWLIST` and is currently empty. Any temporary exception
   must be scoped to one workflow path and one literal reference, with a
@@ -96,6 +96,37 @@ The security workflow runs this policy for both same-repository and fork pull
 requests before actionlint. The unit-test suite runs it as well, so a mutable
 reference cannot pass the required CI path.
 
+## First-Party Action Content Currency
+
+Repository-qualified `launchplane-request` references are immutable, but a
+well-formed SHA is not enough: every ordinary consumer must resolve to an action
+subtree identical to the action subtree under review. The required security
+gate verifies that identity from full local git history and fails closed when a
+pinned object is unavailable, content-stale, or unreachable from the reviewed
+head. Unrelated Launchplane commits do not require a repin because the action
+subtree remains unchanged.
+
+An action change and its consumer update land in one pull request using two
+commits. The first commit contains the action implementation and tests. The
+second runs:
+
+```bash
+uv run launchplane action-pins update --release-sha <first-commit-sha>
+uv run launchplane action-pins check
+```
+
+The release SHA must be an ancestor of the pull-request head and contain the
+same action subtree as the final head. This requires merge-commit landing:
+squashing, rebasing, amending the release commit, or force-pushing after the pin
+sweep can orphan the referenced commit. Privileged reusable-workflow pins are a
+separate authorization identity and remain under their documented two-landing
+rollout; the action-pin tool refuses to update them.
+
+Local `./.github/actions/launchplane-request` references remain acceptable only
+when the job already checks out a trusted exact Launchplane revision. Do not add
+a checkout to an OIDC-capable job merely to avoid an immutable remote pin, and
+do not allow a cross-repository caller to supply the workspace action code.
+
 Detached application retirement follows a two-phase trust rollout. Phase one
 landed only the service contract, persistence, managed authz selector/secret
 routing, and a protected `workflow_call` worker. Phase two adds the thin
@@ -116,8 +147,10 @@ before any protected plan/apply run or provider mutation is possible.
 Each public action pin carries the exact release tag in an inline comment, for
 example `actions/checkout@<full-sha> # v7.0.0`. The comment makes a pin directly
 reviewable and lets Dependabot update the SHA and tag together in a normal pull
-request. First-party cross-repository pins use `# main`; Dependabot tracks the
-GitHub Actions ecosystem weekly through `.github/dependabot.yml`.
+request. Dependabot tracks third-party GitHub Actions weekly through
+`.github/dependabot.yml`; it does not update same-repository first-party action
+pins. Launchplane maintains those pins through the required content check and
+`action-pins update` command instead.
 
 Dependabot does not update container references embedded in workflow scripts.
 For those images, resolve the reviewed release manifest with

--- a/docs/merge-train-policy.md
+++ b/docs/merge-train-policy.md
@@ -329,7 +329,7 @@ uv run launchplane merge-train-policies build-import-request \
 ```
 
 ```yaml
-- uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+- uses: cbusillo/launchplane/.github/actions/launchplane-request@<launchplane-request-sha> # launchplane-request
   with:
     launchplane-url: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}
     route-path: /v1/merge-train/policies/import

--- a/tests/support/workflows.py
+++ b/tests/support/workflows.py
@@ -5,6 +5,11 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TypeAlias, cast
 
+from control_plane.first_party_action_pins import (
+    discover_action_pin_sites,
+    launchplane_request_action_source,
+)
+
 
 YamlScalar: TypeAlias = str | int | bool | None
 YamlValue: TypeAlias = YamlScalar | list["YamlValue"] | dict[str, "YamlValue"]
@@ -27,6 +32,18 @@ LAUNCHPLANE_REQUEST_USES = (
 TIMING_SNAPSHOT_ARTIFACT = "unittest-timing-snapshot"
 TIMING_SNAPSHOT_PATH = "${{ runner.temp }}/unittest-timing-snapshot"
 TIMING_SNAPSHOT_HISTORY = '"${RUNNER_TEMP}/unittest-timing-snapshot/history.json"'
+
+
+def launchplane_request_action_reference(repo_root: Path = Path(".")) -> str:
+    revisions = {
+        site.revision for site in discover_action_pin_sites(repo_root) if len(site.revision) == 40
+    }
+    if len(revisions) != 1:
+        raise AssertionError(
+            "Launchplane request action consumers must share one immutable revision; "
+            f"found {sorted(revisions)}"
+        )
+    return f"{launchplane_request_action_source(repo_root)}@{next(iter(revisions))}"
 
 
 @dataclass(frozen=True)

--- a/tests/test_external_route_binding_operator_workflow.py
+++ b/tests/test_external_route_binding_operator_workflow.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 from pathlib import Path
 import unittest
 
-from tests.support.workflows import SELF_HOSTED_RUNNER, load_workflow
+from tests.support.workflows import (
+    SELF_HOSTED_RUNNER,
+    launchplane_request_action_reference,
+    load_workflow,
+)
 
 
 class ExternalRouteBindingOperatorWorkflowTests(unittest.TestCase):
@@ -29,8 +33,7 @@ class ExternalRouteBindingOperatorWorkflowTests(unittest.TestCase):
         assert current_step is not None
         self.assertEqual(
             current_step.uses,
-            "cbusillo/launchplane/.github/actions/launchplane-request@"
-            "adcf937c6aef14e02478724040852d1d2a82a850",
+            launchplane_request_action_reference(),
         )
         self.assertEqual(current_step.with_values["method"], "GET")
         self.assertEqual(current_step.with_values["expected-status"], "200,404")
@@ -43,8 +46,7 @@ class ExternalRouteBindingOperatorWorkflowTests(unittest.TestCase):
         assert reconcile_step is not None
         self.assertEqual(
             reconcile_step.uses,
-            "cbusillo/launchplane/.github/actions/launchplane-request@"
-            "adcf937c6aef14e02478724040852d1d2a82a850",
+            launchplane_request_action_reference(),
         )
         self.assertEqual(
             reconcile_step.with_values["route-path"],

--- a/tests/test_first_party_action_pins.py
+++ b/tests/test_first_party_action_pins.py
@@ -1,0 +1,288 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+from control_plane.first_party_action_pins import (
+    ActionPinError,
+    FIRST_PARTY_ACTION_PROVENANCE,
+    PrivilegedReferenceRefused,
+    build_action_pin_report,
+    launchplane_request_action_source,
+    update_action_pins,
+)
+
+
+class FirstPartyActionPinTests(unittest.TestCase):
+    def setUp(self) -> None:
+        github_repository_patch = patch.dict(os.environ, {"GITHUB_REPOSITORY": ""})
+        github_repository_patch.start()
+        self.addCleanup(github_repository_patch.stop)
+
+    def test_content_current_pin_passes(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            repo_root = Path(temporary_directory_name)
+            release_sha = _initialize_repository(repo_root)
+
+            report = build_action_pin_report(repo_root)
+
+        self.assertEqual(report.status, "pass")
+        self.assertEqual(report.violations, ())
+        self.assertEqual({site.revision for site in report.references}, {release_sha})
+
+    def test_unrelated_commit_does_not_make_pin_stale(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            repo_root = Path(temporary_directory_name)
+            _initialize_repository(repo_root)
+            (repo_root / "README.md").write_text("unrelated\n", encoding="utf-8")
+            _commit(repo_root, "unrelated change")
+
+            report = build_action_pin_report(repo_root)
+
+        self.assertEqual(report.violations, ())
+
+    def test_action_change_without_pin_sweep_fails(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            repo_root = Path(temporary_directory_name)
+            _initialize_repository(repo_root)
+            _write_action(repo_root, "console.log('v2');\n")
+            _commit(repo_root, "change action")
+
+            report = build_action_pin_report(repo_root)
+
+        self.assertIn(
+            "action_pin_content_stale",
+            {violation.code for violation in report.violations},
+        )
+
+    def test_missing_git_object_fails_closed(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            repo_root = Path(temporary_directory_name)
+            _initialize_repository(repo_root)
+            _write_workflow(repo_root, "f" * 40)
+            _commit(repo_root, "point at missing action commit")
+
+            report = build_action_pin_report(repo_root)
+
+        self.assertIn(
+            "action_pin_object_unavailable",
+            {violation.code for violation in report.violations},
+        )
+
+    def test_wrong_provenance_fails(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            repo_root = Path(temporary_directory_name)
+            release_sha = _initialize_repository(repo_root)
+            _write_workflow(repo_root, release_sha, provenance="main")
+
+            report = build_action_pin_report(repo_root)
+
+        self.assertIn(
+            "action_pin_invalid_provenance",
+            {violation.code for violation in report.violations},
+        )
+
+    def test_dirty_action_fails_closed(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            repo_root = Path(temporary_directory_name)
+            _initialize_repository(repo_root)
+            _write_action(repo_root, "console.log('dirty');\n")
+
+            report = build_action_pin_report(repo_root)
+
+        self.assertIn(
+            "action_worktree_dirty",
+            {violation.code for violation in report.violations},
+        )
+
+    def test_yaml_workflow_is_discovered(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            repo_root = Path(temporary_directory_name)
+            release_sha = _initialize_repository(repo_root)
+            workflow_path = repo_root / ".github/workflows/example.yml"
+            workflow_path.rename(workflow_path.with_suffix(".yaml"))
+            _commit(repo_root, "rename workflow extension")
+
+            report = build_action_pin_report(repo_root)
+
+        self.assertEqual(report.violations, ())
+        self.assertEqual(report.references[0].revision, release_sha)
+
+    def test_unreachable_content_equivalent_pin_fails_closed(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            repo_root = Path(temporary_directory_name)
+            _initialize_repository(repo_root)
+            main_sha = _git(repo_root, "rev-parse", "HEAD").stdout.strip()
+            _git(repo_root, "checkout", "--orphan", "side")
+            _git(repo_root, "rm", "-rf", ".")
+            _write_action(repo_root, "console.log('v1');\n")
+            orphan_sha = _commit(repo_root, "orphan action identity")
+            _git(repo_root, "checkout", "main")
+            self.assertEqual(_git(repo_root, "rev-parse", "HEAD").stdout.strip(), main_sha)
+            _write_workflow(repo_root, orphan_sha)
+            _commit(repo_root, "point at unreachable action commit")
+
+            report = build_action_pin_report(repo_root)
+
+        self.assertIn(
+            "action_pin_unreachable",
+            {violation.code for violation in report.violations},
+        )
+
+    def test_update_rewrites_only_action_reference_and_is_idempotent(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            repo_root = Path(temporary_directory_name)
+            stale_sha = _initialize_repository(repo_root)
+            _write_action(repo_root, "console.log('v2');\n")
+            release_sha = _commit(repo_root, "release v2 action")
+            workflow_path = repo_root / ".github/workflows/example.yml"
+            action_source = launchplane_request_action_source(repo_root)
+            workflow_path.write_text(
+                "---\n"
+                "jobs:\n"
+                "  call:\n"
+                f"    uses: {action_source}@{stale_sha} # main\n"
+                "  privileged:\n"
+                "    uses: cbusillo/launchplane/.github/workflows/reusable-worker.yml@"
+                f"{stale_sha} # main\n",
+                encoding="utf-8",
+            )
+            privileged_line = workflow_path.read_text(encoding="utf-8").splitlines()[-1]
+
+            changed_paths = update_action_pins(repo_root, release_sha=release_sha)
+            second_changed_paths = update_action_pins(repo_root, release_sha=release_sha)
+            updated_lines = workflow_path.read_text(encoding="utf-8").splitlines()
+
+        self.assertEqual(changed_paths, (Path(".github/workflows/example.yml"),))
+        self.assertEqual(second_changed_paths, ())
+        self.assertTrue(
+            any(
+                line.strip()
+                == (f"uses: {action_source}@{release_sha} # {FIRST_PARTY_ACTION_PROVENANCE}")
+                for line in updated_lines
+            )
+        )
+        self.assertEqual(updated_lines[-1], privileged_line)
+
+    def test_update_rejects_content_mismatched_release(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            repo_root = Path(temporary_directory_name)
+            stale_sha = _initialize_repository(repo_root)
+            _write_action(repo_root, "console.log('v2');\n")
+            _commit(repo_root, "release v2 action")
+
+            with self.assertRaisesRegex(ActionPinError, "does not match current action tree"):
+                update_action_pins(repo_root, release_sha=stale_sha)
+
+    def test_update_rejects_dirty_action(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            repo_root = Path(temporary_directory_name)
+            release_sha = _initialize_repository(repo_root)
+            _write_action(repo_root, "console.log('dirty');\n")
+
+            with self.assertRaisesRegex(ActionPinError, "Commit the launchplane-request"):
+                update_action_pins(repo_root, release_sha=release_sha)
+
+    def test_update_refuses_privileged_workflow_source(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            repo_root = Path(temporary_directory_name)
+            release_sha = _initialize_repository(repo_root)
+
+            with self.assertRaises(PrivilegedReferenceRefused):
+                update_action_pins(
+                    repo_root,
+                    release_sha=release_sha,
+                    source=(
+                        "cbusillo/launchplane/.github/workflows/reusable-authz-policy-reconcile.yml"
+                    ),
+                )
+
+    def test_report_payload_is_deterministic(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            repo_root = Path(temporary_directory_name)
+            _initialize_repository(repo_root)
+
+            first = build_action_pin_report(repo_root).as_dict()
+            second = build_action_pin_report(repo_root).as_dict()
+
+        self.assertEqual(first, second)
+
+    def test_github_repository_identifies_base_repo_for_fork_checkout(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            repo_root = Path(temporary_directory_name)
+            _initialize_repository(repo_root)
+
+            with patch.dict(os.environ, {"GITHUB_REPOSITORY": "example/base"}):
+                action_source = launchplane_request_action_source(repo_root)
+
+        self.assertEqual(
+            action_source,
+            "example/base/.github/actions/launchplane-request",
+        )
+
+
+def _initialize_repository(repo_root: Path) -> str:
+    _git(repo_root, "init", "-b", "main")
+    _git(repo_root, "config", "user.name", "Launchplane Tests")
+    _git(repo_root, "config", "user.email", "launchplane-tests@example.invalid")
+    _git(repo_root, "remote", "add", "origin", "git@github.com:example/launchplane.git")
+    _write_action(repo_root, "console.log('v1');\n")
+    release_sha = _commit(repo_root, "release v1 action")
+    _write_workflow(repo_root, release_sha)
+    _commit(repo_root, "add action consumer")
+    return release_sha
+
+
+def _write_action(repo_root: Path, javascript: str) -> None:
+    action_root = repo_root / ".github/actions/launchplane-request"
+    (action_root / "dist").mkdir(parents=True, exist_ok=True)
+    (action_root / "action.yml").write_text(
+        "name: Launchplane Request\nruns:\n  using: node20\n  main: dist/index.js\n",
+        encoding="utf-8",
+    )
+    (action_root / "dist/index.js").write_text(javascript, encoding="utf-8")
+
+
+def _write_workflow(
+    repo_root: Path,
+    release_sha: str,
+    *,
+    provenance: str = FIRST_PARTY_ACTION_PROVENANCE,
+) -> None:
+    action_source = launchplane_request_action_source(repo_root)
+    workflow_path = repo_root / ".github/workflows/example.yml"
+    workflow_path.parent.mkdir(parents=True, exist_ok=True)
+    workflow_path.write_text(
+        f"---\njobs:\n  call:\n    uses: {action_source}@{release_sha} # {provenance}\n",
+        encoding="utf-8",
+    )
+
+
+def _commit(repo_root: Path, message: str) -> str:
+    _git(repo_root, "add", ".")
+    _git(repo_root, "commit", "-m", message)
+    return _git(repo_root, "rev-parse", "HEAD").stdout.strip()
+
+
+def _git(repo_root: Path, *arguments: str) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        ("git", *arguments),
+        cwd=repo_root,
+        check=False,
+        capture_output=True,
+        text=True,
+        env=os.environ
+        | {
+            "GIT_AUTHOR_DATE": "2026-08-13T00:00:00Z",
+            "GIT_COMMITTER_DATE": "2026-08-13T00:00:00Z",
+        },
+    )
+    if result.returncode != 0:
+        raise AssertionError(
+            f"git {' '.join(arguments)} failed:\nstdout={result.stdout}\nstderr={result.stderr}"
+        )
+    return result

--- a/tests/test_github_actions_security.py
+++ b/tests/test_github_actions_security.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from unittest import TestCase
 
+from control_plane.first_party_action_pins import build_action_pin_report
 from tests.support.workflows import WorkflowInvariantViolation
 from tests.support.workflows import check_security_policy_runs_for_all_pull_requests
 from tests.support.workflows import load_workflow
@@ -348,6 +349,74 @@ def _container_references() -> Iterator[ContainerReference]:
 
 
 class GitHubActionsSecurityTests(TestCase):
+    def test_launchplane_request_action_pins_are_content_current(self) -> None:
+        report = build_action_pin_report(Path("."))
+
+        self.assertEqual(
+            [],
+            [
+                f"{violation.location} [{violation.code}]: {violation.message}"
+                for violation in report.violations
+            ],
+        )
+
+    def test_local_launchplane_request_actions_use_trusted_same_repo_checkout(self) -> None:
+        violations: list[str] = []
+        workflow_root = Path(".github/workflows")
+        workflow_paths = sorted((*workflow_root.glob("*.yml"), *workflow_root.glob("*.yaml")))
+        for path in workflow_paths:
+            workflow = load_workflow(path)
+            trigger = workflow.data.get("on")
+            if not isinstance(trigger, dict):
+                trigger = {}
+            for job_id in workflow.jobs:
+                local_steps = [
+                    step
+                    for step in workflow.steps(job_id)
+                    if step.uses == "./.github/actions/launchplane-request"
+                ]
+                if not local_steps:
+                    continue
+                checkout_steps = [
+                    step
+                    for step in workflow.steps(job_id)
+                    if step.uses.startswith("actions/checkout@")
+                ]
+                if "workflow_call" in trigger:
+                    violations.append(
+                        f"{path}:{job_id}: workflow_call jobs must use the immutable remote "
+                        "launchplane-request action because local action code can come from the caller."
+                    )
+                if len(checkout_steps) != 1:
+                    violations.append(
+                        f"{path}:{job_id}: local launchplane-request use requires exactly one "
+                        "trusted checkout step."
+                    )
+                    continue
+                checkout = checkout_steps[0]
+                if "repository" in checkout.with_values or "ref" in checkout.with_values:
+                    violations.append(
+                        f"{path}:{job_id}: local launchplane-request checkout must use the "
+                        "workflow's exact same-repository revision without repository/ref overrides."
+                    )
+
+        self.assertEqual([], violations)
+
+    def test_action_pin_security_jobs_fetch_full_history(self) -> None:
+        workflow = load_workflow(".github/workflows/security.yml")
+
+        for job_id in ("workflow_lint", "workflow_lint_fork"):
+            checkout = workflow.step_named(job_id, "Checkout")
+            self.assertIsNotNone(checkout)
+            assert checkout is not None
+            self.assertEqual(checkout.with_values.get("fetch-depth"), 0)
+
+    def test_repository_merge_policy_preserves_action_release_commits(self) -> None:
+        metadata = json.loads(Path(".github/github.json").read_text(encoding="utf-8"))
+
+        self.assertEqual(metadata["pullRequests"]["allowedMergeMethods"], ["merge"])
+        self.assertEqual(metadata["pullRequests"]["preferredMergeMethod"], "merge")
+
     def test_product_repo_config_authority_uses_called_workflow_revision(self) -> None:
         workflow = Path(".github/workflows/reusable-product-repo-config-authority.yml").read_text(
             encoding="utf-8"
@@ -471,10 +540,17 @@ class GitHubActionsSecurityTests(TestCase):
                 violations.append(
                     f"{action.location}: remote action {source!r} must document its provenance."
                 )
+            elif source == ("cbusillo/launchplane/.github/actions/launchplane-request"):
+                if action.provenance != "launchplane-request":
+                    violations.append(
+                        f"{action.location}: first-party cross-repository action provenance "
+                        "must be 'launchplane-request'."
+                    )
             elif source.startswith(FIRST_PARTY_CROSS_REPOSITORY_ACTION_PREFIX):
                 if action.provenance != "main":
                     violations.append(
-                        f"{action.location}: first-party cross-repository action provenance must be 'main'."
+                        f"{action.location}: first-party cross-repository action provenance "
+                        "must be 'main'."
                     )
             elif source.startswith(SELF_REUSABLE_WORKFLOW_PREFIX):
                 if action.provenance != "main":
@@ -553,5 +629,7 @@ class GitHubActionsSecurityTests(TestCase):
         self.assertIn("container image", policy)
         self.assertIn("MUTABLE_REFERENCE_ALLOWLIST", policy)
         self.assertIn("Dependabot", policy)
+        self.assertIn("action-pins update", policy)
+        self.assertIn("same-repository first-party action", policy)
         self.assertIn("package-ecosystem: github-actions", dependabot)
         self.assertIn("interval: weekly", dependabot)

--- a/tests/test_odoo_target_replacement_workflows.py
+++ b/tests/test_odoo_target_replacement_workflows.py
@@ -3,13 +3,10 @@ from __future__ import annotations
 from pathlib import Path
 import unittest
 
-from tests.support.workflows import load_workflow
+from tests.support.workflows import launchplane_request_action_reference, load_workflow
 
 
-_LAUNCHPLANE_REQUEST = (
-    "cbusillo/launchplane/.github/actions/launchplane-request@"
-    "adcf937c6aef14e02478724040852d1d2a82a850"
-)
+_LAUNCHPLANE_REQUEST = launchplane_request_action_reference()
 _PLAN_WORKER_SHA = "e605d8ab9ec26950247233c4237d65ea8b44a6d6"
 _APPLY_WORKER_SHA = "480c9280b1ae3610f05547192783da2230dc7ff5"
 

--- a/tests/test_odoo_website_bootstrap_override_workflow.py
+++ b/tests/test_odoo_website_bootstrap_override_workflow.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import unittest
 
-from tests.support.workflows import load_workflow
+from tests.support.workflows import launchplane_request_action_reference, load_workflow
 
 
 class OdooWebsiteBootstrapOverrideWorkflowTests(unittest.TestCase):
@@ -106,7 +106,7 @@ class OdooWebsiteBootstrapOverrideWorkflowTests(unittest.TestCase):
         self.assertIn("source_label", payload_step.run)
         self.assertEqual(
             request_step.uses,
-            "cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850",
+            launchplane_request_action_reference(),
         )
         self.assertEqual(
             request_step.with_values["route-path"],

--- a/tests/test_product_health_monitoring_operator_workflow.py
+++ b/tests/test_product_health_monitoring_operator_workflow.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 import unittest
 
-from tests.support.workflows import load_workflow
+from tests.support.workflows import launchplane_request_action_reference, load_workflow
 
 
 class ProductHealthMonitoringOperatorWorkflowTests(unittest.TestCase):
@@ -26,8 +26,7 @@ class ProductHealthMonitoringOperatorWorkflowTests(unittest.TestCase):
         assert request_step is not None
         self.assertEqual(
             request_step.uses,
-            "cbusillo/launchplane/.github/actions/launchplane-request@"
-            "adcf937c6aef14e02478724040852d1d2a82a850",
+            launchplane_request_action_reference(),
         )
         self.assertEqual(
             request_step.with_values["route-path"],

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -1248,7 +1248,10 @@ class ProductOnboardingTests(unittest.TestCase):
             workflow_text,
             r"uses: actions/checkout@(?:v\d+(?:\.\d+){0,2}|[0-9a-f]{40})(?:\s|$)",
         )
-        self.assertIn("uses: ./.github/actions/launchplane-request", workflow_text)
+        self.assertIn(
+            "uses: cbusillo/launchplane/.github/actions/launchplane-request@",
+            workflow_text,
+        )
         self.assertIn("route-path: /v1/drivers/odoo/artifact-publish-inputs", workflow_text)
         self.assertIn("Render authenticated Odoo route probe payloads", workflow_text)
         self.assertIn("Probe Odoo preview apply inputs route", workflow_text)
@@ -1361,7 +1364,10 @@ class ProductOnboardingTests(unittest.TestCase):
             workflow_text,
             r"uses: actions/checkout@(?:v\d+(?:\.\d+){0,2}|[0-9a-f]{40})(?:\s|$)",
         )
-        self.assertIn("uses: ./.github/actions/launchplane-request", workflow_text)
+        self.assertIn(
+            "uses: cbusillo/launchplane/.github/actions/launchplane-request@",
+            workflow_text,
+        )
         self.assertIn("PRODUCT: ${{ inputs.product }}", workflow_text)
         self.assertIn("CONTEXT: ${{ inputs.context }}", workflow_text)
         self.assertIn("DOMAIN: ${{ inputs.domain }}", workflow_text)
@@ -1510,7 +1516,10 @@ class ProductOnboardingTests(unittest.TestCase):
         self.assertIn("allow_create: $allow_create", workflow_text)
         self.assertIn('allow_update: option("allow_update"; true)', workflow_text)
         self.assertIn('allow_enable_disable: option("allow_enable_disable"; false)', workflow_text)
-        self.assertIn("uses: ./.github/actions/launchplane-request", workflow_text)
+        self.assertIn(
+            "uses: cbusillo/launchplane/.github/actions/launchplane-request@",
+            workflow_text,
+        )
         self.assertIn("route-path: /v1/drivers/ingress/route-apply", workflow_text)
         self.assertIn("PRODUCT: ${{ inputs.product }}", workflow_text)
         self.assertIn("CONTEXT: ${{ inputs.context }}", workflow_text)

--- a/tests/test_product_prelaunch_rebuild_policy_operator_workflow.py
+++ b/tests/test_product_prelaunch_rebuild_policy_operator_workflow.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 import unittest
 
-from tests.support.workflows import load_workflow
+from tests.support.workflows import launchplane_request_action_reference, load_workflow
 
 
 class ProductPrelaunchRebuildPolicyOperatorWorkflowTests(unittest.TestCase):
@@ -28,8 +28,7 @@ class ProductPrelaunchRebuildPolicyOperatorWorkflowTests(unittest.TestCase):
         assert request_step is not None
         self.assertEqual(
             request_step.uses,
-            "cbusillo/launchplane/.github/actions/launchplane-request@"
-            "adcf937c6aef14e02478724040852d1d2a82a850",
+            launchplane_request_action_reference(),
         )
         self.assertEqual(
             request_step.with_values["route-path"],

--- a/tests/test_route_binding_operator_workflow.py
+++ b/tests/test_route_binding_operator_workflow.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 from pathlib import Path
 import unittest
 
-from tests.support.workflows import SELF_HOSTED_RUNNER, load_workflow
+from tests.support.workflows import (
+    SELF_HOSTED_RUNNER,
+    launchplane_request_action_reference,
+    load_workflow,
+)
 
 
 class RouteBindingOperatorWorkflowTests(unittest.TestCase):
@@ -27,8 +31,7 @@ class RouteBindingOperatorWorkflowTests(unittest.TestCase):
         assert current_step is not None
         self.assertEqual(
             current_step.uses,
-            "cbusillo/launchplane/.github/actions/launchplane-request@"
-            "adcf937c6aef14e02478724040852d1d2a82a850",
+            launchplane_request_action_reference(),
         )
         self.assertEqual(current_step.with_values["method"], "GET")
         self.assertEqual(current_step.with_values["expected-status"], "200,404")
@@ -39,8 +42,7 @@ class RouteBindingOperatorWorkflowTests(unittest.TestCase):
         assert reconcile_step is not None
         self.assertEqual(
             reconcile_step.uses,
-            "cbusillo/launchplane/.github/actions/launchplane-request@"
-            "adcf937c6aef14e02478724040852d1d2a82a850",
+            launchplane_request_action_reference(),
         )
         self.assertEqual(
             reconcile_step.with_values["route-path"],

--- a/tests/test_route_binding_refresh_workflow.py
+++ b/tests/test_route_binding_refresh_workflow.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 from pathlib import Path
 import unittest
 
-from tests.support.workflows import SELF_HOSTED_RUNNER, load_workflow
+from tests.support.workflows import (
+    SELF_HOSTED_RUNNER,
+    launchplane_request_action_reference,
+    load_workflow,
+)
 
 
 class RouteBindingRefreshWorkflowTests(unittest.TestCase):
@@ -96,8 +100,7 @@ class RouteBindingRefreshWorkflowTests(unittest.TestCase):
         assert request_step is not None
         self.assertEqual(
             request_step.uses,
-            "cbusillo/launchplane/.github/actions/launchplane-request@"
-            "adcf937c6aef14e02478724040852d1d2a82a850",
+            launchplane_request_action_reference(),
         )
         self.assertEqual(
             request_step.with_values["route-path"],

--- a/tests/test_tracked_target_logs_operator_workflow.py
+++ b/tests/test_tracked_target_logs_operator_workflow.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 import unittest
 
-from tests.support.workflows import SELF_HOSTED_RUNNER, load_workflow
+from tests.support.workflows import (
+    SELF_HOSTED_RUNNER,
+    launchplane_request_action_reference,
+    load_workflow,
+)
 
 
 class TrackedTargetLogsOperatorWorkflowTests(unittest.TestCase):
@@ -99,7 +103,7 @@ class TrackedTargetLogsOperatorWorkflowTests(unittest.TestCase):
         assert artifact_step is not None
         self.assertEqual(
             request_step.uses,
-            "cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850",
+            launchplane_request_action_reference(),
         )
         self.assertEqual(request_step.with_values["method"], "GET")
         self.assertEqual(request_step.with_values["log-response-body"], False)


### PR DESCRIPTION
## Summary

- add deterministic `launchplane action-pins check`, `report`, and `update` commands
- fail required security CI when ordinary `launchplane-request` pins are stale, unreachable, malformed, or unverifiable
- migrate 107 ordinary consumers to the current content-equivalent release and move reusable callers off caller-supplied local action code
- document the same-PR two-commit release protocol and clarify Dependabot's third-party-only coverage

## Validation

- `uv run --extra dev launchplane ci unittest-shard local` — passed 2,907 targets; one prior run had three unrelated ASGI lifespan startup timeouts, all passed in isolation and the full rerun passed
- `uv run --extra dev python -m unittest tests.test_first_party_action_pins tests.test_github_actions_security tests.test_external_route_binding_operator_workflow tests.test_odoo_target_replacement_workflows tests.test_odoo_website_bootstrap_override_workflow tests.test_product_health_monitoring_operator_workflow tests.test_product_onboarding tests.test_product_prelaunch_rebuild_policy_operator_workflow tests.test_route_binding_operator_workflow tests.test_route_binding_refresh_workflow tests.test_tracked_target_logs_operator_workflow`
- `uv run --extra dev mypy control_plane tests`
- `uv run --extra dev ruff check .`
- changed-file `uv run --extra dev ruff format --check ...`
- pinned `rhysd/actionlint:1.7.12` container with `.github/actionlint.yaml`
- `uv run --extra dev launchplane action-pins check`
- updater dry-run is idempotent with no changed files
- JetBrains closeout attempted; plugin returned `UNKNOWN` because proof-file capture exceeded its limit, with zero reported problems

## Review

- Opus exact-head review: approved with no blocking or important findings; one `.yaml` coverage note was incorporated before the final commit and the amended head was approved
- Gemini/Antigravity: three review attempts completed with empty output, so no Gemini approval is claimed

Closes #2143
