### PR TITLE
Refresh util-linux security packages in runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,13 +44,22 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 RUN apt-get update \
     && apt-get upgrade -y \
     && apt-get install -y --no-install-recommends --only-upgrade \
+        bsdutils \
+        libblkid1 \
         libgssapi-krb5-2 \
         libk5crypto3 \
         libkrb5-3 \
         libkrb5support0 \
+        liblastlog2-2 \
+        libmount1 \
+        libsmartcols1 \
         libssl3t64 \
+        libuuid1 \
+        login \
+        mount \
         openssl \
         openssl-provider-legacy \
+        util-linux \
     && apt-get install -y --no-install-recommends ca-certificates openssh-client \
     && rm -rf /var/lib/apt/lists/*
 

--- a/tests/test_service_image_contract.py
+++ b/tests/test_service_image_contract.py
@@ -19,6 +19,17 @@ GITHUB_CLI_MODULE_CONTRACTS = {
         "GITHUB_CLI_X_TEXT_VERSION",
     ),
 }
+RUNTIME_SECURITY_UPGRADE_PACKAGES = {
+    "bsdutils",
+    "libblkid1",
+    "liblastlog2-2",
+    "libmount1",
+    "libsmartcols1",
+    "libuuid1",
+    "login",
+    "mount",
+    "util-linux",
+}
 GO_VERSION_PATTERN = re.compile(
     r"^v(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)"
     r"(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?"
@@ -100,6 +111,36 @@ class ServiceImageContractTests(unittest.TestCase):
 
         self.assertIn("openssh-client", dockerfile_text)
         self.assertIn("rm -rf /var/lib/apt/lists/*", dockerfile_text)
+
+    def test_service_image_refreshes_runtime_security_packages(self) -> None:
+        dockerfile = Path(__file__).resolve().parents[1] / "Dockerfile"
+
+        dockerfile_text = dockerfile.read_text(encoding="utf-8")
+        runtime_stage = re.search(
+            r"(?ms)^FROM\s+\S*python:3\.13-slim\s*$"
+            r"(?P<body>.*?)(?=^FROM\s|\Z)",
+            dockerfile_text,
+        )
+
+        self.assertIsNotNone(runtime_stage)
+        assert runtime_stage is not None
+        runtime_stage_text = runtime_stage.group("body")
+        upgrade = re.search(
+            r"(?ms)apt-get install -y --no-install-recommends --only-upgrade\s+\\\n"
+            r"(?P<packages>.*?)\n\s*&& apt-get install -y --no-install-recommends",
+            runtime_stage_text,
+        )
+
+        self.assertIsNotNone(upgrade)
+        assert upgrade is not None
+        observed_packages = set(
+            re.findall(
+                r"(?m)^\s+(?P<package>[a-z0-9][a-z0-9+.-]*)\s+\\?\s*$",
+                upgrade.group("packages"),
+            )
+        )
+
+        self.assertTrue(RUNTIME_SECURITY_UPGRADE_PACKAGES.issubset(observed_packages))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- explicitly refresh the nine installed `util-linux` binary packages affected by `CVE-2026-53615`
- invalidate the stale final-runtime apt layer in both CI and deployment caches without disabling BuildKit caching
- add a final-stage Dockerfile contract test so the security-upgrade package set cannot silently drift into a builder stage

## Context
Post-merge Launchplane CI run `31992091598` found nine HIGH findings at installed version `2.41-5`. Debian trixie-security now publishes fixed version `2.41.5-0+deb13u1`. The existing Dockerfile already runs `apt-get update` and `apt-get upgrade`, but the unchanged RUN instruction was eligible for reuse from GHA and registry BuildKit caches.

## Validation
- `uv run --extra dev python -m unittest tests.test_service_image_contract` — 3 passed
- `uv run --extra dev ruff check --no-fix tests/test_service_image_contract.py` — passed
- `uv run --extra dev ruff format --check tests/test_service_image_contract.py` — passed
- `git diff --check` — passed
- Opus and Gemini approved the remediation plan before implementation

The PR intentionally does not suppress the CVE, disable caching, roll back the Owner cutover, refresh VeriReel PR #343, or contact an Owner.

Refs #2164
