### PR TITLE
Make Owner acceptance discoverable from product PRs

### DIFF
--- a/control_plane/contracts/advisory_check_projection.py
+++ b/control_plane/contracts/advisory_check_projection.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import Final, Literal
+from urllib.parse import urlsplit
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
@@ -48,6 +49,21 @@ class AdvisoryCheckProjection(BaseModel):
             raise ValueError("Advisory check projection repository must use owner/name.")
         if self.details_url.strip() != self.details_url or not self.details_url:
             raise ValueError("Advisory check projection requires a canonical details URL.")
+        parsed_details_url = urlsplit(self.details_url)
+        if (
+            parsed_details_url.scheme not in {"http", "https"}
+            or not parsed_details_url.netloc
+            or parsed_details_url.username is not None
+            or parsed_details_url.password is not None
+            or any(character.isspace() or ord(character) < 32 for character in self.details_url)
+        ):
+            raise ValueError("Advisory check projection requires an absolute public details URL.")
+        try:
+            parsed_details_url.port
+        except ValueError as error:
+            raise ValueError(
+                "Advisory check projection requires a valid details URL port."
+            ) from error
         if self.title.strip() != self.title or self.summary.strip() != self.summary:
             raise ValueError("Advisory check projection text must be canonical.")
         return self

--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -21097,6 +21097,7 @@ def create_launchplane_fastapi_app(
                 api_request=github_api_request,
             ),
             github_api=github_api_request,
+            public_origin=(human_session_manager.public_origin if human_session_manager else None),
         ),
     )
     register_governance_projection_routes(

--- a/control_plane/http_routes/owner_acceptance.py
+++ b/control_plane/http_routes/owner_acceptance.py
@@ -1,6 +1,7 @@
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timezone
+import logging
 from typing import Annotated, Literal, cast
 
 from fastapi import Depends, Header, Path, Query
@@ -59,6 +60,9 @@ from control_plane.service_auth import AuthorizationTarget, GitHubHumanIdentity,
 from control_plane.workflows.launchplane import github_api_request
 
 
+logger = logging.getLogger(__name__)
+
+
 OWNER_ACCEPTANCE_EVALUATION_ROUTE = "/v1/owner-acceptance/evaluation"
 OWNER_ACCEPTANCE_EVENTS_ROUTE = "/v1/owner-acceptance/events"
 OWNER_ACCEPTANCE_EVENT_ROUTE = "/v1/owner-acceptance/events/{event_id}"
@@ -75,6 +79,7 @@ class OwnerAcceptanceRouteDependencies:
     read_write_identity: Callable[..., LaunchplaneIdentity] | None = None
     github_app_token: Callable[[str, str], GitHubAppInstallationToken] | None = None
     github_api: Callable[..., object] = github_api_request
+    public_origin: str | None = None
 
 
 class OwnerAcceptanceEventEnvelope(BaseModel):
@@ -272,6 +277,25 @@ def _validate_projection_target(
             raise ValueError("Owner acceptance projection target changed during evaluation.")
 
 
+def _resolve_owner_acceptance_projection_state(
+    *,
+    store: object,
+    target: ChangeImpactTargetReference,
+    repository_evidence_provider: ChangeImpactRepositoryEvidenceProvider,
+) -> tuple[OwnerAcceptanceDecision, ChangeImpactTarget]:
+    initial_evidence = repository_evidence_provider.resolve(target)
+    decision = evaluate_owner_acceptance(
+        store=store,
+        target=target,
+        repository_evidence_provider=repository_evidence_provider,
+    )
+    evidence = repository_evidence_provider.resolve(target)
+    if initial_evidence.target != evidence.target:
+        raise ValueError("Owner acceptance projection target changed during evaluation.")
+    _validate_projection_target(decision, evidence.target)
+    return decision, evidence.target
+
+
 def register_owner_acceptance_routes(
     app: ApiRouteRegistrar,
     *,
@@ -306,6 +330,54 @@ def register_owner_acceptance_routes(
             event_write_authorized=event_write_authorized,
             bindings=bindings,
         )
+
+    def project_current_decision(
+        *,
+        target: ChangeImpactTargetReference,
+        record_store: object,
+    ) -> tuple[OwnerAcceptanceDecision, AdvisoryCheckProjectionResult]:
+        if dependencies.github_app_token is None:
+            raise ValueError("Owner acceptance projection identity is unavailable.")
+        if dependencies.public_origin is None:
+            raise ValueError("Owner acceptance projection public origin is unavailable.")
+        decision, resolved_target = _resolve_owner_acceptance_projection_state(
+            store=record_store,
+            target=target,
+            repository_evidence_provider=dependencies.repository_evidence_provider,
+        )
+        installation_token = dependencies.github_app_token(
+            resolved_target.repository,
+            resolved_target.repository_id,
+        )
+        try:
+            result = project_owner_acceptance_decision(
+                decision=decision,
+                target=resolved_target,
+                public_origin=dependencies.public_origin,
+                installation_token=installation_token,
+                api_request=dependencies.github_api,
+            )
+        finally:
+            revoke_installation_token(
+                installation_token=installation_token,
+                api_request=dependencies.github_api,
+            )
+        return decision, result
+
+    def project_current_decision_best_effort(
+        *,
+        target: ChangeImpactTargetReference,
+        record_store: object,
+    ) -> None:
+        if dependencies.github_app_token is None or dependencies.public_origin is None:
+            return
+        try:
+            project_current_decision(target=target, record_store=record_store)
+        except Exception:
+            logger.warning(
+                "Owner acceptance advisory projection failed after event write.",
+                exc_info=True,
+            )
 
     def evaluate(
         repository: Annotated[
@@ -463,6 +535,10 @@ def register_owner_acceptance_routes(
                 code="database_storage_required",
                 message=str(error),
             ) from error
+        project_current_decision_best_effort(
+            target=envelope.target,
+            record_store=record_store,
+        )
         return OwnerAcceptanceEventResponse(
             trace_id=trace_id,
             write_status=result.status,
@@ -650,34 +726,10 @@ def register_owner_acceptance_routes(
                 message="Caller cannot project Owner acceptance decisions.",
             )
         try:
-            if dependencies.github_app_token is None:
-                raise ValueError("Owner acceptance projection identity is unavailable.")
-            initial_evidence = dependencies.repository_evidence_provider.resolve(request.target)
-            decision = evaluate_owner_acceptance(
-                store=record_store,
+            decision, result = project_current_decision(
                 target=request.target,
-                repository_evidence_provider=dependencies.repository_evidence_provider,
+                record_store=record_store,
             )
-            evidence = dependencies.repository_evidence_provider.resolve(request.target)
-            if initial_evidence.target != evidence.target:
-                raise ValueError("Owner acceptance projection target changed during evaluation.")
-            _validate_projection_target(decision, evidence.target)
-            installation_token = dependencies.github_app_token(
-                evidence.target.repository,
-                evidence.target.repository_id,
-            )
-            try:
-                result = project_owner_acceptance_decision(
-                    decision=decision,
-                    target=evidence.target,
-                    installation_token=installation_token,
-                    api_request=dependencies.github_api,
-                )
-            finally:
-                revoke_installation_token(
-                    installation_token=installation_token,
-                    api_request=dependencies.github_api,
-                )
         except (OwnerAcceptanceEvaluationUnavailableError, TypeError, ValueError) as error:
             raise common.http_error(
                 status_code=503,

--- a/control_plane/owner_acceptance_projection.py
+++ b/control_plane/owner_acceptance_projection.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import Callable
 import hashlib
 import json
+from urllib.parse import quote, urlsplit
 
 from control_plane.advisory_check_projection import write_advisory_check_projection
 from control_plane.contracts.advisory_check_projection import (
@@ -17,17 +18,22 @@ from control_plane.workflows.launchplane import github_api_request
 
 
 GitHubApiRequest = Callable[..., object]
+OWNER_ACCEPTANCE_WORKBENCH_PATH = "/ui/engineering/owner-acceptance"
 
 
 def project_owner_acceptance_decision(
     *,
     decision: OwnerAcceptanceDecision,
     target: ChangeImpactTarget,
+    public_origin: str,
     installation_token: GitHubAppInstallationToken,
     api_request: GitHubApiRequest = github_api_request,
 ) -> AdvisoryCheckProjectionResult:
     external_id = owner_acceptance_projection_sha256(decision)
-    details_url = f"https://github.com/{target.repository}/pull/{target.pull_request_number}"
+    details_url = owner_acceptance_workbench_url(
+        public_origin=public_origin,
+        target=target,
+    )
     return write_advisory_check_projection(
         projection=AdvisoryCheckProjection(
             name=OWNER_ACCEPTANCE_CHECK_NAME,
@@ -41,6 +47,47 @@ def project_owner_acceptance_decision(
         ),
         installation_token=installation_token,
         api_request=api_request,
+    )
+
+
+def owner_acceptance_workbench_url(
+    *,
+    public_origin: str,
+    target: ChangeImpactTarget,
+) -> str:
+    origin = public_origin.strip()
+    try:
+        parsed_origin = urlsplit(origin)
+    except ValueError as error:
+        raise ValueError(
+            "Owner acceptance projection requires a valid browser public origin."
+        ) from error
+    if (
+        parsed_origin.scheme not in {"http", "https"}
+        or not parsed_origin.netloc
+        or parsed_origin.path not in {"", "/"}
+        or parsed_origin.query
+        or parsed_origin.fragment
+        or parsed_origin.username is not None
+        or parsed_origin.password is not None
+    ):
+        raise ValueError("Owner acceptance projection requires a valid browser public origin.")
+    try:
+        if parsed_origin.port is not None and not 1 <= parsed_origin.port <= 65535:
+            raise ValueError
+    except ValueError as error:
+        raise ValueError(
+            "Owner acceptance projection requires a valid browser public origin."
+        ) from error
+    if any(character.isspace() or ord(character) < 32 for character in origin):
+        raise ValueError("Owner acceptance projection requires a valid browser public origin.")
+    if target.repository.count("/") != 1 or any(
+        not part or part != part.strip() for part in target.repository.split("/", 1)
+    ):
+        raise ValueError("Owner acceptance projection requires a valid repository target.")
+    return (
+        f"{origin.rstrip('/')}{OWNER_ACCEPTANCE_WORKBENCH_PATH}"
+        f"?repository={quote(target.repository, safe='')}&pull_request={target.pull_request_number}"
     )
 
 

--- a/docs/advisory-governance-checks.md
+++ b/docs/advisory-governance-checks.md
@@ -52,10 +52,22 @@ reference. Launchplane evaluates current Owner acceptance from server-owned
 evidence, re-resolves the exact target, and rejects any mid-flight head, tree,
 repository-id, or owner-id drift before writing GitHub.
 
+Owner acceptance `details_url` values point to the server-derived Launchplane
+Owner workbench, not directly to GitHub. Launchplane validates the configured
+browser public origin and URL-encodes the exact repository and pull-request
+query parameters before constructing `/ui/engineering/owner-acceptance`; an
+invalid origin or target fails the projection closed. Opening that link expands
+Exact lookup and automatically evaluates the same target in the browser.
+
 Each check run stores the Launchplane decision digest as `external_id`.
 Identical state replays without a write. Changed binding or decision state on
 the same head updates the App-owned check run. A changed head receives its own
 new check run and cannot reuse evidence from the prior head.
+
+Successful browser Owner event writes also trigger a best-effort refresh of the
+current App-owned check. This delivery attempt is non-authoritative: projection
+or token-revocation failure does not roll back the persisted event or alter its
+successful API response, and browser sessions do not gain projection authority.
 
 ## No Feedback Loop
 

--- a/docs/owner-acceptance.md
+++ b/docs/owner-acceptance.md
@@ -76,6 +76,14 @@ Owner requirement, Owner membership, and prior events from server-owned
 providers and storage. The pure read remains outside the browser-mutation
 surface and cannot consume a request body.
 
+The Owner workbench also accepts `repository` and `pull_request` query
+parameters at `/ui/engineering/owner-acceptance`. A server-issued advisory
+check details link uses the configured browser public origin and those exact
+parameters, so opening the link expands Exact lookup, prefills the repository
+and pull-request fields, and evaluates the target automatically. The browser
+still sends only the exact repository and PR reference to the evaluation API;
+fixture navigation remains preserved for local UI rehearsal.
+
 The response includes `viewer_capabilities.event_write_authorized`, a
 server-issued route-level capability for the evaluated identity. It allows the
 workbench to render explicit read-only engineering visibility instead of
@@ -386,6 +394,13 @@ the stable `launchplane/owner-acceptance` GitHub App check run. The caller
 supplies only repository and pull-request reference. Launchplane derives every
 product decision and exact binding, rechecks the current target before the
 provider write, and uses the decision digest as the check-run `external_id`.
+
+After a successful browser Owner event write, Launchplane best-effort
+re-evaluates the current exact target and refreshes this same App-owned check
+run. Projection or token-revocation failure is logged as advisory delivery
+failure only: the persisted human event and its `202` response are not rolled
+back or rewritten. Browsers never receive projection credentials or projection
+authority.
 
 The completed check conclusion is always `neutral`; the output lists the
 aggregate state plus each affected product and binding. The check remains

--- a/frontend/src/EngineeringOwnerAcceptanceRoute.tsx
+++ b/frontend/src/EngineeringOwnerAcceptanceRoute.tsx
@@ -39,6 +39,8 @@ import { formatTime } from "./format";
 import { StatusIcon } from "./status-ui";
 import { safeExternalUrl } from "./url";
 import { useBrowserOperationController } from "./use-browser-operation";
+import { useAppSearchParams } from "./router";
+import { ownerAcceptanceLookupFromSearch } from "./route-model";
 import {
   ownerAcceptanceFailure,
   ownerAcceptanceFailureCertainty,
@@ -65,6 +67,8 @@ export function EngineeringOwnerAcceptanceRoute({
 }: {
   fixtureMode: DevFixtureMode;
 }) {
+  const searchParams = useAppSearchParams();
+  const lookup = ownerAcceptanceLookupFromSearch(searchParams.toString());
   const [statusFilter, setStatusFilter] = useState<OwnerAcceptanceStatusFilter>("all");
   const [repositoryFilter, setRepositoryFilter] = useState("");
   const [repositoryDraft, setRepositoryDraft] = useState("");
@@ -170,9 +174,17 @@ export function EngineeringOwnerAcceptanceRoute({
         {(data) => <OwnerAcceptanceCurrentItems data={data} fixtureMode={fixtureMode} />}
       </EngineeringResourceGate>
 
-      <details className="engineering-owner-acceptance-lookup-fallback">
+      <details
+        className="engineering-owner-acceptance-lookup-fallback"
+        open={lookup.requested || undefined}
+      >
         <summary>Exact lookup fallback</summary>
-        <OwnerAcceptanceLookupPane fixtureMode={fixtureMode} />
+        <OwnerAcceptanceLookupPane
+          autoLookup={lookup.valid}
+          fixtureMode={fixtureMode}
+          initialPullRequest={lookup.pullRequest}
+          initialRepository={lookup.repository}
+        />
       </details>
 
       <EngineeringResourceGate
@@ -383,9 +395,19 @@ function OwnerAcceptanceCurrentItemCard({
   );
 }
 
-function OwnerAcceptanceLookupPane({ fixtureMode }: { fixtureMode: DevFixtureMode }) {
-  const [repository, setRepository] = useState("");
-  const [prNumber, setPrNumber] = useState("");
+function OwnerAcceptanceLookupPane({
+  autoLookup,
+  fixtureMode,
+  initialPullRequest,
+  initialRepository,
+}: {
+  autoLookup: boolean;
+  fixtureMode: DevFixtureMode;
+  initialPullRequest: string;
+  initialRepository: string;
+}) {
+  const [repository, setRepository] = useState(initialRepository);
+  const [prNumber, setPrNumber] = useState(initialPullRequest);
   const [decision, setDecision] = useState<OwnerAcceptanceDecision | null>(null);
   const [viewerCapabilities, setViewerCapabilities] =
     useState<OwnerAcceptanceViewerCapabilities | null>(null);
@@ -393,10 +415,11 @@ function OwnerAcceptanceLookupPane({ fixtureMode }: { fixtureMode: DevFixtureMod
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const abortRef = useRef<AbortController | null>(null);
+  const lastAutoLookupRef = useRef("");
 
-  const handleLookup = useCallback(async () => {
-    const repo = repository.trim();
-    const pr = parseInt(prNumber, 10);
+  const runLookup = useCallback(async (repositoryValue: string, prValue: string) => {
+    const repo = repositoryValue.trim();
+    const pr = parseInt(prValue, 10);
     if (!repo || !pr || pr < 1) return;
 
     abortRef.current?.abort();
@@ -438,7 +461,27 @@ function OwnerAcceptanceLookupPane({ fixtureMode }: { fixtureMode: DevFixtureMod
         setLoading(false);
       }
     }
-  }, [repository, prNumber, fixtureMode]);
+  }, [fixtureMode]);
+
+  const handleLookup = useCallback(
+    () => runLookup(repository, prNumber),
+    [prNumber, repository, runLookup],
+  );
+
+  useEffect(() => {
+    setRepository(initialRepository);
+    setPrNumber(initialPullRequest);
+    if (!autoLookup) {
+      lastAutoLookupRef.current = "";
+      return;
+    }
+    const lookupKey = `${initialRepository}:${initialPullRequest}`;
+    if (lastAutoLookupRef.current === lookupKey) {
+      return;
+    }
+    lastAutoLookupRef.current = lookupKey;
+    void runLookup(initialRepository, initialPullRequest);
+  }, [autoLookup, initialPullRequest, initialRepository, runLookup]);
 
   const refreshCurrentEvaluation = useCallback(async (reviewedBinding: OwnerAcceptanceBinding) => {
     const repo = reviewedBinding.repository;
@@ -509,7 +552,7 @@ function OwnerAcceptanceLookupPane({ fixtureMode }: { fixtureMode: DevFixtureMod
           className="button"
           type="button"
           disabled={!isValid || loading}
-          onClick={handleLookup}
+          onClick={() => void handleLookup()}
           aria-label="Look up current Owner acceptance evaluation"
         >
           {loading ? "Loading…" : "Look up"}

--- a/frontend/src/route-model.ts
+++ b/frontend/src/route-model.ts
@@ -155,6 +155,24 @@ export function parseAppRoute(pathname: string): AppRoute {
   return { kind: "not-found", path: pathname };
 }
 
+export function ownerAcceptanceLookupFromSearch(search: string): {
+  repository: string;
+  pullRequest: string;
+  requested: boolean;
+  valid: boolean;
+} {
+  const searchParams = new URLSearchParams(search);
+  const repository = searchParams.get("repository")?.trim() ?? "";
+  const pullRequest = searchParams.get("pull_request")?.trim() ?? "";
+  return {
+    repository,
+    pullRequest,
+    requested: Boolean(repository || pullRequest),
+    valid:
+      /^[^/\s]+\/[^/\s]+$/.test(repository) && /^[1-9][0-9]*$/.test(pullRequest),
+  };
+}
+
 export function routeProductKey(route: AppRoute): string {
   return route.kind === "product-workspace" ||
     route.kind === "product-activity" ||

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -12,6 +12,22 @@ export * from "./route-model";
 const NAVIGATION_EVENT = "launchplane:navigation";
 
 export function useAppRoute(): AppRoute {
+  const locationKey = useLocationKey();
+  return useMemo(() => {
+    const location = new URL(locationKey, window.location.origin);
+    return parseAppRoute(location.pathname);
+  }, [locationKey]);
+}
+
+export function useAppSearchParams(): URLSearchParams {
+  const locationKey = useLocationKey();
+  return useMemo(
+    () => new URLSearchParams(new URL(locationKey, window.location.origin).search),
+    [locationKey],
+  );
+}
+
+function useLocationKey(): string {
   const [locationKey, setLocationKey] = useState(currentLocationKey);
 
   useEffect(() => {
@@ -24,10 +40,7 @@ export function useAppRoute(): AppRoute {
     };
   }, []);
 
-  return useMemo(() => {
-    const location = new URL(locationKey, window.location.origin);
-    return parseAppRoute(location.pathname);
-  }, [locationKey]);
+  return locationKey;
 }
 
 export function navigateTo(path: string, replace = false): void {

--- a/frontend/tests/browser/operator-journeys.spec.ts
+++ b/frontend/tests/browser/operator-journeys.spec.ts
@@ -902,6 +902,31 @@ test.describe("operator journeys", () => {
     diagnostics.assertClean();
   });
 
+  test("Owner acceptance deep link opens and evaluates the exact target", async ({ page }) => {
+    const diagnostics = monitorBrowser(page);
+
+    await page.goto(
+      "/ui/engineering/owner-acceptance?fixture=products&repository=example%2Fcontrol-plane&pull_request=308",
+    );
+
+    await expect(page.getByText("Exact lookup — Current evaluation")).toBeVisible();
+    await expect(
+      page.getByRole("textbox", { name: "Repository (owner/repo)" }),
+    ).toHaveValue("example/control-plane");
+    await expect(
+      page.getByRole("spinbutton", { name: "Pull request number" }),
+    ).toHaveValue("308");
+    await expect(page.getByLabel("Current evaluation result")).toBeVisible();
+    await expect(
+      page.getByLabel("Exact PR lookup").getByText("Owner product review: pending"),
+    ).toBeVisible();
+    const repositoryInput = page.getByRole("textbox", { name: "Repository (owner/repo)" });
+    await repositoryInput.fill("example/another-repo");
+    await expect(repositoryInput).toHaveValue("example/another-repo");
+    await assertDocumentBasics(page);
+    diagnostics.assertClean();
+  });
+
   test("engineering viewer sees Current evidence without Owner controls", async ({
     page,
   }, testInfo) => {

--- a/frontend/tests/engineering-router.test.mjs
+++ b/frontend/tests/engineering-router.test.mjs
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   engineeringPath,
   engineeringViewLabel,
+  ownerAcceptanceLookupFromSearch,
   parseAppRoute,
 } from "../src/route-model.ts";
 
@@ -45,4 +46,22 @@ test("engineering labels are route-specific", () => {
   assert.equal(engineeringViewLabel("tenant-admission"), "Tenant admission");
   assert.equal(engineeringViewLabel("owner-acceptance"), "Owner product review");
   assert.equal(engineeringViewLabel("governance-projection"), "Governance evidence");
+});
+
+test("Owner acceptance deep-link query selects one exact lookup", () => {
+  assert.deepEqual(
+    ownerAcceptanceLookupFromSearch(
+      "fixture=products&repository=example%2Fcontrol-plane&pull_request=308",
+    ),
+    {
+      repository: "example/control-plane",
+      pullRequest: "308",
+      requested: true,
+      valid: true,
+    },
+  );
+  assert.equal(
+    ownerAcceptanceLookupFromSearch("fixture=products&repository=example%2Fcontrol-plane").valid,
+    false,
+  );
 });

--- a/tests/test_advisory_check_projection.py
+++ b/tests/test_advisory_check_projection.py
@@ -6,11 +6,13 @@ from control_plane.advisory_check_projection import (
     AdvisoryCheckProjectionError,
     write_advisory_check_projection,
 )
+from control_plane.contracts.change_impact import ChangeImpactTarget
 from control_plane.contracts.advisory_check_projection import (
     AdvisoryCheckProjection,
     OWNER_ACCEPTANCE_CHECK_NAME,
 )
 from control_plane.github_app_identity import GitHubAppInstallationToken
+from control_plane.owner_acceptance_projection import owner_acceptance_workbench_url
 
 
 HEAD_SHA = "a" * 40
@@ -57,6 +59,40 @@ def _check_run(*, external_id: str = EXTERNAL_ID, app_id: int = 42) -> dict[str,
 
 
 class AdvisoryCheckProjectionTests(unittest.TestCase):
+    def test_owner_acceptance_details_url_is_server_owned_and_encoded(self) -> None:
+        target = ChangeImpactTarget(
+            repository_id="123",
+            repository_owner_id="456",
+            repository="example/repo",
+            pull_request_number=7,
+            head_sha=HEAD_SHA,
+            tree_sha="c" * 40,
+        )
+
+        self.assertEqual(
+            owner_acceptance_workbench_url(
+                public_origin="https://ops.example.test/",
+                target=target,
+            ),
+            "https://ops.example.test/ui/engineering/owner-acceptance?repository=example%2Frepo&pull_request=7",
+        )
+
+    def test_owner_acceptance_details_url_rejects_invalid_origin(self) -> None:
+        target = ChangeImpactTarget(
+            repository_id="123",
+            repository_owner_id="456",
+            repository="example/repo",
+            pull_request_number=7,
+            head_sha=HEAD_SHA,
+            tree_sha="c" * 40,
+        )
+
+        with self.assertRaisesRegex(ValueError, "valid browser public origin"):
+            owner_acceptance_workbench_url(
+                public_origin="https://github.com/example/repo/pull/7",
+                target=target,
+            )
+
     def test_replays_identical_exact_projection_without_write(self) -> None:
         calls: list[dict[str, object]] = []
 

--- a/tests/test_owner_acceptance_http.py
+++ b/tests/test_owner_acceptance_http.py
@@ -57,6 +57,7 @@ def _app(
     authorization_allows: Callable[..., bool] | None = None,
     github_app_token: Callable[[str, str], GitHubAppInstallationToken] | None = None,
     github_api: Callable[..., object] | None = None,
+    public_origin: str | None = None,
 ) -> FastAPI:
     resolved_identity = identity or _human()
     resolved_browser_identity = browser_identity or resolved_identity
@@ -79,6 +80,7 @@ def _app(
                 repository_evidence_provider or _EvidenceProvider(_repository_evidence())
             ),
             github_app_token=github_app_token,
+            public_origin=public_origin,
             **({"github_api": github_api} if github_api is not None else {}),
         ),
     )
@@ -121,6 +123,7 @@ class OwnerAcceptanceHttpTests(unittest.IsolatedAsyncioTestCase):
                     expires_at="2026-08-07T15:00:00Z",
                 ),
                 github_api=github_api,
+                public_origin="https://ops.example.test",
             )
 
             async with lifespan_client(app) as client:
@@ -139,8 +142,120 @@ class OwnerAcceptanceHttpTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(payload["decision"]["status"], "pending")
         self.assertEqual(payload["result"]["name"], "launchplane/owner-acceptance")
         self.assertEqual(payload["result"]["conclusion"], "neutral")
+        self.assertEqual(
+            calls[-2]["body"]["details_url"],
+            "https://ops.example.test/ui/engineering/owner-acceptance?repository=example%2Fweb&pull_request=2022",
+        )
         self.assertEqual(calls[-2]["body"]["conclusion"], "neutral")
         self.assertEqual(calls[-1]["method"], "DELETE")
+
+    async def test_successful_event_best_effort_projects_current_decision(self) -> None:
+        with TemporaryDirectory() as directory:
+            store = _store(Path(directory))
+            calls: list[dict[str, Any]] = []
+
+            def github_api(**kwargs):  # type: ignore[no-untyped-def]
+                calls.append(kwargs)
+                if kwargs.get("method") == "DELETE":
+                    return None
+                if kwargs.get("method") == "POST":
+                    body = kwargs["body"]
+                    return {
+                        "id": 92,
+                        "name": body["name"],
+                        "head_sha": body["head_sha"],
+                        "status": body["status"],
+                        "conclusion": body["conclusion"],
+                        "external_id": body["external_id"],
+                        "details_url": body["details_url"],
+                        "output": body["output"],
+                        "app": {"id": 42},
+                    }
+                return {"check_runs": []}
+
+            app = _app(
+                store=store,
+                github_app_token=lambda _repository, _repository_id: GitHubAppInstallationToken(
+                    token="installation-token",
+                    app_id=42,
+                    installation_id=77,
+                    repository_id=int(REPOSITORY_ID),
+                    repository=REPOSITORY,
+                    expires_at="2026-08-07T15:00:00Z",
+                ),
+                github_api=github_api,
+                public_origin="https://ops.example.test",
+            )
+
+            async with lifespan_client(app) as client:
+                evaluated = await client.get(
+                    OWNER_ACCEPTANCE_EVALUATION_ROUTE,
+                    params={"repository": REPOSITORY, "pull_request_number": 2022},
+                )
+                response = await client.post(
+                    OWNER_ACCEPTANCE_EVENTS_ROUTE,
+                    json={
+                        "target": {"repository": REPOSITORY, "pull_request_number": 2022},
+                        "action": "accepted",
+                        "expected_binding_sha256": evaluated.json()["decision"]["binding"][
+                            "binding_sha256"
+                        ],
+                    },
+                    headers={"Idempotency-Key": "accept-and-project"},
+                )
+                event_count = len(store.list_owner_acceptance_event_records())
+
+        self.assertEqual(response.status_code, 202, response.text)
+        self.assertEqual(event_count, 1)
+        projection_body = next(call for call in calls if call.get("method") == "POST")["body"]
+        self.assertEqual(
+            projection_body["details_url"],
+            "https://ops.example.test/ui/engineering/owner-acceptance?repository=example%2Fweb&pull_request=2022",
+        )
+        self.assertEqual(projection_body["output"]["title"], "Owner acceptance: accepted")
+
+    async def test_event_response_and_persisted_event_survive_projection_failure(self) -> None:
+        with TemporaryDirectory() as directory:
+            store = _store(Path(directory))
+
+            def failing_github_api(**_kwargs):  # type: ignore[no-untyped-def]
+                raise RuntimeError("GitHub is unavailable")
+
+            app = _app(
+                store=store,
+                github_app_token=lambda _repository, _repository_id: GitHubAppInstallationToken(
+                    token="installation-token",
+                    app_id=42,
+                    installation_id=77,
+                    repository_id=int(REPOSITORY_ID),
+                    repository=REPOSITORY,
+                    expires_at="2026-08-07T15:00:00Z",
+                ),
+                github_api=failing_github_api,
+                public_origin="https://ops.example.test",
+            )
+
+            async with lifespan_client(app) as client:
+                evaluated = await client.get(
+                    OWNER_ACCEPTANCE_EVALUATION_ROUTE,
+                    params={"repository": REPOSITORY, "pull_request_number": 2022},
+                )
+                response = await client.post(
+                    OWNER_ACCEPTANCE_EVENTS_ROUTE,
+                    json={
+                        "target": {"repository": REPOSITORY, "pull_request_number": 2022},
+                        "action": "accepted",
+                        "expected_binding_sha256": evaluated.json()["decision"]["binding"][
+                            "binding_sha256"
+                        ],
+                    },
+                    headers={"Idempotency-Key": "accept-with-projection-failure"},
+                )
+                event_count = len(store.list_owner_acceptance_event_records())
+
+        self.assertEqual(response.status_code, 202, response.text)
+        self.assertEqual(response.json()["write_status"], "written")
+        self.assertEqual(event_count, 1)
 
     async def test_projection_rejects_head_drift_before_github_write(self) -> None:
         class _DriftingProvider(_EvidenceProvider):


### PR DESCRIPTION
## Summary

- Link the neutral Owner acceptance check to the exact Launchplane workbench target instead of back to the GitHub PR.
- Support repository/PR deep links that open and evaluate the exact Owner review item.
- Best-effort refresh the advisory check after a successful human Owner action without changing the persisted event response.
- Preserve shadow, non-authoritative, non-blocking semantics and exact-head evidence validation.

## Safety

- The browser still submits only repository, PR, action, and the exact server-issued binding digest.
- Launchplane resolves repository/head/tree evidence before and after evaluation and rejects drift before any GitHub write.
- GitHub App installation tokens remain repository-scoped and are revoked in `finally`.
- Projection failures do not roll back or reinterpret the human event.
- The check conclusion remains `neutral`; required checks and merge admission are unchanged.

## Validation

- 2,914 unittest targets passed across 12 shards.
- Mypy passed across 726 source files.
- Ruff checks passed; changed Python files are formatted.
- Frontend unit tests, OpenAPI drift, TypeScript, and production build passed.
- 90 browser journeys passed at desktop and narrow widths.
- JetBrains changed-files inspection: GREEN, zero actionable findings.
- Final Opus review: APPROVE.
- Final Gemini review: APPROVE.

Refs #2159
