### PR TITLE
Preserve generic web deploy identity across reruns

### DIFF
--- a/.github/workflows/reusable-generic-web-stable-deploy.yml
+++ b/.github/workflows/reusable-generic-web-stable-deploy.yml
@@ -94,7 +94,7 @@ jobs:
               exit 1
             fi
           done
-          run_scope="${GITHUB_RUN_ID}:${GITHUB_RUN_ATTEMPT}"
+          run_scope="${GITHUB_RUN_ID}:1"
           {
             echo "product=$PRODUCT"
             echo "instance=$INSTANCE"

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -295,6 +295,11 @@ former replaces the previous process-local apply lock. Both require an
 - A concurrent request with the same key while the effect runs returns `409
   mutation_in_progress`; a completed effect replays; a different request
   fingerprint returns `409 idempotency_key_reused`.
+- GitHub workflow retries must preserve the original operation key. The generic
+  web stable-deploy workflow keeps the first-attempt `:<run_id>:1` suffix on
+  every rerun so **Re-run failed jobs** can reconcile or replay the existing
+  provider operation instead of colliding with its target fence under a new
+  key.
 - A stable provider-target key identifies the mutation target independently of
   request timeout or deploy settings. A partial unique database fence allows
   only one `running` or `reconcile_required` mutation for that target, including

--- a/tests/test_deploy_reference_workflows.py
+++ b/tests/test_deploy_reference_workflows.py
@@ -25,7 +25,9 @@ class DeployReferenceWorkflowContractTests(unittest.TestCase):
                 request_step = workflow.step_named("stable-deploy", request_step_name)
                 self.assertIsNotNone(request_step)
                 assert request_step is not None
-                payload_fields = str(request_step.with_values["payload-fields"])
+                payload_fields = request_step.with_values["payload-fields"]
+                self.assertIsInstance(payload_fields, str)
+                assert isinstance(payload_fields, str)
                 self.assertIn(
                     "deploy.deploy_reference=${{ inputs.deploy_reference }}",
                     payload_fields,
@@ -42,6 +44,16 @@ class DeployReferenceWorkflowContractTests(unittest.TestCase):
         self.assertIn('"$ARTIFACT_ID"', resolve_step.run)
         self.assertIn('"$DEPLOY_REFERENCE"', resolve_step.run)
 
+    def test_generic_stable_deploy_reruns_reuse_initial_operation_identity(self) -> None:
+        workflow = load_workflow(
+            REPO_ROOT / ".github/workflows/reusable-generic-web-stable-deploy.yml"
+        )
+        resolve_step = workflow.step_named("stable-deploy", "Resolve Launchplane deploy request")
+        self.assertIsNotNone(resolve_step)
+        assert resolve_step is not None
+        self.assertIn('run_scope="${GITHUB_RUN_ID}:1"', resolve_step.run)
+        self.assertNotIn("GITHUB_RUN_ATTEMPT", resolve_step.run)
+
     def test_prod_promotion_workflows_accept_and_forward_deploy_reference(self) -> None:
         workflow = load_workflow(
             REPO_ROOT / ".github/workflows/reusable-product-driver-prod-promotion.yml"
@@ -52,7 +64,9 @@ class DeployReferenceWorkflowContractTests(unittest.TestCase):
         )
         self.assertIsNotNone(request_step)
         assert request_step is not None
-        payload_fields = str(request_step.with_values["payload-fields"])
+        payload_fields = request_step.with_values["payload-fields"]
+        self.assertIsInstance(payload_fields, str)
+        assert isinstance(payload_fields, str)
         self.assertIn(
             "promotion.deploy_reference=${{ inputs.deploy_reference }}",
             payload_fields,


### PR DESCRIPTION
## Summary
- keep generic web stable-deploy idempotency keys stable across GitHub reruns
- preserve existing first-attempt `:<run_id>:1` keys for backward-compatible recovery
- document the failed-job rerun contract and add regression coverage

## Why
`GITHUB_RUN_ATTEMPT` changed the durable operation key on every rerun. Launchplane correctly fenced the provider target, but the new key could not reconcile the prior operation and returned `mutation_in_progress`. This has blocked `repairshopr-sync` deploys since July 17, 2026.

## Validation
- 2,914 unittest targets passed across 12 shards
- targeted workflow/docs tests passed
- Ruff check/format and mypy passed for the changed Python test
- `actionlint` passed for the reusable workflow
- PyCharm changed-files inspection: GREEN, 0 findings

## Recovery
After merge, rerun the failed deploy job so its original `:<run_id>:1` key can reconcile or replay the durable provider operation.