### PR TITLE
Publish agent/operator contract

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -64,6 +64,11 @@
       "frontendGenerate": "pnpm --dir frontend generate:openapi",
       "frontendDrift": "pnpm --dir frontend check:openapi-drift"
     },
+    "agentContract": {
+      "artifact": "contracts/agent-operator-contract.json",
+      "export": "uv run launchplane service export-agent-contract --output contracts/agent-operator-contract.json",
+      "drift": "pnpm --dir frontend check:openapi-drift"
+    },
     "audit": {
       "pythonDependencies": "uv run --with pip-audit pip-audit --ignore-vuln PYSEC-2025-183",
       "container": "docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v \"${RUNNER_TEMP}/trivy-cache:/root/.cache\" ghcr.io/aquasecurity/trivy:0.70.0 image --scanners vulnerability --ignore-unfixed --severity HIGH,CRITICAL --exit-code 1 launchplane-ci:test",

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN pnpm install --frozen-lockfile
 COPY frontend /app/frontend
 RUN pnpm build
 
-FROM mirror.gcr.io/library/golang:1.26.5-bookworm AS github-cli-build
+FROM mirror.gcr.io/library/golang:1.26.6-bookworm AS github-cli-build
 
 ARG GITHUB_CLI_VERSION=v2.96.0
 ARG GITHUB_CLI_GRPC_VERSION=v1.82.1

--- a/contracts/agent-operator-contract.json
+++ b/contracts/agent-operator-contract.json
@@ -422,7 +422,7 @@
   },
   "normalization_version": 1,
   "provenance": {
-    "source_commit_sha": "5c6dc652b12513a1e0397da156ec9ba83417bf2c"
+    "source_commit_sha": "52baf0aa7f470e0fabecbf7110dd512b490f88e1"
   },
   "schema_version": 1,
   "semantic_digest_sha256": "1be9595525bf2e87aa8c658176cff0bf4f43fac99faee75e88b85e737a57f0ab"

--- a/contracts/agent-operator-contract.json
+++ b/contracts/agent-operator-contract.json
@@ -422,7 +422,7 @@
   },
   "normalization_version": 1,
   "provenance": {
-    "source_commit_sha": "f38b4c9aa6779a20fc472dd7617713a505829d96"
+    "source_commit_sha": "ef953b66251d8dce8f87405e54e6150d8e4b19a1"
   },
   "schema_version": 1,
   "semantic_digest_sha256": "a3f2c6602376cd0cd8638283f186471fe4f8a53516f531d4ff613b9ed5203479"

--- a/contracts/agent-operator-contract.json
+++ b/contracts/agent-operator-contract.json
@@ -1,0 +1,429 @@
+{
+  "contract": {
+    "invariants": {
+      "detached_retirement": {
+        "authority_write_count": 0,
+        "completion_requires_candidate_absence": true
+      },
+      "governance": {
+        "authorization_admission_and_landing_are_independent": true,
+        "shadow_evidence_authoritative": false,
+        "shadow_evidence_role": "advisory_only"
+      },
+      "product_lifecycle": {
+        "active_automation_states": [
+          "active"
+        ],
+        "retired_previews_enabled": false,
+        "states": [
+          "active",
+          "retiring",
+          "retired"
+        ],
+        "transitions": [
+          "active->retiring",
+          "retiring->retired"
+        ]
+      },
+      "protected_workflow_policy": {
+        "dispatch_and_watch_helper": "github_workflow_babysit.py",
+        "raw_workflow_dispatch_allowed": false
+      },
+      "reconciliation": {
+        "effect_unknown": "reconciliation_required_before_reexecution",
+        "landing_sha_source": "terminal_controller_result_only",
+        "pre_effect": "retry_only_after_fixing_the_block"
+      },
+      "stable_deploy_identity": {
+        "artifact_id": "digest_pinned_evidence_and_runtime_identity",
+        "deploy_reference": "published_same_repository_immutable_sha_tag",
+        "floating_tags_allowed": false,
+        "image_reference": "provider_tag_readback",
+        "target_category": "application"
+      }
+    },
+    "operations": [
+      {
+        "idempotency": "none",
+        "identity_dependencies": [
+          "read_identity"
+        ],
+        "method": "GET",
+        "modes": [
+          "read"
+        ],
+        "openapi_fingerprint_sha256": "c49fedac49b94dbc12172b8a8cf85fe3e2684565f3f072baa065e89d1ad92c9b",
+        "operation_id": "read_agent_context",
+        "path": "/v1/agent/context",
+        "purpose": "Read public-safe Launchplane context for an agent task.",
+        "response_statuses": [
+          "200",
+          "400",
+          "401",
+          "403",
+          "409",
+          "503"
+        ],
+        "reviewed_evidence": [],
+        "supported_surfaces": [
+          "agent_helper",
+          "read_only_service"
+        ]
+      },
+      {
+        "idempotency": "optional",
+        "identity_dependencies": [
+          "read_browser_mutation_identity"
+        ],
+        "method": "POST",
+        "modes": [
+          "preflight"
+        ],
+        "openapi_fingerprint_sha256": "1f0c8b32c85ddf362d9ee75b310a9c21948d59ee50af95043e991c1ba3e1d87c",
+        "operation_id": "evaluate_agent_write_intent",
+        "path": "/v1/agent/write-intents/evaluate",
+        "purpose": "Evaluate a bounded agent write intent before mutation.",
+        "response_statuses": [
+          "202",
+          "400",
+          "401",
+          "409",
+          "503"
+        ],
+        "reviewed_evidence": [],
+        "supported_surfaces": [
+          "agent_helper",
+          "service_api"
+        ]
+      },
+      {
+        "idempotency": "apply",
+        "identity_dependencies": [
+          "read_browser_mutation_identity"
+        ],
+        "method": "POST",
+        "modes": [
+          "dry-run",
+          "apply"
+        ],
+        "openapi_fingerprint_sha256": "e333fb2783fbefcc0c15c44efb40f2ceb13a60095e4e7287a04cf89c937ca6eb",
+        "operation_id": "apply_product_config",
+        "path": "/v1/product-config/apply",
+        "purpose": "Dry-run or apply reviewed product configuration.",
+        "response_statuses": [
+          "202",
+          "400",
+          "401",
+          "403",
+          "409",
+          "503"
+        ],
+        "reviewed_evidence": [
+          "reviewed_dry_run"
+        ],
+        "supported_surfaces": [
+          "agent_helper",
+          "operator_ui",
+          "service_api"
+        ]
+      },
+      {
+        "idempotency": "none",
+        "identity_dependencies": [
+          "read_write_identity"
+        ],
+        "method": "POST",
+        "modes": [
+          "dry-run",
+          "apply"
+        ],
+        "openapi_fingerprint_sha256": "56d45106f7ec59d196201e101da8e74a63e2c697cc145200325fec68466e14b8",
+        "operation_id": "apply_change_impact_policy",
+        "path": "/v1/change-impact/policies/apply",
+        "purpose": "Dry-run or apply a reviewed change-impact policy revision.",
+        "response_statuses": [
+          "202",
+          "403",
+          "409",
+          "503"
+        ],
+        "reviewed_evidence": [
+          "reviewed_dry_run",
+          "expected_policy_digest"
+        ],
+        "supported_surfaces": [
+          "agent_helper",
+          "operator_ui",
+          "service_api"
+        ]
+      },
+      {
+        "idempotency": "none",
+        "identity_dependencies": [
+          "read_identity"
+        ],
+        "method": "GET",
+        "modes": [
+          "read"
+        ],
+        "openapi_fingerprint_sha256": "810ce55fdcb429797375cb8a624d6ee36dc20ec80bf3fb17ac0e882b174e9d18",
+        "operation_id": "read_change_impact_policy",
+        "path": "/v1/change-impact/policy",
+        "purpose": "Read active change-impact policy revision evidence.",
+        "response_statuses": [
+          "200",
+          "403",
+          "409",
+          "503"
+        ],
+        "reviewed_evidence": [],
+        "supported_surfaces": [
+          "agent_helper",
+          "read_only_service"
+        ]
+      },
+      {
+        "idempotency": "mutate",
+        "identity_dependencies": [
+          "read_write_identity"
+        ],
+        "method": "POST",
+        "modes": [
+          "dry-run",
+          "mutate"
+        ],
+        "openapi_fingerprint_sha256": "c7351558badf1ffc4c955a82c5152bb878a2c0b652f9d8df6f2ee748e640ae83",
+        "operation_id": "write_merge_train_controller_run_once",
+        "path": "/v1/work-graph/merge-train/controller/run-once",
+        "purpose": "Advance one merge-train controller phase with bounded recovery evidence.",
+        "response_statuses": [
+          "202",
+          "400",
+          "401",
+          "403",
+          "409",
+          "502",
+          "503"
+        ],
+        "reviewed_evidence": [],
+        "supported_surfaces": [
+          "agent_helper",
+          "operator_ui",
+          "service_api"
+        ]
+      },
+      {
+        "idempotency": "apply",
+        "identity_dependencies": [
+          "read_write_identity"
+        ],
+        "method": "POST",
+        "modes": [
+          "dry-run",
+          "apply"
+        ],
+        "openapi_fingerprint_sha256": "5b2b1930447b9b0b1ff88c95e9395b4bf27625922d55d7f7b642a4bcb7fa49be",
+        "operation_id": "remediate_preview_pr_feedback",
+        "path": "/v1/previews/pr-feedback/remediation",
+        "purpose": "Dry-run or apply bounded historical preview-feedback remediation.",
+        "response_statuses": [
+          "202",
+          "400",
+          "401",
+          "403",
+          "409",
+          "503"
+        ],
+        "reviewed_evidence": [
+          "reviewed_dry_run"
+        ],
+        "supported_surfaces": [
+          "agent_helper",
+          "operator_ui",
+          "service_api"
+        ]
+      },
+      {
+        "idempotency": "always",
+        "identity_dependencies": [
+          "read_write_identity"
+        ],
+        "method": "POST",
+        "modes": [
+          "plan",
+          "apply"
+        ],
+        "openapi_fingerprint_sha256": "2557624b0cdc6c8bc56f13efbe706499eb75e859a08fa12698f42287fd36ee4d",
+        "operation_id": "execute_product_retirement",
+        "path": "/v1/product-retirement",
+        "purpose": "Plan or apply protected product retirement.",
+        "response_statuses": [
+          "202",
+          "400",
+          "401",
+          "403",
+          "404",
+          "409",
+          "503"
+        ],
+        "reviewed_evidence": [
+          "reviewed_plan_digest"
+        ],
+        "supported_surfaces": [
+          "protected_workflow",
+          "operator_ui",
+          "service_api"
+        ]
+      },
+      {
+        "idempotency": "always",
+        "identity_dependencies": [
+          "read_write_identity"
+        ],
+        "method": "POST",
+        "modes": [
+          "plan",
+          "apply"
+        ],
+        "openapi_fingerprint_sha256": "67c78f2fad901e7f865073383374a1cdd2eb153eed16e4110c9155915e771c8b",
+        "operation_id": "execute_detached_application_retirement",
+        "path": "/v1/detached-application-retirement",
+        "purpose": "Plan or apply detached application retirement with zero authority writes.",
+        "response_statuses": [
+          "202",
+          "400",
+          "401",
+          "403",
+          "404",
+          "409",
+          "503"
+        ],
+        "reviewed_evidence": [
+          "reviewed_plan_digest"
+        ],
+        "supported_surfaces": [
+          "protected_workflow",
+          "operator_ui",
+          "service_api"
+        ]
+      },
+      {
+        "idempotency": "apply",
+        "identity_dependencies": [
+          "read_browser_mutation_identity"
+        ],
+        "method": "POST",
+        "modes": [
+          "dry-run",
+          "apply"
+        ],
+        "openapi_fingerprint_sha256": "115bc60d6691fdcbd7bc8ffd42667a523a5e89f106503083150dbb3bf4e29425",
+        "operation_id": "reconcile_managed_authz_policy",
+        "path": "/v1/authz-policies/managed-rule-sets/reconcile",
+        "purpose": "Dry-run or apply managed authorization reconciliation.",
+        "response_statuses": [
+          "202",
+          "400",
+          "401",
+          "403",
+          "409",
+          "503"
+        ],
+        "reviewed_evidence": [
+          "reviewed_plan_digest"
+        ],
+        "supported_surfaces": [
+          "protected_workflow",
+          "operator_ui",
+          "service_api"
+        ]
+      },
+      {
+        "idempotency": "apply",
+        "identity_dependencies": [
+          "read_write_identity"
+        ],
+        "method": "POST",
+        "modes": [
+          "dry-run",
+          "apply"
+        ],
+        "openapi_fingerprint_sha256": "31b99d73df6ce6efcf92c2c2384780949b46b225e8379ad9dc3d08e0d5a0b8e3",
+        "operation_id": "apply_product_stable_lane_repair",
+        "path": "/v1/product-profiles/stable-lane-repair/apply",
+        "purpose": "Dry-run or apply a bounded stable-lane profile repair.",
+        "response_statuses": [
+          "202",
+          "400",
+          "401",
+          "403",
+          "404",
+          "409",
+          "503"
+        ],
+        "reviewed_evidence": [
+          "reviewed_plan_digest"
+        ],
+        "supported_surfaces": [
+          "protected_workflow",
+          "operator_ui",
+          "service_api"
+        ]
+      },
+      {
+        "idempotency": "none",
+        "identity_dependencies": [
+          "read_identity"
+        ],
+        "method": "GET",
+        "modes": [
+          "read"
+        ],
+        "openapi_fingerprint_sha256": "9140bde34ab5930422c2e9f654db3e7af1ede283a69bd8289c62a93931f2d11e",
+        "operation_id": "read_governance_projection",
+        "path": "/v1/governance/projection",
+        "purpose": "Read governance evidence without granting shadow authority.",
+        "response_statuses": [
+          "200",
+          "400",
+          "401",
+          "403",
+          "409",
+          "503"
+        ],
+        "reviewed_evidence": [],
+        "supported_surfaces": [
+          "read_only_service",
+          "operator_ui"
+        ]
+      }
+    ],
+    "protected_workflows": [
+      {
+        "reusable_workflow_file": ".github/workflows/reusable-product-retirement.yml",
+        "route": "/v1/product-retirement",
+        "workflow_file": ".github/workflows/product-retirement.yml"
+      },
+      {
+        "reusable_workflow_file": ".github/workflows/reusable-detached-application-retirement.yml",
+        "route": "/v1/detached-application-retirement",
+        "workflow_file": ".github/workflows/detached-application-retirement.yml"
+      },
+      {
+        "reusable_workflow_file": ".github/workflows/reusable-authz-policy-reconcile.yml",
+        "route": "/v1/authz-policies/managed-rule-sets/reconcile",
+        "workflow_file": ".github/workflows/authz-policy-reconcile.yml"
+      },
+      {
+        "route": "/v1/product-profiles/stable-lane-repair/apply",
+        "workflow_file": ".github/workflows/product-onboarding-manifest.yml"
+      }
+    ]
+  },
+  "normalization_version": 1,
+  "provenance": {
+    "source_commit_sha": "5c6dc652b12513a1e0397da156ec9ba83417bf2c"
+  },
+  "schema_version": 1,
+  "semantic_digest_sha256": "1be9595525bf2e87aa8c658176cff0bf4f43fac99faee75e88b85e737a57f0ab"
+}

--- a/contracts/agent-operator-contract.json
+++ b/contracts/agent-operator-contract.json
@@ -52,7 +52,6 @@
         "modes": [
           "read"
         ],
-        "openapi_fingerprint_sha256": "c49fedac49b94dbc12172b8a8cf85fe3e2684565f3f072baa065e89d1ad92c9b",
         "operation_id": "read_agent_context",
         "path": "/v1/agent/context",
         "purpose": "Read public-safe Launchplane context for an agent task.",
@@ -65,6 +64,7 @@
           "503"
         ],
         "reviewed_evidence": [],
+        "schema_fingerprint_sha256": "c49fedac49b94dbc12172b8a8cf85fe3e2684565f3f072baa065e89d1ad92c9b",
         "supported_surfaces": [
           "agent_helper",
           "read_only_service"
@@ -79,7 +79,6 @@
         "modes": [
           "preflight"
         ],
-        "openapi_fingerprint_sha256": "1f0c8b32c85ddf362d9ee75b310a9c21948d59ee50af95043e991c1ba3e1d87c",
         "operation_id": "evaluate_agent_write_intent",
         "path": "/v1/agent/write-intents/evaluate",
         "purpose": "Evaluate a bounded agent write intent before mutation.",
@@ -91,6 +90,7 @@
           "503"
         ],
         "reviewed_evidence": [],
+        "schema_fingerprint_sha256": "1f0c8b32c85ddf362d9ee75b310a9c21948d59ee50af95043e991c1ba3e1d87c",
         "supported_surfaces": [
           "agent_helper",
           "service_api"
@@ -106,7 +106,6 @@
           "dry-run",
           "apply"
         ],
-        "openapi_fingerprint_sha256": "e333fb2783fbefcc0c15c44efb40f2ceb13a60095e4e7287a04cf89c937ca6eb",
         "operation_id": "apply_product_config",
         "path": "/v1/product-config/apply",
         "purpose": "Dry-run or apply reviewed product configuration.",
@@ -121,6 +120,7 @@
         "reviewed_evidence": [
           "reviewed_dry_run"
         ],
+        "schema_fingerprint_sha256": "e333fb2783fbefcc0c15c44efb40f2ceb13a60095e4e7287a04cf89c937ca6eb",
         "supported_surfaces": [
           "agent_helper",
           "operator_ui",
@@ -137,7 +137,6 @@
           "dry-run",
           "apply"
         ],
-        "openapi_fingerprint_sha256": "56d45106f7ec59d196201e101da8e74a63e2c697cc145200325fec68466e14b8",
         "operation_id": "apply_change_impact_policy",
         "path": "/v1/change-impact/policies/apply",
         "purpose": "Dry-run or apply a reviewed change-impact policy revision.",
@@ -151,6 +150,7 @@
           "reviewed_dry_run",
           "expected_policy_digest"
         ],
+        "schema_fingerprint_sha256": "56d45106f7ec59d196201e101da8e74a63e2c697cc145200325fec68466e14b8",
         "supported_surfaces": [
           "agent_helper",
           "operator_ui",
@@ -166,7 +166,6 @@
         "modes": [
           "read"
         ],
-        "openapi_fingerprint_sha256": "810ce55fdcb429797375cb8a624d6ee36dc20ec80bf3fb17ac0e882b174e9d18",
         "operation_id": "read_change_impact_policy",
         "path": "/v1/change-impact/policy",
         "purpose": "Read active change-impact policy revision evidence.",
@@ -177,6 +176,7 @@
           "503"
         ],
         "reviewed_evidence": [],
+        "schema_fingerprint_sha256": "810ce55fdcb429797375cb8a624d6ee36dc20ec80bf3fb17ac0e882b174e9d18",
         "supported_surfaces": [
           "agent_helper",
           "read_only_service"
@@ -192,7 +192,6 @@
           "dry-run",
           "mutate"
         ],
-        "openapi_fingerprint_sha256": "c7351558badf1ffc4c955a82c5152bb878a2c0b652f9d8df6f2ee748e640ae83",
         "operation_id": "write_merge_train_controller_run_once",
         "path": "/v1/work-graph/merge-train/controller/run-once",
         "purpose": "Advance one merge-train controller phase with bounded recovery evidence.",
@@ -206,6 +205,7 @@
           "503"
         ],
         "reviewed_evidence": [],
+        "schema_fingerprint_sha256": "c7351558badf1ffc4c955a82c5152bb878a2c0b652f9d8df6f2ee748e640ae83",
         "supported_surfaces": [
           "agent_helper",
           "operator_ui",
@@ -222,7 +222,6 @@
           "dry-run",
           "apply"
         ],
-        "openapi_fingerprint_sha256": "5b2b1930447b9b0b1ff88c95e9395b4bf27625922d55d7f7b642a4bcb7fa49be",
         "operation_id": "remediate_preview_pr_feedback",
         "path": "/v1/previews/pr-feedback/remediation",
         "purpose": "Dry-run or apply bounded historical preview-feedback remediation.",
@@ -237,6 +236,7 @@
         "reviewed_evidence": [
           "reviewed_dry_run"
         ],
+        "schema_fingerprint_sha256": "5b2b1930447b9b0b1ff88c95e9395b4bf27625922d55d7f7b642a4bcb7fa49be",
         "supported_surfaces": [
           "agent_helper",
           "operator_ui",
@@ -253,7 +253,6 @@
           "plan",
           "apply"
         ],
-        "openapi_fingerprint_sha256": "2557624b0cdc6c8bc56f13efbe706499eb75e859a08fa12698f42287fd36ee4d",
         "operation_id": "execute_product_retirement",
         "path": "/v1/product-retirement",
         "purpose": "Plan or apply protected product retirement.",
@@ -269,6 +268,7 @@
         "reviewed_evidence": [
           "reviewed_plan_digest"
         ],
+        "schema_fingerprint_sha256": "2557624b0cdc6c8bc56f13efbe706499eb75e859a08fa12698f42287fd36ee4d",
         "supported_surfaces": [
           "protected_workflow",
           "operator_ui",
@@ -285,7 +285,6 @@
           "plan",
           "apply"
         ],
-        "openapi_fingerprint_sha256": "67c78f2fad901e7f865073383374a1cdd2eb153eed16e4110c9155915e771c8b",
         "operation_id": "execute_detached_application_retirement",
         "path": "/v1/detached-application-retirement",
         "purpose": "Plan or apply detached application retirement with zero authority writes.",
@@ -301,6 +300,7 @@
         "reviewed_evidence": [
           "reviewed_plan_digest"
         ],
+        "schema_fingerprint_sha256": "67c78f2fad901e7f865073383374a1cdd2eb153eed16e4110c9155915e771c8b",
         "supported_surfaces": [
           "protected_workflow",
           "operator_ui",
@@ -317,7 +317,6 @@
           "dry-run",
           "apply"
         ],
-        "openapi_fingerprint_sha256": "115bc60d6691fdcbd7bc8ffd42667a523a5e89f106503083150dbb3bf4e29425",
         "operation_id": "reconcile_managed_authz_policy",
         "path": "/v1/authz-policies/managed-rule-sets/reconcile",
         "purpose": "Dry-run or apply managed authorization reconciliation.",
@@ -332,6 +331,7 @@
         "reviewed_evidence": [
           "reviewed_plan_digest"
         ],
+        "schema_fingerprint_sha256": "115bc60d6691fdcbd7bc8ffd42667a523a5e89f106503083150dbb3bf4e29425",
         "supported_surfaces": [
           "protected_workflow",
           "operator_ui",
@@ -348,7 +348,6 @@
           "dry-run",
           "apply"
         ],
-        "openapi_fingerprint_sha256": "31b99d73df6ce6efcf92c2c2384780949b46b225e8379ad9dc3d08e0d5a0b8e3",
         "operation_id": "apply_product_stable_lane_repair",
         "path": "/v1/product-profiles/stable-lane-repair/apply",
         "purpose": "Dry-run or apply a bounded stable-lane profile repair.",
@@ -364,6 +363,7 @@
         "reviewed_evidence": [
           "reviewed_plan_digest"
         ],
+        "schema_fingerprint_sha256": "31b99d73df6ce6efcf92c2c2384780949b46b225e8379ad9dc3d08e0d5a0b8e3",
         "supported_surfaces": [
           "protected_workflow",
           "operator_ui",
@@ -379,7 +379,6 @@
         "modes": [
           "read"
         ],
-        "openapi_fingerprint_sha256": "9140bde34ab5930422c2e9f654db3e7af1ede283a69bd8289c62a93931f2d11e",
         "operation_id": "read_governance_projection",
         "path": "/v1/governance/projection",
         "purpose": "Read governance evidence without granting shadow authority.",
@@ -392,6 +391,7 @@
           "503"
         ],
         "reviewed_evidence": [],
+        "schema_fingerprint_sha256": "9140bde34ab5930422c2e9f654db3e7af1ede283a69bd8289c62a93931f2d11e",
         "supported_surfaces": [
           "read_only_service",
           "operator_ui"
@@ -422,8 +422,8 @@
   },
   "normalization_version": 1,
   "provenance": {
-    "source_commit_sha": "52baf0aa7f470e0fabecbf7110dd512b490f88e1"
+    "source_commit_sha": "f38b4c9aa6779a20fc472dd7617713a505829d96"
   },
   "schema_version": 1,
-  "semantic_digest_sha256": "1be9595525bf2e87aa8c658176cff0bf4f43fac99faee75e88b85e737a57f0ab"
+  "semantic_digest_sha256": "a3f2c6602376cd0cd8638283f186471fe4f8a53516f531d4ff613b9ed5203479"
 }

--- a/control_plane/agent_operator_contract.py
+++ b/control_plane/agent_operator_contract.py
@@ -507,7 +507,7 @@ def build_agent_operator_contract(
                     (str(status) for status in operation.get("responses", {})),
                     key=lambda status: (not status.isdigit(), status),
                 ),
-                "openapi_fingerprint_sha256": _digest(normalized_operation),
+                "schema_fingerprint_sha256": _digest(normalized_operation),
             }
         )
 
@@ -604,7 +604,7 @@ def validate_agent_operator_contract(artifact: Mapping[str, Any]) -> None:
         "idempotency",
         "reviewed_evidence",
         "response_statuses",
-        "openapi_fingerprint_sha256",
+        "schema_fingerprint_sha256",
     }
     for operation in operations:
         if not isinstance(operation, Mapping):
@@ -648,7 +648,7 @@ def validate_agent_operator_contract(artifact: Mapping[str, Any]) -> None:
                 raise AgentOperatorContractError(f"Invalid operation {field_name}")
         if not operation["identity_dependencies"]:
             raise AgentOperatorContractError("Operation has no identity dependencies")
-        fingerprint = operation["openapi_fingerprint_sha256"]
+        fingerprint = operation["schema_fingerprint_sha256"]
         if not isinstance(fingerprint, str) or not _SHA256_PATTERN.fullmatch(fingerprint):
             raise AgentOperatorContractError("Invalid operation fingerprint")
     if seen_operations != expected_operations:

--- a/control_plane/agent_operator_contract.py
+++ b/control_plane/agent_operator_contract.py
@@ -1,0 +1,702 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import subprocess
+from collections.abc import Mapping, Sequence
+from copy import deepcopy
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from fastapi import FastAPI
+from fastapi.routing import APIRoute
+
+from control_plane.openapi_export import (
+    build_deterministic_export_app,
+    canonical_openapi_document,
+)
+
+
+SCHEMA_VERSION = 1
+NORMALIZATION_VERSION = 1
+_REPOSITORY_ROOT = Path(__file__).resolve().parent.parent
+
+_SCHEMA_KEYS = frozenset(
+    {
+        "additionalProperties",
+        "allOf",
+        "anyOf",
+        "const",
+        "default",
+        "deprecated",
+        "enum",
+        "exclusiveMaximum",
+        "exclusiveMinimum",
+        "format",
+        "items",
+        "maxItems",
+        "maxLength",
+        "maxProperties",
+        "maximum",
+        "minItems",
+        "minLength",
+        "minProperties",
+        "minimum",
+        "multipleOf",
+        "oneOf",
+        "pattern",
+        "properties",
+        "required",
+        "type",
+        "uniqueItems",
+    }
+)
+_SEMANTICALLY_UNORDERED_LIST_KEYS = frozenset({"enum", "required"})
+_SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+_SOURCE_SHA_PATTERN = re.compile(r"^(unknown|[0-9a-f]{40}|[0-9a-f]{64})$")
+_UNSAFE_STRING_PATTERNS = (
+    re.compile(r"https?://", re.IGNORECASE),
+    re.compile(r"\bLAUNCHPLANE_[A-Z0-9_]+\b"),
+    re.compile(r"\b(?:token|password|private[_-]?key)\s*[:=]", re.IGNORECASE),
+)
+
+
+class AgentOperatorContractError(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class OperationSpec:
+    method: str
+    path: str
+    purpose: str
+    supported_surfaces: tuple[str, ...]
+    modes: tuple[str, ...]
+    idempotency: str
+    reviewed_evidence: tuple[str, ...]
+
+
+OPERATION_SPECS = (
+    OperationSpec(
+        "GET",
+        "/v1/agent/context",
+        "Read public-safe Launchplane context for an agent task.",
+        ("agent_helper", "read_only_service"),
+        ("read",),
+        "none",
+        (),
+    ),
+    OperationSpec(
+        "POST",
+        "/v1/agent/write-intents/evaluate",
+        "Evaluate a bounded agent write intent before mutation.",
+        ("agent_helper", "service_api"),
+        ("preflight",),
+        "optional",
+        (),
+    ),
+    OperationSpec(
+        "POST",
+        "/v1/product-config/apply",
+        "Dry-run or apply reviewed product configuration.",
+        ("agent_helper", "operator_ui", "service_api"),
+        ("dry-run", "apply"),
+        "apply",
+        ("reviewed_dry_run",),
+    ),
+    OperationSpec(
+        "POST",
+        "/v1/change-impact/policies/apply",
+        "Dry-run or apply a reviewed change-impact policy revision.",
+        ("agent_helper", "operator_ui", "service_api"),
+        ("dry-run", "apply"),
+        "none",
+        ("reviewed_dry_run", "expected_policy_digest"),
+    ),
+    OperationSpec(
+        "GET",
+        "/v1/change-impact/policy",
+        "Read active change-impact policy revision evidence.",
+        ("agent_helper", "read_only_service"),
+        ("read",),
+        "none",
+        (),
+    ),
+    OperationSpec(
+        "POST",
+        "/v1/work-graph/merge-train/controller/run-once",
+        "Advance one merge-train controller phase with bounded recovery evidence.",
+        ("agent_helper", "operator_ui", "service_api"),
+        ("dry-run", "mutate"),
+        "mutate",
+        (),
+    ),
+    OperationSpec(
+        "POST",
+        "/v1/previews/pr-feedback/remediation",
+        "Dry-run or apply bounded historical preview-feedback remediation.",
+        ("agent_helper", "operator_ui", "service_api"),
+        ("dry-run", "apply"),
+        "apply",
+        ("reviewed_dry_run",),
+    ),
+    OperationSpec(
+        "POST",
+        "/v1/product-retirement",
+        "Plan or apply protected product retirement.",
+        ("protected_workflow", "operator_ui", "service_api"),
+        ("plan", "apply"),
+        "always",
+        ("reviewed_plan_digest",),
+    ),
+    OperationSpec(
+        "POST",
+        "/v1/detached-application-retirement",
+        "Plan or apply detached application retirement with zero authority writes.",
+        ("protected_workflow", "operator_ui", "service_api"),
+        ("plan", "apply"),
+        "always",
+        ("reviewed_plan_digest",),
+    ),
+    OperationSpec(
+        "POST",
+        "/v1/authz-policies/managed-rule-sets/reconcile",
+        "Dry-run or apply managed authorization reconciliation.",
+        ("protected_workflow", "operator_ui", "service_api"),
+        ("dry-run", "apply"),
+        "apply",
+        ("reviewed_plan_digest",),
+    ),
+    OperationSpec(
+        "POST",
+        "/v1/product-profiles/stable-lane-repair/apply",
+        "Dry-run or apply a bounded stable-lane profile repair.",
+        ("protected_workflow", "operator_ui", "service_api"),
+        ("dry-run", "apply"),
+        "apply",
+        ("reviewed_plan_digest",),
+    ),
+    OperationSpec(
+        "GET",
+        "/v1/governance/projection",
+        "Read governance evidence without granting shadow authority.",
+        ("read_only_service", "operator_ui"),
+        ("read",),
+        "none",
+        (),
+    ),
+)
+
+PROTECTED_WORKFLOWS = (
+    {
+        "workflow_file": ".github/workflows/product-retirement.yml",
+        "reusable_workflow_file": ".github/workflows/reusable-product-retirement.yml",
+        "route": "/v1/product-retirement",
+    },
+    {
+        "workflow_file": ".github/workflows/detached-application-retirement.yml",
+        "reusable_workflow_file": ".github/workflows/reusable-detached-application-retirement.yml",
+        "route": "/v1/detached-application-retirement",
+    },
+    {
+        "workflow_file": ".github/workflows/authz-policy-reconcile.yml",
+        "reusable_workflow_file": ".github/workflows/reusable-authz-policy-reconcile.yml",
+        "route": "/v1/authz-policies/managed-rule-sets/reconcile",
+    },
+    {
+        "workflow_file": ".github/workflows/product-onboarding-manifest.yml",
+        "route": "/v1/product-profiles/stable-lane-repair/apply",
+    },
+)
+
+INVARIANTS = {
+    "product_lifecycle": {
+        "states": ["active", "retiring", "retired"],
+        "transitions": ["active->retiring", "retiring->retired"],
+        "active_automation_states": ["active"],
+        "retired_previews_enabled": False,
+    },
+    "detached_retirement": {
+        "authority_write_count": 0,
+        "completion_requires_candidate_absence": True,
+    },
+    "stable_deploy_identity": {
+        "target_category": "application",
+        "artifact_id": "digest_pinned_evidence_and_runtime_identity",
+        "deploy_reference": "published_same_repository_immutable_sha_tag",
+        "image_reference": "provider_tag_readback",
+        "floating_tags_allowed": False,
+    },
+    "reconciliation": {
+        "pre_effect": "retry_only_after_fixing_the_block",
+        "effect_unknown": "reconciliation_required_before_reexecution",
+        "landing_sha_source": "terminal_controller_result_only",
+    },
+    "governance": {
+        "shadow_evidence_authoritative": False,
+        "shadow_evidence_role": "advisory_only",
+        "authorization_admission_and_landing_are_independent": True,
+    },
+    "protected_workflow_policy": {
+        "dispatch_and_watch_helper": "github_workflow_babysit.py",
+        "raw_workflow_dispatch_allowed": False,
+    },
+}
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, separators=(",", ":"), sort_keys=True)
+
+
+def _digest(value: Any) -> str:
+    return hashlib.sha256(_canonical_json(value).encode()).hexdigest()
+
+
+def _collect_definitions(value: Any, definitions: dict[str, Any]) -> None:
+    if not isinstance(value, Mapping):
+        return
+    nested = value.get("$defs")
+    if isinstance(nested, Mapping):
+        definitions.update({str(key): item for key, item in nested.items()})
+
+
+def _resolve_schema(
+    schema: Any,
+    components: Mapping[str, Any],
+    definitions: Mapping[str, Any],
+    resolving: tuple[str, ...],
+) -> Any:
+    if not isinstance(schema, Mapping) or "$ref" not in schema:
+        return schema
+    reference = schema["$ref"]
+    if not isinstance(reference, str):
+        raise AgentOperatorContractError("OpenAPI schema reference must be a string")
+    if reference.startswith("#/components/schemas/"):
+        name = reference.rsplit("/", maxsplit=1)[-1]
+        resolution_key = f"component:{name}"
+        if resolution_key in resolving:
+            return {"type": "object", "recursive_reference": reference}
+        if name not in components:
+            raise AgentOperatorContractError(f"Missing OpenAPI schema reference: {reference}")
+        return _normalize_schema(components[name], components, {}, (*resolving, resolution_key))
+    elif reference.startswith("#/$defs/"):
+        name = reference.rsplit("/", maxsplit=1)[-1]
+        resolution_key = f"definition:{name}"
+        if resolution_key in resolving:
+            return {"type": "object", "recursive_reference": reference}
+        if name not in definitions:
+            raise AgentOperatorContractError(f"Missing OpenAPI schema reference: {reference}")
+        return _normalize_schema(
+            definitions[name],
+            components,
+            definitions,
+            (*resolving, resolution_key),
+        )
+    else:
+        raise AgentOperatorContractError(f"Unsupported OpenAPI schema reference: {reference}")
+
+
+def _normalize_schema(
+    schema: Any,
+    components: Mapping[str, Any],
+    definitions: Mapping[str, Any],
+    resolving: tuple[str, ...] = (),
+) -> Any:
+    local_definitions = dict(definitions)
+    _collect_definitions(schema, local_definitions)
+    resolved = _resolve_schema(schema, components, local_definitions, resolving)
+    if resolved is not schema:
+        siblings = {key: value for key, value in schema.items() if key != "$ref"}
+        normalized_siblings = _normalize_schema(
+            siblings,
+            components,
+            local_definitions,
+            resolving,
+        )
+        if not normalized_siblings:
+            return resolved
+        return {"allOf": sorted([resolved, normalized_siblings], key=_canonical_json)}
+    if isinstance(schema, bool):
+        return schema
+    if not isinstance(schema, Mapping):
+        raise AgentOperatorContractError("OpenAPI schema must be an object or boolean")
+    normalized: dict[str, Any] = {}
+    for key in sorted(_SCHEMA_KEYS & set(schema)):
+        value = schema[key]
+        if key == "properties":
+            if not isinstance(value, Mapping):
+                raise AgentOperatorContractError("OpenAPI properties must be an object")
+            normalized[key] = {
+                str(name): _normalize_schema(item, components, local_definitions, resolving)
+                for name, item in sorted(value.items())
+            }
+        elif key in {"items", "additionalProperties"} and isinstance(value, (Mapping, bool)):
+            normalized[key] = _normalize_schema(value, components, local_definitions, resolving)
+        elif key in {"anyOf", "oneOf", "allOf"}:
+            if not isinstance(value, Sequence) or isinstance(value, str | bytes):
+                raise AgentOperatorContractError(f"OpenAPI {key} must be an array")
+            normalized_items = [
+                _normalize_schema(item, components, local_definitions, resolving) for item in value
+            ]
+            normalized[key] = sorted(normalized_items, key=_canonical_json)
+        elif key in _SEMANTICALLY_UNORDERED_LIST_KEYS:
+            if not isinstance(value, Sequence) or isinstance(value, str | bytes):
+                raise AgentOperatorContractError(f"OpenAPI {key} must be an array")
+            normalized[key] = sorted(deepcopy(list(value)), key=_canonical_json)
+        else:
+            normalized[key] = deepcopy(value)
+    return normalized
+
+
+def _normalize_content(
+    content: Any,
+    components: Mapping[str, Any],
+    definitions: Mapping[str, Any],
+) -> dict[str, Any]:
+    if not isinstance(content, Mapping):
+        return {}
+    return {
+        str(media_type): _normalize_schema(payload.get("schema", {}), components, definitions)
+        for media_type, payload in sorted(content.items())
+        if isinstance(payload, Mapping)
+    }
+
+
+def _normalize_operation(
+    operation: Mapping[str, Any],
+    components: Mapping[str, Any],
+    definitions: Mapping[str, Any],
+) -> dict[str, Any]:
+    parameters = []
+    for parameter in operation.get("parameters", []):
+        if not isinstance(parameter, Mapping):
+            raise AgentOperatorContractError("OpenAPI parameters must be objects")
+        parameters.append(
+            {
+                "name": str(parameter.get("name", "")),
+                "in": str(parameter.get("in", "")),
+                "required": bool(parameter.get("required", False)),
+                "schema": _normalize_schema(parameter.get("schema", {}), components, definitions),
+            }
+        )
+    parameters.sort(key=lambda item: (item["in"], item["name"]))
+
+    request_body = operation.get("requestBody")
+    normalized_request = None
+    if isinstance(request_body, Mapping):
+        normalized_request = {
+            "required": bool(request_body.get("required", False)),
+            "content": _normalize_content(request_body.get("content", {}), components, definitions),
+        }
+
+    responses = operation.get("responses", {})
+    if not isinstance(responses, Mapping):
+        raise AgentOperatorContractError("OpenAPI responses must be an object")
+    normalized_responses = {
+        str(status): _normalize_content(response.get("content", {}), components, definitions)
+        for status, response in sorted(responses.items(), key=lambda item: str(item[0]))
+        if isinstance(response, Mapping)
+    }
+    return {
+        "parameters": parameters,
+        "request_body": normalized_request,
+        "responses": normalized_responses,
+    }
+
+
+def _live_routes(app: FastAPI) -> dict[tuple[str, str], APIRoute]:
+    allowed = {(spec.method, spec.path) for spec in OPERATION_SPECS}
+    routes: dict[tuple[str, str], APIRoute] = {}
+    for route in app.routes:
+        if not isinstance(route, APIRoute):
+            continue
+        for method in route.methods or set():
+            key = (method.upper(), route.path)
+            if key not in allowed:
+                continue
+            if key in routes:
+                raise AgentOperatorContractError(f"Duplicate allow-listed route: {key}")
+            routes[key] = route
+    missing = sorted(allowed - set(routes))
+    if missing:
+        raise AgentOperatorContractError(f"Missing allow-listed routes: {missing}")
+    return routes
+
+
+def _dependency_names(route: APIRoute) -> list[str]:
+    names = []
+    for dependency in route.dependant.dependencies:
+        call = dependency.call
+        name = getattr(call, "__name__", "") if call is not None else ""
+        if name and name != "get_record_store":
+            names.append(name)
+    return sorted(set(names))
+
+
+def _source_commit_sha() -> str:
+    configured = os.environ.get("GITHUB_SHA")
+    if configured:
+        return configured
+    try:
+        completed = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=_REPOSITORY_ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return "unknown"
+    return completed.stdout.strip() or "unknown"
+
+
+def _semantic_payload(contract: Mapping[str, Any]) -> dict[str, Any]:
+    return {"normalization_version": NORMALIZATION_VERSION, "contract": contract}
+
+
+def build_agent_operator_contract(
+    *,
+    openapi_document: Mapping[str, Any] | None = None,
+    app: FastAPI | None = None,
+    source_commit_sha: str | None = None,
+) -> dict[str, Any]:
+    document = openapi_document or canonical_openapi_document()
+    paths = document.get("paths")
+    components = document.get("components", {}).get("schemas", {})
+    if not isinstance(paths, Mapping) or not isinstance(components, Mapping):
+        raise AgentOperatorContractError("Canonical OpenAPI paths or schemas are unavailable")
+    routes = _live_routes(app or build_deterministic_export_app())
+
+    operations = []
+    for spec in OPERATION_SPECS:
+        path_item = paths.get(spec.path)
+        operation = path_item.get(spec.method.lower()) if isinstance(path_item, Mapping) else None
+        if not isinstance(operation, Mapping):
+            raise AgentOperatorContractError(
+                f"Missing allow-listed OpenAPI operation: {spec.method} {spec.path}"
+            )
+        operation_id = operation.get("operationId")
+        if not isinstance(operation_id, str) or not operation_id:
+            raise AgentOperatorContractError(f"Missing operation ID: {spec.method} {spec.path}")
+        normalized_operation = _normalize_operation(operation, components, {})
+        parameter_names = {
+            str(parameter.get("name", "")).lower()
+            for parameter in operation.get("parameters", [])
+            if isinstance(parameter, Mapping)
+        }
+        has_idempotency_header = "idempotency-key" in parameter_names
+        if (spec.idempotency != "none") != has_idempotency_header:
+            raise AgentOperatorContractError(
+                f"Idempotency metadata differs from OpenAPI: {spec.method} {spec.path}"
+            )
+        operations.append(
+            {
+                "method": spec.method,
+                "path": spec.path,
+                "operation_id": operation_id,
+                "identity_dependencies": _dependency_names(routes[(spec.method, spec.path)]),
+                "purpose": spec.purpose,
+                "supported_surfaces": list(spec.supported_surfaces),
+                "modes": list(spec.modes),
+                "idempotency": spec.idempotency,
+                "reviewed_evidence": list(spec.reviewed_evidence),
+                "response_statuses": sorted(
+                    (str(status) for status in operation.get("responses", {})),
+                    key=lambda status: (not status.isdigit(), status),
+                ),
+                "openapi_fingerprint_sha256": _digest(normalized_operation),
+            }
+        )
+
+    for workflow in PROTECTED_WORKFLOWS:
+        for key in ("workflow_file", "reusable_workflow_file"):
+            value = workflow.get(key)
+            if value and not (_REPOSITORY_ROOT / value).is_file():
+                raise AgentOperatorContractError(f"Missing protected workflow: {value}")
+
+    contract = {
+        "operations": operations,
+        "protected_workflows": deepcopy(list(PROTECTED_WORKFLOWS)),
+        "invariants": deepcopy(INVARIANTS),
+    }
+    artifact = {
+        "schema_version": SCHEMA_VERSION,
+        "normalization_version": NORMALIZATION_VERSION,
+        "semantic_digest_sha256": _digest(_semantic_payload(contract)),
+        "provenance": {"source_commit_sha": source_commit_sha or _source_commit_sha()},
+        "contract": contract,
+    }
+    validate_agent_operator_contract(artifact)
+    return artifact
+
+
+def _assert_exact_keys(value: Mapping[str, Any], expected: set[str], location: str) -> None:
+    if set(value) != expected:
+        raise AgentOperatorContractError(f"Unexpected {location} keys: {sorted(value)}")
+
+
+def _validate_public_safety(value: Any, location: str = "artifact") -> None:
+    if isinstance(value, str):
+        if any(pattern.search(value) for pattern in _UNSAFE_STRING_PATTERNS):
+            raise AgentOperatorContractError(f"Unsafe public contract value at {location}")
+        return
+    if isinstance(value, Mapping):
+        for key, item in value.items():
+            _validate_public_safety(str(key), f"{location}.key")
+            _validate_public_safety(item, f"{location}.{key}")
+        return
+    if isinstance(value, list | tuple):
+        for index, item in enumerate(value):
+            _validate_public_safety(item, f"{location}[{index}]")
+        return
+    if value is not None and not isinstance(value, bool | int | float):
+        raise AgentOperatorContractError(f"Non-JSON contract value at {location}")
+
+
+def validate_agent_operator_contract(artifact: Mapping[str, Any]) -> None:
+    _assert_exact_keys(
+        artifact,
+        {
+            "schema_version",
+            "normalization_version",
+            "semantic_digest_sha256",
+            "provenance",
+            "contract",
+        },
+        "artifact",
+    )
+    if artifact["schema_version"] != SCHEMA_VERSION:
+        raise AgentOperatorContractError("Unsupported schema_version")
+    if artifact["normalization_version"] != NORMALIZATION_VERSION:
+        raise AgentOperatorContractError("Unsupported normalization_version")
+    digest = artifact["semantic_digest_sha256"]
+    if not isinstance(digest, str) or not _SHA256_PATTERN.fullmatch(digest):
+        raise AgentOperatorContractError("Invalid semantic_digest_sha256")
+    provenance = artifact["provenance"]
+    if not isinstance(provenance, Mapping):
+        raise AgentOperatorContractError("Invalid provenance")
+    _assert_exact_keys(provenance, {"source_commit_sha"}, "provenance")
+    source_sha = provenance["source_commit_sha"]
+    if not isinstance(source_sha, str) or not _SOURCE_SHA_PATTERN.fullmatch(source_sha):
+        raise AgentOperatorContractError("Invalid provenance source_commit_sha")
+    contract = artifact["contract"]
+    if not isinstance(contract, Mapping):
+        raise AgentOperatorContractError("Invalid contract")
+    _assert_exact_keys(contract, {"operations", "protected_workflows", "invariants"}, "contract")
+
+    operations = contract["operations"]
+    if not isinstance(operations, list) or len(operations) != len(OPERATION_SPECS):
+        raise AgentOperatorContractError("Invalid operation allow-list")
+    expected_operations = {(spec.method, spec.path) for spec in OPERATION_SPECS}
+    expected_specs = {(spec.method, spec.path): spec for spec in OPERATION_SPECS}
+    seen_operations = set()
+    operation_keys = {
+        "method",
+        "path",
+        "operation_id",
+        "identity_dependencies",
+        "purpose",
+        "supported_surfaces",
+        "modes",
+        "idempotency",
+        "reviewed_evidence",
+        "response_statuses",
+        "openapi_fingerprint_sha256",
+    }
+    for operation in operations:
+        if not isinstance(operation, Mapping):
+            raise AgentOperatorContractError("Invalid operation entry")
+        _assert_exact_keys(operation, operation_keys, "operation")
+        operation_key = (operation["method"], operation["path"])
+        if operation_key not in expected_operations or operation_key in seen_operations:
+            raise AgentOperatorContractError("Unexpected or duplicate operation")
+        seen_operations.add(operation_key)
+        spec = expected_specs[operation_key]
+        for field_name in (
+            "method",
+            "path",
+            "operation_id",
+            "purpose",
+            "idempotency",
+        ):
+            if not isinstance(operation[field_name], str) or not operation[field_name]:
+                raise AgentOperatorContractError(f"Invalid operation {field_name}")
+        if operation["purpose"] != spec.purpose:
+            raise AgentOperatorContractError("Operation purpose differs from the allow-list")
+        if operation["supported_surfaces"] != list(spec.supported_surfaces):
+            raise AgentOperatorContractError("Operation surfaces differ from the allow-list")
+        if operation["modes"] != list(spec.modes):
+            raise AgentOperatorContractError("Operation modes differ from the allow-list")
+        if operation["idempotency"] != spec.idempotency:
+            raise AgentOperatorContractError("Operation idempotency differs from the allow-list")
+        if operation["reviewed_evidence"] != list(spec.reviewed_evidence):
+            raise AgentOperatorContractError(
+                "Operation reviewed evidence differs from the allow-list"
+            )
+        for field_name in (
+            "identity_dependencies",
+            "supported_surfaces",
+            "modes",
+            "reviewed_evidence",
+            "response_statuses",
+        ):
+            value = operation[field_name]
+            if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+                raise AgentOperatorContractError(f"Invalid operation {field_name}")
+        if not operation["identity_dependencies"]:
+            raise AgentOperatorContractError("Operation has no identity dependencies")
+        fingerprint = operation["openapi_fingerprint_sha256"]
+        if not isinstance(fingerprint, str) or not _SHA256_PATTERN.fullmatch(fingerprint):
+            raise AgentOperatorContractError("Invalid operation fingerprint")
+    if seen_operations != expected_operations:
+        raise AgentOperatorContractError("Operation allow-list is incomplete")
+
+    workflows = contract["protected_workflows"]
+    if not isinstance(workflows, list | tuple) or len(workflows) != len(PROTECTED_WORKFLOWS):
+        raise AgentOperatorContractError("Invalid protected workflows")
+    if workflows != list(PROTECTED_WORKFLOWS):
+        raise AgentOperatorContractError("Protected workflows differ from the allow-list")
+    invariants = contract["invariants"]
+    if not isinstance(invariants, Mapping) or invariants != INVARIANTS:
+        raise AgentOperatorContractError("Invalid invariant set")
+    expected_digest = _digest(_semantic_payload(contract))
+    if digest != expected_digest:
+        raise AgentOperatorContractError("Semantic digest does not match contract")
+    _validate_public_safety(artifact)
+
+
+def write_agent_operator_contract(
+    output_path: Path,
+    *,
+    source_commit_sha: str | None = None,
+) -> Path:
+    artifact = build_agent_operator_contract(source_commit_sha=source_commit_sha)
+    if output_path.exists():
+        try:
+            current = json.loads(output_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            current = None
+        current_provenance = current.get("provenance") if isinstance(current, Mapping) else None
+        current_source_sha = (
+            current_provenance.get("source_commit_sha")
+            if isinstance(current_provenance, Mapping)
+            else None
+        )
+        if (
+            isinstance(current, Mapping)
+            and current.get("semantic_digest_sha256") == artifact["semantic_digest_sha256"]
+            and isinstance(current_source_sha, str)
+            and current_source_sha != "unknown"
+            and _SOURCE_SHA_PATTERN.fullmatch(current_source_sha)
+        ):
+            artifact["provenance"] = {"source_commit_sha": current_source_sha}
+    validate_agent_operator_contract(artifact)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(
+        json.dumps(artifact, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return output_path

--- a/control_plane/cli_service.py
+++ b/control_plane/cli_service.py
@@ -10,6 +10,7 @@ import uuid
 
 import click
 
+from control_plane.agent_operator_contract import write_agent_operator_contract
 from control_plane.cli_shared import DATABASE_URL_ENV_KEYS as _DATABASE_URL_ENV_KEYS
 from control_plane.outbox_worker import (
     DEFAULT_OUTBOX_WORKER_ERROR_BACKOFF_SECONDS,
@@ -1216,4 +1217,21 @@ def service_inspect_data_freshness(
 )
 def service_export_openapi(output: Path) -> None:
     written_path = write_canonical_openapi(output)
+    click.echo(str(written_path))
+
+
+@service.command("export-agent-contract")
+@click.option(
+    "--output",
+    type=click.Path(path_type=Path),
+    required=True,
+    help="Write the public-safe Launchplane agent/operator contract to this path.",
+)
+@click.option(
+    "--source-sha",
+    default=None,
+    help="Optional source commit SHA recorded as non-gating provenance.",
+)
+def service_export_agent_contract(output: Path, source_sha: str | None) -> None:
+    written_path = write_agent_operator_contract(output, source_commit_sha=source_sha)
     click.echo(str(written_path))

--- a/control_plane/openapi_export.py
+++ b/control_plane/openapi_export.py
@@ -104,6 +104,10 @@ def _build_export_app() -> FastAPI:
     )
 
 
+def build_deterministic_export_app() -> FastAPI:
+    return _build_export_app()
+
+
 def _scrub_openapi_payload(value: Any) -> Any:
     if isinstance(value, Mapping):
         scrubbed: dict[str, Any] = {}
@@ -118,7 +122,7 @@ def _scrub_openapi_payload(value: Any) -> Any:
 
 
 def canonical_openapi_document() -> dict[str, Any]:
-    app = _build_export_app()
+    app = build_deterministic_export_app()
     openapi_payload: dict[str, Any] = app.openapi()
     scrubbed_payload: dict[str, Any] = _scrub_openapi_payload(openapi_payload)
     info = scrubbed_payload.get("info", {})

--- a/docs/README.md
+++ b/docs/README.md
@@ -48,6 +48,8 @@ Use these docs as the source of truth for `launchplane`.
   host hygiene evidence, budgets, and future apply boundary.
 - [agent-context-boundary.md](agent-context-boundary.md) — public-safe agent
   context, caller profiles, scoped intent, redaction, and provenance boundary.
+- [agent-operator-contract.md](agent-operator-contract.md) — generated,
+  public-safe agent/operator operation, workflow, lifecycle, and safety contract.
 - [engineering-review-runs.md](engineering-review-runs.md) — shadow-only review
   run records, dispatch binding, credential boundary, and worker lifecycle.
 - [engineering-review-decisions.md](engineering-review-decisions.md) — exact-head

--- a/docs/agent-context-boundary.md
+++ b/docs/agent-context-boundary.md
@@ -12,6 +12,12 @@ Launchplane compiles product/runtime/evidence facts it owns, links back to
 source systems, and records provenance so agents can decide what to inspect or
 request next.
 
+The checked `contracts/agent-operator-contract.json` artifact is the
+machine-readable operation, workflow, lifecycle, and safety projection for
+external agent tooling. See [agent-operator-contract.md](agent-operator-contract.md)
+for generation, normalization, freshness, and ownership rules. The artifact is
+routing and safety evidence only; it never becomes live runtime authority.
+
 ## Source Of Truth
 
 - GitHub remains authoritative for issue bodies, PR review, merge state, Project

--- a/docs/agent-operator-contract.md
+++ b/docs/agent-operator-contract.md
@@ -1,0 +1,93 @@
+---
+title: Agent Operator Contract
+---
+
+# Agent Operator Contract
+
+Launchplane publishes a checked-in, public-safe contract for external agent and
+operator tooling at `contracts/agent-operator-contract.json`. Launchplane owns
+the producer artifact and its quality gate. External skills are consumers; they
+do not become runtime authority and must not block ordinary Launchplane feature
+delivery.
+
+## Generate And Check
+
+Generate the canonical OpenAPI document, UI bindings, and agent/operator
+contract together:
+
+```bash
+pnpm --dir frontend generate:openapi
+```
+
+Generate only the agent/operator contract:
+
+```bash
+uv run launchplane service export-agent-contract \
+  --output contracts/agent-operator-contract.json
+```
+
+Check every generated contract without changing checked-in files:
+
+```bash
+pnpm --dir frontend check:openapi-drift
+```
+
+The drift check compares `normalization_version` and
+`semantic_digest_sha256`. It deliberately ignores provenance-only source SHA
+changes.
+
+## Contract Shape
+
+The artifact contains:
+
+- `schema_version`: the public artifact schema version.
+- `normalization_version`: the version of the structural projection rules.
+  Digests from different normalization versions are not comparable.
+- `semantic_digest_sha256`: the canonical digest of the normalized contract,
+  excluding provenance.
+- `provenance.source_commit_sha`: the source revision recorded when the current
+  semantic artifact was generated. It is evidence, not a freshness gate.
+- `contract.operations`: an explicit allow-list of agent-relevant HTTP
+  operations with live operation IDs and dependency names, supported surfaces,
+  mutation modes, idempotency and reviewed-evidence requirements, response
+  statuses, and structural OpenAPI fingerprints.
+- `contract.protected_workflows`: the protected GitHub workflows that own
+  product retirement, detached application retirement, managed authorization
+  reconciliation, and bounded stable-lane repair.
+- `contract.invariants`: durable lifecycle, deploy identity, reconciliation,
+  and governance boundaries that OpenAPI cannot express.
+
+Anything not explicitly selected by the generator is absent. The artifact must
+never contain real product, tenant, repository, branch, domain, lane,
+provider-target, credential, operator, or runtime-topology authority.
+
+## Normalization Version 1
+
+The structural projection follows these rules:
+
+- Only the allow-listed method/path pairs and schemas reachable from their
+  parameters, request body, and responses participate.
+- Structural fields such as types, required properties, enums, formats,
+  constants, unions, collection shapes, bounds, patterns, defaults, and
+  deprecation state are retained.
+- Raw OpenAPI descriptions, summaries, titles, examples, and unrelated routes
+  or schemas are excluded. Agent-facing purpose and safety summaries are owned
+  explicitly by the semantic overlay and are included in the digest.
+- Mapping keys and semantically unordered lists are normalized before hashing.
+- `provenance` and `semantic_digest_sha256` are excluded from the digest input.
+
+Changing a selected route, operation ID, dependency boundary, structural
+request/response shape, protected workflow, or semantic invariant changes the
+digest. Adding an unrelated route or schema, editing a raw OpenAPI description,
+or changing only the source SHA does not.
+
+## Ownership Boundary
+
+Launchplane closes the producer work when the artifact, generator, drift gate,
+tests, and documentation are live. Consumer publication is independent. A
+consumer may vendor the artifact and compare its digest offline, while a
+separate scheduled check determines whether the vendored digest is current.
+
+Protected workflow dispatch and watching remain owned by the installed
+`github_workflow_babysit.py` helper. The contract names supported entrypoints;
+it does not authorize a mutation or replace live Launchplane context.

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -524,6 +524,16 @@ browser client binding. Generated request, success, validation, and error
 bindings are the API boundary consumed by the UI. Handwritten frontend types
 remain only for UI view models and explicit normalization.
 
+The same canonical export also feeds the narrower checked
+`contracts/agent-operator-contract.json` artifact. Run
+`uv run launchplane service export-agent-contract --output contracts/agent-operator-contract.json`
+to project only the explicit agent/operator allow-list plus the semantic
+lifecycle, deploy, reconciliation, workflow, and governance overlay. The
+artifact carries a semantic digest and non-gating source revision. The existing
+`pnpm --dir frontend check:openapi-drift` gate regenerates it in a temporary
+path and compares only its normalization version and semantic digest, so
+unrelated OpenAPI or provenance-only changes do not create consumer drift.
+
 The browser client keeps those four write paths in one generated-type-checked
 allowlist. The shared mutation transport serializes cookie-backed writes,
 refreshes the single-use CSRF token immediately before every attempt, and copies

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,8 @@
   "scripts": {
     "build": "pnpm typecheck && vite build && node scripts/assert-production-fixtures.mjs",
     "dev": "vite --host 127.0.0.1",
-    "generate:openapi": "uv run launchplane service export-openapi --output generated/openapi-canonical.json && node scripts/build-openapi-ui-schema.mjs && node scripts/generate-openapi-types.mjs",
+    "generate:agent-contract": "uv run launchplane service export-agent-contract --output ../contracts/agent-operator-contract.json",
+    "generate:openapi": "uv run launchplane service export-openapi --output generated/openapi-canonical.json && node scripts/build-openapi-ui-schema.mjs && node scripts/generate-openapi-types.mjs && pnpm generate:agent-contract",
     "preview": "vite preview --host 127.0.0.1",
     "check:openapi-drift": "node scripts/check-openapi-drift.mjs",
     "test": "node --experimental-strip-types --import ./tests/register-typescript.mjs --test tests/*.test.mjs",

--- a/frontend/scripts/check-openapi-drift.mjs
+++ b/frontend/scripts/check-openapi-drift.mjs
@@ -8,6 +8,7 @@ const frontendRoot = path.resolve(new URL("..", import.meta.url).pathname);
 const checkedCanonicalPath = path.join(frontendRoot, "generated", "openapi-canonical.json");
 const checkedUiSchemaPath = path.join(frontendRoot, "generated", "openapi-ui.json");
 const checkedTypesPath = path.join(frontendRoot, "src", "generated", "openapi.ts");
+const checkedAgentContractPath = path.join(repoRoot, "contracts", "agent-operator-contract.json");
 
 async function readDirectoryTree(rootPath) {
   const entries = await readdir(rootPath, { withFileTypes: true });
@@ -65,6 +66,7 @@ async function main() {
     const regeneratedCanonicalPath = path.join(tempDir, "openapi-canonical.json");
     const regeneratedUiSchemaPath = path.join(tempDir, "openapi-ui.json");
     const regeneratedTypesPath = path.join(tempDir, "openapi.ts");
+    const regeneratedAgentContractPath = path.join(tempDir, "agent-operator-contract.json");
 
     await run(
       "uv",
@@ -93,24 +95,46 @@ async function main() {
       ],
       frontendRoot,
     );
+    await run(
+      "uv",
+      ["run", "launchplane", "service", "export-agent-contract", "--output", regeneratedAgentContractPath],
+      repoRoot,
+    );
 
-    const [checkedCanonical, regeneratedCanonical, checkedUiSchema, regeneratedUiSchema, checkedTypes, regeneratedTypes] =
-      await Promise.all([
-        readFile(checkedCanonicalPath, "utf-8"),
-        readFile(regeneratedCanonicalPath, "utf-8"),
-        readFile(checkedUiSchemaPath, "utf-8"),
-        readFile(regeneratedUiSchemaPath, "utf-8"),
-        readDirectoryContents(checkedTypesPath),
-        readDirectoryContents(regeneratedTypesPath),
-      ]);
+    const [
+      checkedCanonical,
+      regeneratedCanonical,
+      checkedUiSchema,
+      regeneratedUiSchema,
+      checkedTypes,
+      regeneratedTypes,
+      checkedAgentContractText,
+      regeneratedAgentContractText,
+    ] = await Promise.all([
+      readFile(checkedCanonicalPath, "utf-8"),
+      readFile(regeneratedCanonicalPath, "utf-8"),
+      readFile(checkedUiSchemaPath, "utf-8"),
+      readFile(regeneratedUiSchemaPath, "utf-8"),
+      readDirectoryContents(checkedTypesPath),
+      readDirectoryContents(regeneratedTypesPath),
+      readFile(checkedAgentContractPath, "utf-8"),
+      readFile(regeneratedAgentContractPath, "utf-8"),
+    ]);
+    const checkedAgentContract = JSON.parse(checkedAgentContractText);
+    const regeneratedAgentContract = JSON.parse(regeneratedAgentContractText);
+    const agentContractDrifted =
+      checkedAgentContract.schema_version !== regeneratedAgentContract.schema_version ||
+      checkedAgentContract.normalization_version !== regeneratedAgentContract.normalization_version ||
+      checkedAgentContract.semantic_digest_sha256 !== regeneratedAgentContract.semantic_digest_sha256;
 
     if (
       checkedCanonical !== regeneratedCanonical ||
       checkedUiSchema !== regeneratedUiSchema ||
-      JSON.stringify(checkedTypes) !== JSON.stringify(regeneratedTypes)
+      JSON.stringify(checkedTypes) !== JSON.stringify(regeneratedTypes) ||
+      agentContractDrifted
     ) {
       throw new Error(
-        "OpenAPI contracts are out of date. Run `pnpm --dir frontend generate:openapi` and commit the results.",
+        "Generated contracts are out of date. Run `pnpm --dir frontend generate:openapi` and commit the results.",
       );
     }
   } finally {

--- a/tests/test_agent_operator_contract.py
+++ b/tests/test_agent_operator_contract.py
@@ -75,7 +75,7 @@ class AgentOperatorContractTests(unittest.TestCase):
                 operation["identity_dependencies"],
                 expected_dependencies[operation["operation_id"]],
             )
-            self.assertRegex(operation["openapi_fingerprint_sha256"], r"^[0-9a-f]{64}$")
+            self.assertRegex(operation["schema_fingerprint_sha256"], r"^[0-9a-f]{64}$")
 
         change_impact = next(
             operation

--- a/tests/test_agent_operator_contract.py
+++ b/tests/test_agent_operator_contract.py
@@ -1,0 +1,290 @@
+from __future__ import annotations
+
+import copy
+import json
+import tempfile
+import unittest
+from contextlib import chdir
+from dataclasses import replace
+from pathlib import Path
+from unittest.mock import patch
+
+from control_plane import agent_operator_contract as contract_module
+from control_plane.agent_operator_contract import (
+    INVARIANTS,
+    OPERATION_SPECS,
+    PROTECTED_WORKFLOWS,
+    AgentOperatorContractError,
+    build_agent_operator_contract,
+    validate_agent_operator_contract,
+    write_agent_operator_contract,
+)
+from control_plane.openapi_export import canonical_openapi_document
+
+
+class AgentOperatorContractTests(unittest.TestCase):
+    def test_exact_operations_dependencies_and_workflows(self) -> None:
+        artifact = build_agent_operator_contract(source_commit_sha="a" * 40)
+        operations = artifact["contract"]["operations"]
+
+        self.assertEqual(
+            [(operation["method"], operation["path"]) for operation in operations],
+            [(spec.method, spec.path) for spec in OPERATION_SPECS],
+        )
+        expected_operation_ids = {
+            ("GET", "/v1/agent/context"): "read_agent_context",
+            ("POST", "/v1/agent/write-intents/evaluate"): "evaluate_agent_write_intent",
+            ("POST", "/v1/product-config/apply"): "apply_product_config",
+            ("POST", "/v1/change-impact/policies/apply"): "apply_change_impact_policy",
+            ("GET", "/v1/change-impact/policy"): "read_change_impact_policy",
+            (
+                "POST",
+                "/v1/work-graph/merge-train/controller/run-once",
+            ): "write_merge_train_controller_run_once",
+            ("POST", "/v1/previews/pr-feedback/remediation"): "remediate_preview_pr_feedback",
+            ("POST", "/v1/product-retirement"): "execute_product_retirement",
+            ("POST", "/v1/detached-application-retirement"): (
+                "execute_detached_application_retirement"
+            ),
+            ("POST", "/v1/authz-policies/managed-rule-sets/reconcile"): (
+                "reconcile_managed_authz_policy"
+            ),
+            ("POST", "/v1/product-profiles/stable-lane-repair/apply"): (
+                "apply_product_stable_lane_repair"
+            ),
+            ("GET", "/v1/governance/projection"): "read_governance_projection",
+        }
+        expected_dependencies = {
+            "read_agent_context": ["read_identity"],
+            "evaluate_agent_write_intent": ["read_browser_mutation_identity"],
+            "apply_product_config": ["read_browser_mutation_identity"],
+            "apply_change_impact_policy": ["read_write_identity"],
+            "read_change_impact_policy": ["read_identity"],
+            "write_merge_train_controller_run_once": ["read_write_identity"],
+            "remediate_preview_pr_feedback": ["read_write_identity"],
+            "execute_product_retirement": ["read_write_identity"],
+            "execute_detached_application_retirement": ["read_write_identity"],
+            "reconcile_managed_authz_policy": ["read_browser_mutation_identity"],
+            "apply_product_stable_lane_repair": ["read_write_identity"],
+            "read_governance_projection": ["read_identity"],
+        }
+        for operation in operations:
+            key = (operation["method"], operation["path"])
+            self.assertEqual(operation["operation_id"], expected_operation_ids[key])
+            self.assertEqual(
+                operation["identity_dependencies"],
+                expected_dependencies[operation["operation_id"]],
+            )
+            self.assertRegex(operation["openapi_fingerprint_sha256"], r"^[0-9a-f]{64}$")
+
+        change_impact = next(
+            operation
+            for operation in operations
+            if operation["path"] == "/v1/change-impact/policies/apply"
+        )
+        self.assertEqual(change_impact["idempotency"], "none")
+        self.assertEqual(
+            change_impact["reviewed_evidence"],
+            ["reviewed_dry_run", "expected_policy_digest"],
+        )
+
+        self.assertEqual(artifact["contract"]["protected_workflows"], list(PROTECTED_WORKFLOWS))
+        self.assertEqual(artifact["contract"]["invariants"], INVARIANTS)
+
+    def test_noise_and_provenance_do_not_change_semantic_digest(self) -> None:
+        document = canonical_openapi_document()
+        noisy_document = copy.deepcopy(document)
+        noisy_document["paths"]["/v1/unrelated"] = {
+            "get": {"responses": {"200": {"description": "unrelated"}}}
+        }
+        noisy_document["components"]["schemas"]["Unrelated"] = {
+            "description": "unrelated",
+            "type": "string",
+        }
+        noisy_document["paths"]["/v1/agent/context"]["get"]["summary"] = "changed"
+        noisy_document["components"]["schemas"]["AgentContextResponse"]["description"] = (
+            "changed raw description"
+        )
+
+        original = build_agent_operator_contract(
+            openapi_document=document,
+            source_commit_sha="a" * 40,
+        )
+        noisy = build_agent_operator_contract(
+            openapi_document=noisy_document,
+            source_commit_sha="b" * 40,
+        )
+
+        self.assertEqual(original["semantic_digest_sha256"], noisy["semantic_digest_sha256"])
+        self.assertEqual(original["contract"], noisy["contract"])
+
+    def test_unrelated_local_definitions_cannot_change_selected_fingerprints(self) -> None:
+        document = canonical_openapi_document()
+        polluted_document = copy.deepcopy(document)
+        polluted_document["components"]["schemas"]["Unrelated"] = {
+            "$defs": {
+                "ProductConfigRuntimeInput": {
+                    "properties": {"polluted": {"type": "boolean"}},
+                    "type": "object",
+                }
+            },
+            "$ref": "#/$defs/ProductConfigRuntimeInput",
+        }
+
+        original = build_agent_operator_contract(openapi_document=document)
+        polluted = build_agent_operator_contract(openapi_document=polluted_document)
+
+        self.assertEqual(original["contract"], polluted["contract"])
+
+    def test_nested_local_definitions_cannot_pollute_sibling_schemas(self) -> None:
+        document = canonical_openapi_document()
+        polluted_document = copy.deepcopy(document)
+        request_schema = polluted_document["paths"]["/v1/product-config/apply"]["post"][
+            "requestBody"
+        ]["content"]["application/json"]["schema"]
+        request_schema["properties"]["runtime_env"]["anyOf"][0]["$defs"] = {
+            "ProductConfigSecretInput": {"type": "integer"}
+        }
+
+        original = build_agent_operator_contract(openapi_document=document)
+        polluted = build_agent_operator_contract(openapi_document=polluted_document)
+
+        self.assertEqual(original["contract"], polluted["contract"])
+
+    def test_reference_sibling_semantics_change_digest(self) -> None:
+        document = canonical_openapi_document()
+        changed_document = copy.deepcopy(document)
+        request_schema = changed_document["paths"]["/v1/product-config/apply"]["post"][
+            "requestBody"
+        ]["content"]["application/json"]["schema"]
+        request_schema["properties"]["runtime_env"]["anyOf"][1]["default"] = {"env": {}}
+
+        original = build_agent_operator_contract(openapi_document=document)
+        changed = build_agent_operator_contract(openapi_document=changed_document)
+
+        self.assertNotEqual(original["semantic_digest_sha256"], changed["semantic_digest_sha256"])
+
+    def test_idempotency_metadata_must_match_live_openapi_parameters(self) -> None:
+        document = canonical_openapi_document()
+        missing_header = copy.deepcopy(document)
+        product_config = missing_header["paths"]["/v1/product-config/apply"]["post"]
+        product_config["parameters"] = [
+            parameter
+            for parameter in product_config["parameters"]
+            if parameter.get("name") != "Idempotency-Key"
+        ]
+        with self.assertRaisesRegex(AgentOperatorContractError, "Idempotency metadata"):
+            build_agent_operator_contract(openapi_document=missing_header)
+
+        unexpected_header = copy.deepcopy(document)
+        change_impact = unexpected_header["paths"]["/v1/change-impact/policies/apply"]["post"]
+        change_impact.setdefault("parameters", []).append(
+            {
+                "in": "header",
+                "name": "Idempotency-Key",
+                "required": True,
+                "schema": {"type": "string"},
+            }
+        )
+        with self.assertRaisesRegex(AgentOperatorContractError, "Idempotency metadata"):
+            build_agent_operator_contract(openapi_document=unexpected_header)
+
+    def test_contract_build_is_independent_of_current_working_directory(self) -> None:
+        frontend_directory = Path("frontend").resolve()
+
+        with chdir(frontend_directory):
+            artifact = build_agent_operator_contract(source_commit_sha="a" * 40)
+
+        self.assertEqual(len(artifact["contract"]["protected_workflows"]), 4)
+
+    def test_structural_and_agent_owned_semantics_change_digest(self) -> None:
+        document = canonical_openapi_document()
+        changed_document = copy.deepcopy(document)
+        intent_schema = changed_document["components"]["schemas"]["AgentWriteIntentRequest"]
+        intent_schema["properties"]["intent"]["enum"].append("new_intent")
+
+        original = build_agent_operator_contract(
+            openapi_document=document,
+            source_commit_sha="a" * 40,
+        )
+        changed = build_agent_operator_contract(
+            openapi_document=changed_document,
+            source_commit_sha="a" * 40,
+        )
+        self.assertNotEqual(original["semantic_digest_sha256"], changed["semantic_digest_sha256"])
+
+        changed_specs = list(OPERATION_SPECS)
+        changed_specs[0] = replace(changed_specs[0], purpose="Changed agent-owned purpose.")
+        with patch.object(contract_module, "OPERATION_SPECS", tuple(changed_specs)):
+            changed_overlay = build_agent_operator_contract(source_commit_sha="a" * 40)
+        self.assertNotEqual(
+            original["semantic_digest_sha256"],
+            changed_overlay["semantic_digest_sha256"],
+        )
+
+    def test_validation_is_strict_and_public_safe(self) -> None:
+        artifact = build_agent_operator_contract(source_commit_sha="a" * 40)
+        validate_agent_operator_contract(artifact)
+
+        unexpected = copy.deepcopy(artifact)
+        unexpected["unexpected"] = True
+        with self.assertRaises(AgentOperatorContractError):
+            validate_agent_operator_contract(unexpected)
+
+        unsafe_specs = list(OPERATION_SPECS)
+        unsafe_specs[0] = replace(
+            unsafe_specs[0],
+            purpose="Read from https://private.example.invalid.",
+        )
+        with patch.object(contract_module, "OPERATION_SPECS", tuple(unsafe_specs)):
+            with self.assertRaisesRegex(AgentOperatorContractError, "Unsafe public"):
+                build_agent_operator_contract(source_commit_sha="a" * 40)
+
+        broken_digest = copy.deepcopy(artifact)
+        broken_digest["semantic_digest_sha256"] = "0" * 64
+        with self.assertRaisesRegex(AgentOperatorContractError, "Semantic digest"):
+            validate_agent_operator_contract(broken_digest)
+
+    def test_write_preserves_provenance_for_unchanged_semantics(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            output_path = Path(temporary_directory) / "agent-operator-contract.json"
+            write_agent_operator_contract(output_path, source_commit_sha="a" * 40)
+            write_agent_operator_contract(output_path, source_commit_sha="b" * 40)
+            payload = json.loads(output_path.read_text(encoding="utf-8"))
+
+        self.assertEqual(payload["provenance"]["source_commit_sha"], "a" * 40)
+
+    def test_write_recovers_unknown_or_malformed_preserved_provenance(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            output_path = Path(temporary_directory) / "agent-operator-contract.json"
+            write_agent_operator_contract(output_path, source_commit_sha="unknown")
+            write_agent_operator_contract(output_path, source_commit_sha="b" * 40)
+            payload = json.loads(output_path.read_text(encoding="utf-8"))
+            self.assertEqual(payload["provenance"], {"source_commit_sha": "b" * 40})
+
+            payload["provenance"]["unexpected"] = "ignored"
+            output_path.write_text(json.dumps(payload), encoding="utf-8")
+            write_agent_operator_contract(output_path, source_commit_sha="c" * 40)
+            recovered = json.loads(output_path.read_text(encoding="utf-8"))
+
+        self.assertEqual(recovered["provenance"], {"source_commit_sha": "b" * 40})
+
+    def test_checked_artifact_matches_generated_semantics(self) -> None:
+        checked_path = Path("contracts/agent-operator-contract.json")
+        if not checked_path.exists():
+            self.skipTest("checked agent/operator contract has not been generated")
+        checked = json.loads(checked_path.read_text(encoding="utf-8"))
+        generated = build_agent_operator_contract(source_commit_sha="a" * 40)
+
+        self.assertEqual(
+            checked["normalization_version"],
+            generated["normalization_version"],
+        )
+        self.assertEqual(
+            checked["semantic_digest_sha256"],
+            generated["semantic_digest_sha256"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_docs_contracts.py
+++ b/tests/test_docs_contracts.py
@@ -137,6 +137,11 @@ class DocsContractsTests(TestCase):
         metadata = json.loads(Path(".github/github.json").read_text(encoding="utf-8"))
         ci_workflow = Path(".github/workflows/ci.yml").read_text(encoding="utf-8")
         service_boundary = Path("docs/service-boundary.md").read_text(encoding="utf-8")
+        agent_context_boundary = Path("docs/agent-context-boundary.md").read_text(encoding="utf-8")
+        agent_operator_contract = Path("docs/agent-operator-contract.md").read_text(
+            encoding="utf-8"
+        )
+        docs_index = Path("docs/README.md").read_text(encoding="utf-8")
         canonical_openapi = json.loads(
             Path("frontend/generated/openapi-canonical.json").read_text(encoding="utf-8")
         )
@@ -152,6 +157,7 @@ class DocsContractsTests(TestCase):
         )
         action_model = Path("frontend/src/action-model.ts").read_text(encoding="utf-8")
         frontend_package = json.loads(Path("frontend/package.json").read_text(encoding="utf-8"))
+        openapi_drift = Path("frontend/scripts/check-openapi-drift.mjs").read_text(encoding="utf-8")
 
         self.assertEqual(
             "uv run launchplane service export-openapi --output frontend/generated/openapi-canonical.json",
@@ -165,11 +171,40 @@ class DocsContractsTests(TestCase):
             "pnpm --dir frontend check:openapi-drift",
             metadata["qualityGate"]["openapi"]["frontendDrift"],
         )
+        self.assertEqual(
+            "contracts/agent-operator-contract.json",
+            metadata["qualityGate"]["agentContract"]["artifact"],
+        )
+        self.assertEqual(
+            "uv run launchplane service export-agent-contract --output contracts/agent-operator-contract.json",
+            metadata["qualityGate"]["agentContract"]["export"],
+        )
+        self.assertEqual(
+            "pnpm --dir frontend check:openapi-drift",
+            metadata["qualityGate"]["agentContract"]["drift"],
+        )
         self.assertIn(
             "`uv run launchplane service export-openapi --output frontend/generated/openapi-canonical.json`",
             service_boundary,
         )
         self.assertIn("`pnpm --dir frontend check:openapi-drift`", service_boundary)
+        self.assertIn(
+            "`uv run launchplane service export-agent-contract --output contracts/agent-operator-contract.json`",
+            service_boundary,
+        )
+        self.assertIn("agent-operator-contract.md", docs_index)
+        self.assertIn("contracts/agent-operator-contract.json", agent_context_boundary)
+        self.assertIn("`semantic_digest_sha256`", agent_operator_contract)
+        self.assertIn("`normalization_version`", agent_operator_contract)
+        self.assertEqual(
+            "uv run launchplane service export-agent-contract --output ../contracts/agent-operator-contract.json",
+            frontend_package["scripts"]["generate:agent-contract"],
+        )
+        self.assertIn(
+            "pnpm generate:agent-contract",
+            frontend_package["scripts"]["generate:openapi"],
+        )
+        self.assertIn("checkedAgentContract.schema_version", openapi_drift)
         self.assertIn("Install uv", ci_workflow)
         self.assertIn("Install Python", ci_workflow)
         read_operations = canonical_openapi["x-launchplane-ui-read-operations"]

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -2564,6 +2564,32 @@ class LaunchplaneServiceTests(unittest.TestCase):
         )
         self.assertNotIn('"examples"', json.dumps(payload, sort_keys=True))
 
+    def test_service_export_agent_contract_writes_public_semantic_artifact(self) -> None:
+        runner = CliRunner()
+        with TemporaryDirectory() as temporary_directory_name:
+            output_path = Path(temporary_directory_name) / "agent-operator-contract.json"
+
+            result = runner.invoke(
+                CLI_MAIN,
+                [
+                    "service",
+                    "export-agent-contract",
+                    "--output",
+                    str(output_path),
+                    "--source-sha",
+                    "a" * 40,
+                ],
+            )
+            payload = json.loads(output_path.read_text(encoding="utf-8"))
+
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+        self.assertEqual(result.output.strip(), str(output_path))
+        self.assertEqual(payload["schema_version"], 1)
+        self.assertEqual(payload["normalization_version"], 1)
+        self.assertRegex(payload["semantic_digest_sha256"], r"^[0-9a-f]{64}$")
+        self.assertEqual(payload["provenance"]["source_commit_sha"], "a" * 40)
+        self.assertEqual(len(payload["contract"]["operations"]), 12)
+
     def test_product_onboarding_endpoint_writes_full_launchplane_owned_bundle(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)


### PR DESCRIPTION
## Summary
- publish a checked, public-safe agent/operator contract for 12 allow-listed Launchplane operations and four protected workflows
- derive structural fingerprints from canonical OpenAPI plus explicit lifecycle, deploy, reconciliation, and governance invariants
- add CLI generation, frontend drift enforcement, repository metadata, documentation, and fail-closed regression coverage
- update the Go builder from 1.26.5 to 1.26.6 after Trivy's August 14 database began blocking the existing `gh` binary on two fixed HIGH CVEs

## Safety and drift behavior
- excludes provenance, raw descriptions, examples, and unrelated routes from the semantic digest
- verifies live identity dependencies and Idempotency-Key wiring against the operation allow-list
- scopes local `$defs`, fingerprints `$ref` siblings, anchors workflow validation to the repository root, and rejects unsafe public values
- compares schema version, normalization version, and semantic digest while ignoring provenance-only source revision changes

## Validation
- `uv run --extra dev python -m unittest tests.test_agent_operator_contract tests.test_service.LaunchplaneServiceTests.test_service_export_agent_contract_writes_public_semantic_artifact tests.test_docs_contracts` (27 passed)
- `uv run --extra dev launchplane ci unittest-shard local` (12/12 shards, 2,914 tests)
- `uv run --extra dev ruff check .`
- changed Python files: `uv run --extra dev ruff format --check ...`
- `uv run --extra dev mypy control_plane tests` (726 files)
- `pnpm --dir frontend validate` (61 tests, drift, typecheck, production build)
- exact Gitleaks tree scan: no leaks found
- `docker build -t launchplane-ci:issue-2151 .` and exact Trivy CI scan: 0 HIGH/CRITICAL findings
- GitHub Actions: 26/26 checks passed
- final independent Opus and Gemini reviews: APPROVE

## Reviewability
The large diff is one coherent producer contract: 429 lines are the generated artifact and 290 lines are focused regression tests. Splitting those from the generator would temporarily remove either the checked contract or its drift proof.

Refs #2151
