### PR TITLE
Fix pending Owner check projection UX

### DIFF
--- a/control_plane/advisory_check_projection.py
+++ b/control_plane/advisory_check_projection.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+import logging
 from urllib.parse import quote, urlencode
 
 import click
@@ -16,6 +17,7 @@ from control_plane.workflows.launchplane import github_api_request
 
 
 GitHubApiRequest = Callable[..., object]
+logger = logging.getLogger(__name__)
 
 
 class AdvisoryCheckProjectionError(ValueError):
@@ -63,38 +65,55 @@ def write_advisory_check_projection(
         raise AdvisoryCheckProjectionError(
             "GitHub advisory check runs response must include check_runs."
         )
-    current = next(
-        (
-            json_object(
-                item,
-                "GitHub advisory check run",
-                error_type=AdvisoryCheckProjectionError,
-            )
-            for item in raw_check_runs
-            if isinstance(item, dict)
-            and str(item.get("name") or "") == projection.name
-            and str(item.get("head_sha") or "").lower() == projection.head_sha
-            and _app_id(item.get("app")) == installation_token.app_id
-        ),
+    matching_runs = tuple(
+        json_object(
+            item,
+            "GitHub advisory check run",
+            error_type=AdvisoryCheckProjectionError,
+        )
+        for item in raw_check_runs
+        if isinstance(item, dict)
+        and item.get("name") == projection.name
+        and isinstance(item.get("head_sha"), str)
+        and item["head_sha"].lower() == projection.head_sha
+        and _app_id(item.get("app")) == installation_token.app_id
+    )
+    exact_match = next(
+        (check_run for check_run in matching_runs if _matches_projection(check_run, projection)),
         None,
     )
-    if current is not None and _matches_projection(current, projection):
+    if exact_match is not None:
         return _result(
             status="replayed",
             projection=projection,
             installation_token=installation_token,
-            check_run=current,
+            check_run=exact_match,
         )
-    body = {
+    current = matching_runs[0] if matching_runs else None
+    body: dict[str, object] = {
         "name": projection.name,
-        "status": "completed",
-        "conclusion": projection.conclusion,
+        "status": projection.check_status,
         "external_id": projection.external_id,
         "details_url": projection.details_url,
         "output": {"title": projection.title, "summary": projection.summary},
     }
+    if projection.conclusion is not None:
+        body["conclusion"] = projection.conclusion
     status: AdvisoryCheckProjectionStatus
-    if current is None:
+    recreate_incomplete = (
+        current is not None
+        and current.get("status") == "completed"
+        and projection.check_status == "in_progress"
+    )
+    if current is None or recreate_incomplete:
+        if recreate_incomplete:
+            logger.info(
+                "Creating a fresh in-progress advisory check after GitHub completed the prior run.",
+                extra={
+                    "advisory_check_name": projection.name,
+                    "advisory_check_head_sha": projection.head_sha,
+                },
+            )
         response = _github_api_request(
             api_request,
             path=f"/repos/{repository_path}/check-runs",
@@ -137,13 +156,13 @@ def write_advisory_check_projection(
 def _matches_projection(check_run: dict[str, object], projection: AdvisoryCheckProjection) -> bool:
     output = check_run.get("output")
     return (
-        str(check_run.get("status") or "") == "completed"
-        and str(check_run.get("conclusion") or "") == projection.conclusion
-        and str(check_run.get("external_id") or "") == projection.external_id
-        and str(check_run.get("details_url") or "") == projection.details_url
+        check_run.get("status") == projection.check_status
+        and _conclusion_matches(check_run, projection)
+        and check_run.get("external_id") == projection.external_id
+        and check_run.get("details_url") == projection.details_url
         and isinstance(output, dict)
-        and str(output.get("title") or "") == projection.title
-        and str(output.get("summary") or "") == projection.summary
+        and output.get("title") == projection.title
+        and output.get("summary") == projection.summary
     )
 
 
@@ -154,6 +173,7 @@ def _result(
     installation_token: GitHubAppInstallationToken,
     check_run: dict[str, object],
 ) -> AdvisoryCheckProjectionResult:
+    output = check_run.get("output")
     if (
         required_string_text(
             check_run.get("name"),
@@ -174,9 +194,12 @@ def _result(
         )
         != projection.external_id
         or _app_id(check_run.get("app")) != installation_token.app_id
-        or str(check_run.get("status") or "") != "completed"
-        or str(check_run.get("conclusion") or "") != projection.conclusion
-        or str(check_run.get("details_url") or "") != projection.details_url
+        or check_run.get("status") != projection.check_status
+        or not _conclusion_matches(check_run, projection)
+        or check_run.get("details_url") != projection.details_url
+        or not isinstance(output, dict)
+        or output.get("title") != projection.title
+        or output.get("summary") != projection.summary
     ):
         raise AdvisoryCheckProjectionError(
             "GitHub advisory check run response did not match exact projection identity."
@@ -193,8 +216,15 @@ def _result(
             "GitHub advisory check run response requires id.",
             error_type=AdvisoryCheckProjectionError,
         ),
+        check_status=projection.check_status,
         conclusion=projection.conclusion,
     )
+
+
+def _conclusion_matches(check_run: dict[str, object], projection: AdvisoryCheckProjection) -> bool:
+    if projection.conclusion is None:
+        return check_run.get("conclusion") is None
+    return check_run.get("conclusion") == projection.conclusion
 
 
 def _app_id(value: object) -> int:

--- a/control_plane/contracts/advisory_check_projection.py
+++ b/control_plane/contracts/advisory_check_projection.py
@@ -19,6 +19,7 @@ LAUNCHPLANE_PROJECTED_CHECK_NAMES = frozenset(
 )
 
 AdvisoryCheckProjectionStatus = Literal["projected", "updated", "replayed"]
+AdvisoryCheckRunStatus = Literal["in_progress", "completed"]
 AdvisoryCheckConclusion = Literal["neutral", "success", "failure", "action_required"]
 
 
@@ -34,7 +35,8 @@ class AdvisoryCheckProjection(BaseModel):
     details_url: str
     title: str = Field(min_length=1, max_length=255)
     summary: str = Field(min_length=1, max_length=65535)
-    conclusion: AdvisoryCheckConclusion = "neutral"
+    check_status: AdvisoryCheckRunStatus = "completed"
+    conclusion: AdvisoryCheckConclusion | None = "neutral"
 
     @model_validator(mode="after")
     def _validate_projection(self) -> "AdvisoryCheckProjection":
@@ -68,13 +70,17 @@ class AdvisoryCheckProjection(BaseModel):
             ) from error
         if self.title.strip() != self.title or self.summary.strip() != self.summary:
             raise ValueError("Advisory check projection text must be canonical.")
+        if self.check_status == "completed" and self.conclusion is None:
+            raise ValueError("Completed advisory checks require a conclusion.")
+        if self.check_status == "in_progress" and self.conclusion is not None:
+            raise ValueError("In-progress advisory checks cannot have a conclusion.")
         return self
 
 
 class AdvisoryCheckProjectionResult(BaseModel):
     model_config = ConfigDict(extra="forbid", frozen=True)
 
-    schema_version: int = Field(default=1, ge=1)
+    schema_version: Literal[2] = 2
     status: AdvisoryCheckProjectionStatus
     name: str
     head_sha: str = Field(pattern=r"^[0-9a-f]{40}$")
@@ -82,7 +88,8 @@ class AdvisoryCheckProjectionResult(BaseModel):
     app_id: int = Field(ge=1)
     installation_id: int = Field(ge=1)
     check_run_id: int = Field(ge=1)
-    conclusion: AdvisoryCheckConclusion
+    check_status: AdvisoryCheckRunStatus
+    conclusion: AdvisoryCheckConclusion | None
 
 
 def is_launchplane_projected_check(name: str) -> bool:

--- a/control_plane/every_code_worker.py
+++ b/control_plane/every_code_worker.py
@@ -22,6 +22,7 @@ from control_plane.child_process_errors import (
     normalize_child_process_failure,
     redact_untrusted_text,
 )
+from control_plane.contracts.advisory_check_projection import is_launchplane_projected_check
 from control_plane.contracts.every_code_pr_feedback_record import (
     EveryCodePrFeedbackRecord,
     EveryCodePrFeedbackStatus,
@@ -3758,7 +3759,9 @@ def _every_code_relevant_pr_checks(
     return [
         item
         for item in check_rollup
-        if isinstance(item, dict) and _github_check_conclusion(item) != "SKIPPED"
+        if isinstance(item, dict)
+        and _github_check_conclusion(item) != "SKIPPED"
+        and not is_launchplane_projected_check(_github_check_name(item))
     ]
 
 

--- a/control_plane/http_routes/owner_acceptance.py
+++ b/control_plane/http_routes/owner_acceptance.py
@@ -23,6 +23,7 @@ from control_plane.contracts.owner_acceptance import (
     OwnerAcceptanceResolutionEvidence,
     OwnerAcceptanceTransitionError,
     OwnerAcceptanceViewerBindingEligibility,
+    owner_acceptance_event_replay_digest,
     owner_acceptance_human_action_semantics,
 )
 from control_plane.github_app_identity import GitHubAppInstallationToken
@@ -76,6 +77,18 @@ class OwnerAcceptanceProjectionUnavailableError(RuntimeError):
 
 
 class OwnerAcceptanceProjectionReconciliationRequiredError(RuntimeError):
+    pass
+
+
+class OwnerAcceptanceEventNotPersistedError(RuntimeError):
+    pass
+
+
+class OwnerAcceptanceEventNotPersistedProjectionError(RuntimeError):
+    pass
+
+
+class OwnerAcceptanceEventPersistenceUnknownError(RuntimeError):
     pass
 
 
@@ -249,6 +262,31 @@ def _event_semantics(record: OwnerAcceptanceEventRecord) -> OwnerAcceptanceEvent
     )
 
 
+def _owner_acceptance_event_persistence_outcome(
+    *,
+    store: object,
+    record: OwnerAcceptanceEventRecord,
+) -> Literal["persisted", "absent", "unknown"]:
+    try:
+        persisted = require_owner_acceptance_event_store(store).read_owner_acceptance_event_record(
+            record.event_id
+        )
+    except FileNotFoundError:
+        return "absent"
+    except Exception:
+        logger.warning(
+            "Could not determine Owner acceptance event persistence outcome.",
+            exc_info=True,
+        )
+        return "unknown"
+    if owner_acceptance_event_replay_digest(persisted) == owner_acceptance_event_replay_digest(
+        record
+    ):
+        return "persisted"
+    logger.error("Owner acceptance event id resolved to a different persisted payload.")
+    return "unknown"
+
+
 def register_owner_acceptance_routes(
     app: ApiRouteRegistrar,
     *,
@@ -402,8 +440,11 @@ def register_owner_acceptance_routes(
                 store=record_store,
                 target=envelope.target,
             ) as locked_projection_target:
+                prewrite_projection_target: ChangeImpactTarget | None = None
+                prewrite_event_record: OwnerAcceptanceEventRecord | None = None
 
                 def project_conservative_check(record: OwnerAcceptanceEventRecord) -> None:
+                    nonlocal prewrite_event_record, prewrite_projection_target
                     binding = record.binding
                     record_target = ChangeImpactTarget(
                         repository_id=binding.repository_id,
@@ -419,22 +460,101 @@ def register_owner_acceptance_routes(
                             exact_target=record_target,
                             source_event_id=idempotency_key,
                         )
-                    except Exception as error:
-                        raise OwnerAcceptanceProjectionUnavailableError(str(error)) from error
+                    except Exception as projection_error:
+                        raise OwnerAcceptanceProjectionUnavailableError(
+                            str(projection_error)
+                        ) from projection_error
+                    prewrite_event_record = record
+                    prewrite_projection_target = record_target
 
-                result: OwnerAcceptanceWriteResult = record_owner_acceptance_event(
-                    store=record_store,
-                    repository_evidence_provider=dependencies.repository_evidence_provider,
-                    target=envelope.target,
-                    identity=identity,
-                    action=envelope.action,
-                    expected_binding_sha256=envelope.expected_binding_sha256,
-                    source_event_kind="browser_api",
-                    source_event_id=idempotency_key,
-                    reason=envelope.reason,
-                    resolution=envelope.resolution,
-                    before_write=project_conservative_check,
-                )
+                try:
+                    result: OwnerAcceptanceWriteResult = record_owner_acceptance_event(
+                        store=record_store,
+                        repository_evidence_provider=dependencies.repository_evidence_provider,
+                        target=envelope.target,
+                        identity=identity,
+                        action=envelope.action,
+                        expected_binding_sha256=envelope.expected_binding_sha256,
+                        source_event_kind="browser_api",
+                        source_event_id=idempotency_key,
+                        reason=envelope.reason,
+                        resolution=envelope.resolution,
+                        before_write=project_conservative_check,
+                    )
+                except Exception as event_error:
+                    if prewrite_projection_target is not None and prewrite_event_record is not None:
+                        persistence_outcome = _owner_acceptance_event_persistence_outcome(
+                            store=record_store,
+                            record=prewrite_event_record,
+                        )
+                        if persistence_outcome == "absent" and isinstance(
+                            event_error,
+                            (
+                                OwnerAcceptanceSelfReviewDeniedError,
+                                OwnerAcceptanceAuthorizationError,
+                                OwnerAcceptanceEventConflictError,
+                                OwnerAcceptanceTransitionError,
+                                OwnerAcceptanceBindingConflictError,
+                            ),
+                        ):
+                            try:
+                                projection_service.reconcile_locked(
+                                    store=record_store,
+                                    target=envelope.target,
+                                    lock_target=locked_projection_target,
+                                    source_event_id=idempotency_key,
+                                )
+                            except OwnerAcceptanceProjectionReconciliationError as recovery_error:
+                                raise OwnerAcceptanceEventNotPersistedProjectionError(
+                                    str(recovery_error)
+                                ) from event_error
+                            raise
+                        try:
+                            if persistence_outcome == "persisted":
+                                projection_service.restore_reconciliation_required_locked(
+                                    store=record_store,
+                                    target=envelope.target,
+                                    lock_target=locked_projection_target,
+                                    exact_target=prewrite_projection_target,
+                                    source_event_id=idempotency_key,
+                                )
+                            else:
+                                projection_service.restore_event_write_failure_locked(
+                                    store=record_store,
+                                    target=envelope.target,
+                                    lock_target=locked_projection_target,
+                                    exact_target=prewrite_projection_target,
+                                    source_event_id=idempotency_key,
+                                    persistence_outcome=persistence_outcome,
+                                )
+                        except Exception as restoration_error:
+                            combined_error = ExceptionGroup(
+                                "Owner acceptance event handling and GitHub recovery both failed.",
+                                [event_error, restoration_error],
+                            )
+                            if persistence_outcome == "persisted":
+                                raise OwnerAcceptanceProjectionReconciliationRequiredError(
+                                    str(restoration_error)
+                                ) from combined_error
+                            if persistence_outcome == "absent":
+                                raise OwnerAcceptanceEventNotPersistedProjectionError(
+                                    str(restoration_error)
+                                ) from combined_error
+                            raise OwnerAcceptanceEventPersistenceUnknownError(
+                                str(restoration_error)
+                            ) from combined_error
+                        if persistence_outcome == "persisted":
+                            raise OwnerAcceptanceProjectionReconciliationRequiredError(
+                                str(event_error)
+                            ) from event_error
+                        if persistence_outcome == "absent":
+                            raise OwnerAcceptanceEventNotPersistedError(
+                                str(event_error)
+                            ) from event_error
+                        raise OwnerAcceptanceEventPersistenceUnknownError(
+                            str(event_error)
+                        ) from event_error
+                    raise
                 try:
                     projection_outcome = projection_service.reconcile_locked(
                         store=record_store,
@@ -470,6 +590,50 @@ def register_owner_acceptance_routes(
                     "Owner acceptance event was persisted, but the final GitHub status "
                     "projection requires reconciliation. Retry with the same Idempotency-Key "
                     "or use the Owner acceptance projection endpoint."
+                ),
+            ) from error
+        except OwnerAcceptanceEventNotPersistedError as error:
+            logger.error(
+                "Owner acceptance event write failed without persistence.",
+                exc_info=True,
+            )
+            raise common.http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="owner_acceptance_event_write_failed",
+                message=(
+                    "Owner acceptance event was not persisted. GitHub shows the failed "
+                    "update; retry with the same Idempotency-Key."
+                ),
+            ) from error
+        except OwnerAcceptanceEventNotPersistedProjectionError as error:
+            logger.error(
+                "Owner acceptance event was not persisted and GitHub recovery failed.",
+                exc_info=True,
+            )
+            raise common.http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="owner_acceptance_event_write_failed_projection_unknown",
+                message=(
+                    "Owner acceptance event was not persisted, but Launchplane could not "
+                    "confirm the restored GitHub projection. Reconcile Owner acceptance "
+                    "before retrying with the same Idempotency-Key."
+                ),
+            ) from error
+        except OwnerAcceptanceEventPersistenceUnknownError as error:
+            logger.error(
+                "Owner acceptance event persistence outcome is unknown.",
+                exc_info=True,
+            )
+            raise common.http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="owner_acceptance_event_write_outcome_unknown",
+                message=(
+                    "Launchplane could not determine whether the Owner acceptance event was "
+                    "persisted. Reconcile the Owner acceptance state before retrying with the "
+                    "same Idempotency-Key."
                 ),
             ) from error
         except OwnerAcceptanceSelfReviewDeniedError as error:

--- a/control_plane/owner_acceptance_projection.py
+++ b/control_plane/owner_acceptance_projection.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 import hashlib
 import json
 import logging
+from typing import Literal
 from urllib.parse import quote, urlsplit
 
 from control_plane.advisory_check_projection import write_advisory_check_projection
@@ -14,6 +15,7 @@ from control_plane.contracts.advisory_check_projection import (
     AdvisoryCheckProjection,
     AdvisoryCheckConclusion,
     AdvisoryCheckProjectionResult,
+    AdvisoryCheckRunStatus,
     OWNER_ACCEPTANCE_CHECK_NAME,
 )
 from control_plane.contracts.change_impact import ChangeImpactTarget, ChangeImpactTargetReference
@@ -31,6 +33,7 @@ from control_plane.workflows.launchplane import github_api_request
 
 GitHubApiRequest = Callable[..., object]
 GitHubAppTokenProvider = Callable[[str, str], GitHubAppInstallationToken]
+OwnerAcceptanceEventPersistenceOutcome = Literal["absent", "unknown"]
 OWNER_ACCEPTANCE_WORKBENCH_PATH = "/ui/engineering/owner-acceptance"
 logger = logging.getLogger(__name__)
 
@@ -112,6 +115,42 @@ class OwnerAcceptanceProjectionService:
                 api_request=self.api_request,
             )
 
+    def project_reconciliation_required_locked(
+        self,
+        *,
+        lock_target: ChangeImpactTarget,
+        exact_target: ChangeImpactTarget,
+        source_event_id: str,
+    ) -> AdvisoryCheckProjectionResult:
+        _require_projection_lock_target(lock_target, exact_target)
+        with self._installation_token(exact_target) as installation_token:
+            return project_owner_acceptance_reconciliation_required(
+                target=exact_target,
+                source_event_id=source_event_id,
+                public_origin=self._public_origin(),
+                installation_token=installation_token,
+                api_request=self.api_request,
+            )
+
+    def project_event_write_failure_locked(
+        self,
+        *,
+        lock_target: ChangeImpactTarget,
+        exact_target: ChangeImpactTarget,
+        source_event_id: str,
+        persistence_outcome: OwnerAcceptanceEventPersistenceOutcome,
+    ) -> AdvisoryCheckProjectionResult:
+        _require_projection_lock_target(lock_target, exact_target)
+        with self._installation_token(exact_target) as installation_token:
+            return project_owner_acceptance_event_write_failure(
+                target=exact_target,
+                source_event_id=source_event_id,
+                persistence_outcome=persistence_outcome,
+                public_origin=self._public_origin(),
+                installation_token=installation_token,
+                api_request=self.api_request,
+            )
+
     def reconcile_locked(
         self,
         *,
@@ -158,7 +197,7 @@ class OwnerAcceptanceProjectionService:
             raise ValueError("Owner acceptance changed repeatedly during GitHub projection.")
         except Exception as error:
             try:
-                self.restore_conservative_locked(
+                self.restore_reconciliation_required_locked(
                     store=store,
                     target=target,
                     lock_target=lock_target,
@@ -166,12 +205,14 @@ class OwnerAcceptanceProjectionService:
                     source_event_id=source_event_id,
                 )
             except Exception as restoration_error:
-                raise OwnerAcceptanceProjectionReconciliationError(
-                    str(error)
-                ) from restoration_error
+                combined_error = ExceptionGroup(
+                    "Owner acceptance projection and reconciliation recovery both failed.",
+                    [error, restoration_error],
+                )
+                raise OwnerAcceptanceProjectionReconciliationError(str(error)) from combined_error
             raise OwnerAcceptanceProjectionReconciliationError(str(error)) from error
 
-    def restore_conservative_locked(
+    def restore_reconciliation_required_locked(
         self,
         *,
         store: object,
@@ -180,7 +221,7 @@ class OwnerAcceptanceProjectionService:
         exact_target: ChangeImpactTarget,
         source_event_id: str,
     ) -> None:
-        self.project_conservative_locked(
+        self.project_reconciliation_required_locked(
             lock_target=lock_target,
             exact_target=exact_target,
             source_event_id=source_event_id,
@@ -188,10 +229,36 @@ class OwnerAcceptanceProjectionService:
         _, current_target = self.resolve_current(store=store, target=target)
         _require_projection_lock_target(lock_target, current_target)
         if current_target != exact_target:
-            self.project_conservative_locked(
+            self.project_reconciliation_required_locked(
                 lock_target=lock_target,
                 exact_target=current_target,
                 source_event_id=source_event_id,
+            )
+
+    def restore_event_write_failure_locked(
+        self,
+        *,
+        store: object,
+        target: ChangeImpactTargetReference,
+        lock_target: ChangeImpactTarget,
+        exact_target: ChangeImpactTarget,
+        source_event_id: str,
+        persistence_outcome: OwnerAcceptanceEventPersistenceOutcome,
+    ) -> None:
+        self.project_event_write_failure_locked(
+            lock_target=lock_target,
+            exact_target=exact_target,
+            source_event_id=source_event_id,
+            persistence_outcome=persistence_outcome,
+        )
+        _, current_target = self.resolve_current(store=store, target=target)
+        _require_projection_lock_target(lock_target, current_target)
+        if current_target != exact_target:
+            self.project_event_write_failure_locked(
+                lock_target=lock_target,
+                exact_target=current_target,
+                source_event_id=source_event_id,
+                persistence_outcome=persistence_outcome,
             )
 
     def reconcile(
@@ -309,6 +376,7 @@ def project_owner_acceptance_decision(
         public_origin=public_origin,
         target=target,
     )
+    check_status, conclusion = _check_state(decision)
     return write_advisory_check_projection(
         projection=AdvisoryCheckProjection(
             name=OWNER_ACCEPTANCE_CHECK_NAME,
@@ -319,7 +387,8 @@ def project_owner_acceptance_decision(
             details_url=details_url,
             title=f"Owner acceptance: {decision.status.replace('_', ' ')}",
             summary=_summary(decision),
-            conclusion=_conclusion(decision),
+            check_status=check_status,
+            conclusion=conclusion,
         ),
         installation_token=installation_token,
         api_request=api_request,
@@ -354,9 +423,94 @@ def project_owner_acceptance_update_in_progress(
                 "Launchplane is updating the authoritative Owner-review decision. "
                 "GitHub success is intentionally withheld until the current decision "
                 "is projected. Reconcile from the Launchplane Owner-review workbench "
-                "if this check remains action required."
+                "if this check remains in progress."
+            ),
+            check_status="in_progress",
+            conclusion=None,
+        ),
+        installation_token=installation_token,
+        api_request=api_request,
+    )
+
+
+def project_owner_acceptance_reconciliation_required(
+    *,
+    target: ChangeImpactTarget,
+    source_event_id: str,
+    public_origin: str,
+    installation_token: GitHubAppInstallationToken,
+    api_request: GitHubApiRequest = github_api_request,
+) -> AdvisoryCheckProjectionResult:
+    details_url = owner_acceptance_workbench_url(
+        public_origin=public_origin,
+        target=target,
+    )
+    return write_advisory_check_projection(
+        projection=AdvisoryCheckProjection(
+            name=OWNER_ACCEPTANCE_CHECK_NAME,
+            repository=target.repository,
+            repository_id=target.repository_id,
+            head_sha=target.head_sha,
+            external_id=owner_acceptance_reconciliation_projection_sha256(
+                target=target,
+                source_event_id=source_event_id,
+            ),
+            details_url=details_url,
+            title="Owner acceptance: reconciliation required",
+            summary=(
+                "Launchplane could not confirm the final authoritative Owner-review "
+                "projection. Reconcile from the Launchplane Owner-review workbench "
+                "before relying on this pull request state."
             ),
             conclusion="action_required",
+        ),
+        installation_token=installation_token,
+        api_request=api_request,
+    )
+
+
+def project_owner_acceptance_event_write_failure(
+    *,
+    target: ChangeImpactTarget,
+    source_event_id: str,
+    persistence_outcome: OwnerAcceptanceEventPersistenceOutcome,
+    public_origin: str,
+    installation_token: GitHubAppInstallationToken,
+    api_request: GitHubApiRequest = github_api_request,
+) -> AdvisoryCheckProjectionResult:
+    details_url = owner_acceptance_workbench_url(
+        public_origin=public_origin,
+        target=target,
+    )
+    if persistence_outcome == "absent":
+        title = "Owner acceptance: update failed"
+        summary = (
+            "Launchplane could not persist the Owner-review event and confirmed that no "
+            "event was recorded. Retry the action with the same Idempotency-Key from the "
+            "Launchplane Owner-review workbench."
+        )
+    else:
+        title = "Owner acceptance: write outcome unknown"
+        summary = (
+            "Launchplane could not determine whether the Owner-review event was persisted. "
+            "Reconcile from the Launchplane Owner-review workbench before relying on this "
+            "pull request state or retrying the action."
+        )
+    return write_advisory_check_projection(
+        projection=AdvisoryCheckProjection(
+            name=OWNER_ACCEPTANCE_CHECK_NAME,
+            repository=target.repository,
+            repository_id=target.repository_id,
+            head_sha=target.head_sha,
+            external_id=owner_acceptance_event_write_failure_projection_sha256(
+                target=target,
+                source_event_id=source_event_id,
+                persistence_outcome=persistence_outcome,
+            ),
+            details_url=details_url,
+            title=title,
+            summary=summary,
+            conclusion="failure",
         ),
         installation_token=installation_token,
         api_request=api_request,
@@ -449,6 +603,46 @@ def owner_acceptance_update_projection_sha256(
     ).hexdigest()
 
 
+def owner_acceptance_reconciliation_projection_sha256(
+    *,
+    target: ChangeImpactTarget,
+    source_event_id: str,
+) -> str:
+    payload = {
+        "kind": "owner_acceptance_reconciliation_required",
+        "repository": target.repository,
+        "repository_id": target.repository_id,
+        "pull_request_number": target.pull_request_number,
+        "head_sha": target.head_sha,
+        "tree_sha": target.tree_sha,
+        "source_event_id": source_event_id,
+    }
+    return hashlib.sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+
+
+def owner_acceptance_event_write_failure_projection_sha256(
+    *,
+    target: ChangeImpactTarget,
+    source_event_id: str,
+    persistence_outcome: OwnerAcceptanceEventPersistenceOutcome,
+) -> str:
+    payload = {
+        "kind": "owner_acceptance_event_write_failure",
+        "persistence_outcome": persistence_outcome,
+        "repository": target.repository,
+        "repository_id": target.repository_id,
+        "pull_request_number": target.pull_request_number,
+        "head_sha": target.head_sha,
+        "tree_sha": target.tree_sha,
+        "source_event_id": source_event_id,
+    }
+    return hashlib.sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+
+
 def _summary(decision: OwnerAcceptanceDecision) -> str:
     lines = [
         "Launchplane is the authoritative Owner-review system. This GitHub check is a "
@@ -480,9 +674,13 @@ def _summary(decision: OwnerAcceptanceDecision) -> str:
     return "\n".join(lines)
 
 
-def _conclusion(decision: OwnerAcceptanceDecision) -> AdvisoryCheckConclusion:
+def _check_state(
+    decision: OwnerAcceptanceDecision,
+) -> tuple[AdvisoryCheckRunStatus, AdvisoryCheckConclusion | None]:
+    if decision.status == "pending":
+        return "in_progress", None
     if decision.status in {"accepted", "not_required"}:
-        return "success"
+        return "completed", "success"
     if decision.status == "unavailable":
-        return "failure"
-    return "action_required"
+        return "completed", "failure"
+    return "completed", "action_required"

--- a/docs/advisory-governance-checks.md
+++ b/docs/advisory-governance-checks.md
@@ -15,10 +15,12 @@ The two stable check names are:
 - `launchplane/owner-acceptance`
 
 Engineering review remains a neutral advisory observation. Owner acceptance uses
-`success`, `action_required`, or `failure` to make current, pending/stale, and
-unavailable states unmistakable. Its summary routes the reviewer to Launchplane,
-the only Owner action surface. Owner projection uses one stable aggregate check
-and lists each affected product decision instead of product-derived check names.
+an `in_progress` check while an ordinary Owner decision is pending, `success`
+after acceptance or when review is not required, `action_required` for stale or
+negative human decisions, and `failure` when authority or evidence is
+unavailable. Its summary routes the reviewer to Launchplane, the only Owner
+action surface. Owner projection uses one stable aggregate check and lists each
+affected product decision instead of product-derived check names.
 
 ## GitHub App Identity
 
@@ -64,13 +66,18 @@ Exact lookup and automatically evaluates the same target in the browser.
 
 Each check run stores the Launchplane decision digest as `external_id`.
 Identical state replays without a write. Changed binding or decision state on
-the same head updates the App-owned check run. A changed head receives its own
-new check run and cannot reuse evidence from the prior head.
+the same head updates the App-owned check run. GitHub does not reliably reopen a
+completed check run, so a transition from a completed state to ordinary pending
+Owner review creates a fresh same-name, same-head `in_progress` run; GitHub's
+latest-run filter then makes that run canonical. This also recovers a pending
+projection after GitHub marks an incomplete check stale at fourteen days. A
+changed head receives its own new check run and cannot reuse evidence from the
+prior head.
 
-Browser Owner event writes first replace the exact-head check with a
-conservative `action_required` state. Failure to establish that non-green state
-blocks the immutable append. Launchplane then projects the stored event's final
-decision from a fresh current-ledger evaluation while holding a store-backed
+Browser Owner event writes first replace the exact-head check with an
+`in_progress` **updating decision** state. Failure to establish that non-green
+state blocks the immutable append. Launchplane then projects the stored event's
+final decision from a fresh current-ledger evaluation while holding a store-backed
 immutable-repository-id projection lock for the pull request. Repository-id
 changes are rejected and retried before the critical section, and the resolved
 event binding must still match the held lock before projection or append.
@@ -86,21 +93,32 @@ released, and every minted installation token is revoked after its attempt.
 PostgreSQL waiters use dedicated unpooled advisory-lock connections rather than
 consuming the record-store pool. Successful acquisition is committed before
 provider work; cleanup explicitly unlocks, commits, and verifies the session
-lock. Final delivery, token cleanup, or confirmation failure demotes the exact
-attempted target before any potentially failing re-resolution, then returns a
-reconciliation-required error. Idempotent replay uses stable GitHub user ID
-rather than mutable Owner login and can safely retry the final projection. This
-sequence remains non-authoritative for admission, and browser sessions do not
-gain projection authority.
+lock. If the event is confirmed persisted but final delivery, token cleanup, or
+confirmation fails, Launchplane replaces the exact attempted target with a
+completed `action_required` **reconciliation required** check. A failed event
+write is read back by deterministic event id: confirmed absence projects a
+completed `failure` **update failed** check, while an unreadable or mismatched
+record projects a completed `failure` **write outcome unknown** check. The API
+reports these outcomes separately and never claims persistence without read-back
+evidence. If that recovery projection also fails, the API reports that the event
+was not persisted but the GitHub projection is unconfirmed rather than claiming
+that GitHub shows the failed update. Concurrent domain conflicts confirmed absent
+are reconciled to the current authoritative decision before their original 4xx
+response is returned. Idempotent replay uses stable GitHub user ID rather than
+mutable Owner login and can safely retry the final projection. Projection results
+use public schema version 2 because they include exact check-run status and
+nullable conclusion. This sequence remains non-authoritative for admission, and
+browser sessions do not gain projection authority.
 
 ## No Feedback Loop
 
-Launchplane-owned governance check names are excluded from merge-train check-run
-aggregation and from tenant-admission commit-status, check-run, and required-
-check inputs. The legacy `launchplane/engineering-review-shadow` status is also
-excluded from tenant admission during its separate cutover. Tests prove that merge
-and admission results are unchanged when GitHub projections are present, pending,
-or failed.
+Launchplane-owned governance check names are excluded from Every Code preview
+readiness, merge-train check-run aggregation, and tenant-admission commit-status,
+check-run, and required-check inputs. The legacy
+`launchplane/engineering-review-shadow` status is also excluded during its
+separate cutover. Tests prove that preview, merge, and admission results are
+unchanged when GitHub projections are present, `in_progress`, completed, or
+failed.
 
 Do not make the Owner projection a required GitHub status until the separate
 ruleset reconciliation work proves refresh behavior for every staleness source.

--- a/docs/owner-acceptance.md
+++ b/docs/owner-acceptance.md
@@ -400,9 +400,9 @@ product decision and exact binding, rechecks the current target before the
 provider write, and uses the decision digest as the check-run `external_id`.
 
 Before appending a browser Owner event, Launchplane replaces the exact-head
-check with an `action_required` **updating decision** projection. If that
-conservative projection or its token lifecycle fails, the event is not
-persisted. After append, Launchplane projects the resulting decision against the
+check with an `in_progress` **updating decision** projection. If that non-green
+projection or its token lifecycle fails, the event is not persisted. After
+append, Launchplane projects the resulting decision against the
 current exact target and ledger. Browser events, explicit reconciliation, and
 ready preview-feedback hydration all use the same shared projection service.
 Preview feedback executes the synchronous reconciliation in a worker thread so
@@ -420,20 +420,35 @@ including post-mint validation failures inside the identity provider.
 PostgreSQL lock waiters use dedicated unpooled advisory-lock connections so they
 cannot exhaust the record-store pool needed by the lock holder. Acquisition is
 committed before provider work begins; cleanup explicitly unlocks the session,
-commits, and verifies that the lock was held. If final projection, token cleanup,
-or current-state confirmation fails, Launchplane first restores the conservative
-non-green check on the exact attempted target before any current-target
-re-resolution can fail, then returns
-`503 owner_acceptance_projection_reconciliation_required`; retrying with the
-same idempotency key replays the immutable event and retries projection. The
-explicit projection endpoint provides the same reconciliation path. Browsers
-never receive projection credentials or projection authority.
+commits, and verifies that the lock was held. If the event is confirmed persisted
+but final projection, token cleanup, or current-state confirmation fails,
+Launchplane first writes a completed `action_required` **reconciliation
+required** check on the exact attempted target, then returns
+`503 owner_acceptance_projection_reconciliation_required`. If the event write
+fails, Launchplane reads the deterministic event id before describing the
+outcome: confirmed absence returns `owner_acceptance_event_write_failed` and a
+completed `failure` **update failed** check; an unreadable or mismatched record
+returns `owner_acceptance_event_write_outcome_unknown` and a completed `failure`
+**write outcome unknown** check. If the failed write's GitHub recovery cannot be
+confirmed, Launchplane returns
+`owner_acceptance_event_write_failed_projection_unknown` without claiming that
+GitHub shows the failure. Concurrent domain conflicts confirmed absent restore
+the current authoritative decision before retaining their original 4xx response.
+Retrying with the same idempotency key safely replays any persisted immutable
+event. The explicit projection endpoint provides the same reconciliation path.
+Browsers never receive projection credentials or projection authority.
 
-The completed check conclusion is `success` for accepted or not-required state,
-`action_required` for pending, stale, revoked, or changes-requested state, and
-`failure` when authoritative evidence is unavailable. The output lists the
-aggregate state plus each affected product and binding. The check is excluded
-from Launchplane technical-check inputs and cannot replace the Launchplane decision.
+The GitHub check remains `in_progress` with no conclusion for ordinary pending
+Owner review. It is completed with `success` for accepted or not-required state,
+`action_required` for stale, revoked, changes-requested, or reconciliation-required
+state, and `failure` when authoritative evidence is unavailable. Because GitHub
+does not reliably reopen completed check runs, a completed-to-pending transition
+creates a fresh same-name, same-head check run. GitHub may mark incomplete checks
+stale after fourteen days; the next Launchplane projection creates a fresh
+pending run. The output lists the aggregate state plus each affected product and
+binding. The check is excluded from Launchplane technical-check inputs and cannot
+replace the Launchplane decision. The projection response is schema version 2 and
+reports both the exact GitHub check-run status and its nullable conclusion.
 
 ## Combined Governance Read Model
 

--- a/frontend/generated/openapi-canonical.json
+++ b/frontend/generated/openapi-canonical.json
@@ -74,15 +74,30 @@
             "title": "Check Run Id",
             "type": "integer"
           },
-          "conclusion": {
+          "check_status": {
             "enum": [
-              "neutral",
-              "success",
-              "failure",
-              "action_required"
+              "in_progress",
+              "completed"
             ],
-            "title": "Conclusion",
+            "title": "Check Status",
             "type": "string"
+          },
+          "conclusion": {
+            "anyOf": [
+              {
+                "enum": [
+                  "neutral",
+                  "success",
+                  "failure",
+                  "action_required"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Conclusion"
           },
           "external_id": {
             "pattern": "^[0-9a-f]{64}$",
@@ -104,8 +119,8 @@
             "type": "string"
           },
           "schema_version": {
-            "default": 1,
-            "minimum": 1.0,
+            "const": 2,
+            "default": 2,
             "title": "Schema Version",
             "type": "integer"
           },
@@ -127,6 +142,7 @@
           "app_id",
           "installation_id",
           "check_run_id",
+          "check_status",
           "conclusion"
         ],
         "title": "AdvisoryCheckProjectionResult",

--- a/tests/test_advisory_check_projection.py
+++ b/tests/test_advisory_check_projection.py
@@ -8,7 +8,9 @@ from control_plane.advisory_check_projection import (
 )
 from control_plane.contracts.change_impact import ChangeImpactTarget
 from control_plane.contracts.advisory_check_projection import (
+    AdvisoryCheckConclusion,
     AdvisoryCheckProjection,
+    AdvisoryCheckRunStatus,
     OWNER_ACCEPTANCE_CHECK_NAME,
 )
 from control_plane.github_app_identity import GitHubAppInstallationToken
@@ -19,7 +21,11 @@ HEAD_SHA = "a" * 40
 EXTERNAL_ID = "b" * 64
 
 
-def _projection() -> AdvisoryCheckProjection:
+def _projection(
+    *,
+    check_status: AdvisoryCheckRunStatus = "completed",
+    conclusion: AdvisoryCheckConclusion | None = "neutral",
+) -> AdvisoryCheckProjection:
     return AdvisoryCheckProjection(
         name=OWNER_ACCEPTANCE_CHECK_NAME,
         repository="example/repo",
@@ -29,6 +35,8 @@ def _projection() -> AdvisoryCheckProjection:
         details_url="https://github.com/example/repo/pull/7",
         title="Owner acceptance: pending",
         summary="Launchplane advisory projection.",
+        check_status=check_status,
+        conclusion=conclusion,
     )
 
 
@@ -43,14 +51,20 @@ def _token() -> GitHubAppInstallationToken:
     )
 
 
-def _check_run(*, external_id: str = EXTERNAL_ID, app_id: int = 42) -> dict[str, object]:
-    projection = _projection()
+def _check_run(
+    *,
+    external_id: str = EXTERNAL_ID,
+    app_id: int = 42,
+    check_status: AdvisoryCheckRunStatus = "completed",
+    conclusion: AdvisoryCheckConclusion | None = "neutral",
+) -> dict[str, object]:
+    projection = _projection(check_status=check_status, conclusion=conclusion)
     return {
         "id": 91,
         "name": projection.name,
         "head_sha": projection.head_sha,
-        "status": "completed",
-        "conclusion": "neutral",
+        "status": check_status,
+        "conclusion": conclusion,
         "external_id": external_id,
         "details_url": projection.details_url,
         "output": {"title": projection.title, "summary": projection.summary},
@@ -59,6 +73,14 @@ def _check_run(*, external_id: str = EXTERNAL_ID, app_id: int = 42) -> dict[str,
 
 
 class AdvisoryCheckProjectionTests(unittest.TestCase):
+    def test_projection_requires_completed_checks_to_have_a_conclusion(self) -> None:
+        with self.assertRaisesRegex(ValueError, "require a conclusion"):
+            _projection(conclusion=None)
+
+    def test_projection_forbids_in_progress_checks_from_having_a_conclusion(self) -> None:
+        with self.assertRaisesRegex(ValueError, "cannot have a conclusion"):
+            _projection(check_status="in_progress")
+
     def test_owner_acceptance_details_url_is_server_owned_and_encoded(self) -> None:
         target = ChangeImpactTarget(
             repository_id="123",
@@ -107,6 +129,7 @@ class AdvisoryCheckProjectionTests(unittest.TestCase):
         )
 
         self.assertEqual(result.status, "replayed")
+        self.assertEqual(result.schema_version, 2)
         self.assertEqual(len(calls), 1)
         self.assertIn("check_name=launchplane%2Fowner-acceptance", str(calls[0]["path"]))
 
@@ -131,11 +154,140 @@ class AdvisoryCheckProjectionTests(unittest.TestCase):
         self.assertEqual(calls[-1]["method"], "PATCH")
         self.assertEqual(calls[-1]["path"], "/repos/example/repo/check-runs/91")
 
+    def test_replays_identical_in_progress_projection_without_write(self) -> None:
+        calls: list[dict[str, object]] = []
+        projection = _projection(check_status="in_progress", conclusion=None)
+
+        def api_request(**kwargs):  # type: ignore[no-untyped-def]
+            calls.append(kwargs)
+            return {"check_runs": [_check_run(check_status="in_progress", conclusion=None)]}
+
+        result = write_advisory_check_projection(
+            projection=projection,
+            installation_token=_token(),
+            api_request=api_request,
+        )
+
+        self.assertEqual(result.status, "replayed")
+        self.assertEqual(result.check_status, "in_progress")
+        self.assertIsNone(result.conclusion)
+        self.assertEqual(len(calls), 1)
+
+    def test_creates_fresh_in_progress_run_after_completed_run(self) -> None:
+        calls: list[dict[str, object]] = []
+        projection = _projection(check_status="in_progress", conclusion=None)
+
+        def api_request(**kwargs):  # type: ignore[no-untyped-def]
+            calls.append(kwargs)
+            if kwargs.get("method") == "POST":
+                body = kwargs["body"]
+                self.assertNotIn("conclusion", body)
+                return {
+                    "id": 92,
+                    **body,
+                    "conclusion": None,
+                    "app": {"id": 42},
+                }
+            return {"check_runs": [_check_run()]}
+
+        result = write_advisory_check_projection(
+            projection=projection,
+            installation_token=_token(),
+            api_request=api_request,
+        )
+
+        self.assertEqual(result.status, "projected")
+        self.assertEqual(result.check_status, "in_progress")
+        self.assertEqual(calls[-1]["method"], "POST")
+
+    def test_replays_exact_pending_run_even_when_completed_run_is_listed_first(self) -> None:
+        calls: list[dict[str, object]] = []
+        projection = _projection(check_status="in_progress", conclusion=None)
+
+        def api_request(**kwargs):  # type: ignore[no-untyped-def]
+            calls.append(kwargs)
+            return {
+                "check_runs": [
+                    _check_run(),
+                    _check_run(check_status="in_progress", conclusion=None),
+                ]
+            }
+
+        result = write_advisory_check_projection(
+            projection=projection,
+            installation_token=_token(),
+            api_request=api_request,
+        )
+
+        self.assertEqual(result.status, "replayed")
+        self.assertEqual(result.check_status, "in_progress")
+        self.assertEqual(len(calls), 1)
+
+    def test_completes_existing_in_progress_run(self) -> None:
+        calls: list[dict[str, object]] = []
+
+        def api_request(**kwargs):  # type: ignore[no-untyped-def]
+            calls.append(kwargs)
+            if kwargs.get("method") == "PATCH":
+                body = kwargs["body"]
+                return {
+                    **_check_run(check_status="in_progress", conclusion=None),
+                    **body,
+                }
+            return {"check_runs": [_check_run(check_status="in_progress", conclusion=None)]}
+
+        result = write_advisory_check_projection(
+            projection=_projection(conclusion="success"),
+            installation_token=_token(),
+            api_request=api_request,
+        )
+
+        self.assertEqual(result.status, "updated")
+        self.assertEqual(result.check_status, "completed")
+        self.assertEqual(result.conclusion, "success")
+        self.assertEqual(calls[-1]["method"], "PATCH")
+
     def test_rejects_check_run_written_by_another_app(self) -> None:
         def api_request(**kwargs):  # type: ignore[no-untyped-def]
             if kwargs.get("method") == "POST":
                 return _check_run(app_id=99)
             return {"check_runs": []}
+
+        with self.assertRaisesRegex(AdvisoryCheckProjectionError, "exact projection identity"):
+            write_advisory_check_projection(
+                projection=_projection(),
+                installation_token=_token(),
+                api_request=api_request,
+            )
+
+    def test_rejects_post_response_with_mismatched_output_identity(self) -> None:
+        def api_request(**kwargs):  # type: ignore[no-untyped-def]
+            if kwargs.get("method") == "POST":
+                check_run = _check_run()
+                check_run["output"] = {
+                    "title": "Unexpected title",
+                    "summary": "Launchplane advisory projection.",
+                }
+                return check_run
+            return {"check_runs": []}
+
+        with self.assertRaisesRegex(AdvisoryCheckProjectionError, "exact projection identity"):
+            write_advisory_check_projection(
+                projection=_projection(),
+                installation_token=_token(),
+                api_request=api_request,
+            )
+
+    def test_rejects_patch_response_with_mismatched_output_identity(self) -> None:
+        def api_request(**kwargs):  # type: ignore[no-untyped-def]
+            if kwargs.get("method") == "PATCH":
+                check_run = _check_run()
+                check_run["output"] = {
+                    "title": "Owner acceptance: pending",
+                    "summary": "Unexpected summary",
+                }
+                return check_run
+            return {"check_runs": [_check_run(external_id="c" * 64)]}
 
         with self.assertRaisesRegex(AdvisoryCheckProjectionError, "exact projection identity"):
             write_advisory_check_projection(

--- a/tests/test_every_code_worker.py
+++ b/tests/test_every_code_worker.py
@@ -1329,6 +1329,11 @@ class EveryCodeWorkerTests(unittest.TestCase):
                     "statusCheckRollup": [
                         {"name": "static_checks", "status": "COMPLETED", "conclusion": "SUCCESS"},
                         {"name": "preview", "status": "COMPLETED", "conclusion": "SKIPPED"},
+                        {
+                            "name": "launchplane/owner-acceptance",
+                            "status": "IN_PROGRESS",
+                            "conclusion": "",
+                        },
                     ],
                 }
             )
@@ -1346,6 +1351,7 @@ class EveryCodeWorkerTests(unittest.TestCase):
         self.assertEqual(len(gate_records), 1)
         self.assertEqual(gate_records[0].status, "labeled")
         self.assertEqual(gate_records[0].head_sha, "abcdef1234567890")
+        self.assertNotIn("owner-acceptance", gate_records[0].check_summary)
         self.assertIn(
             (
                 "gh",

--- a/tests/test_merge_train_github.py
+++ b/tests/test_merge_train_github.py
@@ -795,7 +795,7 @@ class GitHubMergeTrainClientTests(unittest.TestCase):
                         },
                         {
                             "name": "launchplane/owner-acceptance",
-                            **_check_run("completed", "failure"),
+                            **_check_run("in_progress", None),
                         },
                     ]
                 },

--- a/tests/test_owner_acceptance_http.py
+++ b/tests/test_owner_acceptance_http.py
@@ -15,6 +15,7 @@ from control_plane.contracts.owner_acceptance import (
     OWNER_ACCEPTANCE_EVENT_WRITE_ACTION,
     OWNER_ACCEPTANCE_READ_ACTION,
     OwnerAcceptanceDecision,
+    OwnerAcceptanceTransitionError,
 )
 from control_plane.contracts.change_impact import ChangeImpactTargetReference
 from control_plane.contracts.product_owner import ProductOwnerGrant, ProductOwnerIdentity
@@ -93,6 +94,7 @@ class _GitHubCheckApi:
             self.check_run = {
                 "id": 91,
                 **body,
+                "conclusion": body.get("conclusion"),
                 "app": {"id": 42},
             }
         else:
@@ -394,7 +396,7 @@ class OwnerAcceptanceHttpTests(unittest.IsolatedAsyncioTestCase):
         self.assertIsNone(outcome.result)
         self.assertEqual(github_api.calls, [])
 
-    async def test_restoration_demotes_exact_target_before_reresolution(self) -> None:
+    async def test_restoration_marks_exact_target_before_reresolution(self) -> None:
         exact_target = _repository_evidence().target
         service = OwnerAcceptanceProjectionService(
             repository_evidence_provider=_EvidenceProvider(_repository_evidence()),
@@ -403,8 +405,8 @@ class OwnerAcceptanceHttpTests(unittest.IsolatedAsyncioTestCase):
         )
         operations: list[str] = []
 
-        def project_conservative(*_args: object, **_kwargs: object) -> MagicMock:
-            operations.append("demote")
+        def project_reconciliation_required(*_args: object, **_kwargs: object) -> MagicMock:
+            operations.append("mark-required")
             return MagicMock()
 
         def fail_resolution(*_args: object, **_kwargs: object) -> object:
@@ -414,8 +416,8 @@ class OwnerAcceptanceHttpTests(unittest.IsolatedAsyncioTestCase):
         with (
             patch.object(
                 OwnerAcceptanceProjectionService,
-                "project_conservative_locked",
-                side_effect=project_conservative,
+                "project_reconciliation_required_locked",
+                side_effect=project_reconciliation_required,
             ),
             patch.object(
                 OwnerAcceptanceProjectionService,
@@ -424,7 +426,7 @@ class OwnerAcceptanceHttpTests(unittest.IsolatedAsyncioTestCase):
             ),
             self.assertRaisesRegex(RuntimeError, "repository evidence is unavailable"),
         ):
-            service.restore_conservative_locked(
+            service.restore_reconciliation_required_locked(
                 store=MagicMock(),
                 target=ChangeImpactTargetReference(
                     repository=REPOSITORY,
@@ -435,9 +437,9 @@ class OwnerAcceptanceHttpTests(unittest.IsolatedAsyncioTestCase):
                 source_event_id="restore-exact-first",
             )
 
-        self.assertEqual(operations, ["demote", "resolve"])
+        self.assertEqual(operations, ["mark-required", "resolve"])
 
-    async def test_projects_pending_owner_decision_as_action_required_check(self) -> None:
+    async def test_projects_pending_owner_decision_as_in_progress_check(self) -> None:
         with TemporaryDirectory() as directory:
             store = _store(Path(directory))
             calls: list[dict[str, Any]] = []
@@ -453,7 +455,7 @@ class OwnerAcceptanceHttpTests(unittest.IsolatedAsyncioTestCase):
                         "name": body["name"],
                         "head_sha": body["head_sha"],
                         "status": body["status"],
-                        "conclusion": body["conclusion"],
+                        "conclusion": body.get("conclusion"),
                         "external_id": body["external_id"],
                         "details_url": body["details_url"],
                         "output": body["output"],
@@ -490,12 +492,14 @@ class OwnerAcceptanceHttpTests(unittest.IsolatedAsyncioTestCase):
         payload = response.json()
         self.assertEqual(payload["decision"]["status"], "pending")
         self.assertEqual(payload["result"]["name"], "launchplane/owner-acceptance")
-        self.assertEqual(payload["result"]["conclusion"], "action_required")
+        self.assertEqual(payload["result"]["check_status"], "in_progress")
+        self.assertIsNone(payload["result"]["conclusion"])
         self.assertEqual(
             calls[-2]["body"]["details_url"],
             "https://ops.example.test/ui/engineering/owner-acceptance?repository=example%2Fweb&pull_request=2022",
         )
-        self.assertEqual(calls[-2]["body"]["conclusion"], "action_required")
+        self.assertEqual(calls[-2]["body"]["status"], "in_progress")
+        self.assertNotIn("conclusion", calls[-2]["body"])
         self.assertEqual(calls[-1]["method"], "DELETE")
 
     async def test_successful_event_projects_conservative_then_final_decision(self) -> None:
@@ -529,8 +533,12 @@ class OwnerAcceptanceHttpTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(response.status_code, 202, response.text)
         self.assertEqual(event_count, 1)
         self.assertEqual(
-            [body["conclusion"] for body in github_api.successful_write_bodies],
-            ["action_required", "success"],
+            [body.get("conclusion") for body in github_api.successful_write_bodies],
+            [None, "success"],
+        )
+        self.assertEqual(
+            [body["status"] for body in github_api.successful_write_bodies],
+            ["in_progress", "completed"],
         )
         self.assertEqual(
             [body["output"]["title"] for body in github_api.successful_write_bodies],
@@ -576,6 +584,243 @@ class OwnerAcceptanceHttpTests(unittest.IsolatedAsyncioTestCase):
         )
         self.assertEqual(event_count, 0)
 
+    async def test_event_write_failure_confirms_absence_and_projects_failure(self) -> None:
+        with TemporaryDirectory() as directory:
+            store = _store(Path(directory))
+            github_api = _GitHubCheckApi()
+            app = _app(store=store, github_api=github_api)
+
+            async with lifespan_client(app) as client:
+                evaluated = await client.get(
+                    OWNER_ACCEPTANCE_EVALUATION_ROUTE,
+                    params={"repository": REPOSITORY, "pull_request_number": 2022},
+                )
+                with patch.object(
+                    store,
+                    "write_owner_acceptance_event_record",
+                    side_effect=RuntimeError("storage write failed"),
+                ):
+                    response = await client.post(
+                        OWNER_ACCEPTANCE_EVENTS_ROUTE,
+                        json={
+                            "target": {
+                                "repository": REPOSITORY,
+                                "pull_request_number": 2022,
+                            },
+                            "action": "accepted",
+                            "expected_binding_sha256": evaluated.json()["decision"]["binding"][
+                                "binding_sha256"
+                            ],
+                        },
+                        headers={"Idempotency-Key": "accept-with-storage-failure"},
+                    )
+
+        self.assertEqual(response.status_code, 503, response.text)
+        self.assertEqual(
+            response.json()["detail"]["code"],
+            "owner_acceptance_event_write_failed",
+        )
+        self.assertIn("was not persisted", response.json()["detail"]["message"])
+        assert github_api.check_run is not None
+        self.assertEqual(github_api.check_run["status"], "completed")
+        self.assertEqual(github_api.check_run["conclusion"], "failure")
+        self.assertEqual(
+            github_api.check_run["output"]["title"],
+            "Owner acceptance: update failed",
+        )
+        self.assertEqual(
+            [body.get("conclusion") for body in github_api.successful_write_bodies],
+            [None, "failure"],
+        )
+
+    async def test_event_write_failure_reports_unrestored_github_projection(self) -> None:
+        with TemporaryDirectory() as directory:
+            store = _store(Path(directory))
+            github_api = _GitHubCheckApi(fail_read_numbers=(2,))
+            app = _app(store=store, github_api=github_api)
+
+            async with lifespan_client(app) as client:
+                evaluated = await client.get(
+                    OWNER_ACCEPTANCE_EVALUATION_ROUTE,
+                    params={"repository": REPOSITORY, "pull_request_number": 2022},
+                )
+                with patch.object(
+                    store,
+                    "write_owner_acceptance_event_record",
+                    side_effect=RuntimeError("storage write failed"),
+                ):
+                    response = await client.post(
+                        OWNER_ACCEPTANCE_EVENTS_ROUTE,
+                        json={
+                            "target": {
+                                "repository": REPOSITORY,
+                                "pull_request_number": 2022,
+                            },
+                            "action": "accepted",
+                            "expected_binding_sha256": evaluated.json()["decision"]["binding"][
+                                "binding_sha256"
+                            ],
+                        },
+                        headers={"Idempotency-Key": "accept-with-unrestored-failure"},
+                    )
+
+        self.assertEqual(response.status_code, 503, response.text)
+        self.assertEqual(
+            response.json()["detail"]["code"],
+            "owner_acceptance_event_write_failed_projection_unknown",
+        )
+        self.assertIn("could not confirm", response.json()["detail"]["message"])
+        self.assertNotIn("GitHub shows", response.json()["detail"]["message"])
+        assert github_api.check_run is not None
+        self.assertEqual(github_api.check_run["status"], "in_progress")
+        self.assertIsNone(github_api.check_run["conclusion"])
+
+    async def test_concurrent_transition_error_preserves_domain_response(self) -> None:
+        with TemporaryDirectory() as directory:
+            store = _store(Path(directory))
+            github_api = _GitHubCheckApi()
+            app = _app(store=store, github_api=github_api)
+
+            async with lifespan_client(app) as client:
+                evaluated = await client.get(
+                    OWNER_ACCEPTANCE_EVALUATION_ROUTE,
+                    params={"repository": REPOSITORY, "pull_request_number": 2022},
+                )
+                with patch.object(
+                    store,
+                    "write_owner_acceptance_event_record",
+                    side_effect=OwnerAcceptanceTransitionError("concurrent transition"),
+                ):
+                    response = await client.post(
+                        OWNER_ACCEPTANCE_EVENTS_ROUTE,
+                        json={
+                            "target": {
+                                "repository": REPOSITORY,
+                                "pull_request_number": 2022,
+                            },
+                            "action": "accepted",
+                            "expected_binding_sha256": evaluated.json()["decision"]["binding"][
+                                "binding_sha256"
+                            ],
+                        },
+                        headers={"Idempotency-Key": "accept-with-transition-race"},
+                    )
+
+        self.assertEqual(response.status_code, 409, response.text)
+        self.assertEqual(
+            response.json()["detail"]["code"],
+            "owner_acceptance_transition_invalid",
+        )
+        assert github_api.check_run is not None
+        self.assertEqual(github_api.check_run["status"], "in_progress")
+        self.assertIsNone(github_api.check_run["conclusion"])
+        self.assertEqual(
+            github_api.check_run["output"]["title"],
+            "Owner acceptance: pending",
+        )
+
+    async def test_event_write_failure_detects_confirmed_persistence(self) -> None:
+        with TemporaryDirectory() as directory:
+            store = _store(Path(directory))
+            github_api = _GitHubCheckApi()
+            app = _app(store=store, github_api=github_api)
+            persist_event = store.write_owner_acceptance_event_record
+
+            def persist_then_fail(record):  # type: ignore[no-untyped-def]
+                persist_event(record)
+                raise RuntimeError("storage acknowledgement failed")
+
+            async with lifespan_client(app) as client:
+                evaluated = await client.get(
+                    OWNER_ACCEPTANCE_EVALUATION_ROUTE,
+                    params={"repository": REPOSITORY, "pull_request_number": 2022},
+                )
+                with patch.object(
+                    store,
+                    "write_owner_acceptance_event_record",
+                    side_effect=persist_then_fail,
+                ):
+                    response = await client.post(
+                        OWNER_ACCEPTANCE_EVENTS_ROUTE,
+                        json={
+                            "target": {
+                                "repository": REPOSITORY,
+                                "pull_request_number": 2022,
+                            },
+                            "action": "accepted",
+                            "expected_binding_sha256": evaluated.json()["decision"]["binding"][
+                                "binding_sha256"
+                            ],
+                        },
+                        headers={"Idempotency-Key": "accept-with-unknown-ack"},
+                    )
+                event_count = len(store.list_owner_acceptance_event_records())
+
+        self.assertEqual(response.status_code, 503, response.text)
+        self.assertEqual(
+            response.json()["detail"]["code"],
+            "owner_acceptance_projection_reconciliation_required",
+        )
+        self.assertIn("was persisted", response.json()["detail"]["message"])
+        self.assertEqual(event_count, 1)
+        assert github_api.check_run is not None
+        self.assertEqual(github_api.check_run["conclusion"], "action_required")
+        self.assertEqual(
+            github_api.check_run["output"]["title"],
+            "Owner acceptance: reconciliation required",
+        )
+
+    async def test_event_write_failure_projects_unknown_persistence_outcome(self) -> None:
+        with TemporaryDirectory() as directory:
+            store = _store(Path(directory))
+            github_api = _GitHubCheckApi()
+            app = _app(store=store, github_api=github_api)
+
+            async with lifespan_client(app) as client:
+                evaluated = await client.get(
+                    OWNER_ACCEPTANCE_EVALUATION_ROUTE,
+                    params={"repository": REPOSITORY, "pull_request_number": 2022},
+                )
+                with (
+                    patch.object(
+                        store,
+                        "write_owner_acceptance_event_record",
+                        side_effect=RuntimeError("storage write failed"),
+                    ),
+                    patch.object(
+                        store,
+                        "read_owner_acceptance_event_record",
+                        side_effect=RuntimeError("storage read failed"),
+                    ),
+                ):
+                    response = await client.post(
+                        OWNER_ACCEPTANCE_EVENTS_ROUTE,
+                        json={
+                            "target": {
+                                "repository": REPOSITORY,
+                                "pull_request_number": 2022,
+                            },
+                            "action": "accepted",
+                            "expected_binding_sha256": evaluated.json()["decision"]["binding"][
+                                "binding_sha256"
+                            ],
+                        },
+                        headers={"Idempotency-Key": "accept-with-unknown-write"},
+                    )
+
+        self.assertEqual(response.status_code, 503, response.text)
+        self.assertEqual(
+            response.json()["detail"]["code"],
+            "owner_acceptance_event_write_outcome_unknown",
+        )
+        self.assertIn("could not determine", response.json()["detail"]["message"])
+        assert github_api.check_run is not None
+        self.assertEqual(github_api.check_run["conclusion"], "failure")
+        self.assertEqual(
+            github_api.check_run["output"]["title"],
+            "Owner acceptance: write outcome unknown",
+        )
+
     async def test_final_projection_failure_requires_idempotent_reconciliation(self) -> None:
         with TemporaryDirectory() as directory:
             store = _store(Path(directory))
@@ -601,7 +846,7 @@ class OwnerAcceptanceHttpTests(unittest.IsolatedAsyncioTestCase):
                 )
                 event_count_after_failure = len(store.list_owner_acceptance_event_records())
                 assert github_api.check_run is not None
-                conclusion_after_failure = github_api.check_run["conclusion"]
+                conclusion_after_failure = github_api.check_run.get("conclusion")
                 reconciled = await client.post(
                     OWNER_ACCEPTANCE_EVENTS_ROUTE,
                     json=request,
@@ -622,8 +867,12 @@ class OwnerAcceptanceHttpTests(unittest.IsolatedAsyncioTestCase):
         assert github_api.check_run is not None
         self.assertEqual(github_api.check_run["conclusion"], "success")
         self.assertEqual(
-            [body["conclusion"] for body in github_api.successful_write_bodies],
-            ["action_required", "success"],
+            [body.get("conclusion") for body in github_api.successful_write_bodies],
+            [None, "action_required", None, "success"],
+        )
+        self.assertEqual(
+            [body["status"] for body in github_api.successful_write_bodies],
+            ["in_progress", "completed", "in_progress", "completed"],
         )
 
     async def test_final_token_revoke_failure_restores_conservative_projection(self) -> None:
@@ -663,11 +912,15 @@ class OwnerAcceptanceHttpTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(github_api.check_run["conclusion"], "action_required")
         self.assertEqual(
             github_api.check_run["output"]["title"],
-            "Owner acceptance: updating decision",
+            "Owner acceptance: reconciliation required",
         )
         self.assertEqual(
-            [body["conclusion"] for body in github_api.successful_write_bodies],
-            ["action_required", "success", "action_required"],
+            [body.get("conclusion") for body in github_api.successful_write_bodies],
+            [None, "success", "action_required"],
+        )
+        self.assertEqual(
+            [body["status"] for body in github_api.successful_write_bodies],
+            ["in_progress", "completed", "completed"],
         )
 
     async def test_concurrent_negative_event_cannot_restore_stale_success(self) -> None:

--- a/tests/test_tenant_admission_controller.py
+++ b/tests/test_tenant_admission_controller.py
@@ -1083,7 +1083,7 @@ class _TenantControllerTransport:
                             "name": "launchplane/owner-acceptance",
                             "head_sha": _candidate().head_sha,
                             "app": {"id": 42},
-                            "status": "queued",
+                            "status": "in_progress",
                             "conclusion": None,
                         },
                     ]


### PR DESCRIPTION
## Summary
- project ordinary pending Owner review as an in-progress GitHub check instead of a completed action-required result
- preserve green success for accepted/not-required decisions and red terminal failure states
- fail closed across event-write, reconciliation, and completed-to-pending transitions without feeding Launchplane-owned checks back into technical readiness
- version the projection result contract and validate exact GitHub response identity

## Validation
- `uv run --extra dev launchplane ci unittest-shard local` (2,980 targets)
- `uv run --extra dev ruff check .`
- `uv run --extra dev mypy control_plane tests`
- `pnpm --dir frontend validate`
- `pnpm --dir frontend check:openapi-drift`
- targeted Owner/advisory/Every Code/merge/admission tests (240 tests)
- JetBrains changed-file inspection triaged: newly introduced findings resolved; 45 pre-existing warnings remain in touched large files

## Behavior
- pending / acceptance missing: `in_progress`, no conclusion
- accepted / not required: completed `success`
- stale / revoked / changes requested / reconciliation required: completed `action_required`
- unavailable evidence or failed/unknown event write: completed `failure`
