### PR TITLE
Add read-only authorization diagnostics

### DIFF
--- a/control_plane/contracts/authz_access_read.py
+++ b/control_plane/contracts/authz_access_read.py
@@ -1,0 +1,273 @@
+from __future__ import annotations
+
+from typing import Annotated, Literal, TypeAlias
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from control_plane.service_auth import (
+    AuthzDecisionReason,
+    GitHubActionsIdentity,
+    GitHubHumanIdentity,
+    LaunchplaneIdentity,
+    LocalAdminIdentity,
+    LocalOperatorIdentity,
+    TerminalAgentIdentity,
+)
+
+
+EFFECTIVE_ACCESS_READ_ACTION = "authz_policy_effective_access.read"
+AUTHZ_DENIAL_EXPLANATION_READ_ACTION = "authz_denial_explanation.read"
+
+
+class GitHubActionsAccessPrincipal(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    principal_type: Literal["github_actions"] = "github_actions"
+    repository: str
+    repository_owner: str
+    workflow_ref: str
+    job_workflow_ref: str = ""
+    ref: str
+    ref_type: str
+    event_name: str
+    environment: str = ""
+    subject: str
+    sha: str = ""
+    repository_id: str = ""
+    repository_owner_id: str = ""
+
+    @field_validator(
+        "repository",
+        "repository_owner",
+        "workflow_ref",
+        "job_workflow_ref",
+        "ref",
+        "ref_type",
+        "event_name",
+        "environment",
+        "subject",
+        "sha",
+        "repository_id",
+        "repository_owner_id",
+    )
+    @classmethod
+    def _normalize_text(cls, value: str) -> str:
+        normalized = value.strip()
+        if len(normalized) > 2048:
+            raise ValueError("GitHub Actions access principal fields are too long.")
+        return normalized
+
+    @model_validator(mode="after")
+    def _validate_required_identity(self) -> "GitHubActionsAccessPrincipal":
+        required_values = (
+            self.repository,
+            self.repository_owner,
+            self.workflow_ref,
+            self.ref,
+            self.ref_type,
+            self.event_name,
+            self.subject,
+        )
+        if not all(required_values):
+            raise ValueError("GitHub Actions access principal requires exact identity fields.")
+        return self
+
+    def to_identity(self) -> GitHubActionsIdentity:
+        return GitHubActionsIdentity(
+            repository=self.repository,
+            repository_owner=self.repository_owner,
+            workflow_ref=self.workflow_ref,
+            job_workflow_ref=self.job_workflow_ref,
+            ref=self.ref,
+            ref_type=self.ref_type,
+            event_name=self.event_name,
+            environment=self.environment,
+            subject=self.subject,
+            sha=self.sha,
+            raw_claims={},
+            repository_id=self.repository_id,
+            repository_owner_id=self.repository_owner_id,
+        )
+
+
+class GitHubHumanAccessPrincipal(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    principal_type: Literal["github_human"] = "github_human"
+    login: str
+    github_id: int = Field(default=0, ge=0)
+    organizations: tuple[str, ...] = ()
+    teams: tuple[str, ...] = ()
+    role: Literal["read_only", "admin"]
+
+    @field_validator("login")
+    @classmethod
+    def _normalize_login(cls, value: str) -> str:
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("GitHub human access principal requires login.")
+        if len(normalized) > 256:
+            raise ValueError("GitHub human access principal login is too long.")
+        return normalized
+
+    @field_validator("organizations", "teams")
+    @classmethod
+    def _normalize_memberships(cls, values: tuple[str, ...]) -> tuple[str, ...]:
+        normalized = tuple(dict.fromkeys(value.strip() for value in values if value.strip()))
+        if len(normalized) > 128 or any(len(value) > 512 for value in normalized):
+            raise ValueError("GitHub human access principal memberships are too broad.")
+        return normalized
+
+    def to_identity(self) -> GitHubHumanIdentity:
+        return GitHubHumanIdentity(
+            login=self.login,
+            github_id=self.github_id,
+            name="",
+            email="",
+            organizations=frozenset(self.organizations),
+            teams=frozenset(self.teams),
+            role=self.role,
+        )
+
+
+class TokenBoundAccessPrincipal(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    subject: str
+    token_label: str
+
+    @field_validator("subject", "token_label")
+    @classmethod
+    def _normalize_required_text(cls, value: str) -> str:
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("Token-bound access principal requires subject and token label.")
+        if len(normalized) > 512:
+            raise ValueError("Token-bound access principal field is too long.")
+        return normalized
+
+
+class TerminalAgentAccessPrincipal(TokenBoundAccessPrincipal):
+    principal_type: Literal["terminal_agent"] = "terminal_agent"
+
+    def to_identity(self) -> TerminalAgentIdentity:
+        return TerminalAgentIdentity(subject=self.subject, token_label=self.token_label)
+
+
+class LocalOperatorAccessPrincipal(TokenBoundAccessPrincipal):
+    principal_type: Literal["local_operator"] = "local_operator"
+
+    def to_identity(self) -> LocalOperatorIdentity:
+        return LocalOperatorIdentity(subject=self.subject, token_label=self.token_label)
+
+
+class LocalAdminAccessPrincipal(TokenBoundAccessPrincipal):
+    principal_type: Literal["local_admin"] = "local_admin"
+
+    def to_identity(self) -> LocalAdminIdentity:
+        return LocalAdminIdentity(subject=self.subject, token_label=self.token_label)
+
+
+EffectiveAccessPrincipal: TypeAlias = Annotated[
+    GitHubActionsAccessPrincipal
+    | GitHubHumanAccessPrincipal
+    | TerminalAgentAccessPrincipal
+    | LocalOperatorAccessPrincipal
+    | LocalAdminAccessPrincipal,
+    Field(discriminator="principal_type"),
+]
+
+
+class EffectiveAccessEvaluateRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    principal: EffectiveAccessPrincipal
+    action: str
+    product: str
+    context: str
+    target_scope: Literal["context", "instance"]
+    instance: str = ""
+
+    @field_validator("action", "product", "context")
+    @classmethod
+    def _normalize_required_scope(cls, value: str) -> str:
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("Effective access evaluation requires an explicit scope.")
+        if len(normalized) > 512:
+            raise ValueError("Effective access evaluation scope is too long.")
+        return normalized
+
+    @field_validator("instance")
+    @classmethod
+    def _normalize_instance(cls, value: str) -> str:
+        normalized = value.strip()
+        if len(normalized) > 512:
+            raise ValueError("Effective access evaluation instance is too long.")
+        if any(character in normalized for character in "*?[]"):
+            raise ValueError("Effective access evaluation requires one exact instance.")
+        return normalized
+
+    @model_validator(mode="after")
+    def _validate_target_scope(self) -> "EffectiveAccessEvaluateRequest":
+        if self.target_scope == "instance" and not self.instance:
+            raise ValueError("Instance target scope requires one exact instance.")
+        if self.target_scope == "context" and self.instance:
+            raise ValueError("Context target scope cannot declare an instance.")
+        return self
+
+    def identity(self) -> LaunchplaneIdentity:
+        return self.principal.to_identity()
+
+
+class EffectiveAccessRequestSummary(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    principal_type: Literal[
+        "github_actions", "github_human", "terminal_agent", "local_operator", "local_admin"
+    ]
+    action: str
+    product: str
+    context: str
+    target_scope: Literal["context", "instance"]
+    instance: str = ""
+
+
+class EffectiveAccessDecision(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    decision: Literal["allowed", "denied"]
+    reason_code: AuthzDecisionReason
+
+
+class EffectiveAccessEvaluateResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["ok"] = "ok"
+    trace_id: str
+    policy_record_id: str
+    policy_revision: int = Field(ge=1)
+    policy_sha256: str
+    request: EffectiveAccessRequestSummary
+    evaluation: EffectiveAccessDecision
+
+
+class AuthzDenialExplanationResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["ok"] = "ok"
+    trace_id: str
+    recorded_at: str
+    route_path: str
+    principal_type: Literal[
+        "github_actions", "github_human", "terminal_agent", "local_operator", "local_admin"
+    ]
+    action: str
+    product: str
+    context: str
+    target_scope: Literal["global", "context", "instance", "preview"]
+    instance_specified: bool
+    reason_code: AuthzDecisionReason
+    policy_record_id: str
+    policy_revision: int = Field(ge=1)
+    policy_sha256: str

--- a/control_plane/contracts/authz_denial_record.py
+++ b/control_plane/contracts/authz_denial_record.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from control_plane.service_auth import (
+    AgentConsumerSubjectType,
+    AuthorizationScope,
+    AuthzDecisionReason,
+    AuthzEvaluation,
+)
+
+
+class AuthzDenialRecord(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    trace_id: str
+    recorded_at: str
+    expires_at: str
+    route_path: str
+    principal_type: AgentConsumerSubjectType
+    action: str
+    product: str
+    context: str
+    target_scope: AuthorizationScope
+    instance_specified: bool
+    reason_code: AuthzDecisionReason
+    policy_record_id: str
+    policy_revision: int = Field(ge=1)
+    policy_sha256: str
+
+    @field_validator("recorded_at", "expires_at")
+    @classmethod
+    def _normalize_timestamp(cls, value: str) -> str:
+        timestamp = datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+        if timestamp.tzinfo is None:
+            raise ValueError("Authz denial timestamps require an explicit timezone.")
+        return timestamp.astimezone(timezone.utc).isoformat()
+
+    @model_validator(mode="after")
+    def _validate_record(self) -> "AuthzDenialRecord":
+        required_values = (
+            self.trace_id,
+            self.recorded_at,
+            self.expires_at,
+            self.route_path,
+            self.principal_type,
+            self.policy_record_id,
+            self.policy_sha256,
+        )
+        if not all(value.strip() for value in required_values):
+            raise ValueError("Authz denial record requires complete redacted evidence.")
+        bounded_values = {
+            "trace_id": (self.trace_id, 128),
+            "recorded_at": (self.recorded_at, 64),
+            "expires_at": (self.expires_at, 64),
+            "route_path": (self.route_path, 512),
+            "action": (self.action, 512),
+            "product": (self.product, 512),
+            "context": (self.context, 512),
+            "policy_record_id": (self.policy_record_id, 512),
+            "policy_sha256": (self.policy_sha256, 128),
+        }
+        for field_name, (value, maximum_length) in bounded_values.items():
+            if len(value) > maximum_length:
+                raise ValueError(f"Authz denial record {field_name} is too long.")
+        if self.reason_code == "allowed":
+            raise ValueError("Authz denial record cannot persist an allowed decision.")
+        return self
+
+
+def build_authz_denial_record(
+    *,
+    trace_id: str,
+    recorded_at: str,
+    expires_at: str,
+    route_path: str,
+    evaluation: AuthzEvaluation,
+    policy_record_id: str,
+    policy_revision: int,
+    policy_sha256: str,
+) -> AuthzDenialRecord:
+    if evaluation.decision != "denied":
+        raise ValueError("Authz denial record requires a denied evaluation.")
+    return AuthzDenialRecord(
+        trace_id=trace_id,
+        recorded_at=recorded_at,
+        expires_at=expires_at,
+        route_path=route_path,
+        principal_type=evaluation.principal_type,
+        action=evaluation.action,
+        product=evaluation.product,
+        context=evaluation.context,
+        target_scope=evaluation.target_scope,
+        instance_specified=evaluation.instance_specified,
+        reason_code=evaluation.reason_code,
+        policy_record_id=policy_record_id,
+        policy_revision=policy_revision,
+        policy_sha256=policy_sha256,
+    )

--- a/control_plane/contracts/every_code_work_request.py
+++ b/control_plane/contracts/every_code_work_request.py
@@ -131,7 +131,7 @@ def build_every_code_work_request_id(
             "Every Code work request id requires repository, issue_number, and trigger_label"
         )
     digest = hashlib.sha256(
-        f"{normalized_repository}#{issue_number}:{normalized_label}".encode("utf-8")
+        f"{normalized_repository}#{issue_number}:{normalized_label}".encode()
     ).hexdigest()[:16]
     return f"every-code-{normalized_repository.replace('/', '-')}-{issue_number}-{digest}"
 
@@ -152,7 +152,7 @@ def build_every_code_work_request_lifecycle_id(
             },
             sort_keys=True,
             separators=(",", ":"),
-        ).encode("utf-8")
+        ).encode()
     ).hexdigest()[:16]
     return f"every-code-lifecycle-{digest}"
 
@@ -173,7 +173,7 @@ def claim_every_code_work_request(
     if record.state != "queued":
         return None
     new_attempt = record.attempt + 1
-    resolved_lease_expires_at = lease_expires_at.strip() or _add_seconds_to_timestamp(
+    resolved_lease_expires_at = lease_expires_at.strip() or add_seconds_to_timestamp(
         claimed_at, lease_seconds
     )
     return record.model_copy(
@@ -403,10 +403,13 @@ def close_every_code_work_request_for_issue(
     return record.model_copy(update=updates)
 
 
-def _add_seconds_to_timestamp(timestamp: str, seconds: int) -> str:
+def add_seconds_to_timestamp(timestamp: str, seconds: int) -> str:
     try:
         dt = datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
     except (ValueError, AttributeError):
         return timestamp
     result = dt.astimezone(UTC) + timedelta(seconds=seconds)
     return result.replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+_add_seconds_to_timestamp = add_seconds_to_timestamp

--- a/control_plane/drivers/native_routes.py
+++ b/control_plane/drivers/native_routes.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass
-from typing import Protocol, cast
+from typing import Any, Protocol
 
 from control_plane.contracts.driver_descriptor import DriverActionScope
 from control_plane.drivers.generic_web_dispatch import (
@@ -157,16 +157,24 @@ class _AuthorizationAllows(Protocol):
     ) -> bool: ...
 
 
+def _iterable_values(value: Any) -> Iterable[Any]:
+    return value if isinstance(value, Iterable) else ()
+
+
+def _text_value(value: Any) -> str:
+    return str(value)
+
+
 def _fastapi_route_paths_by_method(app: object, method: str) -> frozenset[str]:
     normalized_method = method.upper()
     route_paths: set[str] = set()
-    for route in cast(Iterable[object], getattr(app, "routes", ())):
+    for route in _iterable_values(getattr(app, "routes", ())):
         route_path = getattr(route, "path", None)
         route_methods = getattr(route, "methods", None)
         if not isinstance(route_path, str) or route_methods is None:
             continue
         methods = {
-            str(route_method).upper() for route_method in cast(Iterable[object], route_methods)
+            _text_value(route_method).upper() for route_method in _iterable_values(route_methods)
         }
         if normalized_method in methods:
             route_paths.add(route_path)
@@ -238,11 +246,11 @@ def _descriptor_driver_route_authz_action(route_path: str) -> str:
     return _descriptor_driver_route_metadata(route_path).authz_action
 
 
-def _is_native_fastapi_driver_route_path(route_path: str) -> bool:
+def is_native_fastapi_driver_route_path(route_path: str) -> bool:
     return route_path in _NATIVE_FASTAPI_DRIVER_ROUTE_PATHS
 
 
-def _bind_native_fastapi_driver_handler(
+def bind_native_fastapi_driver_handler(
     *,
     route_path: str,
     endpoint: Callable[..., object],
@@ -252,7 +260,7 @@ def _bind_native_fastapi_driver_handler(
         raise ValueError(f"Unknown native FastAPI driver route: {route_path}")
     route_metadata = _descriptor_driver_route_metadata(route_path)
     if declared_methods is not None:
-        normalized_methods = frozenset(str(method).upper() for method in declared_methods)
+        normalized_methods = frozenset(_text_value(method).upper() for method in declared_methods)
         if normalized_methods != frozenset({route_metadata.method}):
             actual_methods = ", ".join(sorted(normalized_methods)) or "<none>"
             raise ValueError(
@@ -276,11 +284,11 @@ def _native_driver_route_metadata_for_handler(endpoint: object) -> _DriverRouteM
     return route_metadata
 
 
-def _native_driver_route_authz_action(endpoint: object) -> str:
+def native_driver_route_authz_action(endpoint: object) -> str:
     return _native_driver_route_metadata_for_handler(endpoint).authz_action
 
 
-def _native_driver_route_authorization_allows(
+def native_driver_route_authorization_allows(
     *,
     endpoint: object,
     authorization_allows: _AuthorizationAllows,
@@ -303,7 +311,7 @@ def _native_driver_route_authorization_allows(
     )
 
 
-def _native_driver_route_alternate_authz_action(endpoint: object) -> str:
+def native_driver_route_alternate_authz_action(endpoint: object) -> str:
     alternate_authz_actions = _native_driver_route_metadata_for_handler(
         endpoint
     ).alternate_authz_actions
@@ -313,6 +321,13 @@ def _native_driver_route_alternate_authz_action(endpoint: object) -> str:
             "authorization action."
         )
     return alternate_authz_actions[0]
+
+
+_is_native_fastapi_driver_route_path = is_native_fastapi_driver_route_path
+_bind_native_fastapi_driver_handler = bind_native_fastapi_driver_handler
+_native_driver_route_authz_action = native_driver_route_authz_action
+_native_driver_route_authorization_allows = native_driver_route_authorization_allows
+_native_driver_route_alternate_authz_action = native_driver_route_alternate_authz_action
 
 
 def _validate_native_descriptor_driver_routes() -> None:
@@ -362,7 +377,7 @@ def _validate_native_fastapi_driver_routes(app: object) -> None:
     route_registrations: dict[str, list[object]] = {
         route_path: [] for route_path in _NATIVE_FASTAPI_DRIVER_ROUTE_PATHS
     }
-    for route in cast(Iterable[object], getattr(app, "routes", ())):
+    for route in _iterable_values(getattr(app, "routes", ())):
         route_path = getattr(route, "path", None)
         if isinstance(route_path, str) and route_path in route_registrations:
             route_registrations[route_path].append(route)
@@ -395,7 +410,8 @@ def _validate_native_fastapi_driver_routes(app: object) -> None:
             frozenset()
             if route_methods is None
             else frozenset(
-                str(route_method).upper() for route_method in cast(Iterable[object], route_methods)
+                _text_value(route_method).upper()
+                for route_method in _iterable_values(route_methods)
             )
         )
         if normalized_methods != frozenset({route_metadata.method}):

--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -7,25 +7,26 @@ import os
 import re
 import secrets
 from copy import deepcopy
-from dataclasses import replace
+from dataclasses import dataclass, replace
 from functools import cache
 from urllib.parse import unquote
-from collections.abc import AsyncIterator, Callable, Mapping
+from collections.abc import AsyncIterator, Awaitable, Callable, Mapping, MutableMapping
 from contextlib import asynccontextmanager
 from datetime import datetime, timedelta, timezone
 from pathlib import Path as FilePath
-from typing import Annotated, Any, Literal, NoReturn, Protocol, cast
+from typing import Annotated, Any, Literal, NoReturn, Protocol, Self, cast
 from uuid import uuid4
 import click
+import fastapi.exceptions as fastapi_exceptions
 from fastapi import Depends, FastAPI, Header, HTTPException, Query, Request, Response
 from fastapi.datastructures import DefaultPlaceholder
+from fastapi.concurrency import run_in_threadpool
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse, RedirectResponse
 from jwt import InvalidTokenError
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator, model_validator
-from starlette.concurrency import run_in_threadpool
-from starlette.exceptions import HTTPException as StarletteHTTPException
-from starlette.types import ASGIApp, Message, Receive, Scope, Send
+from requests.exceptions import RequestException
+from sqlalchemy.exc import SQLAlchemyError
 from control_plane import authz_grant_service as control_plane_authz_grant_service
 from control_plane import authz_diagnostics as control_plane_authz_diagnostics
 from control_plane import ingress_route_scope as control_plane_ingress_route_scope
@@ -70,6 +71,16 @@ from control_plane import live_target_runtime as control_plane_live_target_runti
 from control_plane.change_impact_github import GitHubChangeImpactRepositoryEvidenceProvider
 from control_plane.change_impact_service import ChangeImpactRepositoryEvidenceProvider
 from control_plane.contracts.change_impact import ChangeImpactTargetReference
+from control_plane.contracts.authz_access_read import (
+    AUTHZ_DENIAL_EXPLANATION_READ_ACTION,
+    EFFECTIVE_ACCESS_READ_ACTION,
+    AuthzDenialExplanationResponse,
+    EffectiveAccessDecision,
+    EffectiveAccessEvaluateRequest,
+    EffectiveAccessEvaluateResponse,
+    EffectiveAccessRequestSummary,
+)
+from control_plane.contracts.authz_denial_record import build_authz_denial_record
 from control_plane.contracts.owner_acceptance import OwnerAcceptanceDecisionStatus
 from control_plane.engineering_review_service import (
     EngineeringReviewTargetResolver,
@@ -86,8 +97,6 @@ from control_plane.owner_acceptance_projection import (
 )
 from control_plane.http_routes import (
     AcceptedEvidenceResponse as AcceptedEvidenceResponse,
-    BackupGateEvidenceRequest as BackupGateEvidenceRequest,
-    DeploymentEvidenceRequest as DeploymentEvidenceRequest,
     DriverReadRouteDependencies,
     EVIDENCE_INGRESS_ROUTES as _EVIDENCE_INGRESS_ROUTES,
     EvidenceWriteRouteDependencies,
@@ -108,7 +117,6 @@ from control_plane.http_routes import (
     OwnerAcceptanceRouteDependencies,
     GovernanceProjectionRouteDependencies,
     ProductReadRouteDependencies,
-    PromotionEvidenceRequest as PromotionEvidenceRequest,
     ReadRouteDependencies,
     WorkGraphReadRouteDependencies,
     accepted_evidence_response,
@@ -164,7 +172,7 @@ from control_plane.http_routes import (
     register_work_graph_issue_inbox_read_routes,
     register_work_graph_snapshot_read_routes,
     replay_idempotent_response,
-    request_fingerprint,
+    request_fingerprint as build_request_fingerprint,
     require_product_profile_read_store,
 )
 from control_plane.contracts.authz_policy_record import (
@@ -204,7 +212,7 @@ from control_plane.contracts.every_code_notifications import (
 from control_plane.contracts.every_code_work_request import (
     EveryCodeWorkRequestRecord,
     EveryCodeWorkRequestStatusUpdate,
-    _add_seconds_to_timestamp as _add_lease_seconds,
+    add_seconds_to_timestamp as add_lease_seconds,
     requeue_every_code_work_request,
 )
 from control_plane.contracts.idempotency_record import (
@@ -669,6 +677,7 @@ from control_plane.runtime_key_safety import (
 from control_plane.service_auth import (
     AgentAuthzDecision,
     AuthorizationTarget,
+    AuthzEvaluation,
     BearerIdentityConfig,
     GitHubActionsIdentity,
     GitHubHumanIdentity,
@@ -680,6 +689,8 @@ from control_plane.service_auth import (
     TokenVerifier,
     agent_authz_audit,
     bearer_identity_from_token,
+    clear_authz_evaluation,
+    current_authz_evaluation,
 )
 from control_plane.service_human_auth import (
     BROWSER_CSRF_HEADER_NAME,
@@ -775,6 +786,14 @@ EveryCodeGitHubWebhookHandler = Callable[
 ManagerPreviewApprovalGitHubWebhookHandler = Callable[
     [bytes, str, str, str, object, FilePath, str], tuple[int, dict[str, object]]
 ]
+
+
+Message = MutableMapping[str, Any]
+Scope = MutableMapping[str, Any]
+Receive = Callable[[], Awaitable[Message]]
+Send = Callable[[Message], Awaitable[None]]
+ASGIApp = Callable[[Scope, Receive, Send], Awaitable[None]]
+STARLETTE_HTTP_EXCEPTION: Any = getattr(fastapi_exceptions, "StarletteHTTPException")
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -993,6 +1012,8 @@ _PRODUCT_ONBOARDING_APPLY_ROUTE = "/v1/product-onboarding/apply"
 _MERGE_TRAIN_POLICY_IMPORT_ROUTE = "/v1/merge-train/policies/import"
 _AUTHZ_POLICY_ACTIVE_ROUTE = "/v1/authz-policies/active"
 _AUTHZ_DIAGNOSTIC_EVALUATE_ROUTE = "/v1/authz-diagnostics/github-actions/evaluate"
+_AUTHZ_EFFECTIVE_ACCESS_EVALUATE_ROUTE = "/v1/authz-diagnostics/effective-access/evaluate"
+_AUTHZ_DENIAL_EXPLANATION_ROUTE = "/v1/authz-diagnostics/denials/{trace_id}"
 _AUTHZ_POLICY_MANAGED_RECONCILE_ROUTE = "/v1/authz-policies/managed-rule-sets/reconcile"
 _GENERIC_WEB_PREVIEW_AUTHZ_PLAN_ROUTE = (
     "/v1/authz-policies/managed-rule-sets/generic-web-preview/plan"
@@ -1062,6 +1083,39 @@ class LaunchplaneErrorResponse(BaseModel):
         default=None,
         json_schema_extra={"x-launchplane-optional-response": True},
     )
+
+
+@dataclass(frozen=True)
+class AuthzPolicyProvenance:
+    source: str
+    record_id: str
+    revision: int
+    policy_sha256: str
+
+    @classmethod
+    def from_record(cls, record: LaunchplaneAuthzPolicyRecord) -> Self:
+        return cls(
+            source="db",
+            record_id=record.record_id,
+            revision=record.revision,
+            policy_sha256=record.policy_sha256,
+        )
+
+
+class LaunchplaneHTTPException(HTTPException):
+    def __init__(
+        self,
+        *,
+        status_code: int,
+        detail: dict[str, object],
+        headers: dict[str, str] | None = None,
+        authz_evaluation: AuthzEvaluation | None = None,
+        authz_policy_provenance: AuthzPolicyProvenance | None = None,
+    ) -> None:
+        super().__init__(status_code=status_code, detail=detail, headers=headers)
+        self.structured_detail = detail
+        self.authz_evaluation = authz_evaluation
+        self.authz_policy_provenance = authz_policy_provenance
 
 
 class OdooStableBootstrapOperationActiveResponse(BaseModel):
@@ -1149,7 +1203,7 @@ def bounded_request_body_contract(path: str) -> tuple[str, int, bool, bool] | No
         and path_parts[3] == "environments"
         and path_parts[5:] == ["config", "apply"]
     ):
-        return ("Product config", _PRODUCT_CONFIG_MAX_BODY_BYTES, True, True)
+        return "Product config", _PRODUCT_CONFIG_MAX_BODY_BYTES, True, True
     return None
 
 
@@ -1230,7 +1284,7 @@ class BoundedRequestBodyMiddleware:
                 send=send,
                 status_code=400,
                 code="invalid_request",
-                message=(f"{request_label} Content-Length must be an unsigned decimal integer."),
+                message=f"{request_label} Content-Length must be an unsigned decimal integer.",
             )
             return
         normalized_content_length = content_length.lstrip("0") or "0"
@@ -1308,9 +1362,9 @@ class BoundedRequestBodyMiddleware:
         async def replay_receive() -> Message:
             nonlocal next_message_index
             if next_message_index < len(buffered_messages):
-                message = buffered_messages[next_message_index]
+                buffered_message = buffered_messages[next_message_index]
                 next_message_index += 1
-                return message
+                return buffered_message
             return await receive()
 
         await self.app(scope, replay_receive, send)
@@ -1629,7 +1683,7 @@ class _OdooPreviewProviderMutationAdapter:
 
     def target_key(self) -> str:
         reconciliation_key = self.reconciliation_key()
-        return f"dokploy-provider-target:{hashlib.sha256(reconciliation_key.encode('utf-8')).hexdigest()}"
+        return f"dokploy-provider-target:{hashlib.sha256(reconciliation_key.encode()).hexdigest()}"
 
     def _destroy_invalidation_records(self) -> dict[str, object]:
         provenance = self._issued_plan.plan_provenance
@@ -1646,7 +1700,9 @@ class _OdooPreviewProviderMutationAdapter:
         )
         return {
             "manager_preview_approval_required": bool(result.get("required")),
-            "manager_preview_invalidation_event_status": str(result.get("event_status") or ""),
+            "manager_preview_invalidation_event_status": string_value(
+                result.get("event_status") or ""
+            ),
         }
 
     def _finalize_successful_result(
@@ -1666,7 +1722,9 @@ class _OdooPreviewProviderMutationAdapter:
                 else None
             ),
         )
-        lifecycle_status = str(lifecycle_records.get("lifecycle_evidence_status") or "").strip()
+        lifecycle_status = string_value(
+            lifecycle_records.get("lifecycle_evidence_status") or ""
+        ).strip()
         if lifecycle_status == "stale":
             blocked_result = OdooPreviewDokployApplyResult.model_validate(driver_result).model_copy(
                 update={
@@ -1705,11 +1763,11 @@ class _OdooPreviewProviderMutationAdapter:
         driver_result.pop("provider_effect_attempted", None)
         response_status_code = 202
         records: dict[str, object] = {}
-        if str(driver_result.get("status", "")).strip() == "pass":
+        if string_value(driver_result.get("status", "")).strip() == "pass":
             driver_result, records, response_status_code = self._finalize_successful_result(
                 driver_result
             )
-        terminal_failure = str(driver_result.get("status", "")).strip() == "fail"
+        terminal_failure = string_value(driver_result.get("status", "")).strip() == "fail"
         return ProviderObservation(
             outcome="present",
             response_status_code=502 if terminal_failure else response_status_code,
@@ -1745,10 +1803,10 @@ class _OdooPreviewProviderMutationAdapter:
         ) as error:
             raise ProviderMutationRejectedError(error)
         provider_effect_attempted = driver_result.pop("provider_effect_attempted", False) is True
-        driver_status = str(driver_result.get("status", "")).strip()
+        driver_status = string_value(driver_result.get("status", "")).strip()
         if driver_status == "fail" and provider_effect_attempted:
             raise ProviderMutationUnknownError(
-                str(driver_result.get("error_message", "")).strip()
+                string_value(driver_result.get("error_message", "")).strip()
                 or "Odoo preview provider outcome requires reconciliation."
             )
         response_status_code = 202
@@ -1760,7 +1818,7 @@ class _OdooPreviewProviderMutationAdapter:
                 driver_result
             )
             lease.assert_current()
-            driver_status = str(driver_result.get("status", "")).strip()
+            driver_status = string_value(driver_result.get("status", "")).strip()
         return ProviderMutationOutcome(
             response_status_code=response_status_code,
             response_payload=_provider_operation_response_payload(
@@ -1849,7 +1907,7 @@ class ProductExpectedConfigApplyEnvelope(BaseModel):
 def _runtime_config_requirement_key(
     requirement: ProductRuntimeConfigRequirement,
 ) -> tuple[str, str, str]:
-    return (requirement.context, requirement.instance, requirement.key)
+    return requirement.context, requirement.instance, requirement.key
 
 
 def _secret_config_requirement_key(
@@ -3087,7 +3145,7 @@ def idempotency_request_fingerprint(*, route_path: str, payload: dict[str, objec
         _PRODUCT_ENVIRONMENT_CONFIG_APPLY_ROUTE,
     }:
         return product_config_request_fingerprint(payload)
-    return request_fingerprint(
+    return build_request_fingerprint(
         canonical_request_payload_for_idempotency(route_path=route_path, payload=payload)
     )
 
@@ -3117,7 +3175,7 @@ def product_config_continuity_payload(payload: dict[str, object]) -> dict[str, o
 
 def product_config_request_fingerprint(payload: dict[str, object]) -> str:
     if not payload.get("secrets"):
-        return request_fingerprint(payload)
+        return build_request_fingerprint(payload)
     canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"))
     return control_plane_secrets.keyed_secret_payload_fingerprint(
         canonical,
@@ -3286,7 +3344,7 @@ def product_promotion_dry_run_record(
     if idempotency_store is None:
         return None
     continuity_payload = product_promotion_continuity_payload(status=status, bump=bump)
-    continuity_fingerprint = request_fingerprint(continuity_payload)
+    continuity_fingerprint = build_request_fingerprint(continuity_payload)
     stored_record = idempotency_store.read_idempotency_record(
         scope=idempotency_scope(identity),
         route_path=_PRODUCT_PROMOTION_DRY_RUN_MARKER_ROUTE,
@@ -3320,7 +3378,7 @@ def store_product_promotion_dry_run_record(
     ):
         return
     continuity_payload = product_promotion_continuity_payload(status=status, bump=bump)
-    continuity_fingerprint = request_fingerprint(continuity_payload)
+    continuity_fingerprint = build_request_fingerprint(continuity_payload)
     dry_run_key = product_promotion_dry_run_key(status=status, bump=bump)
     marker_trace_id = f"{trace_id}-product-promotion-dry-run"
     try:
@@ -3442,17 +3500,14 @@ class _LaunchplaneFastAPI(FastAPI):
         endpoint: Callable[..., Any],
         **kwargs: Any,
     ) -> None:
-        if native_routes._is_native_fastapi_driver_route_path(path):
-            route_metadata = native_routes._bind_native_fastapi_driver_handler(
+        if native_routes.is_native_fastapi_driver_route_path(path):
+            route_metadata = native_routes.bind_native_fastapi_driver_handler(
                 route_path=path,
                 endpoint=endpoint,
                 declared_methods=kwargs.get("methods"),
             )
             kwargs["methods"] = [route_metadata.method]
-        responses = cast(
-            dict[int | str, dict[str, Any]] | None,
-            kwargs.get("responses"),
-        )
+        responses = kwargs.get("responses")
         if path.startswith("/v1/") and path != "/v1/health":
             responses = {
                 409: {"model": LaunchplaneErrorResponse},
@@ -3590,6 +3645,14 @@ class LaunchplaneAuthzPolicyRuntime:
             policy=self._policy,
         )
 
+    def provenance(self) -> AuthzPolicyProvenance:
+        return AuthzPolicyProvenance(
+            source=self._source,
+            record_id=self._record_id,
+            revision=self._revision,
+            policy_sha256=self._policy_sha256,
+        )
+
     def update(
         self,
         policy: LaunchplaneAuthzPolicy,
@@ -3619,6 +3682,15 @@ class ResolvedLaunchplaneAuthzPolicy(BaseModel):
     revision: int = Field(default=0, ge=0)
 
 
+def optional_callable_attribute(instance: object, name: str) -> Callable[..., Any] | None:
+    attribute = getattr(instance, name, None)
+    return attribute if callable(attribute) else None
+
+
+def string_value(value: Any) -> str:
+    return str(value)
+
+
 def resolve_launchplane_authz_policy(
     *,
     record_store: object,
@@ -3626,8 +3698,8 @@ def resolve_launchplane_authz_policy(
     policy_source: str,
     now_timestamp: str,
 ) -> ResolvedLaunchplaneAuthzPolicy:
-    list_records = getattr(record_store, "list_authz_policy_records", None)
-    if callable(list_records):
+    list_records = optional_callable_attribute(record_store, "list_authz_policy_records")
+    if list_records is not None:
         records = list_records(status="active", limit=1)
         if records:
             record = records[0]
@@ -3640,8 +3712,8 @@ def resolve_launchplane_authz_policy(
             )
 
     policy_sha256 = authz_policy_sha256(bootstrap_policy)
-    seed_record = getattr(record_store, "seed_authz_policy_if_absent", None)
-    if callable(seed_record):
+    seed_record = optional_callable_attribute(record_store, "seed_authz_policy_if_absent")
+    if seed_record is not None:
         record = LaunchplaneAuthzPolicyRecord(
             record_id=build_authz_policy_record_id(
                 revision=1,
@@ -3720,6 +3792,7 @@ def create_launchplane_fastapi_app(
             token_context=_LAUNCHPLANE_SERVICE_CONTEXT,
         )
     )
+    injected_github_api_request = github_api_request
     owner_acceptance_projection_service = OwnerAcceptanceProjectionService(
         repository_evidence_provider=resolved_change_impact_repository_evidence_provider,
         github_app_token=lambda repository, repository_id: mint_repository_installation_token(
@@ -3728,10 +3801,10 @@ def create_launchplane_fastapi_app(
             ),
             repository=repository,
             repository_id=repository_id,
-            api_request=github_api_request,
+            api_request=injected_github_api_request,
         ),
         public_origin=(human_session_manager.public_origin if human_session_manager else None),
-        api_request=github_api_request,
+        api_request=injected_github_api_request,
     )
     resolved_engineering_review_target_resolver = (
         engineering_review_target_resolver
@@ -3809,11 +3882,12 @@ def create_launchplane_fastapi_app(
         request: Request,
         call_next: Callable[[Request], Any],
     ) -> Response:
+        request_authz_policy_provenance = resolved_authz_policy_runtime.provenance()
         if request.url.path.startswith("/v1/") and request.url.path != "/v1/health":
             trace_id = next_trace_id()
             try:
                 refresh_result = await run_in_threadpool(read_active_authz_policy_records)
-            except Exception:
+            except (OSError, RuntimeError, SQLAlchemyError, TypeError, ValueError):
                 logging.exception("Failed to refresh the active Launchplane authz policy.")
                 return JSONResponse(
                     status_code=503,
@@ -3826,6 +3900,9 @@ def create_launchplane_fastapi_app(
                     ).model_dump(mode="json"),
                 )
             if refresh_result is None:
+                request.state.launchplane_authz_policy_provenance = (
+                    resolved_authz_policy_runtime.provenance()
+                )
                 return cast(Response, await call_next(request))
             active_records = refresh_result
             if not active_records:
@@ -3851,6 +3928,7 @@ def create_launchplane_fastapi_app(
                     ).model_dump(mode="json"),
                 )
             active_record = active_records[0]
+            request_authz_policy_provenance = AuthzPolicyProvenance.from_record(active_record)
             if (
                 resolved_authz_policy_runtime.policy_sha256 != active_record.policy_sha256
                 or resolved_authz_policy_runtime.source != "db"
@@ -3864,7 +3942,19 @@ def create_launchplane_fastapi_app(
                     record_id=active_record.record_id,
                     revision=active_record.revision,
                 )
+        request.state.launchplane_authz_policy_provenance = request_authz_policy_provenance
         return cast(Response, await call_next(request))
+
+    @app.middleware("http")
+    async def isolate_authz_evaluation_context(
+        request: Request,
+        call_next: Callable[[Request], Any],
+    ) -> Response:
+        clear_authz_evaluation()
+        try:
+            return cast(Response, await call_next(request))
+        finally:
+            clear_authz_evaluation()
 
     resolved_oauth_login_state_store = (
         oauth_login_state_store if oauth_login_state_store is not None else OAuthLoginStateStore()
@@ -3897,12 +3987,16 @@ def create_launchplane_fastapi_app(
                 identity=session.identity,
                 authz_policy=resolved_authz_policy_runtime.policy,
             )
-            if current_role is None:
+            if current_role == "admin":
+                resolved_role: Literal["read_only", "admin"] = "admin"
+            elif current_role == "read_only":
+                resolved_role = "read_only"
+            else:
                 return None
-            if current_role != session.identity.role:
+            if resolved_role != session.identity.role:
                 session = replace(
                     session,
-                    identity=replace(session.identity, role=current_role),
+                    identity=replace(session.identity, role=resolved_role),
                 )
         renewed_session = human_session_manager.renew_if_needed(session)
         if renewed_session is None:
@@ -4048,7 +4142,7 @@ def create_launchplane_fastapi_app(
                     ),
                 ).model_dump(mode="json"),
             )
-        except Exception:  # noqa: BLE001
+        except (OSError, RequestException, RuntimeError, ValueError):
             _LOGGER.exception("GitHub OAuth callback failed", extra={"trace_id": trace_id})
             return reject_invalid_github_oauth_callback(
                 trace_id,
@@ -4211,7 +4305,7 @@ def create_launchplane_fastapi_app(
                 status_code=403,
                 trace_id=next_trace_id(),
                 code="authorization_denied",
-                message=("Work graph rank requires GitHub Actions OIDC or a GitHub human session."),
+                message="Work graph rank requires GitHub Actions OIDC or a GitHub human session.",
             )
         try:
             return verifier.verify(bearer_token)
@@ -4295,7 +4389,7 @@ def create_launchplane_fastapi_app(
         assert bearer_identity_config is not None
         try:
             return EngineeringReviewWorkerIdentity(
-                worker_runtime_id=(bearer_identity_config.engineering_review_worker_runtime_id),
+                worker_runtime_id=bearer_identity_config.engineering_review_worker_runtime_id,
                 worker_host=bearer_identity_config.engineering_review_worker_host,
             )
         except ValueError as error:
@@ -4345,7 +4439,7 @@ def create_launchplane_fastapi_app(
                 status_code=404,
                 trace_id=trace_id,
                 code="not_found",
-                message=(f"No Launchplane route for {MANAGER_PREVIEW_APPROVAL_WEBHOOK_ROUTE}."),
+                message=f"No Launchplane route for {MANAGER_PREVIEW_APPROVAL_WEBHOOK_ROUTE}.",
             )
         status_code, payload = manager_preview_approval_github_webhook_handler(
             await request.body(),
@@ -4364,8 +4458,8 @@ def create_launchplane_fastapi_app(
         record_store: Annotated[object, Depends(get_record_store)],
     ) -> dict[str, object]:
         trace_id = next_trace_id()
-        list_profiles = getattr(record_store, "list_product_profile_records", None)
-        if not callable(list_profiles):
+        list_profiles = optional_callable_attribute(record_store, "list_product_profile_records")
+        if list_profiles is None:
             raise _launchplane_http_error(
                 status_code=503,
                 trace_id=trace_id,
@@ -4451,7 +4545,7 @@ def create_launchplane_fastapi_app(
                 status_code=403,
                 trace_id=next_trace_id(),
                 code="authorization_denied",
-                message=("Terminal agent credentials can only read redacted Launchplane context."),
+                message="Terminal agent credentials can only read redacted Launchplane context.",
             )
         try:
             oidc_identity = verifier.verify(bearer_token)
@@ -4494,7 +4588,7 @@ def create_launchplane_fastapi_app(
         http_error=_launchplane_http_error,
         error_response_model=LaunchplaneErrorResponse,
         target_resolver=resolved_engineering_review_target_resolver,
-        repository_evidence_provider=(resolved_change_impact_repository_evidence_provider),
+        repository_evidence_provider=resolved_change_impact_repository_evidence_provider,
     )
     engineering_review_decision_route_dependencies = EngineeringReviewDecisionRouteDependencies(
         read_write_identity=read_write_identity,
@@ -4503,14 +4597,14 @@ def create_launchplane_fastapi_app(
         authorization_allows=resolved_authz_policy_runtime.allows,
         http_error=_launchplane_http_error,
         error_response_model=LaunchplaneErrorResponse,
-        repository_evidence_provider=(resolved_change_impact_repository_evidence_provider),
+        repository_evidence_provider=resolved_change_impact_repository_evidence_provider,
         github_app_token=lambda repository, repository_id: mint_repository_installation_token(
             identity=resolve_advisory_github_app_identity(
                 control_plane_root=resolved_control_plane_root
             ),
             repository=repository,
             repository_id=repository_id,
-            api_request=github_api_request,
+            api_request=injected_github_api_request,
         ),
         github_api=github_api_request,
     )
@@ -4631,9 +4725,9 @@ def create_launchplane_fastapi_app(
             identity=identity,
             trace_id=trace_id,
         )
-        schema_revision_reader = getattr(record_store, "schema_revision", None)
+        schema_revision_reader = optional_callable_attribute(record_store, "schema_revision")
         database_schema_revision = (
-            str(schema_revision_reader()).strip() if callable(schema_revision_reader) else ""
+            str(schema_revision_reader()).strip() if schema_revision_reader is not None else ""
         )
         runtime = LaunchplaneRuntimeStatus.model_validate(
             control_plane_service_status.launchplane_runtime_payload(
@@ -5009,7 +5103,7 @@ def create_launchplane_fastapi_app(
         detail: dict[str, object] = {"trace_id": trace_id, "code": code, "message": message}
         if record_id:
             detail["records"] = {"agent_write_intent_record_id": record_id}
-        return HTTPException(
+        return LaunchplaneHTTPException(
             status_code=404 if code == "agent_write_intent_not_found" else 409,
             detail=detail,
         )
@@ -5306,7 +5400,7 @@ def create_launchplane_fastapi_app(
             ) from error
 
         normalized_idempotency_key = idempotency_key.strip()
-        payload_fingerprint = request_fingerprint(cast(dict[str, object], raw_payload))
+        payload_fingerprint = build_request_fingerprint(raw_payload)
         if normalized_idempotency_key:
             (
                 normalized_idempotency_key,
@@ -5480,7 +5574,7 @@ def create_launchplane_fastapi_app(
             ) from error
 
         normalized_idempotency_key = idempotency_key.strip()
-        payload_fingerprint = request_fingerprint(cast(dict[str, object], raw_payload))
+        payload_fingerprint = build_request_fingerprint(raw_payload)
         if normalized_idempotency_key:
             (
                 normalized_idempotency_key,
@@ -5580,7 +5674,7 @@ def create_launchplane_fastapi_app(
 
             admission_evaluator = LiveMergeAdmissionEvaluator(
                 store=record_store,
-                repository_evidence_provider=(resolved_change_impact_repository_evidence_provider),
+                repository_evidence_provider=resolved_change_impact_repository_evidence_provider,
                 technical_check_client=TenantAdmissionControllerGitHubClient(
                     transport=UrllibMergeTrainGitHubTransport(
                         token=token,
@@ -5727,7 +5821,7 @@ def create_launchplane_fastapi_app(
             ) from error
 
         authorization_product = product_profile.product
-        if not native_routes._native_driver_route_authorization_allows(
+        if not native_routes.native_driver_route_authorization_allows(
             endpoint=write_odoo_artifact_publish,
             authorization_allows=resolved_authz_policy_runtime.policy.allows,
             identity=identity,
@@ -5783,7 +5877,7 @@ def create_launchplane_fastapi_app(
 
         response = accepted_evidence_response(
             trace_id=trace_id,
-            records={key: str(value) for key, value in records.items()},
+            records={key: string_value(value) for key, value in records.items()},
             result=driver_result,
         )
         if should_store_odoo_artifact_publish_idempotency(driver_result):
@@ -5855,7 +5949,7 @@ def create_launchplane_fastapi_app(
                 message="Request could not be completed.",
             ) from error
 
-        if not native_routes._native_driver_route_authorization_allows(
+        if not native_routes.native_driver_route_authorization_allows(
             endpoint=write_odoo_artifact_publish_inputs,
             authorization_allows=resolved_authz_policy_runtime.policy.allows,
             identity=identity,
@@ -5988,7 +6082,7 @@ def create_launchplane_fastapi_app(
                 message="Request could not be completed.",
             ) from error
 
-        if not native_routes._native_driver_route_authorization_allows(
+        if not native_routes.native_driver_route_authorization_allows(
             endpoint=write_odoo_preview_apply_inputs,
             authorization_allows=resolved_authz_policy_runtime.policy.allows,
             identity=identity,
@@ -6022,7 +6116,7 @@ def create_launchplane_fastapi_app(
             )
         payload_fingerprint = idempotency_request_fingerprint(
             route_path=_ODOO_PREVIEW_APPLY_INPUTS_ROUTE,
-            payload=cast(dict[str, object], raw_payload),
+            payload=raw_payload,
         )
         plan_id = build_odoo_preview_plan_id(
             scope=idempotency_scope(identity),
@@ -6153,7 +6247,7 @@ def create_launchplane_fastapi_app(
                 message="Request could not be completed.",
             ) from error
 
-        if not native_routes._native_driver_route_authorization_allows(
+        if not native_routes.native_driver_route_authorization_allows(
             endpoint=write_odoo_preview_apply,
             authorization_allows=resolved_authz_policy_runtime.policy.allows,
             identity=identity,
@@ -6226,7 +6320,7 @@ def create_launchplane_fastapi_app(
             ) from error
         payload_fingerprint = idempotency_request_fingerprint(
             route_path=_ODOO_PREVIEW_APPLY_ROUTE,
-            payload=cast(dict[str, object], raw_payload),
+            payload=raw_payload,
         )
         adapter = _OdooPreviewProviderMutationAdapter(
             control_plane_root=resolved_control_plane_root,
@@ -6279,11 +6373,11 @@ def create_launchplane_fastapi_app(
                     "A matching Odoo preview apply is already running. "
                     "Retry with the same Idempotency-Key."
                 ),
-                reconcile_message=("The Odoo preview apply requires reconciliation before retry."),
+                reconcile_message="The Odoo preview apply requires reconciliation before retry.",
                 target_supersession=target_supersession,
             )
             driver_result = response.result or {}
-            if str(driver_result.get("status") or "").strip() != "pass":
+            if string_value(driver_result.get("status") or "").strip() != "pass":
                 return response
             validate_odoo_preview_lifecycle_response_current(
                 record_store=record_store,
@@ -6398,7 +6492,7 @@ def create_launchplane_fastapi_app(
             ) from error
 
         authorization_product = product_profile.product
-        if not native_routes._native_driver_route_authorization_allows(
+        if not native_routes.native_driver_route_authorization_allows(
             endpoint=write_odoo_post_deploy,
             authorization_allows=resolved_authz_policy_runtime.policy.allows,
             identity=identity,
@@ -6455,7 +6549,7 @@ def create_launchplane_fastapi_app(
 
         response = accepted_evidence_response(
             trace_id=trace_id,
-            records={key: str(value) for key, value in records.items()},
+            records={key: string_value(value) for key, value in records.items()},
             result=driver_result,
         )
         store_apply_idempotency(
@@ -6529,7 +6623,7 @@ def create_launchplane_fastapi_app(
             ) from error
 
         authorization_product = product_profile.product
-        if not native_routes._native_driver_route_authorization_allows(
+        if not native_routes.native_driver_route_authorization_allows(
             endpoint=write_odoo_app_maintenance,
             authorization_allows=resolved_authz_policy_runtime.policy.allows,
             identity=identity,
@@ -6586,7 +6680,7 @@ def create_launchplane_fastapi_app(
 
         response = accepted_evidence_response(
             trace_id=trace_id,
-            records={key: str(value) for key, value in records.items()},
+            records={key: string_value(value) for key, value in records.items()},
             result=driver_result,
         )
         if should_store_odoo_app_maintenance_idempotency(driver_result):
@@ -6661,7 +6755,7 @@ def create_launchplane_fastapi_app(
             ) from error
 
         authorization_product = product_profile.product
-        if not native_routes._native_driver_route_authorization_allows(
+        if not native_routes.native_driver_route_authorization_allows(
             endpoint=write_odoo_config_parameter_override,
             authorization_allows=resolved_authz_policy_runtime.policy.allows,
             identity=identity,
@@ -6791,7 +6885,7 @@ def create_launchplane_fastapi_app(
             ) from error
 
         authorization_product = product_profile.product
-        if not native_routes._native_driver_route_authorization_allows(
+        if not native_routes.native_driver_route_authorization_allows(
             endpoint=write_odoo_website_bootstrap_override,
             authorization_allows=resolved_authz_policy_runtime.policy.allows,
             identity=identity,
@@ -6921,7 +7015,7 @@ def create_launchplane_fastapi_app(
             ) from error
 
         authorization_product = product_profile.product
-        if not native_routes._native_driver_route_authorization_allows(
+        if not native_routes.native_driver_route_authorization_allows(
             endpoint=write_odoo_prod_backup_gate,
             authorization_allows=resolved_authz_policy_runtime.policy.allows,
             identity=identity,
@@ -6978,7 +7072,7 @@ def create_launchplane_fastapi_app(
 
         response = accepted_evidence_response(
             trace_id=trace_id,
-            records={key: str(value) for key, value in records.items()},
+            records={key: string_value(value) for key, value in records.items()},
             result=driver_result,
         )
         if should_store_odoo_prod_backup_gate_idempotency(driver_result):
@@ -7053,7 +7147,7 @@ def create_launchplane_fastapi_app(
             ) from error
 
         authorization_product = product_profile.product
-        if not native_routes._native_driver_route_authorization_allows(
+        if not native_routes.native_driver_route_authorization_allows(
             endpoint=write_odoo_prod_backup_verification,
             authorization_allows=resolved_authz_policy_runtime.policy.allows,
             identity=identity,
@@ -7110,7 +7204,7 @@ def create_launchplane_fastapi_app(
 
         response = accepted_evidence_response(
             trace_id=trace_id,
-            records={key: str(value) for key, value in records.items()},
+            records={key: string_value(value) for key, value in records.items()},
             result=driver_result,
         )
         if should_store_odoo_prod_backup_verification_idempotency(driver_result):
@@ -7174,7 +7268,7 @@ def create_launchplane_fastapi_app(
                 code="invalid_request",
                 message="Request payload failed validation.",
             ) from error
-        if not native_routes._native_driver_route_authorization_allows(
+        if not native_routes.native_driver_route_authorization_allows(
             endpoint=write_odoo_prod_backup_restore_plan,
             authorization_allows=resolved_authz_policy_runtime.policy.allows,
             identity=identity,
@@ -7262,7 +7356,7 @@ def create_launchplane_fastapi_app(
                 code="invalid_request",
                 message="Request payload failed validation.",
             ) from error
-        if not native_routes._native_driver_route_authorization_allows(
+        if not native_routes.native_driver_route_authorization_allows(
             endpoint=write_odoo_prod_backup_restore_apply,
             authorization_allows=resolved_authz_policy_runtime.policy.allows,
             identity=identity,
@@ -7288,7 +7382,7 @@ def create_launchplane_fastapi_app(
         try:
             operation_authorization = capture_durable_operation_authorization(
                 identity=identity,
-                action=native_routes._native_driver_route_authz_action(
+                action=native_routes.native_driver_route_authz_action(
                     write_odoo_prod_backup_restore_apply
                 ),
                 product=apply_request.product,
@@ -7311,7 +7405,7 @@ def create_launchplane_fastapi_app(
                 request=apply_request,
                 idempotency_key=normalized_idempotency_key,
                 idempotency_scope=idempotency_scope(identity),
-                request_fingerprint=request_fingerprint(raw_payload),
+                request_fingerprint=build_request_fingerprint(raw_payload),
                 created_at=created_at,
                 authorization=operation_authorization,
             )
@@ -7371,7 +7465,7 @@ def create_launchplane_fastapi_app(
             ) from error
         return accepted_evidence_response(
             trace_id=trace_id,
-            records={key: str(value) for key, value in records.items()},
+            records={key: string_value(value) for key, value in records.items()},
             result=driver_result,
         )
 
@@ -7429,7 +7523,7 @@ def create_launchplane_fastapi_app(
                 code="invalid_request",
                 message="Request payload failed validation.",
             ) from error
-        if not native_routes._native_driver_route_authorization_allows(
+        if not native_routes.native_driver_route_authorization_allows(
             endpoint=write_odoo_prod_retained_volume_backup_import_plan,
             authorization_allows=resolved_authz_policy_runtime.policy.allows,
             identity=identity,
@@ -7455,7 +7549,7 @@ def create_launchplane_fastapi_app(
         try:
             operation_authorization = capture_durable_operation_authorization(
                 identity=identity,
-                action=native_routes._native_driver_route_authz_action(
+                action=native_routes.native_driver_route_authz_action(
                     write_odoo_prod_retained_volume_backup_import_plan
                 ),
                 product=plan_request.product,
@@ -7477,7 +7571,7 @@ def create_launchplane_fastapi_app(
                 request=plan_request,
                 idempotency_key=normalized_idempotency_key,
                 idempotency_scope=idempotency_scope(identity),
-                request_fingerprint=request_fingerprint(raw_payload),
+                request_fingerprint=build_request_fingerprint(raw_payload),
                 created_at=created_at,
                 authorization=operation_authorization,
             )
@@ -7525,7 +7619,7 @@ def create_launchplane_fastapi_app(
             ) from error
         return accepted_evidence_response(
             trace_id=trace_id,
-            records={key: str(value) for key, value in records.items()},
+            records={key: string_value(value) for key, value in records.items()},
             result=driver_result,
         )
 
@@ -7583,7 +7677,7 @@ def create_launchplane_fastapi_app(
                 code="invalid_request",
                 message="Request payload failed validation.",
             ) from error
-        if not native_routes._native_driver_route_authorization_allows(
+        if not native_routes.native_driver_route_authorization_allows(
             endpoint=write_odoo_prod_retained_volume_backup_import_apply,
             authorization_allows=resolved_authz_policy_runtime.policy.allows,
             identity=identity,
@@ -7609,7 +7703,7 @@ def create_launchplane_fastapi_app(
         try:
             operation_authorization = capture_durable_operation_authorization(
                 identity=identity,
-                action=native_routes._native_driver_route_authz_action(
+                action=native_routes.native_driver_route_authz_action(
                     write_odoo_prod_retained_volume_backup_import_apply
                 ),
                 product=apply_request.product,
@@ -7632,7 +7726,7 @@ def create_launchplane_fastapi_app(
                     request=apply_request,
                     idempotency_key=normalized_idempotency_key,
                     idempotency_scope=idempotency_scope(identity),
-                    request_fingerprint=request_fingerprint(raw_payload),
+                    request_fingerprint=build_request_fingerprint(raw_payload),
                     created_at=created_at,
                     authorization=operation_authorization,
                 )
@@ -7688,7 +7782,7 @@ def create_launchplane_fastapi_app(
             ) from error
         return accepted_evidence_response(
             trace_id=trace_id,
-            records={key: str(value) for key, value in records.items()},
+            records={key: string_value(value) for key, value in records.items()},
             result=driver_result,
         )
 
@@ -7703,9 +7797,9 @@ def create_launchplane_fastapi_app(
         cancel_method_name: str,
         cancellation_request: DurableOperationCancellationRequest,
     ) -> Any:
-        read_operation = getattr(record_store, read_method_name, None)
-        cancel_operation = getattr(record_store, cancel_method_name, None)
-        if not callable(read_operation) or not callable(cancel_operation):
+        read_operation = optional_callable_attribute(record_store, read_method_name)
+        cancel_operation = optional_callable_attribute(record_store, cancel_method_name)
+        if read_operation is None or cancel_operation is None:
             raise _launchplane_http_error(
                 status_code=503,
                 trace_id=trace_id,
@@ -7869,7 +7963,7 @@ def create_launchplane_fastapi_app(
             operation_id=operation_id,
             action="odoo_target_replacement_apply.execute",
             read_method_name="read_odoo_stable_target_replacement_operation_record",
-            cancel_method_name=("cancel_pending_odoo_stable_target_replacement_operation_record"),
+            cancel_method_name="cancel_pending_odoo_stable_target_replacement_operation_record",
             cancellation_request=cancellation_request,
         )
         return DurableOperationCancellationResponse(
@@ -7906,12 +8000,11 @@ def create_launchplane_fastapi_app(
         record_store: Annotated[object, Depends(get_record_store)],
     ) -> DurableOperationCancellationResponse:
         trace_id = next_trace_id()
-        read_operation = getattr(
+        read_operation = optional_callable_attribute(
             record_store,
             "read_odoo_prod_retained_volume_backup_import_operation_record",
-            None,
         )
-        if not callable(read_operation):
+        if read_operation is None:
             raise _launchplane_http_error(
                 status_code=503,
                 trace_id=trace_id,
@@ -7938,7 +8031,7 @@ def create_launchplane_fastapi_app(
             identity=identity,
             operation_id=operation_id,
             action=action,
-            read_method_name=("read_odoo_prod_retained_volume_backup_import_operation_record"),
+            read_method_name="read_odoo_prod_retained_volume_backup_import_operation_record",
             cancel_method_name=(
                 "cancel_pending_odoo_prod_retained_volume_backup_import_operation_record"
             ),
@@ -8032,7 +8125,7 @@ def create_launchplane_fastapi_app(
                 message="Request could not be completed.",
             ) from error
 
-        if not native_routes._native_driver_route_authorization_allows(
+        if not native_routes.native_driver_route_authorization_allows(
             endpoint=write_odoo_stable_bootstrap,
             authorization_allows=resolved_authz_policy_runtime.policy.allows,
             identity=identity,
@@ -8062,7 +8155,7 @@ def create_launchplane_fastapi_app(
         try:
             operation_authorization = capture_durable_operation_authorization(
                 identity=identity,
-                action=native_routes._native_driver_route_authz_action(write_odoo_stable_bootstrap),
+                action=native_routes.native_driver_route_authz_action(write_odoo_stable_bootstrap),
                 product=bootstrap_request.product,
                 context=bootstrap_request.bootstrap.context,
                 instances=(bootstrap_request.bootstrap.instance,),
@@ -8081,7 +8174,7 @@ def create_launchplane_fastapi_app(
                 record_store=record_store,
                 request=bootstrap_request,
                 idempotency_key=normalized_idempotency_key,
-                request_fingerprint=request_fingerprint(raw_payload),
+                request_fingerprint=build_request_fingerprint(raw_payload),
                 created_at=created_at,
                 authorization=operation_authorization,
             )
@@ -8128,7 +8221,7 @@ def create_launchplane_fastapi_app(
 
         return accepted_evidence_response(
             trace_id=trace_id,
-            records={key: str(value) for key, value in records.items()},
+            records={key: string_value(value) for key, value in records.items()},
             result=driver_result,
         )
 
@@ -8190,7 +8283,7 @@ def create_launchplane_fastapi_app(
                 message="Request could not be completed.",
             ) from error
 
-        if not native_routes._native_driver_route_authorization_allows(
+        if not native_routes.native_driver_route_authorization_allows(
             endpoint=write_odoo_target_replacement_plan,
             authorization_allows=resolved_authz_policy_runtime.policy.allows,
             identity=identity,
@@ -8289,7 +8382,7 @@ def create_launchplane_fastapi_app(
                 message="Request could not be completed.",
             ) from error
 
-        if not native_routes._native_driver_route_authorization_allows(
+        if not native_routes.native_driver_route_authorization_allows(
             endpoint=write_odoo_target_replacement_apply,
             authorization_allows=resolved_authz_policy_runtime.policy.allows,
             identity=identity,
@@ -8319,7 +8412,7 @@ def create_launchplane_fastapi_app(
         try:
             operation_authorization = capture_durable_operation_authorization(
                 identity=identity,
-                action=native_routes._native_driver_route_authz_action(
+                action=native_routes.native_driver_route_authz_action(
                     write_odoo_target_replacement_apply
                 ),
                 product=apply_request.product,
@@ -8342,7 +8435,7 @@ def create_launchplane_fastapi_app(
                 context=lane.context,
                 idempotency_key=normalized_idempotency_key,
                 idempotency_scope=idempotency_scope(identity),
-                request_fingerprint=request_fingerprint(raw_payload),
+                request_fingerprint=build_request_fingerprint(raw_payload),
                 created_at=created_at,
                 authorization=operation_authorization,
             )
@@ -8396,7 +8489,7 @@ def create_launchplane_fastapi_app(
 
         return accepted_evidence_response(
             trace_id=trace_id,
-            records={key: str(value) for key, value in records.items()},
+            records={key: string_value(value) for key, value in records.items()},
             result=driver_result,
         )
 
@@ -8460,7 +8553,7 @@ def create_launchplane_fastapi_app(
             ) from error
 
         authorization_product = product_profile.product
-        if not native_routes._native_driver_route_authorization_allows(
+        if not native_routes.native_driver_route_authorization_allows(
             endpoint=write_odoo_prod_rollback,
             authorization_allows=resolved_authz_policy_runtime.policy.allows,
             identity=identity,
@@ -8517,7 +8610,7 @@ def create_launchplane_fastapi_app(
 
         response = accepted_evidence_response(
             trace_id=trace_id,
-            records={key: str(value) for key, value in records.items()},
+            records={key: string_value(value) for key, value in records.items()},
             result=driver_result,
         )
         if should_store_odoo_prod_rollback_idempotency(driver_result):
@@ -8595,7 +8688,7 @@ def create_launchplane_fastapi_app(
             ) from error
 
         authorization_product = product_profile.product
-        if not native_routes._native_driver_route_authorization_allows(
+        if not native_routes.native_driver_route_authorization_allows(
             endpoint=write_odoo_prod_promotion,
             authorization_allows=resolved_authz_policy_runtime.policy.allows,
             identity=identity,
@@ -8657,7 +8750,7 @@ def create_launchplane_fastapi_app(
 
         response = accepted_evidence_response(
             trace_id=trace_id,
-            records={key: str(value) for key, value in records.items()},
+            records={key: string_value(value) for key, value in records.items()},
             result=driver_result,
         )
         if should_store_prod_promotion_idempotency(driver_result):
@@ -8735,7 +8828,7 @@ def create_launchplane_fastapi_app(
             ) from error
 
         authorization_product = product_profile.product
-        if not native_routes._native_driver_route_authorization_allows(
+        if not native_routes.native_driver_route_authorization_allows(
             endpoint=write_odoo_prod_promotion_inputs,
             authorization_allows=resolved_authz_policy_runtime.policy.allows,
             identity=identity,
@@ -8799,7 +8892,7 @@ def create_launchplane_fastapi_app(
 
         response = accepted_evidence_response(
             trace_id=trace_id,
-            records={key: str(value) for key, value in records.items()},
+            records={key: string_value(value) for key, value in records.items()},
             result=driver_result,
         )
         if should_store_prod_promotion_idempotency(driver_result):
@@ -8877,7 +8970,7 @@ def create_launchplane_fastapi_app(
             ) from error
 
         authorization_product = product_profile.product
-        if not native_routes._native_driver_route_authorization_allows(
+        if not native_routes.native_driver_route_authorization_allows(
             endpoint=write_odoo_prod_promotion_run,
             authorization_allows=resolved_authz_policy_runtime.policy.allows,
             identity=identity,
@@ -8941,7 +9034,7 @@ def create_launchplane_fastapi_app(
 
         response = accepted_evidence_response(
             trace_id=trace_id,
-            records={key: str(value) for key, value in records.items()},
+            records={key: string_value(value) for key, value in records.items()},
             result=driver_result,
         )
         if should_store_prod_promotion_idempotency(driver_result):
@@ -8990,7 +9083,7 @@ def create_launchplane_fastapi_app(
             ) from error
 
         normalized_idempotency_key = idempotency_key.strip()
-        payload_fingerprint = request_fingerprint(cast(dict[str, object], raw_payload))
+        payload_fingerprint = build_request_fingerprint(raw_payload)
         if not resolved_authz_policy_runtime.policy.allows(
             identity=identity,
             action="launchplane_service_deploy.execute",
@@ -9084,7 +9177,7 @@ def create_launchplane_fastapi_app(
             ) from error
 
         normalized_idempotency_key = idempotency_key.strip()
-        payload_fingerprint = request_fingerprint(cast(dict[str, object], raw_payload))
+        payload_fingerprint = build_request_fingerprint(raw_payload)
         if normalized_idempotency_key:
             (
                 normalized_idempotency_key,
@@ -9289,7 +9382,7 @@ def create_launchplane_fastapi_app(
             ) from error
 
         normalized_idempotency_key = idempotency_key.strip()
-        payload_fingerprint = request_fingerprint(cast(dict[str, object], raw_payload))
+        payload_fingerprint = build_request_fingerprint(raw_payload)
         if normalized_idempotency_key:
             (
                 normalized_idempotency_key,
@@ -9516,7 +9609,7 @@ def create_launchplane_fastapi_app(
             ) from error
 
         normalized_idempotency_key = idempotency_key.strip()
-        payload_fingerprint = request_fingerprint(cast(dict[str, object], raw_payload))
+        payload_fingerprint = build_request_fingerprint(raw_payload)
         if normalized_idempotency_key:
             (
                 normalized_idempotency_key,
@@ -9597,6 +9690,22 @@ def create_launchplane_fastapi_app(
                     trace_id=trace_id,
                     recorded_at=utc_now_timestamp(),
                 )
+                run_record_store.write_merge_train_run_record(run_once_result.run_record)
+                response = accepted_evidence_response(
+                    trace_id=trace_id,
+                    records=run_once_result.records,
+                    result=run_once_result.accepted_result,
+                )
+                store_apply_idempotency(
+                    record_store=record_store,
+                    identity=identity,
+                    route_path=_MERGE_TRAIN_RUN_ONCE_ROUTE,
+                    idempotency_key=normalized_idempotency_key,
+                    request_fingerprint_value=payload_fingerprint,
+                    trace_id=trace_id,
+                    response=response,
+                )
+                return response
             else:
                 with merge_train_controller_mutation_fence(
                     record_store=controller_state_store,
@@ -9642,6 +9751,7 @@ def create_launchplane_fastapi_app(
                         trace_id=trace_id,
                         response=response,
                     )
+                    return response
         except MergeTrainGitHubStaleHeadError as error:
             return merge_train_github_stale_state_response(trace_id=trace_id, error=error)
         except MergeTrainGitHubError as error:
@@ -9653,23 +9763,6 @@ def create_launchplane_fastapi_app(
             MergeTrainControllerAdoptionRejectedError,
         ) as error:
             raise merge_train_controller_fence_http_error(trace_id=trace_id, error=error) from error
-        if controller_state_store is None:
-            run_record_store.write_merge_train_run_record(run_once_result.run_record)
-            response = accepted_evidence_response(
-                trace_id=trace_id,
-                records=run_once_result.records,
-                result=run_once_result.accepted_result,
-            )
-            store_apply_idempotency(
-                record_store=record_store,
-                identity=identity,
-                route_path=_MERGE_TRAIN_RUN_ONCE_ROUTE,
-                idempotency_key=normalized_idempotency_key,
-                request_fingerprint_value=payload_fingerprint,
-                trace_id=trace_id,
-                response=response,
-            )
-        return response
 
     async def write_merge_train_pr_feedback(
         request: Request,
@@ -9705,7 +9798,7 @@ def create_launchplane_fastapi_app(
             ) from error
 
         normalized_idempotency_key = idempotency_key.strip()
-        payload_fingerprint = request_fingerprint(cast(dict[str, object], raw_payload))
+        payload_fingerprint = build_request_fingerprint(raw_payload)
         if normalized_idempotency_key:
             (
                 normalized_idempotency_key,
@@ -10136,6 +10229,7 @@ def create_launchplane_fastapi_app(
         record_store: Annotated[object, Depends(get_record_store)],
         idempotency_key: Annotated[str, Header(alias="Idempotency-Key")] = "",
     ) -> AcceptedEvidenceResponse:
+        del idempotency_key
         trace_id = next_trace_id()
         worker_token_authorized = every_code_worker_token_authorized(
             request.headers.get("Authorization", "")
@@ -10166,7 +10260,7 @@ def create_launchplane_fastapi_app(
                 message=str(error),
             ) from error
         now = utc_now_timestamp()
-        new_lease_expires_at = _add_lease_seconds(now, heartbeat_request.lease_seconds)
+        new_lease_expires_at = add_lease_seconds(now, heartbeat_request.lease_seconds)
         accepted = heartbeat_store.heartbeat_every_code_work_request_record(
             request_id=heartbeat_request.request_id.strip(),
             host=heartbeat_request.host.strip(),
@@ -10202,6 +10296,7 @@ def create_launchplane_fastapi_app(
         ],
         record_store: Annotated[object, Depends(get_record_store)],
     ) -> AcceptedEvidenceResponse:
+        del payload
         trace_id = next_trace_id()
         worker_token_authorized = every_code_worker_token_authorized(
             request.headers.get("Authorization", "")
@@ -10899,7 +10994,7 @@ def create_launchplane_fastapi_app(
                 code="invalid_request",
                 message="Product expected config request failed validation.",
             )
-        request_payload = cast(dict[str, object], raw_payload)
+        request_payload = raw_payload
         try:
             expected_config_request = ProductExpectedConfigApplyEnvelope.model_validate(
                 request_payload
@@ -11115,7 +11210,7 @@ def create_launchplane_fastapi_app(
         if health_monitoring_request.mode == "apply":
             payload_fingerprint = idempotency_request_fingerprint(
                 route_path=_PRODUCT_HEALTH_MONITORING_APPLY_ROUTE,
-                payload=cast(dict[str, object], raw_payload),
+                payload=raw_payload,
             )
             replay_response = prepare_product_health_monitoring_mutation()
             if replay_response is not None:
@@ -11430,7 +11525,7 @@ def create_launchplane_fastapi_app(
         if prelaunch_rebuild_request.mode == "apply":
             payload_fingerprint = idempotency_request_fingerprint(
                 route_path=_PRODUCT_PRELAUNCH_REBUILD_POLICY_APPLY_ROUTE,
-                payload=cast(dict[str, object], raw_payload),
+                payload=raw_payload,
             )
             replay_response = prepare_product_prelaunch_rebuild_policy_mutation()
             if replay_response is not None:
@@ -11725,7 +11820,7 @@ def create_launchplane_fastapi_app(
         if preview_tls_request.mode == "apply":
             payload_fingerprint = idempotency_request_fingerprint(
                 route_path=_PRODUCT_PREVIEW_TLS_APPLY_ROUTE,
-                payload=cast(dict[str, object], raw_payload),
+                payload=raw_payload,
             )
             replay_response = prepare_product_preview_tls_mutation()
             if replay_response is not None:
@@ -11993,7 +12088,7 @@ def create_launchplane_fastapi_app(
         if repair_request.mode == "apply":
             payload_fingerprint = idempotency_request_fingerprint(
                 route_path=_PRODUCT_STABLE_LANE_REPAIR_APPLY_ROUTE,
-                payload=cast(dict[str, object], raw_payload),
+                payload=raw_payload,
             )
             replay_response = prepare_product_stable_lane_repair_mutation()
             if replay_response is not None:
@@ -12344,7 +12439,7 @@ def create_launchplane_fastapi_app(
         normalized_idempotency_key = idempotency_key.strip()
         normalized_scope = idempotency_scope(identity)
         raw_payload = await request.json()
-        payload_fingerprint = request_fingerprint(cast(dict[str, object], raw_payload))
+        payload_fingerprint = build_request_fingerprint(raw_payload)
         idempotency_store = idempotency_capable_store(record_store)
         if idempotency_store is not None and normalized_idempotency_key:
             stored_record = idempotency_store.read_idempotency_record(
@@ -12465,7 +12560,7 @@ def create_launchplane_fastapi_app(
                 status_code=409,
                 trace_id=trace_id,
                 code="mutation_reconciliation_required",
-                message=("The prior Launchplane mutation requires reconciliation before retry."),
+                message="The prior Launchplane mutation requires reconciliation before retry.",
             )
         return replay_idempotent_response(
             trace_id=trace_id,
@@ -12489,7 +12584,7 @@ def create_launchplane_fastapi_app(
         raw_payload = request_payload if request_payload is not None else await request.json()
         payload_fingerprint = idempotency_request_fingerprint(
             route_path=route_path,
-            payload=cast(dict[str, object], raw_payload),
+            payload=raw_payload,
         )
         if normalized_idempotency_key and check_replay:
             replay_response = replay_stored_apply_idempotency(
@@ -12694,15 +12789,20 @@ def create_launchplane_fastapi_app(
         except asyncio.CancelledError as cancellation:
             while not operation_task.done():
                 try:
-                    await asyncio.shield(operation_task)
+                    await asyncio.shield(asyncio.wait({operation_task}))
                 except asyncio.CancelledError:
                     continue
-                except Exception:
-                    _LOGGER.exception(
-                        "Provider mutation failed after request cancellation",
-                        extra={"trace_id": trace_id},
-                    )
-                    break
+            operation_error = operation_task.exception()
+            if operation_error is not None:
+                _LOGGER.error(
+                    "Provider mutation failed after request cancellation",
+                    exc_info=(
+                        type(operation_error),
+                        operation_error,
+                        operation_error.__traceback__,
+                    ),
+                    extra={"trace_id": trace_id},
+                )
             raise cancellation
         return provider_mutation_http_response(
             result=result,
@@ -12850,7 +12950,7 @@ def create_launchplane_fastapi_app(
                 message="Operator product-config apply requires a prior matching dry-run.",
             )
         try:
-            driver_result, authority_bundle = (
+            planned_driver_result, authority_bundle = (
                 control_plane_product_config.plan_product_config_authority_bundle(
                     record_store=database_store,
                     payload=product_config_request.product_config_payload(),
@@ -12869,8 +12969,8 @@ def create_launchplane_fastapi_app(
                 code=product_config_error.code,
                 message=product_config_error.message,
             )
-        driver_result = {
-            **driver_result,
+        driver_result: dict[str, object] = {
+            **planned_driver_result,
             "reason": product_config_request.reason,
         }
         next_actions = product_config_live_target_next_actions(
@@ -13547,7 +13647,7 @@ def create_launchplane_fastapi_app(
                 code="invalid_request",
                 message="Managed-secret re-encryption request failed validation.",
             )
-        request_payload = cast(dict[str, object], raw_payload)
+        request_payload = raw_payload
         try:
             reencryption_request = SecretReencryptionRequest.model_validate(request_payload)
         except ValidationError as error:
@@ -13600,9 +13700,7 @@ def create_launchplane_fastapi_app(
         operation_token = ""
         if reencryption_request.mode == "apply":
             operation_token = hashlib.sha256(
-                "\x1f".join((actor, normalized_idempotency_key, payload_fingerprint)).encode(
-                    "utf-8"
-                )
+                "\x1f".join((actor, normalized_idempotency_key, payload_fingerprint)).encode()
             ).hexdigest()
 
         def reencryption_idempotency_record(
@@ -13773,7 +13871,7 @@ def create_launchplane_fastapi_app(
                         "product": onboarding_request.generic_web.product,
                         "repository": onboarding_request.generic_web.repository,
                         "repository_id": onboarding_request.generic_web.repository_id,
-                        "repository_owner_id": (onboarding_request.generic_web.repository_owner_id),
+                        "repository_owner_id": onboarding_request.generic_web.repository_owner_id,
                         "default_branch": onboarding_request.generic_web.default_branch,
                         "testing_context": onboarding_request.generic_web.testing_context,
                         "preview_context": onboarding_request.generic_web.preview_context,
@@ -13787,7 +13885,7 @@ def create_launchplane_fastapi_app(
                     status_code=409,
                     trace_id=trace_id,
                     code="product_onboarding_plan_mismatch",
-                    message=("Generic-web onboarding inputs no longer match the reviewed dry-run."),
+                    message="Generic-web onboarding inputs no longer match the reviewed dry-run.",
                 )
             try:
                 onboarding_manifest = build_generic_web_onboarding_manifest(
@@ -13828,11 +13926,13 @@ def create_launchplane_fastapi_app(
         onboarding_response = accepted_evidence_response(
             trace_id=trace_id,
             records={
-                "product_profile": str(result["product_profile"]),
-                "provider_target_count": str(result["provider_target_count"]),
-                "provider_target_id_count": str(result["provider_target_id_count"]),
-                "runtime_environment_record_count": str(result["runtime_environment_record_count"]),
-                "secret_binding_count": str(result["secret_binding_count"]),
+                "product_profile": string_value(result["product_profile"]),
+                "provider_target_count": string_value(result["provider_target_count"]),
+                "provider_target_id_count": string_value(result["provider_target_id_count"]),
+                "runtime_environment_record_count": string_value(
+                    result["runtime_environment_record_count"]
+                ),
+                "secret_binding_count": string_value(result["secret_binding_count"]),
             },
             result=driver_result,
         )
@@ -13905,7 +14005,7 @@ def create_launchplane_fastapi_app(
             trace_id=trace_id,
         )
         normalized_idempotency_key = idempotency_key.strip()
-        payload_fingerprint = request_fingerprint(cast(dict[str, object], raw_payload))
+        payload_fingerprint = build_request_fingerprint(raw_payload)
         if policy_import_request.mode == "apply":
             (
                 normalized_idempotency_key,
@@ -13959,7 +14059,7 @@ def create_launchplane_fastapi_app(
         record_id = result.get("authz_policy_record_id")
         if record_id is None:
             return {}
-        return {"authz_policy_record_id": str(record_id)}
+        return {"authz_policy_record_id": string_value(record_id)}
 
     async def plan_generic_web_preview_authz(
         planning_request: GenericWebPreviewAuthzPlanRequest,
@@ -13970,7 +14070,7 @@ def create_launchplane_fastapi_app(
         database_store = require_authz_policy_database_store(
             record_store=record_store,
             trace_id=trace_id,
-            message=("Generic-web preview authz planning requires Launchplane database storage."),
+            message="Generic-web preview authz planning requires Launchplane database storage.",
         )
         if not resolved_authz_policy_runtime.policy.allows(
             identity=identity,
@@ -14129,7 +14229,7 @@ def create_launchplane_fastapi_app(
         database_store = require_authz_policy_database_store(
             record_store=record_store,
             trace_id=trace_id,
-            message=("Managed authz policy reconciliation requires Launchplane database storage."),
+            message="Managed authz policy reconciliation requires Launchplane database storage.",
         )
         if not resolved_authz_policy_runtime.policy.allows(
             identity=identity,
@@ -14145,7 +14245,7 @@ def create_launchplane_fastapi_app(
             )
         route_path = _AUTHZ_POLICY_MANAGED_RECONCILE_ROUTE
         normalized_idempotency_key = idempotency_key.strip()
-        payload_fingerprint = request_fingerprint(cast(dict[str, object], raw_payload))
+        payload_fingerprint = build_request_fingerprint(raw_payload)
         if authz_request.mode == "apply" and not normalized_idempotency_key:
             raise _launchplane_http_error(
                 status_code=400,
@@ -14223,18 +14323,14 @@ def create_launchplane_fastapi_app(
         if authz_request.mode == "apply":
             mutation_scope = idempotency_scope(identity)
             idempotency_record_digest = hashlib.sha256(
-                "\x1f".join((mutation_scope, route_path, normalized_idempotency_key)).encode(
-                    "utf-8"
-                )
+                "\x1f".join((mutation_scope, route_path, normalized_idempotency_key)).encode()
             ).hexdigest()
             audit_context: dict[str, object] = {
                 "request_fingerprint": payload_fingerprint,
-                "idempotency_scope_sha256": hashlib.sha256(
-                    mutation_scope.encode("utf-8")
-                ).hexdigest(),
+                "idempotency_scope_sha256": hashlib.sha256(mutation_scope.encode()).hexdigest(),
                 "idempotency_record_id": f"mutation-reservation-{idempotency_record_digest}",
                 "idempotency_key_sha256": hashlib.sha256(
-                    normalized_idempotency_key.encode("utf-8")
+                    normalized_idempotency_key.encode()
                 ).hexdigest(),
             }
             route_result.authz_policy_record.audit.update(audit_context)
@@ -14379,6 +14475,176 @@ def create_launchplane_fastapi_app(
             policy=control_plane_authz_grant_service.summarize_active_authz_policy_record(
                 active_records[0]
             ),
+        )
+
+    def read_single_active_authz_policy_record(
+        *,
+        database_store: PostgresRecordStore,
+        trace_id: str,
+    ) -> LaunchplaneAuthzPolicyRecord:
+        active_records = database_store.list_authz_policy_records(status="active", limit=2)
+        if not active_records:
+            raise _launchplane_http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="authz_policy_unavailable",
+                message="Launchplane active authz policy is unavailable.",
+            )
+        if len(active_records) > 1:
+            raise _launchplane_http_error(
+                status_code=409,
+                trace_id=trace_id,
+                code="active_authz_policy_ambiguous",
+                message="Multiple active Launchplane authz policy records were found.",
+            )
+        return active_records[0]
+
+    async def evaluate_effective_access(
+        evaluation_request: EffectiveAccessEvaluateRequest,
+        identity: Annotated[LaunchplaneIdentity, Depends(read_browser_mutation_identity)],
+        record_store: Annotated[object, Depends(get_record_store)],
+    ) -> EffectiveAccessEvaluateResponse:
+        trace_id = next_trace_id()
+        is_administrator = isinstance(identity, LocalAdminIdentity) or (
+            isinstance(identity, GitHubHumanIdentity) and identity.role == "admin"
+        )
+        preflight_authorized = resolved_authz_policy_runtime.policy.allows(
+            identity=identity,
+            action=EFFECTIVE_ACCESS_READ_ACTION,
+            product="launchplane",
+            context=_LAUNCHPLANE_SERVICE_CONTEXT,
+        )
+        if not is_administrator or not preflight_authorized:
+            raise _launchplane_http_error(
+                status_code=403,
+                trace_id=trace_id,
+                code="authorization_denied",
+                message="Identity cannot evaluate Launchplane effective access.",
+            )
+        database_store = require_authz_policy_database_store(
+            record_store=record_store,
+            trace_id=trace_id,
+            message="Effective access reads require Launchplane database storage.",
+        )
+        active_record = read_single_active_authz_policy_record(
+            database_store=database_store,
+            trace_id=trace_id,
+        )
+        if not active_record.policy.allows(
+            identity=identity,
+            action=EFFECTIVE_ACCESS_READ_ACTION,
+            product="launchplane",
+            context=_LAUNCHPLANE_SERVICE_CONTEXT,
+        ):
+            raise _launchplane_http_error(
+                status_code=403,
+                trace_id=trace_id,
+                code="authorization_denied",
+                message="Identity cannot evaluate Launchplane effective access.",
+                authz_policy_provenance=AuthzPolicyProvenance.from_record(active_record),
+            )
+        target = (
+            AuthorizationTarget(scope="instance", instances=(evaluation_request.instance,))
+            if evaluation_request.target_scope == "instance"
+            else AuthorizationTarget(scope="context")
+        )
+        evaluation = active_record.policy.evaluate(
+            identity=evaluation_request.identity(),
+            action=evaluation_request.action,
+            product=evaluation_request.product,
+            context=evaluation_request.context,
+            target=target,
+            record_context=False,
+        )
+        return EffectiveAccessEvaluateResponse(
+            trace_id=trace_id,
+            policy_record_id=active_record.record_id,
+            policy_revision=active_record.revision,
+            policy_sha256=active_record.policy_sha256,
+            request=EffectiveAccessRequestSummary(
+                principal_type=evaluation_request.principal.principal_type,
+                action=evaluation_request.action,
+                product=evaluation_request.product,
+                context=evaluation_request.context,
+                target_scope=evaluation_request.target_scope,
+                instance=evaluation_request.instance,
+            ),
+            evaluation=EffectiveAccessDecision(
+                decision=evaluation.decision,
+                reason_code=evaluation.reason_code,
+            ),
+        )
+
+    async def explain_authz_denial(
+        trace_id: str,
+        identity: Annotated[LaunchplaneIdentity, Depends(read_identity)],
+        record_store: Annotated[object, Depends(get_record_store)],
+    ) -> AuthzDenialExplanationResponse:
+        request_trace_id = next_trace_id()
+        is_support_reader = isinstance(
+            identity,
+            GitHubHumanIdentity | LocalOperatorIdentity | LocalAdminIdentity,
+        )
+        preflight_authorized = resolved_authz_policy_runtime.policy.allows(
+            identity=identity,
+            action=AUTHZ_DENIAL_EXPLANATION_READ_ACTION,
+            product="launchplane",
+            context=_LAUNCHPLANE_SERVICE_CONTEXT,
+        )
+        if not is_support_reader or not preflight_authorized:
+            raise _launchplane_http_error(
+                status_code=403,
+                trace_id=request_trace_id,
+                code="authorization_denied",
+                message="Identity cannot explain Launchplane authorization denials.",
+            )
+        database_store = require_authz_policy_database_store(
+            record_store=record_store,
+            trace_id=request_trace_id,
+            message="Authorization denial explanations require Launchplane database storage.",
+        )
+        active_record = read_single_active_authz_policy_record(
+            database_store=database_store,
+            trace_id=request_trace_id,
+        )
+        if not active_record.policy.allows(
+            identity=identity,
+            action=AUTHZ_DENIAL_EXPLANATION_READ_ACTION,
+            product="launchplane",
+            context=_LAUNCHPLANE_SERVICE_CONTEXT,
+        ):
+            raise _launchplane_http_error(
+                status_code=403,
+                trace_id=request_trace_id,
+                code="authorization_denied",
+                message="Identity cannot explain Launchplane authorization denials.",
+                authz_policy_provenance=AuthzPolicyProvenance.from_record(active_record),
+            )
+        denial_record = database_store.read_authz_denial_record(
+            trace_id=trace_id,
+            observed_at=datetime.now(timezone.utc).isoformat(),
+        )
+        if denial_record is None:
+            raise _launchplane_http_error(
+                status_code=404,
+                trace_id=request_trace_id,
+                code="authz_denial_not_found",
+                message="Authorization denial evidence was not found.",
+            )
+        return AuthzDenialExplanationResponse(
+            trace_id=denial_record.trace_id,
+            recorded_at=denial_record.recorded_at,
+            route_path=denial_record.route_path,
+            principal_type=denial_record.principal_type,
+            action=denial_record.action,
+            product=denial_record.product,
+            context=denial_record.context,
+            target_scope=denial_record.target_scope,
+            instance_specified=denial_record.instance_specified,
+            reason_code=denial_record.reason_code,
+            policy_record_id=denial_record.policy_record_id,
+            policy_revision=denial_record.policy_revision,
+            policy_sha256=denial_record.policy_sha256,
         )
 
     async def evaluate_github_actions_authz_diagnostic(
@@ -14611,7 +14877,7 @@ def create_launchplane_fastapi_app(
                 message="Workflow cannot run Launchplane provider-target operations.",
             )
         normalized_idempotency_key = idempotency_key.strip()
-        payload_fingerprint = request_fingerprint(cast(dict[str, object], raw_payload))
+        payload_fingerprint = build_request_fingerprint(raw_payload)
         if provider_target_request.mode == "backfill-apply":
             if not normalized_idempotency_key:
                 raise _launchplane_http_error(
@@ -15196,7 +15462,7 @@ def create_launchplane_fastapi_app(
             product=binding_request.product,
             context_name=binding_request.context,
             instance_name=binding_request.instance,
-            message=("Workflow cannot reconcile external route bindings for the requested lane."),
+            message="Workflow cannot reconcile external route bindings for the requested lane.",
         )
         if binding_request.mode == "apply" and not idempotency_key.strip():
             raise _launchplane_http_error(
@@ -15230,7 +15496,7 @@ def create_launchplane_fastapi_app(
             raw_payload = await request.json()
             payload_fingerprint = idempotency_request_fingerprint(
                 route_path=_EXTERNAL_ROUTE_BINDING_RECONCILE_ROUTE,
-                payload=cast(dict[str, object], raw_payload),
+                payload=raw_payload,
             )
             preflight = mutation_store.prepare_db_only_mutation(
                 scope=idempotency_scope(identity),
@@ -15428,7 +15694,7 @@ def create_launchplane_fastapi_app(
             product=binding_request.product,
             context_name=binding_request.context,
             instance_name=binding_request.instance,
-            message=("Workflow cannot reconcile route bindings for the requested product/context."),
+            message="Workflow cannot reconcile route bindings for the requested product/context.",
         )
         if binding_request.mode == "apply" and not idempotency_key.strip():
             raise _launchplane_http_error(
@@ -15462,7 +15728,7 @@ def create_launchplane_fastapi_app(
             raw_payload = await request.json()
             payload_fingerprint = idempotency_request_fingerprint(
                 route_path=_ROUTE_BINDING_RECONCILE_ROUTE,
-                payload=cast(dict[str, object], raw_payload),
+                payload=raw_payload,
             )
             preflight = mutation_store.prepare_db_only_mutation(
                 scope=idempotency_scope(identity),
@@ -15726,7 +15992,7 @@ def create_launchplane_fastapi_app(
                 product=outcome.product,
                 context_name=outcome.context,
                 instance_name=outcome.instance,
-                message=("Workflow cannot refresh a discovered Odoo testing route binding."),
+                message="Workflow cannot refresh a discovered Odoo testing route binding.",
             )
 
         controller_reservation: LaunchplaneIdempotencyRecord | None = None
@@ -15869,7 +16135,7 @@ def create_launchplane_fastapi_app(
                     "Odoo testing route binding refresh apply requires a mutation store."
                 )
             binding_key = reconcile_plan.current_record.binding_key
-            binding_token = hashlib.sha256(binding_key.encode("utf-8")).hexdigest()[:16]
+            binding_token = hashlib.sha256(binding_key.encode()).hexdigest()[:16]
             binding_idempotency_key = f"{normalized_key}:{binding_token}"
             binding_response_payload: dict[str, object] = {
                 "status": "accepted",
@@ -15932,7 +16198,7 @@ def create_launchplane_fastapi_app(
             else (
                 "attention"
                 if any(
-                    str(outcome.get("status") or "") in attention_statuses
+                    string_value(outcome.get("status") or "") in attention_statuses
                     for outcome in result_outcomes
                 )
                 else "ok"
@@ -16036,9 +16302,9 @@ def create_launchplane_fastapi_app(
     ) -> AcceptedEvidenceResponse:
         trace_id = next_trace_id()
         authz_action = (
-            native_routes._native_driver_route_authz_action(apply_ingress_route)
+            native_routes.native_driver_route_authz_action(apply_ingress_route)
             if route_request.ingress.mode == "apply"
-            else native_routes._native_driver_route_alternate_authz_action(apply_ingress_route)
+            else native_routes.native_driver_route_alternate_authz_action(apply_ingress_route)
         )
         instance_name = route_request.instance.strip()
         if not resolved_authz_policy_runtime.policy.allows(
@@ -16599,6 +16865,7 @@ def create_launchplane_fastapi_app(
                 code="authorization_denied",
                 message="Identity is not authorized for product retirement.",
             )
+        bound: control_plane_product_retirement.BoundProductRetirement | None = None
         try:
             retirement_store = cast(
                 control_plane_product_retirement.ProductRetirementStore,
@@ -16673,6 +16940,8 @@ def create_launchplane_fastapi_app(
         actor_identity = product_retirement_identity(identity)
         requested_at = utc_now_timestamp()
         if retirement_request.mode == "plan":
+            if bound is None:
+                raise RuntimeError("Product retirement plan authority was not bound.")
             existing_plans = retirement_store.list_product_retirement_records(
                 product=retirement_request.product,
                 actor=actor_identity.actor,
@@ -16883,9 +17152,12 @@ def create_launchplane_fastapi_app(
         try:
             retirement_store = cast(
                 control_plane_detached_application_retirement.DetachedApplicationRetirementStore,
-                require_provider_operation_store(
-                    record_store=record_store,
-                    trace_id=trace_id,
+                cast(
+                    object,
+                    require_provider_operation_store(
+                        record_store=record_store,
+                        trace_id=trace_id,
+                    ),
                 ),
             )
             plan_record = None
@@ -17404,7 +17676,7 @@ def create_launchplane_fastapi_app(
                         repository=feedback_request.repository,
                         pull_request_number=feedback_request.anchor_pr_number,
                     )
-            except Exception:
+            except (OSError, RequestException, RuntimeError, ValueError):
                 owner_review_status = "unavailable"
                 owner_review_url = ""
                 _LOGGER.exception(
@@ -17581,7 +17853,7 @@ def create_launchplane_fastapi_app(
 
     def raise_verireel_product_mismatch_error(
         *, trace_id: str, error: VeriReelProductMismatchError
-    ) -> None:
+    ) -> NoReturn:
         raise _launchplane_http_error(
             status_code=403,
             trace_id=trace_id,
@@ -17591,7 +17863,7 @@ def create_launchplane_fastapi_app(
 
     def raise_verireel_invalid_request_error(
         *, trace_id: str, error: ValueError | click.ClickException
-    ) -> None:
+    ) -> NoReturn:
         raise _launchplane_http_error(
             status_code=400,
             trace_id=trace_id,
@@ -17599,7 +17871,7 @@ def create_launchplane_fastapi_app(
             message="Request could not be completed.",
         ) from error
 
-    def raise_verireel_unexpected_driver_error(*, trace_id: str, error: Exception) -> None:
+    def raise_verireel_unexpected_driver_error(*, trace_id: str, error: Exception) -> NoReturn:
         _LOGGER.exception("Unexpected Launchplane service error", extra={"trace_id": trace_id})
         raise _launchplane_http_error(
             status_code=500,
@@ -17632,7 +17904,7 @@ def create_launchplane_fastapi_app(
             raise_verireel_product_mismatch_error(trace_id=trace_id, error=error)
         except (ValueError, click.ClickException) as error:
             raise_verireel_invalid_request_error(trace_id=trace_id, error=error)
-        if not native_routes._native_driver_route_authorization_allows(
+        if not native_routes.native_driver_route_authorization_allows(
             endpoint=apply_verireel_prod_deploy,
             authorization_allows=resolved_authz_policy_runtime.policy.allows,
             identity=identity,
@@ -17718,7 +17990,7 @@ def create_launchplane_fastapi_app(
             raise_verireel_product_mismatch_error(trace_id=trace_id, error=error)
         except (ValueError, click.ClickException) as error:
             raise_verireel_invalid_request_error(trace_id=trace_id, error=error)
-        if not native_routes._native_driver_route_authorization_allows(
+        if not native_routes.native_driver_route_authorization_allows(
             endpoint=apply_verireel_prod_backup_gate,
             authorization_allows=resolved_authz_policy_runtime.policy.allows,
             identity=identity,
@@ -17754,7 +18026,7 @@ def create_launchplane_fastapi_app(
         try:
             operation_authorization = capture_durable_operation_authorization(
                 identity=identity,
-                action=native_routes._native_driver_route_authz_action(
+                action=native_routes.native_driver_route_authz_action(
                     apply_verireel_prod_backup_gate
                 ),
                 product=authorization_product,
@@ -17830,7 +18102,7 @@ def create_launchplane_fastapi_app(
             raise_verireel_product_mismatch_error(trace_id=trace_id, error=error)
         except (ValueError, click.ClickException) as error:
             raise_verireel_invalid_request_error(trace_id=trace_id, error=error)
-        if not native_routes._native_driver_route_authorization_allows(
+        if not native_routes.native_driver_route_authorization_allows(
             endpoint=apply_verireel_prod_promotion,
             authorization_allows=resolved_authz_policy_runtime.policy.allows,
             identity=identity,
@@ -17919,7 +18191,7 @@ def create_launchplane_fastapi_app(
             raise_verireel_product_mismatch_error(trace_id=trace_id, error=error)
         except (ValueError, click.ClickException) as error:
             raise_verireel_invalid_request_error(trace_id=trace_id, error=error)
-        if not native_routes._native_driver_route_authorization_allows(
+        if not native_routes.native_driver_route_authorization_allows(
             endpoint=apply_verireel_prod_rollback,
             authorization_allows=resolved_authz_policy_runtime.policy.allows,
             identity=identity,
@@ -18015,7 +18287,7 @@ def create_launchplane_fastapi_app(
                 code="invalid_request",
                 message="Request could not be completed.",
             ) from error
-        if not native_routes._native_driver_route_authorization_allows(
+        if not native_routes.native_driver_route_authorization_allows(
             endpoint=apply_verireel_testing_deploy,
             authorization_allows=resolved_authz_policy_runtime.policy.allows,
             identity=identity,
@@ -18107,7 +18379,7 @@ def create_launchplane_fastapi_app(
                 code="product_driver_mismatch",
                 message="Product is not configured for the requested driver route.",
             ) from error
-        if not native_routes._native_driver_route_authorization_allows(
+        if not native_routes.native_driver_route_authorization_allows(
             endpoint=apply_verireel_app_maintenance,
             authorization_allows=resolved_authz_policy_runtime.policy.allows,
             identity=identity,
@@ -18205,7 +18477,7 @@ def create_launchplane_fastapi_app(
                 code="invalid_request",
                 message="Request could not be completed.",
             ) from error
-        if not native_routes._native_driver_route_authorization_allows(
+        if not native_routes.native_driver_route_authorization_allows(
             endpoint=apply_verireel_testing_verification,
             authorization_allows=resolved_authz_policy_runtime.policy.allows,
             identity=identity,
@@ -18295,7 +18567,7 @@ def create_launchplane_fastapi_app(
                 code="product_driver_mismatch",
                 message="Product is not configured for the requested driver route.",
             ) from error
-        if not native_routes._native_driver_route_authorization_allows(
+        if not native_routes.native_driver_route_authorization_allows(
             endpoint=read_verireel_stable_environment,
             authorization_allows=resolved_authz_policy_runtime.policy.allows,
             identity=identity,
@@ -18355,7 +18627,7 @@ def create_launchplane_fastapi_app(
                 code="product_driver_mismatch",
                 message="Product is not configured for the requested driver route.",
             ) from error
-        if not native_routes._native_driver_route_authorization_allows(
+        if not native_routes.native_driver_route_authorization_allows(
             endpoint=run_verireel_runtime_verification,
             authorization_allows=resolved_authz_policy_runtime.policy.allows,
             identity=identity,
@@ -18418,7 +18690,7 @@ def create_launchplane_fastapi_app(
                 message="Product is not configured for the requested driver route.",
             ) from error
         authorization_context = inventory_request.inventory.context.strip() or authorization_context
-        if not native_routes._native_driver_route_authorization_allows(
+        if not native_routes.native_driver_route_authorization_allows(
             endpoint=read_verireel_preview_inventory,
             authorization_allows=resolved_authz_policy_runtime.policy.allows,
             identity=identity,
@@ -18480,7 +18752,7 @@ def create_launchplane_fastapi_app(
                 message="Product is not configured for the requested driver route.",
             ) from error
         authorization_context = refresh_request.refresh.context.strip() or authorization_context
-        if not native_routes._native_driver_route_authorization_allows(
+        if not native_routes.native_driver_route_authorization_allows(
             endpoint=apply_verireel_preview_refresh,
             authorization_allows=resolved_authz_policy_runtime.policy.allows,
             identity=identity,
@@ -18583,7 +18855,7 @@ def create_launchplane_fastapi_app(
                 message="Product is not configured for the requested driver route.",
             ) from error
         authorization_context = destroy_request.destroy.context.strip() or authorization_context
-        if not native_routes._native_driver_route_authorization_allows(
+        if not native_routes.native_driver_route_authorization_allows(
             endpoint=apply_verireel_preview_destroy,
             authorization_allows=resolved_authz_policy_runtime.policy.allows,
             identity=identity,
@@ -18680,7 +18952,7 @@ def create_launchplane_fastapi_app(
         authorization_context = (
             verification_request.verification.context.strip() or authorization_context
         )
-        if not native_routes._native_driver_route_authorization_allows(
+        if not native_routes.native_driver_route_authorization_allows(
             endpoint=apply_verireel_preview_verification,
             authorization_allows=resolved_authz_policy_runtime.policy.allows,
             identity=identity,
@@ -19052,7 +19324,7 @@ def create_launchplane_fastapi_app(
         response = accepted_evidence_response(
             trace_id=trace_id,
             records={
-                "runtime_key_safety_policy_record_id": str(
+                "runtime_key_safety_policy_record_id": string_value(
                     route_result.result["runtime_key_safety_policy_record_id"]
                 ),
             },
@@ -19299,7 +19571,7 @@ def create_launchplane_fastapi_app(
         normalized_idempotency_key = idempotency_key.strip()
         normalized_scope = idempotency_scope(identity)
         raw_payload = await request.json()
-        payload_fingerprint = request_fingerprint(cast(dict[str, object], raw_payload))
+        payload_fingerprint = build_request_fingerprint(raw_payload)
         if idempotency_store is not None and normalized_idempotency_key:
             stored_record = idempotency_store.read_idempotency_record(
                 scope=normalized_scope,
@@ -20398,7 +20670,7 @@ def create_launchplane_fastapi_app(
         },
     )
 
-    for route_path, endpoint, operation_id, summary in (
+    for registered_route_path, registered_endpoint, registered_operation_id, summary in (
         (
             _ODOO_STABLE_BOOTSTRAP_OPERATION_CANCEL_ROUTE,
             cancel_odoo_stable_bootstrap_operation,
@@ -20431,12 +20703,12 @@ def create_launchplane_fastapi_app(
         ),
     ):
         app.add_api_route(
-            route_path,
-            endpoint,
+            registered_route_path,
+            registered_endpoint,
             methods=["POST"],
             response_model=DurableOperationCancellationResponse,
             response_model_exclude_none=True,
-            operation_id=operation_id,
+            operation_id=registered_operation_id,
             summary=summary,
             responses={
                 400: {"model": LaunchplaneErrorResponse},
@@ -21133,7 +21405,7 @@ def create_launchplane_fastapi_app(
         dependencies=ChangeImpactReadRouteDependencies(
             common=read_route_dependencies,
             read_evaluation_identity=read_bearer_identity,
-            repository_evidence_provider=(resolved_change_impact_repository_evidence_provider),
+            repository_evidence_provider=resolved_change_impact_repository_evidence_provider,
         ),
     )
     register_owner_acceptance_routes(
@@ -21142,14 +21414,14 @@ def create_launchplane_fastapi_app(
             common=read_route_dependencies,
             read_write_identity=read_write_identity,
             read_browser_mutation_identity=read_browser_mutation_identity,
-            repository_evidence_provider=(resolved_change_impact_repository_evidence_provider),
+            repository_evidence_provider=resolved_change_impact_repository_evidence_provider,
             github_app_token=lambda repository, repository_id: mint_repository_installation_token(
                 identity=resolve_advisory_github_app_identity(
                     control_plane_root=resolved_control_plane_root
                 ),
                 repository=repository,
                 repository_id=repository_id,
-                api_request=github_api_request,
+                api_request=injected_github_api_request,
             ),
             github_api=github_api_request,
             public_origin=(human_session_manager.public_origin if human_session_manager else None),
@@ -21160,7 +21432,7 @@ def create_launchplane_fastapi_app(
         app,
         dependencies=GovernanceProjectionRouteDependencies(
             common=read_route_dependencies,
-            repository_evidence_provider=(resolved_change_impact_repository_evidence_provider),
+            repository_evidence_provider=resolved_change_impact_repository_evidence_provider,
             current_readiness_provider=LiveGovernanceCurrentReadinessProvider(
                 github_token=lambda env_var: os.environ.get(env_var, "").strip(),
             ),
@@ -22006,6 +22278,31 @@ def create_launchplane_fastapi_app(
     )
 
     app.add_api_route(
+        _AUTHZ_EFFECTIVE_ACCESS_EVALUATE_ROUTE,
+        evaluate_effective_access,
+        methods=["POST"],
+        response_model=EffectiveAccessEvaluateResponse,
+        response_model_exclude_none=True,
+        operation_id="evaluate_effective_access",
+        summary="Evaluate one principal and scope against active authorization",
+        responses=authz_diagnostic_route_responses,
+    )
+
+    app.add_api_route(
+        _AUTHZ_DENIAL_EXPLANATION_ROUTE,
+        explain_authz_denial,
+        methods=["GET"],
+        response_model=AuthzDenialExplanationResponse,
+        response_model_exclude_none=True,
+        operation_id="explain_authz_denial",
+        summary="Read one redacted authorization denial explanation",
+        responses={
+            **authz_diagnostic_route_responses,
+            404: {"model": LaunchplaneErrorResponse},
+        },
+    )
+
+    app.add_api_route(
         _GENERIC_WEB_PREVIEW_AUTHZ_PLAN_ROUTE,
         plan_generic_web_preview_authz,
         methods=["POST"],
@@ -22233,23 +22530,87 @@ def create_launchplane_fastapi_app(
         include_in_schema=False,
     )
 
-    def launchplane_http_exception_handler(request: Request, error: Exception) -> JSONResponse:
+    async def persist_authz_denial_best_effort(
+        *,
+        request: Request,
+        trace_id: str,
+        evaluation: AuthzEvaluation | None,
+        policy_provenance: AuthzPolicyProvenance | None,
+    ) -> None:
+        if evaluation is None:
+            evaluation = current_authz_evaluation()
+        if evaluation is None or evaluation.decision != "denied" or policy_provenance is None:
+            return
+
+        def write_denial_record() -> None:
+            store = get_record_store()
+            if not isinstance(store, PostgresRecordStore):
+                return
+            if policy_provenance.source != "db" or not policy_provenance.record_id:
+                return
+            recorded_at = datetime.now(timezone.utc)
+            route = request.scope.get("route")
+            route_path = str(getattr(route, "path", request.url.path))
+            store.write_authz_denial_record(
+                build_authz_denial_record(
+                    trace_id=trace_id,
+                    recorded_at=recorded_at.isoformat(),
+                    expires_at=(recorded_at + timedelta(days=30)).isoformat(),
+                    route_path=route_path,
+                    evaluation=evaluation,
+                    policy_record_id=policy_provenance.record_id,
+                    policy_revision=policy_provenance.revision,
+                    policy_sha256=policy_provenance.policy_sha256,
+                )
+            )
+
+        try:
+            await run_in_threadpool(write_denial_record)
+        except (OSError, RuntimeError, SQLAlchemyError, TypeError, ValueError):
+            logging.exception("Failed to persist redacted authorization denial evidence.")
+
+    async def launchplane_http_exception_handler(
+        request: Request, error: Exception
+    ) -> JSONResponse:
         if not isinstance(error, HTTPException):
             raise error
-        http_error = error
+        http_error: HTTPException = error
         trace_id = next_trace_id()
         code = "authentication_required" if http_error.status_code == 401 else "http_error"
-        if isinstance(http_error.detail, dict):
-            detail = http_error.detail
-            trace_id = str(detail.get("trace_id", trace_id))
-            code = str(detail.get("code", code))
-            message = str(detail.get("message", "Launchplane request failed."))
+        if isinstance(http_error, LaunchplaneHTTPException):
+            detail = http_error.structured_detail
+            trace_id = string_value(detail.get("trace_id", trace_id))
+            code = string_value(detail.get("code", code))
+            message = string_value(detail.get("message", "Launchplane request failed."))
             records = detail.get("records")
             authz = detail.get("authz")
+            authz_evaluation = http_error.authz_evaluation
+            authz_policy_provenance = http_error.authz_policy_provenance
         else:
-            message = str(http_error.detail)
+            message = (
+                http_error.detail
+                if isinstance(http_error.detail, str)
+                else "Launchplane request failed."
+            )
             records = None
             authz = None
+            authz_evaluation = None
+            authz_policy_provenance = None
+        if http_error.status_code == 403 and code == "authorization_denied":
+            if authz_policy_provenance is None:
+                request_provenance = getattr(
+                    request.state,
+                    "launchplane_authz_policy_provenance",
+                    None,
+                )
+                if isinstance(request_provenance, AuthzPolicyProvenance):
+                    authz_policy_provenance = request_provenance
+            await persist_authz_denial_best_effort(
+                request=request,
+                trace_id=trace_id,
+                evaluation=authz_evaluation,
+                policy_provenance=authz_policy_provenance,
+            )
         payload = LaunchplaneErrorResponse(
             trace_id=trace_id,
             error=LaunchplaneErrorDetail(code=code, message=message),
@@ -22267,21 +22628,26 @@ def create_launchplane_fastapi_app(
     def launchplane_starlette_http_exception_handler(
         request: Request, error: Exception
     ) -> JSONResponse:
-        if not isinstance(error, StarletteHTTPException):
+        if not isinstance(error, STARLETTE_HTTP_EXCEPTION):
             raise error
+        http_error: Any = error
         trace_id = next_trace_id()
-        if error.status_code == 404:
+        if http_error.status_code == 404:
             status_code = 404
             code = "not_found"
             message = f"No Launchplane route for {request.url.path}."
-        elif error.status_code == 405:
+        elif http_error.status_code == 405:
             status_code = 405
             code = "method_not_allowed"
             message = "Only GET and POST are allowed for Launchplane routes."
         else:
-            status_code = error.status_code
+            status_code = http_error.status_code
             code = "http_error"
-            message = str(error.detail)
+            message = (
+                http_error.detail
+                if isinstance(http_error.detail, str)
+                else "Launchplane request failed."
+            )
         payload = LaunchplaneErrorResponse(
             trace_id=trace_id,
             error=LaunchplaneErrorDetail(code=code, message=message),
@@ -22289,7 +22655,7 @@ def create_launchplane_fastapi_app(
         response = JSONResponse(
             status_code=status_code,
             content=payload.model_dump(mode="json", exclude_none=True),
-            headers=error.headers,
+            headers=http_error.headers,
         )
         preserve_renewed_session_cookie(request, response)
         return response
@@ -22323,7 +22689,7 @@ def create_launchplane_fastapi_app(
     )
     app.add_exception_handler(HTTPException, launchplane_http_exception_handler)
     app.add_exception_handler(
-        StarletteHTTPException,
+        STARLETTE_HTTP_EXCEPTION,
         launchplane_starlette_http_exception_handler,
     )
     app.add_exception_handler(
@@ -22367,13 +22733,21 @@ def _launchplane_http_error(
     code: str,
     message: str,
     authz: dict[str, object] | None = None,
-) -> HTTPException:
+    authz_policy_provenance: AuthzPolicyProvenance | None = None,
+) -> LaunchplaneHTTPException:
     detail: dict[str, object] = {"trace_id": trace_id, "code": code, "message": message}
     if authz is not None:
         detail["authz"] = authz
-    return HTTPException(
+    authz_evaluation = None
+    if code == "authorization_denied":
+        evaluation = current_authz_evaluation()
+        if evaluation is not None and evaluation.decision == "denied":
+            authz_evaluation = evaluation
+    return LaunchplaneHTTPException(
         status_code=status_code,
         detail=detail,
+        authz_evaluation=authz_evaluation,
+        authz_policy_provenance=authz_policy_provenance,
     )
 
 
@@ -22459,8 +22833,8 @@ def _record_slug(value: str) -> str:
     return normalized or "launchplane-record"
 
 
-def _authentication_required_error(message: str) -> HTTPException:
-    return HTTPException(
+def _authentication_required_error(message: str) -> LaunchplaneHTTPException:
+    return LaunchplaneHTTPException(
         status_code=401,
         detail={"code": "authentication_required", "message": message},
         headers=_BEARER_CHALLENGE_HEADER,

--- a/control_plane/service_auth.py
+++ b/control_plane/service_auth.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
+import asyncio
 from fnmatch import fnmatchcase
 import re
 import secrets
 import tomllib
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Annotated, Any, Literal, Protocol, cast
+from threading import local
+from typing import Annotated, Any, Literal, Protocol, TypeAlias, cast
+from weakref import WeakKeyDictionary
 
 import jwt
 from pydantic import (
@@ -74,25 +77,25 @@ class LocalAdminIdentity:
     token_label: str
 
 
-LaunchplaneIdentity = (
+LaunchplaneIdentity: TypeAlias = (
     GitHubActionsIdentity
     | GitHubHumanIdentity
     | TerminalAgentIdentity
     | LocalOperatorIdentity
     | LocalAdminIdentity
 )
-AuthorizationScope = Literal["global", "context", "instance", "preview"]
-AuthzPolicySchemaVersion = Literal[1, 2]
-AgentConsumerSubjectType = Literal[
+AuthorizationScope: TypeAlias = Literal["global", "context", "instance", "preview"]
+AuthzPolicySchemaVersion: TypeAlias = Literal[1, 2]
+AgentConsumerSubjectType: TypeAlias = Literal[
     "github_actions", "github_human", "terminal_agent", "local_operator", "local_admin"
 ]
-AgentConsumerAccessProfile = Literal[
+AgentConsumerAccessProfile: TypeAlias = Literal[
     "automation_worker",
     "human_admin",
     "limited_remote_user",
     "owner_local_agent",
 ]
-AgentConsumerActionSafety = Literal[
+AgentConsumerActionSafety: TypeAlias = Literal[
     "read",
     "safe_write",
     "mutation",
@@ -101,7 +104,98 @@ AgentConsumerActionSafety = Literal[
     "secret_backed",
     "policy_admin",
 ]
-AgentAuthzDecision = Literal["allowed", "denied"]
+AgentAuthzDecision: TypeAlias = Literal["allowed", "denied"]
+AuthzDecisionReason: TypeAlias = Literal[
+    "allowed",
+    "authz_policy_schema_incompatible",
+    "instance_scope_required",
+    "principal_role_restricted",
+    "principal_binding_invalid",
+    "no_matching_grant",
+]
+
+
+class AuthzEvaluation(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    decision: AgentAuthzDecision
+    reason_code: AuthzDecisionReason
+    principal_type: AgentConsumerSubjectType
+    action: str
+    product: str
+    context: str
+    target_scope: AuthorizationScope
+    instance_specified: bool
+
+
+_AUTHZ_EVALUATION_BY_TASK: WeakKeyDictionary[asyncio.Task[Any], AuthzEvaluation] = (
+    WeakKeyDictionary()
+)
+_AUTHZ_EVALUATION_BY_THREAD = local()
+
+
+def _current_asyncio_task() -> asyncio.Task[Any] | None:
+    try:
+        return asyncio.current_task()
+    except RuntimeError:
+        return None
+
+
+def current_authz_evaluation() -> AuthzEvaluation | None:
+    task = _current_asyncio_task()
+    if task is not None:
+        return _AUTHZ_EVALUATION_BY_TASK.get(task)
+    evaluation = getattr(_AUTHZ_EVALUATION_BY_THREAD, "evaluation", None)
+    return evaluation if isinstance(evaluation, AuthzEvaluation) else None
+
+
+def clear_authz_evaluation() -> None:
+    task = _current_asyncio_task()
+    if task is not None:
+        _AUTHZ_EVALUATION_BY_TASK.pop(task, None)
+    _AUTHZ_EVALUATION_BY_THREAD.evaluation = None
+
+
+def _authz_principal_type(identity: LaunchplaneIdentity) -> AgentConsumerSubjectType:
+    if isinstance(identity, GitHubHumanIdentity):
+        return "github_human"
+    if isinstance(identity, TerminalAgentIdentity):
+        return "terminal_agent"
+    if isinstance(identity, LocalOperatorIdentity):
+        return "local_operator"
+    if isinstance(identity, LocalAdminIdentity):
+        return "local_admin"
+    return "github_actions"
+
+
+def _record_authz_evaluation(
+    *,
+    identity: LaunchplaneIdentity,
+    action: str,
+    product: str,
+    context: str,
+    target: AuthorizationTarget,
+    allowed: bool,
+    reason_code: AuthzDecisionReason,
+    record_context: bool,
+) -> AuthzEvaluation:
+    evaluation = AuthzEvaluation(
+        decision="allowed" if allowed else "denied",
+        reason_code=reason_code,
+        principal_type=_authz_principal_type(identity),
+        action=action,
+        product=product,
+        context=context,
+        target_scope=target.scope,
+        instance_specified=bool(target.instances),
+    )
+    if record_context:
+        task = _current_asyncio_task()
+        if task is not None:
+            _AUTHZ_EVALUATION_BY_TASK[task] = evaluation
+        else:
+            _AUTHZ_EVALUATION_BY_THREAD.evaluation = evaluation
+    return evaluation
 
 
 def _validated_instance_selectors(instances: tuple[str, ...]) -> tuple[str, ...]:
@@ -185,6 +279,78 @@ def _instances_allowed(
     if allowed_instances == ("*",):
         return True
     return set(target.instances).issubset(allowed_instances)
+
+
+def authz_selector_matches(value: str, selectors: tuple[str, ...]) -> bool:
+    normalized_value = value.strip()
+    return any(fnmatchcase(normalized_value, selector) for selector in selectors)
+
+
+class ScopedAuthzPolicyRule(ManagedAuthzPolicyRule):
+    products: tuple[str, ...] = ()
+    contexts: tuple[str, ...] = ()
+    instances: AuthzInstanceSelectors = ()
+    actions: tuple[str, ...] = ()
+
+    def _scope_selector_matches(self, value: str, selectors: tuple[str, ...]) -> bool:
+        return value in selectors
+
+    def allows_scope(
+        self,
+        *,
+        action: str,
+        product: str,
+        context: str,
+        target: AuthorizationTarget | None,
+        schema_version: AuthzPolicySchemaVersion,
+    ) -> bool:
+        return (
+            (not self.products or self._scope_selector_matches(product, self.products))
+            and (not self.contexts or self._scope_selector_matches(context, self.contexts))
+            and _instances_allowed(
+                allowed_instances=self.instances,
+                target=target,
+                schema_version=schema_version,
+            )
+            and (not self.actions or action in self.actions)
+        )
+
+
+class PatternScopedAuthzPolicyRule(ScopedAuthzPolicyRule):
+    def _scope_selector_matches(self, value: str, selectors: tuple[str, ...]) -> bool:
+        return authz_selector_matches(value, selectors)
+
+
+class TokenBoundAuthzPolicyRule(ScopedAuthzPolicyRule):
+    subjects: tuple[str, ...] = ()
+    token_labels: tuple[str, ...] = ()
+
+    def allows_token_bound_identity(
+        self,
+        *,
+        subject: str,
+        token_label: str,
+        action: str,
+        product: str,
+        context: str,
+        target: AuthorizationTarget | None,
+        schema_version: AuthzPolicySchemaVersion,
+    ) -> bool:
+        return (
+            (not self.subjects or authz_selector_matches(subject, self.subjects))
+            and (not self.token_labels or authz_selector_matches(token_label, self.token_labels))
+            and self.allows_scope(
+                action=action,
+                product=product,
+                context=context,
+                target=target,
+                schema_version=schema_version,
+            )
+        )
+
+
+class PatternTokenBoundAuthzPolicyRule(TokenBoundAuthzPolicyRule, PatternScopedAuthzPolicyRule):
+    pass
 
 
 class TokenVerifier(Protocol):
@@ -334,7 +500,7 @@ class GitHubOidcVerifier:
         )
 
 
-class GitHubActionsPolicyRule(ManagedAuthzPolicyRule):
+class GitHubActionsPolicyRule(PatternScopedAuthzPolicyRule):
     model_config = ConfigDict(extra="forbid")
 
     repository: str
@@ -345,10 +511,6 @@ class GitHubActionsPolicyRule(ManagedAuthzPolicyRule):
     event_names: tuple[str, ...] = ()
     refs: tuple[str, ...] = ()
     environments: tuple[str, ...] = ()
-    products: tuple[str, ...] = ()
-    contexts: tuple[str, ...] = ()
-    instances: AuthzInstanceSelectors = ()
-    actions: tuple[str, ...] = ()
 
     @model_validator(mode="after")
     def _validate_repository_identity(self) -> "GitHubActionsPolicyRule":
@@ -370,8 +532,7 @@ class GitHubActionsPolicyRule(ManagedAuthzPolicyRule):
 
     @staticmethod
     def _matches_claim(value: str, allowed_values: tuple[str, ...]) -> bool:
-        normalized_value = value.strip()
-        return any(fnmatchcase(normalized_value, allowed_value) for allowed_value in allowed_values)
+        return authz_selector_matches(value, allowed_values)
 
     def allows(
         self,
@@ -403,22 +564,16 @@ class GitHubActionsPolicyRule(ManagedAuthzPolicyRule):
             return False
         if self.environments and identity.environment not in self.environments:
             return False
-        if self.products and not self._matches_claim(product, self.products):
-            return False
-        if self.contexts and not self._matches_claim(context, self.contexts):
-            return False
-        if not _instances_allowed(
-            allowed_instances=self.instances,
+        return self.allows_scope(
+            action=action,
+            product=product,
+            context=context,
             target=target,
             schema_version=schema_version,
-        ):
-            return False
-        if self.actions and action not in self.actions:
-            return False
-        return True
+        )
 
 
-class GitHubHumanPolicyRule(ManagedAuthzPolicyRule):
+class GitHubHumanPolicyRule(ScopedAuthzPolicyRule):
     model_config = ConfigDict(extra="forbid")
 
     github_ids: tuple[int, ...] = ()
@@ -426,10 +581,6 @@ class GitHubHumanPolicyRule(ManagedAuthzPolicyRule):
     organizations: tuple[str, ...] = ()
     teams: tuple[str, ...] = ()
     roles: tuple[Literal["read_only", "admin"], ...] = ()
-    products: tuple[str, ...] = ()
-    contexts: tuple[str, ...] = ()
-    instances: AuthzInstanceSelectors = ()
-    actions: tuple[str, ...] = ()
 
     @model_validator(mode="after")
     def _validate_github_ids(self) -> "GitHubHumanPolicyRule":
@@ -440,8 +591,7 @@ class GitHubHumanPolicyRule(ManagedAuthzPolicyRule):
 
     @staticmethod
     def _matches_any(value: str, allowed_values: tuple[str, ...]) -> bool:
-        normalized_value = value.strip()
-        return any(fnmatchcase(normalized_value, allowed_value) for allowed_value in allowed_values)
+        return authz_selector_matches(value, allowed_values)
 
     @staticmethod
     def _intersects(values: frozenset[str], allowed_values: tuple[str, ...]) -> bool:
@@ -469,19 +619,13 @@ class GitHubHumanPolicyRule(ManagedAuthzPolicyRule):
             role=identity.role,
         ):
             return False
-        if self.products and product not in self.products:
-            return False
-        if self.contexts and context not in self.contexts:
-            return False
-        if not _instances_allowed(
-            allowed_instances=self.instances,
+        return self.allows_scope(
+            action=action,
+            product=product,
+            context=context,
             target=target,
             schema_version=schema_version,
-        ):
-            return False
-        if self.actions and action not in self.actions:
-            return False
-        return True
+        )
 
     def matches_principal(
         self,
@@ -505,20 +649,8 @@ class GitHubHumanPolicyRule(ManagedAuthzPolicyRule):
         return True
 
 
-class TerminalAgentPolicyRule(ManagedAuthzPolicyRule):
+class TerminalAgentPolicyRule(TokenBoundAuthzPolicyRule):
     model_config = ConfigDict(extra="forbid")
-
-    subjects: tuple[str, ...] = ()
-    token_labels: tuple[str, ...] = ()
-    products: tuple[str, ...] = ()
-    contexts: tuple[str, ...] = ()
-    instances: AuthzInstanceSelectors = ()
-    actions: tuple[str, ...] = ()
-
-    @staticmethod
-    def _matches_any(value: str, allowed_values: tuple[str, ...]) -> bool:
-        normalized_value = value.strip()
-        return any(fnmatchcase(normalized_value, allowed_value) for allowed_value in allowed_values)
 
     def allows(
         self,
@@ -530,39 +662,19 @@ class TerminalAgentPolicyRule(ManagedAuthzPolicyRule):
         target: AuthorizationTarget | None = None,
         schema_version: AuthzPolicySchemaVersion = 1,
     ) -> bool:
-        if self.subjects and not self._matches_any(identity.subject, self.subjects):
-            return False
-        if self.token_labels and not self._matches_any(identity.token_label, self.token_labels):
-            return False
-        if self.products and product not in self.products:
-            return False
-        if self.contexts and context not in self.contexts:
-            return False
-        if not _instances_allowed(
-            allowed_instances=self.instances,
+        return self.allows_token_bound_identity(
+            subject=identity.subject,
+            token_label=identity.token_label,
+            action=action,
+            product=product,
+            context=context,
             target=target,
             schema_version=schema_version,
-        ):
-            return False
-        if self.actions and action not in self.actions:
-            return False
-        return True
+        )
 
 
-class LocalOperatorPolicyRule(ManagedAuthzPolicyRule):
+class LocalOperatorPolicyRule(PatternTokenBoundAuthzPolicyRule):
     model_config = ConfigDict(extra="forbid")
-
-    subjects: tuple[str, ...] = ()
-    token_labels: tuple[str, ...] = ()
-    products: tuple[str, ...] = ()
-    contexts: tuple[str, ...] = ()
-    instances: AuthzInstanceSelectors = ()
-    actions: tuple[str, ...] = ()
-
-    @staticmethod
-    def _matches_any(value: str, allowed_values: tuple[str, ...]) -> bool:
-        normalized_value = value.strip()
-        return any(fnmatchcase(normalized_value, allowed_value) for allowed_value in allowed_values)
 
     def allows(
         self,
@@ -574,39 +686,19 @@ class LocalOperatorPolicyRule(ManagedAuthzPolicyRule):
         target: AuthorizationTarget | None = None,
         schema_version: AuthzPolicySchemaVersion = 1,
     ) -> bool:
-        if self.subjects and not self._matches_any(identity.subject, self.subjects):
-            return False
-        if self.token_labels and not self._matches_any(identity.token_label, self.token_labels):
-            return False
-        if self.products and not self._matches_any(product, self.products):
-            return False
-        if self.contexts and not self._matches_any(context, self.contexts):
-            return False
-        if not _instances_allowed(
-            allowed_instances=self.instances,
+        return self.allows_token_bound_identity(
+            subject=identity.subject,
+            token_label=identity.token_label,
+            action=action,
+            product=product,
+            context=context,
             target=target,
             schema_version=schema_version,
-        ):
-            return False
-        if self.actions and action not in self.actions:
-            return False
-        return True
+        )
 
 
-class LocalAdminPolicyRule(ManagedAuthzPolicyRule):
+class LocalAdminPolicyRule(PatternTokenBoundAuthzPolicyRule):
     model_config = ConfigDict(extra="forbid")
-
-    subjects: tuple[str, ...] = ()
-    token_labels: tuple[str, ...] = ()
-    products: tuple[str, ...] = ()
-    contexts: tuple[str, ...] = ()
-    instances: AuthzInstanceSelectors = ()
-    actions: tuple[str, ...] = ()
-
-    @staticmethod
-    def _matches_any(value: str, allowed_values: tuple[str, ...]) -> bool:
-        normalized_value = value.strip()
-        return any(fnmatchcase(normalized_value, allowed_value) for allowed_value in allowed_values)
 
     def allows(
         self,
@@ -618,23 +710,15 @@ class LocalAdminPolicyRule(ManagedAuthzPolicyRule):
         target: AuthorizationTarget | None = None,
         schema_version: AuthzPolicySchemaVersion = 1,
     ) -> bool:
-        if self.subjects and not self._matches_any(identity.subject, self.subjects):
-            return False
-        if self.token_labels and not self._matches_any(identity.token_label, self.token_labels):
-            return False
-        if self.products and not self._matches_any(product, self.products):
-            return False
-        if self.contexts and not self._matches_any(context, self.contexts):
-            return False
-        if not _instances_allowed(
-            allowed_instances=self.instances,
+        return self.allows_token_bound_identity(
+            subject=identity.subject,
+            token_label=identity.token_label,
+            action=action,
+            product=product,
+            context=context,
             target=target,
             schema_version=schema_version,
-        ):
-            return False
-        if self.actions and action not in self.actions:
-            return False
-        return True
+        )
 
 
 class AgentConsumerSubject(BaseModel):
@@ -751,7 +835,6 @@ def agent_consumer_subject(
             action=action,
             action_safety=safety,
             read_only_context=True,
-            approval_capable=False,
         )
     if isinstance(identity, LocalOperatorIdentity):
         return AgentConsumerSubject(
@@ -898,7 +981,7 @@ class LaunchplaneAuthzPolicy(BaseModel):
                     rule.pop("managed_rule_id", None)
         return payload
 
-    def allows(
+    def evaluate(
         self,
         *,
         identity: LaunchplaneIdentity,
@@ -906,20 +989,48 @@ class LaunchplaneAuthzPolicy(BaseModel):
         product: str,
         context: str,
         target: AuthorizationTarget | None = None,
-    ) -> bool:
+        record_context: bool = True,
+    ) -> AuthzEvaluation:
         resolved_target = target or AuthorizationTarget(scope="context")
         if self.schema_version != 2 and action in exact_instance_workflow_authz_actions():
-            return False
+            return _record_authz_evaluation(
+                identity=identity,
+                action=action,
+                product=product,
+                context=context,
+                target=resolved_target,
+                allowed=False,
+                reason_code="authz_policy_schema_incompatible",
+                record_context=record_context,
+            )
         if (
             self.schema_version == 2
             and action in exclusively_instance_scoped_authz_actions()
             and resolved_target.scope != "instance"
         ):
-            return False
+            return _record_authz_evaluation(
+                identity=identity,
+                action=action,
+                product=product,
+                context=context,
+                target=resolved_target,
+                allowed=False,
+                reason_code="instance_scope_required",
+                record_context=record_context,
+            )
         if isinstance(identity, GitHubHumanIdentity):
             if identity.role == "read_only" and not limited_remote_user_action_allowed(action):
-                return False
-            return any(
+                return _record_authz_evaluation(
+                    identity=identity,
+                    action=action,
+                    product=product,
+                    context=context,
+                    target=resolved_target,
+                    allowed=False,
+                    reason_code="principal_role_restricted",
+                    record_context=record_context,
+                )
+            allowed = any(
                 rule.allows(
                     identity=identity,
                     action=action,
@@ -930,8 +1041,8 @@ class LaunchplaneAuthzPolicy(BaseModel):
                 )
                 for rule in self.github_humans
             )
-        if isinstance(identity, TerminalAgentIdentity):
-            return any(
+        elif isinstance(identity, TerminalAgentIdentity):
+            allowed = any(
                 rule.allows(
                     identity=identity,
                     action=action,
@@ -942,8 +1053,19 @@ class LaunchplaneAuthzPolicy(BaseModel):
                 )
                 for rule in self.terminal_agents
             )
-        if isinstance(identity, LocalOperatorIdentity):
-            return local_operator_identity_valid(identity=identity, action=action) and any(
+        elif isinstance(identity, LocalOperatorIdentity):
+            if not local_operator_identity_valid(identity=identity, action=action):
+                return _record_authz_evaluation(
+                    identity=identity,
+                    action=action,
+                    product=product,
+                    context=context,
+                    target=resolved_target,
+                    allowed=False,
+                    reason_code="principal_binding_invalid",
+                    record_context=record_context,
+                )
+            allowed = any(
                 rule.allows(
                     identity=identity,
                     action=action,
@@ -954,8 +1076,19 @@ class LaunchplaneAuthzPolicy(BaseModel):
                 )
                 for rule in self.local_operators
             )
-        if isinstance(identity, LocalAdminIdentity):
-            return local_admin_identity_valid(identity=identity, action=action) and any(
+        elif isinstance(identity, LocalAdminIdentity):
+            if not local_admin_identity_valid(identity=identity, action=action):
+                return _record_authz_evaluation(
+                    identity=identity,
+                    action=action,
+                    product=product,
+                    context=context,
+                    target=resolved_target,
+                    allowed=False,
+                    reason_code="principal_binding_invalid",
+                    record_context=record_context,
+                )
+            allowed = any(
                 rule.allows(
                     identity=identity,
                     action=action,
@@ -966,16 +1099,47 @@ class LaunchplaneAuthzPolicy(BaseModel):
                 )
                 for rule in self.local_admins
             )
-        return any(
-            rule.allows(
+        else:
+            allowed = any(
+                rule.allows(
+                    identity=identity,
+                    action=action,
+                    product=product,
+                    context=context,
+                    target=resolved_target,
+                    schema_version=self.schema_version,
+                )
+                for rule in self.github_actions
+            )
+        return _record_authz_evaluation(
+            identity=identity,
+            action=action,
+            product=product,
+            context=context,
+            target=resolved_target,
+            allowed=allowed,
+            reason_code="allowed" if allowed else "no_matching_grant",
+            record_context=record_context,
+        )
+
+    def allows(
+        self,
+        *,
+        identity: LaunchplaneIdentity,
+        action: str,
+        product: str,
+        context: str,
+        target: AuthorizationTarget | None = None,
+    ) -> bool:
+        return (
+            self.evaluate(
                 identity=identity,
                 action=action,
                 product=product,
                 context=context,
-                target=resolved_target,
-                schema_version=self.schema_version,
-            )
-            for rule in self.github_actions
+                target=target,
+            ).decision
+            == "allowed"
         )
 
     def allows_product_instance_preflight(

--- a/control_plane/storage/migrations/versions/a2c4e6f8b0d3_add_authz_denial_records.py
+++ b/control_plane/storage/migrations/versions/a2c4e6f8b0d3_add_authz_denial_records.py
@@ -1,0 +1,61 @@
+"""add authz denial records
+
+Revision ID: a2c4e6f8b0d3
+Revises: f0a2c4e6b8d1
+Create Date: 2026-08-18 00:00:00.000000+00:00
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision: str = "a2c4e6f8b0d3"
+down_revision: str | None = "f0a2c4e6b8d1"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    if "launchplane_authz_denials" in sa.inspect(op.get_bind()).get_table_names():
+        return
+    op.create_table(
+        "launchplane_authz_denials",
+        sa.Column("trace_id", sa.String(), nullable=False),
+        sa.Column("recorded_at", sa.String(), nullable=False),
+        sa.Column("expires_at", sa.String(), nullable=False),
+        sa.Column(
+            "payload",
+            sa.JSON().with_variant(postgresql.JSONB(astext_type=sa.Text()), "postgresql"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("trace_id"),
+    )
+    op.create_index(
+        "launchplane_authz_denials_recorded_idx",
+        "launchplane_authz_denials",
+        [sa.text("recorded_at DESC")],
+    )
+    op.create_index(
+        "launchplane_authz_denials_expires_idx",
+        "launchplane_authz_denials",
+        ["expires_at"],
+    )
+
+
+def downgrade() -> None:
+    if "launchplane_authz_denials" not in sa.inspect(op.get_bind()).get_table_names():
+        return
+    op.drop_index(
+        "launchplane_authz_denials_expires_idx",
+        table_name="launchplane_authz_denials",
+    )
+    op.drop_index(
+        "launchplane_authz_denials_recorded_idx",
+        table_name="launchplane_authz_denials",
+    )
+    op.drop_table("launchplane_authz_denials")

--- a/control_plane/storage/postgres.py
+++ b/control_plane/storage/postgres.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Iterator, Sequence
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 import fcntl
@@ -39,6 +39,7 @@ from sqlalchemy.pool import NullPool
 
 from control_plane.contracts.artifact_identity import ArtifactIdentityManifest
 from control_plane.contracts.agent_write_intent import AgentWriteIntentRecord
+from control_plane.contracts.authz_denial_record import AuthzDenialRecord
 from control_plane.contracts.authz_policy_record import (
     AuthzPolicyCompareWriteResult,
     LaunchplaneAuthzPolicyRecord,
@@ -639,8 +640,8 @@ class _TenantTechnicalHumanWaiverAuthoritySnapshot:
         )
         return records if limit is None else records[: max(limit, 0)]
 
+    @staticmethod
     def list_tenant_technical_human_waiver_event_records(
-        self,
         **_: object,
     ) -> tuple[TenantTechnicalHumanWaiverEventRecord, ...]:
         return ()
@@ -688,8 +689,8 @@ class _TrustedMaintenanceAuthoritySnapshot:
         )
         return records if limit is None else records[: max(limit, 0)]
 
+    @staticmethod
     def list_trusted_maintenance_evidence_records(
-        self,
         **_: object,
     ) -> tuple[TrustedMaintenanceEvidenceRecord, ...]:
         return ()
@@ -701,6 +702,14 @@ def _utc_now_timestamp() -> str:
 
 class _PayloadRow(Protocol):
     payload: PayloadDict
+
+
+def _string_value(value: Any) -> str:
+    return str(value)
+
+
+def _payload_from_row(row: object) -> PayloadDict:
+    return cast(_PayloadRow, row).payload
 
 
 class Base(DeclarativeBase):
@@ -1934,6 +1943,19 @@ class LaunchplaneAuthzPolicyRow(Base):
     source: Mapped[str] = mapped_column(String, nullable=False)
     updated_at: Mapped[str] = mapped_column(String, nullable=False)
     policy_sha256: Mapped[str] = mapped_column(String, nullable=False)
+    payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
+
+
+class LaunchplaneAuthzDenialRow(Base):
+    __tablename__ = "launchplane_authz_denials"
+    __table_args__ = (
+        Index("launchplane_authz_denials_recorded_idx", desc("recorded_at")),
+        Index("launchplane_authz_denials_expires_idx", "expires_at"),
+    )
+
+    trace_id: Mapped[str] = mapped_column(String, primary_key=True)
+    recorded_at: Mapped[str] = mapped_column(String, nullable=False)
+    expires_at: Mapped[str] = mapped_column(String, nullable=False)
     payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
 
 
@@ -3508,7 +3530,9 @@ class PostgresRecordStore(HumanSessionStore):
             existing_columns = {column["name"] for column in inspector.get_columns(table_name)}
             for column_name in sorted(table.columns.keys()):
                 if column_name not in existing_columns:
-                    missing_columns.append(f"{table_name}.{column_name}")
+                    missing_columns.append(
+                        f"{_string_value(table_name)}.{_string_value(column_name)}"
+                    )
         if missing_columns:
             missing = ", ".join(missing_columns)
             raise RuntimeError(
@@ -3534,15 +3558,15 @@ class PostgresRecordStore(HumanSessionStore):
         self._engine.dispose()
 
     def __del__(self) -> None:
-        try:
+        with suppress(Exception):
             self.close()
-        except Exception:
-            return None
 
-    def _payload_dict(self, model: BaseModel) -> PayloadDict:
+    @staticmethod
+    def _payload_dict(model: BaseModel) -> PayloadDict:
         return model.model_dump(mode="json", exclude_none=True)
 
-    def _read_payload(self, *, model_type: type[RecordModel], payload: PayloadDict) -> RecordModel:
+    @staticmethod
+    def _read_payload(*, model_type: type[RecordModel], payload: PayloadDict) -> RecordModel:
         return model_type.model_validate(payload)
 
     def _write_row(self, row: Base) -> None:
@@ -3556,7 +3580,8 @@ class PostgresRecordStore(HumanSessionStore):
     def _after_authz_policy_write_step(self, step_name: str) -> None:
         return None
 
-    def _after_tenant_technical_human_waiver_write_step(self, step_name: str) -> None:
+    @staticmethod
+    def _after_tenant_technical_human_waiver_write_step(_step_name: str) -> None:
         return None
 
     def _merge_authority_row(self, session: Any, row: Base, *, step_name: str) -> None:
@@ -3932,7 +3957,7 @@ class PostgresRecordStore(HumanSessionStore):
             raise FileNotFoundError(f"{label} was already deleted.")
         current_record = self._read_payload(
             model_type=model_type,
-            payload=cast(_PayloadRow, row).payload,
+            payload=_payload_from_row(row),
         )
         if self._payload_dict(current_record) != self._payload_dict(expected_record):
             raise ValueError(f"{label} changed during bundle write.")
@@ -4040,7 +4065,7 @@ class PostgresRecordStore(HumanSessionStore):
             return tuple(
                 self._read_payload(
                     model_type=model_type,
-                    payload=cast(_PayloadRow, row).payload,
+                    payload=_payload_from_row(row),
                 )
                 for row in rows
             )
@@ -4317,7 +4342,8 @@ class PostgresRecordStore(HumanSessionStore):
                 parsed = parsed.replace(tzinfo=timezone.utc)
         return format_launchplane_mutation_timestamp(parsed)
 
-    def _mutation_lease_expiry(self, *, observed_at: str, lease_seconds: int) -> str:
+    @staticmethod
+    def _mutation_lease_expiry(*, observed_at: str, lease_seconds: int) -> str:
         if lease_seconds < 1 or lease_seconds > 86_400:
             raise ValueError("Mutation reservation lease_seconds must be between 1 and 86400.")
         return format_launchplane_mutation_timestamp(
@@ -4328,8 +4354,8 @@ class PostgresRecordStore(HumanSessionStore):
             + timedelta(seconds=lease_seconds)
         )
 
+    @staticmethod
     def _updated_idempotency_record(
-        self,
         record: LaunchplaneIdempotencyRecord,
         **updates: object,
     ) -> LaunchplaneIdempotencyRecord:
@@ -4337,8 +4363,8 @@ class PostgresRecordStore(HumanSessionStore):
         payload.update(updates)
         return LaunchplaneIdempotencyRecord.model_validate(payload)
 
+    @staticmethod
     def _updated_outbox_delivery_record(
-        self,
         record: OutboxDeliveryRecord,
         **updates: object,
     ) -> OutboxDeliveryRecord:
@@ -4346,8 +4372,8 @@ class PostgresRecordStore(HumanSessionStore):
         payload.update(updates)
         return OutboxDeliveryRecord.model_validate(payload)
 
+    @staticmethod
     def _mutation_transition_identity(
-        self,
         record: LaunchplaneIdempotencyRecord,
     ) -> tuple[object, ...]:
         return (
@@ -4622,7 +4648,7 @@ class PostgresRecordStore(HumanSessionStore):
             if current_record.lease_expires_at <= observed_at:
                 return OutboxDeliveryCompletionResult(status="lease_expired", record=current_record)
             next_updates = dict(updates)
-            if not str(next_updates.get("updated_at") or "").strip():
+            if not _string_value(next_updates.get("updated_at") or "").strip():
                 next_updates["updated_at"] = observed_at
             if require_terminal:
                 next_updates["lease_owner"] = ""
@@ -4949,7 +4975,7 @@ class PostgresRecordStore(HumanSessionStore):
         )
         if normalized_provider_target_key and not normalized_reconciliation_key:
             raise ValueError("Provider target keys require a reconciliation key.")
-        insert_error: IntegrityError | None = None
+        insert_error: IntegrityError
         try:
             with self._session_factory() as session:
                 self._begin_serialized_write(session)
@@ -5007,7 +5033,6 @@ class PostgresRecordStore(HumanSessionStore):
                         provider_target_key=provider_target_key,
                         retry_missing_collision=False,
                     )
-                assert insert_error is not None
                 raise insert_error
             current_record = self._read_payload(
                 model_type=LaunchplaneIdempotencyRecord,
@@ -5860,8 +5885,8 @@ class PostgresRecordStore(HumanSessionStore):
         row.attempt = record.attempt
         row.payload = self._payload_dict(record)
 
+    @staticmethod
     def _lock_odoo_stable_lane(
-        self,
         session: Any,
         *,
         product: str,
@@ -5881,8 +5906,8 @@ class PostgresRecordStore(HumanSessionStore):
         elif dialect_name == "sqlite":
             session.execute(text("BEGIN IMMEDIATE"))
 
+    @staticmethod
     def _active_odoo_stable_lane_operation_owner(
-        self,
         session: Any,
         *,
         product: str,
@@ -8654,7 +8679,7 @@ class PostgresRecordStore(HumanSessionStore):
                 if not database or database == ":memory:":
                     yield
                     return
-                lock_digest = hashlib.sha256(lock_key.encode("utf-8")).hexdigest()
+                lock_digest = hashlib.sha256(lock_key.encode()).hexdigest()
                 database_path = Path(database).expanduser().resolve()
                 lock_path = database_path.parent / (
                     f".{database_path.name}.owner-acceptance-{lock_digest}.lock"
@@ -8770,8 +8795,8 @@ class PostgresRecordStore(HumanSessionStore):
                     )
                 return "replayed"
 
+    @staticmethod
     def _next_owner_acceptance_subject_sequence(
-        self,
         *,
         session: Any,
         record: OwnerAcceptanceEventRecord,
@@ -10759,7 +10784,7 @@ class PostgresRecordStore(HumanSessionStore):
             return
         session.execute(
             text("select pg_advisory_xact_lock(hashtextextended(:lock_name, 0))"),
-            {"lock_name": (f"launchplane:tenant-repository-classification:{repository_id}")},
+            {"lock_name": f"launchplane:tenant-repository-classification:{repository_id}"},
         )
 
     def compare_and_write_tenant_repository_classification_record(
@@ -11429,7 +11454,7 @@ class PostgresRecordStore(HumanSessionStore):
             if row is None:
                 raise FileNotFoundError(request_id)
             record = self._read_payload(model_type=EveryCodeWorkRequestRecord, payload=row.payload)
-            if record.fencing_token > 0 and update.fencing_token != record.fencing_token:
+            if 0 < record.fencing_token != update.fencing_token:
                 raise ValueError(
                     f"Every Code status update fencing token {update.fencing_token} "
                     f"does not match record fencing token {record.fencing_token}"
@@ -11953,7 +11978,7 @@ class PostgresRecordStore(HumanSessionStore):
         self,
         submission: EngineeringReviewRunSubmission,
     ) -> EngineeringReviewRunRecord:
-        credential_hash = hashlib.sha256(submission.credential.encode("utf-8")).hexdigest()
+        credential_hash = hashlib.sha256(submission.credential.encode()).hexdigest()
         with self._session_factory() as session:
             self._begin_serialized_write(session)
             statement = select(LaunchplaneEngineeringReviewRunRow).where(
@@ -13908,6 +13933,43 @@ class PostgresRecordStore(HumanSessionStore):
         with self._session_factory() as session:
             return tuple(self._read_authz_policy_row(row) for row in session.scalars(statement))
 
+    def write_authz_denial_record(self, record: AuthzDenialRecord) -> None:
+        with self._session_factory() as session:
+            session.execute(
+                delete(LaunchplaneAuthzDenialRow).where(
+                    LaunchplaneAuthzDenialRow.expires_at <= record.recorded_at
+                )
+            )
+            existing = session.get(LaunchplaneAuthzDenialRow, record.trace_id)
+            if existing is not None:
+                stored_record = AuthzDenialRecord.model_validate(existing.payload)
+                if stored_record != record:
+                    session.rollback()
+                    raise ValueError("Authz denial trace id already stores different evidence.")
+                session.commit()
+                return
+            session.add(
+                LaunchplaneAuthzDenialRow(
+                    trace_id=record.trace_id,
+                    recorded_at=record.recorded_at,
+                    expires_at=record.expires_at,
+                    payload=record.model_dump(mode="json"),
+                )
+            )
+            session.commit()
+
+    def read_authz_denial_record(
+        self,
+        *,
+        trace_id: str,
+        observed_at: str,
+    ) -> AuthzDenialRecord | None:
+        with self._session_factory() as session:
+            row = session.get(LaunchplaneAuthzDenialRow, trace_id.strip())
+            if row is None or row.expires_at <= observed_at:
+                return None
+            return AuthzDenialRecord.model_validate(row.payload)
+
     def write_product_profile_record(self, record: LaunchplaneProductProfileRecord) -> None:
         self._write_row(self._product_profile_row(record))
 
@@ -14250,9 +14312,8 @@ class PostgresRecordStore(HumanSessionStore):
                 return False
         return True
 
-    def _read_product_profile_payload(
-        self, payload: PayloadDict
-    ) -> LaunchplaneProductProfileRecord:
+    @staticmethod
+    def _read_product_profile_payload(payload: PayloadDict) -> LaunchplaneProductProfileRecord:
         return LaunchplaneProductProfileRecord.model_validate(
             migrate_product_profile_lifecycle_payload(
                 migrate_product_profile_monitoring_intent_payload(
@@ -15263,27 +15324,26 @@ class PostgresRecordStore(HumanSessionStore):
                 )
                 authority_changed = route_binding_sha256 != expected_route_binding_sha256
             if authority_changed:
-                session.merge(
-                    LaunchplanePublicIngressObservationRow(
-                        record_id=observation.record_id,
-                        product=observation.product,
-                        context=observation.context,
-                        instance=observation.instance,
-                        status=observation.status,
-                        observed_at=observation.observed_at,
-                        incident_id="",
-                        check_token=check_token,
-                        check_kind=observation.check_kind,
-                        payload=self._payload_dict(
-                            observation.model_copy(
-                                update={
-                                    "incident_id": "",
-                                    "incident_event_id": "",
-                                }
-                            )
-                        ),
-                    )
+                observation_row = LaunchplanePublicIngressObservationRow(
+                    record_id=observation.record_id,
+                    product=observation.product,
+                    context=observation.context,
+                    instance=observation.instance,
+                    status=observation.status,
+                    observed_at=observation.observed_at,
+                    check_token=check_token,
+                    check_kind=observation.check_kind,
+                    payload=self._payload_dict(
+                        observation.model_copy(
+                            update={
+                                "incident_id": "",
+                                "incident_event_id": "",
+                            }
+                        )
+                    ),
                 )
+                observation_row.incident_id = ""
+                session.merge(observation_row)
                 session.commit()
                 return PublicIngressTransitionWriteResult(status="authority_changed")
             self._lock_public_ingress_incident_write(
@@ -15335,20 +15395,19 @@ class PostgresRecordStore(HumanSessionStore):
                 unlinked_observation = observation.model_copy(
                     update={"incident_id": "", "incident_event_id": ""}
                 )
-                session.merge(
-                    LaunchplanePublicIngressObservationRow(
-                        record_id=observation.record_id,
-                        product=observation.product,
-                        context=observation.context,
-                        instance=observation.instance,
-                        status=observation.status,
-                        observed_at=observation.observed_at,
-                        incident_id="",
-                        check_token=check_token,
-                        check_kind=observation.check_kind,
-                        payload=self._payload_dict(unlinked_observation),
-                    )
+                observation_row = LaunchplanePublicIngressObservationRow(
+                    record_id=observation.record_id,
+                    product=observation.product,
+                    context=observation.context,
+                    instance=observation.instance,
+                    status=observation.status,
+                    observed_at=observation.observed_at,
+                    check_token=check_token,
+                    check_kind=observation.check_kind,
+                    payload=self._payload_dict(unlinked_observation),
                 )
+                observation_row.incident_id = ""
+                session.merge(observation_row)
                 session.commit()
                 return PublicIngressTransitionWriteResult(status="incident_changed")
             self._lock_outbox_dedupe_keys(
@@ -15655,7 +15714,7 @@ class PostgresRecordStore(HumanSessionStore):
                 )
             current_record = self._read_payload(
                 model_type=DokployTargetRecord,
-                payload=cast(_PayloadRow, row).payload,
+                payload=_payload_from_row(row),
             )
             if current_record != expected_record:
                 raise ValueError("Dokploy target record changed during domain authority repair.")
@@ -15676,7 +15735,7 @@ class PostgresRecordStore(HumanSessionStore):
                 )
             current_target_id_record = self._read_payload(
                 model_type=DokployTargetIdRecord,
-                payload=cast(_PayloadRow, target_id_row).payload,
+                payload=_payload_from_row(target_id_row),
             )
             if current_target_id_record != expected_target_id_record:
                 raise ValueError("Dokploy target-id record changed during domain authority repair.")
@@ -15698,7 +15757,7 @@ class PostgresRecordStore(HumanSessionStore):
                 )
             current_provider_target_record = self._read_payload(
                 model_type=ProviderTargetRecord,
-                payload=cast(_PayloadRow, provider_row).payload,
+                payload=_payload_from_row(provider_row),
             )
             if current_provider_target_record != expected_provider_target_record:
                 raise ValueError("Provider-target record changed during domain authority repair.")
@@ -16569,7 +16628,7 @@ class PostgresRecordStore(HumanSessionStore):
         with self._session_factory() as session:
             self._begin_serialized_write(session)
             try:
-                ChangeImpactPolicyRecord.model_validate(record.model_dump(mode="python"))
+                ChangeImpactPolicyRecord.model_validate(record.model_dump())
             except ValueError as error:
                 raise ChangeImpactPolicyConflictError(
                     "Incoming change impact policy payload does not match its derived identifiers."
@@ -16795,10 +16854,12 @@ class PostgresRecordStore(HumanSessionStore):
         conflict_error: type[ValueError],
         label: str,
     ) -> Literal["written", "replayed"]:
+        model_class: Any = model_type
+        row_class: Any = row_type
         with self._session_factory() as session:
             self._begin_serialized_write(session)
             try:
-                model_type.model_validate(record.model_dump(mode="python"))
+                model_class.model_validate(record.model_dump())
             except ValueError as error:
                 raise conflict_error(
                     f"Incoming {label} payload does not match its derived identifiers."
@@ -16814,22 +16875,20 @@ class PostgresRecordStore(HumanSessionStore):
                     text("select pg_advisory_xact_lock(hashtextextended(:lock_name, 0))"),
                     {
                         "lock_name": (
-                            f"product-owner:{row_type.__tablename__}:"
+                            f"product-owner:{row_class.__tablename__}:"
                             f"{record.product}:{record.system}"
                         )
                     },
                 )
             statement = (
-                select(row_type)
-                .where(row_type.product == record.product, row_type.system == record.system)
-                .order_by(getattr(row_type, revision_field).desc())
+                select(row_class)
+                .where(row_class.product == record.product, row_class.system == record.system)
+                .order_by(getattr(row_class, revision_field).desc())
             )
             if self.database_dialect_name == "postgresql":
                 statement = statement.with_for_update()
             rows = tuple(session.scalars(statement).all())
-            records = tuple(
-                self._read_payload(model_type=model_type, payload=row.payload) for row in rows
-            )
+            records = tuple(model_class.model_validate(row.payload) for row in rows)
             same_id = tuple(
                 existing for existing in records if existing.record_id == record.record_id
             )

--- a/control_plane/storage/schema_invariants.py
+++ b/control_plane/storage/schema_invariants.py
@@ -3,14 +3,14 @@ from __future__ import annotations
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 import re
-from typing import Protocol
+from typing import Any, Protocol
 
 from sqlalchemy import inspect, text
 from sqlalchemy.engine import Engine
 from sqlalchemy.exc import SQLAlchemyError
 
 AUTHZ_COMPATIBILITY_FLOOR_REVISION = "f3b5d7e9a1c2"
-EXPECTED_ALEMBIC_HEAD_REVISION = "f0a2c4e6b8d1"
+EXPECTED_ALEMBIC_HEAD_REVISION = "a2c4e6f8b0d3"
 RUNTIME_COMPATIBLE_ALEMBIC_REVISIONS = (EXPECTED_ALEMBIC_HEAD_REVISION,)
 _AUTHZ_POLICY_TABLE = "launchplane_authz_policies"
 _AUTHZ_POLICY_WRITE_FENCE_TRIGGER = "launchplane_authz_policy_write_fence"
@@ -26,6 +26,10 @@ class SchemaInspectorProtocol(Protocol):
 
     def get_pk_constraint(self, table_name: str) -> Mapping[str, object]:
         raise NotImplementedError
+
+
+def _schema_metadata_text(value: Any) -> str:
+    return str(value)
 
 
 @dataclass(frozen=True)
@@ -283,6 +287,11 @@ CRITICAL_POSTGRES_COLUMN_TYPES: tuple[CriticalColumnType, ...] = (
         ("jsonb",),
     ),
     CriticalColumnType(
+        "launchplane_authz_denials",
+        "payload",
+        ("jsonb",),
+    ),
+    CriticalColumnType(
         "launchplane_tenant_repository_classifications",
         "payload",
         ("jsonb",),
@@ -466,6 +475,16 @@ CRITICAL_SCHEMA_INDEXES: tuple[CriticalIndex, ...] = (
         ("status",),
         unique=True,
         predicate_expression="status='active'",
+    ),
+    CriticalIndex(
+        "launchplane_authz_denials",
+        "launchplane_authz_denials_recorded_idx",
+        ("recorded_at",),
+    ),
+    CriticalIndex(
+        "launchplane_authz_denials",
+        "launchplane_authz_denials_expires_idx",
+        ("expires_at",),
     ),
     CriticalIndex(
         "launchplane_idempotency_records",
@@ -1011,7 +1030,7 @@ def critical_column_type_errors(
         if table_names is not None and expected_type.table_name not in table_names:
             continue
         columns = {
-            str(column.get("name", "")): column
+            _schema_metadata_text(column.get("name", "")): column
             for column in inspector.get_columns(expected_type.table_name)
         }
         column = columns.get(expected_type.column_name)
@@ -1041,9 +1060,9 @@ def critical_primary_key_errors(
             continue
         constraint = inspector.get_pk_constraint(expected_key.table_name)
         observed_columns = tuple(
-            str(column_name)
+            _schema_metadata_text(column_name)
             for column_name in _object_sequence(constraint.get("constrained_columns"))
-            if str(column_name)
+            if _schema_metadata_text(column_name)
         )
         if observed_columns != expected_key.column_names:
             observed_summary = ", ".join(observed_columns) or "<none>"
@@ -1068,7 +1087,7 @@ def critical_index_errors(
         if expected_index.table_name not in table_names:
             continue
         indexes_by_name = {
-            str(index.get("name", "")): index
+            _schema_metadata_text(index.get("name", "")): index
             for index in inspector.get_indexes(expected_index.table_name)
         }
         observed_index = indexes_by_name.get(expected_index.index_name)
@@ -1244,7 +1263,7 @@ def postgres_index_definitions(engine: Engine) -> dict[tuple[str, str], str]:
 def _normalized_type_name(type_value: object) -> str:
     tokens = {
         type(type_value).__name__.lower(),
-        str(type_value).lower(),
+        _schema_metadata_text(type_value).lower(),
     }
     return " ".join(sorted(tokens))
 
@@ -1276,7 +1295,7 @@ def _object_sequence(value: object) -> tuple[object, ...]:
 def _normalize_index_column(value: object) -> str:
     if value is None:
         return ""
-    normalized = str(value).strip().strip('"').lower()
+    normalized = _schema_metadata_text(value).strip().strip('"').lower()
     if not normalized:
         return ""
     normalized = normalized.split()[0].strip('"')

--- a/control_plane/storage/schema_migration.py
+++ b/control_plane/storage/schema_migration.py
@@ -48,7 +48,7 @@ def schema_migration_action(
 
 
 def _alembic_predecessor_revisions(target_revision: str) -> frozenset[str]:
-    script_directory = ScriptDirectory.from_config(_alembic_config("sqlite://"))
+    script_directory = ScriptDirectory.from_config(alembic_config("sqlite://"))
     return frozenset(
         revision.revision
         for revision in script_directory.iterate_revisions(target_revision, "base")
@@ -73,17 +73,17 @@ def migrate_schema(
             try:
                 stamp_revision = schema_stamp_revision_for_engine(engine)
                 if stamp_revision:
-                    command.stamp(_alembic_config(database_url), stamp_revision)
+                    command.stamp(alembic_config(database_url), stamp_revision)
                 current_revision = _current_revision(engine)
                 if not current_revision:
-                    command.upgrade(_alembic_config(database_url), target_revision)
+                    command.upgrade(alembic_config(database_url), target_revision)
                 else:
                     action = schema_migration_action(
                         current_revision=current_revision,
                         target_revision=target_revision,
                     )
                     if action == "upgrade":
-                        command.upgrade(_alembic_config(database_url), target_revision)
+                        command.upgrade(alembic_config(database_url), target_revision)
                 final_revision = _current_revision(engine)
                 if not final_revision:
                     raise RuntimeError("Launchplane schema migration did not record a revision.")
@@ -118,7 +118,7 @@ def _current_revision(engine: Engine) -> str:
     return revisions[0] if revisions else ""
 
 
-def _alembic_config(database_url: str) -> Config:
+def alembic_config(database_url: str) -> Config:
     repository_root = Path(__file__).resolve().parents[2]
     config = Config(str(repository_root / "alembic.ini"))
     config.set_main_option("sqlalchemy.url", database_url.replace("%", "%%"))

--- a/docs/authorization-authority.md
+++ b/docs/authorization-authority.md
@@ -78,6 +78,24 @@ through Launchplane's API and UI:
 - export and restore policy without making GitHub the durable desired-state
   store.
 
+The first DB-native read-only slice keeps those capabilities separate:
+
+- `authz_policy_effective_access.read` is restricted to an authenticated
+  GitHub administrator or local administrator and evaluates exactly one supplied
+  principal, action, product, context, explicit context-or-instance target scope,
+  and optional exact instance against the single active DB policy record;
+- `authz_denial_explanation.read` is independently grantable to a human support
+  reader and returns one redacted denial record by trace ID;
+- effective-access responses expose only the supplied scope, decision, bounded
+  reason code, and active policy record identity; they never expose matching
+  rules, selector values, managed-set topology, tokens, or other principals;
+- denial records contain no principal identifier or token label, expire after
+  30 days, and return the same not-found response when absent or expired.
+
+Landing these read contracts does not authorize their production grants and
+does not relax the active freeze. Production policy changes still require the
+separate reviewed administration and recovery gates owned by `#2058`/`#2061`.
+
 After parity and recovery gates pass, protected desired-set secrets and routine
 authorization workflows must be retired. GitHub may remain an identity provider
 and transport for already-authorized workloads, plus a narrowly bounded

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -564,6 +564,25 @@ active policy record/revision plus opaque identity and rule fingerprints and
 failed selector categories; it never returns workflow refs, repositories,
 policy values, or other principal rules. Ordinary route denials remain generic.
 
+`POST /v1/authz-diagnostics/effective-access/evaluate` is the DB-native
+administrator read path for one explicit principal/action/product/context and
+explicit context-or-instance target scope, with one exact instance required for
+instance scope. The caller must be a GitHub administrator or local
+administrator with `authz_policy_effective_access.read`. The route reloads the
+single active DB policy record, delegates the decision to the ordinary policy
+evaluator, and returns only the supplied scope, allowed/denied decision, one
+bounded reason code, and active record/revision/digest. It does not return rule
+matches, selector values, managed IDs, principal values, or permission lists.
+
+Standard `authorization_denied` HTTP failures with a captured policy evaluation
+write a redacted `launchplane_authz_denials` audit record on a best-effort basis.
+`GET /v1/authz-diagnostics/denials/{trace_id}` requires the separately grantable
+`authz_denial_explanation.read` action and returns only that trace's bounded
+request scope, principal type, reason code, route path, and policy provenance.
+The record never stores a principal identifier or token label, expires after 30
+days, and missing and expired traces share `authz_denial_not_found`. Persistence
+failure never weakens or replaces the original denial.
+
 Operators never mutate shared or production authz through direct DB commands or
 a local CLI from an arbitrary checkout. The protected secret/workflow model
 below is transitional compatibility for already-existing managed sets, not the

--- a/docs/records.md
+++ b/docs/records.md
@@ -2332,6 +2332,15 @@ preflights.
 - Agent-facing authorization diagnostics include an `agent_audit` response
   provenance envelope with decision, safe reason code, subject, action, product,
   context, policy source, policy digest, and `authz_policy` source kind.
+- Redacted HTTP authorization denials are persisted in
+  `launchplane_authz_denials` when a standard `authorization_denied` response has
+  bounded policy-evaluation evidence. The trace-keyed record stores only the
+  principal type, requested action/product/context, target scope, whether an
+  instance was supplied, a closed reason code, route path, and active policy
+  record/revision/digest. It never stores principal identifiers, token labels,
+  raw claims, selector values, matching rule IDs, or managed-set topology.
+  Records expire after 30 days; writes opportunistically remove expired rows,
+  and read APIs do not expose a list operation.
 - Agent write-intent evaluations are persisted as
   `launchplane_agent_write_intents` records. Each record stores the request,
   evaluation result, `agent_audit` envelope, trace id, optional idempotency key,

--- a/frontend/generated/openapi-canonical.json
+++ b/frontend/generated/openapi-canonical.json
@@ -1104,6 +1104,108 @@
         "title": "AuthorizationTarget",
         "type": "object"
       },
+      "AuthzDenialExplanationResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "action": {
+            "title": "Action",
+            "type": "string"
+          },
+          "context": {
+            "title": "Context",
+            "type": "string"
+          },
+          "instance_specified": {
+            "title": "Instance Specified",
+            "type": "boolean"
+          },
+          "policy_record_id": {
+            "title": "Policy Record Id",
+            "type": "string"
+          },
+          "policy_revision": {
+            "minimum": 1.0,
+            "title": "Policy Revision",
+            "type": "integer"
+          },
+          "policy_sha256": {
+            "title": "Policy Sha256",
+            "type": "string"
+          },
+          "principal_type": {
+            "enum": [
+              "github_actions",
+              "github_human",
+              "terminal_agent",
+              "local_operator",
+              "local_admin"
+            ],
+            "title": "Principal Type",
+            "type": "string"
+          },
+          "product": {
+            "title": "Product",
+            "type": "string"
+          },
+          "reason_code": {
+            "enum": [
+              "allowed",
+              "authz_policy_schema_incompatible",
+              "instance_scope_required",
+              "principal_role_restricted",
+              "principal_binding_invalid",
+              "no_matching_grant"
+            ],
+            "title": "Reason Code",
+            "type": "string"
+          },
+          "recorded_at": {
+            "title": "Recorded At",
+            "type": "string"
+          },
+          "route_path": {
+            "title": "Route Path",
+            "type": "string"
+          },
+          "status": {
+            "const": "ok",
+            "default": "ok",
+            "title": "Status",
+            "type": "string"
+          },
+          "target_scope": {
+            "enum": [
+              "global",
+              "context",
+              "instance",
+              "preview"
+            ],
+            "title": "Target Scope",
+            "type": "string"
+          },
+          "trace_id": {
+            "title": "Trace Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "trace_id",
+          "recorded_at",
+          "route_path",
+          "principal_type",
+          "action",
+          "product",
+          "context",
+          "target_scope",
+          "instance_specified",
+          "reason_code",
+          "policy_record_id",
+          "policy_revision",
+          "policy_sha256"
+        ],
+        "title": "AuthzDenialExplanationResponse",
+        "type": "object"
+      },
       "AuthzDiagnosticEvaluateEnvelope": {
         "additionalProperties": false,
         "properties": {
@@ -4012,6 +4114,200 @@
           "records"
         ],
         "title": "EdgeEndpointRecordsResponse",
+        "type": "object"
+      },
+      "EffectiveAccessDecision": {
+        "additionalProperties": false,
+        "properties": {
+          "decision": {
+            "enum": [
+              "allowed",
+              "denied"
+            ],
+            "title": "Decision",
+            "type": "string"
+          },
+          "reason_code": {
+            "enum": [
+              "allowed",
+              "authz_policy_schema_incompatible",
+              "instance_scope_required",
+              "principal_role_restricted",
+              "principal_binding_invalid",
+              "no_matching_grant"
+            ],
+            "title": "Reason Code",
+            "type": "string"
+          }
+        },
+        "required": [
+          "decision",
+          "reason_code"
+        ],
+        "title": "EffectiveAccessDecision",
+        "type": "object"
+      },
+      "EffectiveAccessEvaluateRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "action": {
+            "title": "Action",
+            "type": "string"
+          },
+          "context": {
+            "title": "Context",
+            "type": "string"
+          },
+          "instance": {
+            "default": "",
+            "title": "Instance",
+            "type": "string"
+          },
+          "principal": {
+            "discriminator": {
+              "mapping": {
+                "github_actions": "#/components/schemas/GitHubActionsAccessPrincipal",
+                "github_human": "#/components/schemas/GitHubHumanAccessPrincipal",
+                "local_admin": "#/components/schemas/LocalAdminAccessPrincipal",
+                "local_operator": "#/components/schemas/LocalOperatorAccessPrincipal",
+                "terminal_agent": "#/components/schemas/TerminalAgentAccessPrincipal"
+              },
+              "propertyName": "principal_type"
+            },
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/GitHubActionsAccessPrincipal"
+              },
+              {
+                "$ref": "#/components/schemas/GitHubHumanAccessPrincipal"
+              },
+              {
+                "$ref": "#/components/schemas/TerminalAgentAccessPrincipal"
+              },
+              {
+                "$ref": "#/components/schemas/LocalOperatorAccessPrincipal"
+              },
+              {
+                "$ref": "#/components/schemas/LocalAdminAccessPrincipal"
+              }
+            ],
+            "title": "Principal"
+          },
+          "product": {
+            "title": "Product",
+            "type": "string"
+          },
+          "target_scope": {
+            "enum": [
+              "context",
+              "instance"
+            ],
+            "title": "Target Scope",
+            "type": "string"
+          }
+        },
+        "required": [
+          "principal",
+          "action",
+          "product",
+          "context",
+          "target_scope"
+        ],
+        "title": "EffectiveAccessEvaluateRequest",
+        "type": "object"
+      },
+      "EffectiveAccessEvaluateResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "evaluation": {
+            "$ref": "#/components/schemas/EffectiveAccessDecision"
+          },
+          "policy_record_id": {
+            "title": "Policy Record Id",
+            "type": "string"
+          },
+          "policy_revision": {
+            "minimum": 1.0,
+            "title": "Policy Revision",
+            "type": "integer"
+          },
+          "policy_sha256": {
+            "title": "Policy Sha256",
+            "type": "string"
+          },
+          "request": {
+            "$ref": "#/components/schemas/EffectiveAccessRequestSummary"
+          },
+          "status": {
+            "const": "ok",
+            "default": "ok",
+            "title": "Status",
+            "type": "string"
+          },
+          "trace_id": {
+            "title": "Trace Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "trace_id",
+          "policy_record_id",
+          "policy_revision",
+          "policy_sha256",
+          "request",
+          "evaluation"
+        ],
+        "title": "EffectiveAccessEvaluateResponse",
+        "type": "object"
+      },
+      "EffectiveAccessRequestSummary": {
+        "additionalProperties": false,
+        "properties": {
+          "action": {
+            "title": "Action",
+            "type": "string"
+          },
+          "context": {
+            "title": "Context",
+            "type": "string"
+          },
+          "instance": {
+            "default": "",
+            "title": "Instance",
+            "type": "string"
+          },
+          "principal_type": {
+            "enum": [
+              "github_actions",
+              "github_human",
+              "terminal_agent",
+              "local_operator",
+              "local_admin"
+            ],
+            "title": "Principal Type",
+            "type": "string"
+          },
+          "product": {
+            "title": "Product",
+            "type": "string"
+          },
+          "target_scope": {
+            "enum": [
+              "context",
+              "instance"
+            ],
+            "title": "Target Scope",
+            "type": "string"
+          }
+        },
+        "required": [
+          "principal_type",
+          "action",
+          "product",
+          "context",
+          "target_scope"
+        ],
+        "title": "EffectiveAccessRequestSummary",
         "type": "object"
       },
       "EngineeringReviewAuthorityApplyEnvelope": {
@@ -8129,6 +8425,132 @@
         "title": "GenericWebStableVerificationRequest",
         "type": "object"
       },
+      "GitHubActionsAccessPrincipal": {
+        "additionalProperties": false,
+        "properties": {
+          "environment": {
+            "default": "",
+            "title": "Environment",
+            "type": "string"
+          },
+          "event_name": {
+            "title": "Event Name",
+            "type": "string"
+          },
+          "job_workflow_ref": {
+            "default": "",
+            "title": "Job Workflow Ref",
+            "type": "string"
+          },
+          "principal_type": {
+            "const": "github_actions",
+            "default": "github_actions",
+            "title": "Principal Type",
+            "type": "string"
+          },
+          "ref": {
+            "title": "Ref",
+            "type": "string"
+          },
+          "ref_type": {
+            "title": "Ref Type",
+            "type": "string"
+          },
+          "repository": {
+            "title": "Repository",
+            "type": "string"
+          },
+          "repository_id": {
+            "default": "",
+            "title": "Repository Id",
+            "type": "string"
+          },
+          "repository_owner": {
+            "title": "Repository Owner",
+            "type": "string"
+          },
+          "repository_owner_id": {
+            "default": "",
+            "title": "Repository Owner Id",
+            "type": "string"
+          },
+          "sha": {
+            "default": "",
+            "title": "Sha",
+            "type": "string"
+          },
+          "subject": {
+            "title": "Subject",
+            "type": "string"
+          },
+          "workflow_ref": {
+            "title": "Workflow Ref",
+            "type": "string"
+          }
+        },
+        "required": [
+          "repository",
+          "repository_owner",
+          "workflow_ref",
+          "ref",
+          "ref_type",
+          "event_name",
+          "subject"
+        ],
+        "title": "GitHubActionsAccessPrincipal",
+        "type": "object"
+      },
+      "GitHubHumanAccessPrincipal": {
+        "additionalProperties": false,
+        "properties": {
+          "github_id": {
+            "default": 0,
+            "minimum": 0.0,
+            "title": "Github Id",
+            "type": "integer"
+          },
+          "login": {
+            "title": "Login",
+            "type": "string"
+          },
+          "organizations": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Organizations",
+            "type": "array"
+          },
+          "principal_type": {
+            "const": "github_human",
+            "default": "github_human",
+            "title": "Principal Type",
+            "type": "string"
+          },
+          "role": {
+            "enum": [
+              "read_only",
+              "admin"
+            ],
+            "title": "Role",
+            "type": "string"
+          },
+          "teams": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Teams",
+            "type": "array"
+          }
+        },
+        "required": [
+          "login",
+          "role"
+        ],
+        "title": "GitHubHumanAccessPrincipal",
+        "type": "object"
+      },
       "GitHubHumanIdentityResponse": {
         "additionalProperties": false,
         "properties": {
@@ -10054,6 +10476,56 @@
           "storage_backend"
         ],
         "title": "LaunchplaneRuntimeStatus",
+        "type": "object"
+      },
+      "LocalAdminAccessPrincipal": {
+        "additionalProperties": false,
+        "properties": {
+          "principal_type": {
+            "const": "local_admin",
+            "default": "local_admin",
+            "title": "Principal Type",
+            "type": "string"
+          },
+          "subject": {
+            "title": "Subject",
+            "type": "string"
+          },
+          "token_label": {
+            "title": "Token Label",
+            "type": "string"
+          }
+        },
+        "required": [
+          "subject",
+          "token_label"
+        ],
+        "title": "LocalAdminAccessPrincipal",
+        "type": "object"
+      },
+      "LocalOperatorAccessPrincipal": {
+        "additionalProperties": false,
+        "properties": {
+          "principal_type": {
+            "const": "local_operator",
+            "default": "local_operator",
+            "title": "Principal Type",
+            "type": "string"
+          },
+          "subject": {
+            "title": "Subject",
+            "type": "string"
+          },
+          "token_label": {
+            "title": "Token Label",
+            "type": "string"
+          }
+        },
+        "required": [
+          "subject",
+          "token_label"
+        ],
+        "title": "LocalOperatorAccessPrincipal",
         "type": "object"
       },
       "ManagerPreviewApprovalDecision": {
@@ -31240,6 +31712,31 @@
         "title": "TenantTechnicalHumanWaiverExpectedCurrent",
         "type": "object"
       },
+      "TerminalAgentAccessPrincipal": {
+        "additionalProperties": false,
+        "properties": {
+          "principal_type": {
+            "const": "terminal_agent",
+            "default": "terminal_agent",
+            "title": "Principal Type",
+            "type": "string"
+          },
+          "subject": {
+            "title": "Subject",
+            "type": "string"
+          },
+          "token_label": {
+            "title": "Token Label",
+            "type": "string"
+          }
+        },
+        "required": [
+          "subject",
+          "token_label"
+        ],
+        "title": "TerminalAgentAccessPrincipal",
+        "type": "object"
+      },
       "TrackedTargetLogDeploymentResponse": {
         "additionalProperties": false,
         "properties": {
@@ -34553,6 +35050,215 @@
           }
         },
         "summary": "Read human auth session"
+      }
+    },
+    "/v1/authz-diagnostics/denials/{trace_id}": {
+      "get": {
+        "operationId": "explain_authz_denial",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "trace_id",
+            "required": true,
+            "schema": {
+              "title": "Trace Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "Authorization",
+            "required": false,
+            "schema": {
+              "default": "",
+              "title": "Authorization",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "Cookie",
+            "required": false,
+            "schema": {
+              "default": "",
+              "title": "Cookie",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthzDenialExplanationResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "summary": "Read one redacted authorization denial explanation"
+      }
+    },
+    "/v1/authz-diagnostics/effective-access/evaluate": {
+      "post": {
+        "operationId": "evaluate_effective_access",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Authorization",
+            "required": false,
+            "schema": {
+              "default": "",
+              "title": "Authorization",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "Cookie",
+            "required": false,
+            "schema": {
+              "default": "",
+              "title": "Cookie",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EffectiveAccessEvaluateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EffectiveAccessEvaluateResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "summary": "Evaluate one principal and scope against active authorization"
       }
     },
     "/v1/authz-diagnostics/github-actions/evaluate": {

--- a/tests/support/auth.py
+++ b/tests/support/auth.py
@@ -5,9 +5,9 @@ from control_plane.service_auth import (
 )
 
 
-class _StubVerifier:
-    def __init__(self, identity: GitHubActionsIdentity):
-        self.identity = identity
+class StubVerifier:
+    def __init__(self, verified_identity: GitHubActionsIdentity):
+        self.identity = verified_identity
 
     def verify(self, token: str) -> GitHubActionsIdentity:
         if token != "valid-token":
@@ -15,7 +15,7 @@ class _StubVerifier:
         return self.identity
 
 
-def _identity(
+def identity(
     *,
     repository: str = "every/verireel",
     workflow_ref: str = "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main",
@@ -46,6 +46,10 @@ def _identity(
             "run_attempt": "1",
         },
     )
+
+
+_StubVerifier = StubVerifier
+_identity = identity
 
 
 def _local_operator_policy(

--- a/tests/support/work_graph.py
+++ b/tests/support/work_graph.py
@@ -28,7 +28,7 @@ def write_fake_gh_sequence(directory: Path, *, responses: list[dict[str, object]
     return script
 
 
-def _work_graph_snapshot_payload() -> dict[str, object]:
+def work_graph_snapshot_payload() -> dict[str, object]:
     return {
         "generated_at": "2026-05-06T01:45:00Z",
         "repos": [
@@ -65,3 +65,6 @@ def _work_graph_snapshot_payload() -> dict[str, object]:
             },
         ],
     }
+
+
+_work_graph_snapshot_payload = work_graph_snapshot_payload

--- a/tests/test_authz_access_read.py
+++ b/tests/test_authz_access_read.py
@@ -1,0 +1,399 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from tempfile import TemporaryDirectory
+import unittest
+from unittest.mock import patch
+
+from fastapi import FastAPI
+from pydantic import ValidationError
+
+from control_plane.contracts.authz_access_read import (
+    AUTHZ_DENIAL_EXPLANATION_READ_ACTION,
+    EFFECTIVE_ACCESS_READ_ACTION,
+    EffectiveAccessEvaluateRequest,
+)
+from control_plane.contracts.authz_denial_record import build_authz_denial_record
+from control_plane.contracts.authz_policy_record import (
+    LaunchplaneAuthzPolicyRecord,
+    authz_policy_sha256,
+    build_authz_policy_record_id,
+)
+from control_plane.http_app import LaunchplaneAuthzPolicyRuntime, create_launchplane_fastapi_app
+from control_plane.service_auth import (
+    AuthzEvaluation,
+    BearerIdentityConfig,
+    GitHubActionsIdentity,
+    LaunchplaneAuthzPolicy,
+)
+from control_plane.storage.postgres import PostgresRecordStore
+from tests.support.http import lifespan_client
+
+
+class _RejectingVerifier:
+    def verify(self, token: str) -> GitHubActionsIdentity:
+        raise ValueError(f"Unexpected GitHub token: {token}")
+
+
+def _database_url(path: Path) -> str:
+    return f"sqlite+pysqlite:///{path}"
+
+
+def _seed_policy(
+    store: PostgresRecordStore,
+    policy: LaunchplaneAuthzPolicy,
+) -> LaunchplaneAuthzPolicyRecord:
+    digest = authz_policy_sha256(policy)
+    return store.seed_authz_policy_if_absent(
+        LaunchplaneAuthzPolicyRecord(
+            record_id=build_authz_policy_record_id(revision=1, policy_sha256=digest),
+            revision=1,
+            status="active",
+            source="test:authz-access-read",
+            updated_at="2026-08-18T12:00:00+00:00",
+            policy_sha256=digest,
+            policy=policy,
+        )
+    )
+
+
+def _support_reader_policy() -> LaunchplaneAuthzPolicy:
+    return LaunchplaneAuthzPolicy.model_validate(
+        {
+            "schema_version": 2,
+            "local_operators": [
+                {
+                    "subjects": ["support-reader"],
+                    "token_labels": ["support-reader-label"],
+                    "products": ["launchplane"],
+                    "contexts": ["launchplane"],
+                    "actions": [AUTHZ_DENIAL_EXPLANATION_READ_ACTION],
+                }
+            ],
+        }
+    )
+
+
+def _app(
+    *,
+    root: Path,
+    store: PostgresRecordStore,
+    record: LaunchplaneAuthzPolicyRecord,
+) -> FastAPI:
+    return create_launchplane_fastapi_app(
+        verifier=_RejectingVerifier(),
+        authz_policy=record.policy,
+        authz_policy_runtime=LaunchplaneAuthzPolicyRuntime(
+            record.policy,
+            policy_sha256=record.policy_sha256,
+            source="db",
+            record_id=record.record_id,
+            revision=record.revision,
+        ),
+        record_store_factory=lambda: store,
+        bearer_identity_config=BearerIdentityConfig(
+            local_admin_token="admin-token",
+            local_admin_subject="authz-admin",
+            local_admin_token_label="authz-admin-label",
+            local_operator_token="support-token",
+            local_operator_subject="support-reader",
+            local_operator_token_label="support-reader-label",
+        ),
+        control_plane_root_path=root,
+        state_dir=root / "state",
+    )
+
+
+class AuthzAccessReadHttpTests(unittest.IsolatedAsyncioTestCase):
+    async def test_administrator_evaluates_one_explicit_principal_without_selector_leakage(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            store = PostgresRecordStore(database_url=_database_url(root / "launchplane.sqlite3"))
+            store.ensure_schema()
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "schema_version": 2,
+                    "local_admins": [
+                        {
+                            "subjects": ["authz-admin"],
+                            "token_labels": ["authz-admin-label"],
+                            "products": ["launchplane"],
+                            "contexts": ["launchplane"],
+                            "actions": [EFFECTIVE_ACCESS_READ_ACTION],
+                        }
+                    ],
+                    "local_operators": [
+                        {
+                            "subjects": ["evaluated-principal-secret"],
+                            "token_labels": ["evaluated-token-label-secret"],
+                            "products": ["example-product"],
+                            "contexts": ["example-context"],
+                            "actions": ["example_access.read"],
+                        }
+                    ],
+                }
+            )
+            record = _seed_policy(store, policy)
+            app = _app(root=root, store=store, record=record)
+            paths = app.openapi()["paths"]
+            self.assertIn("/v1/authz-diagnostics/effective-access/evaluate", paths)
+            self.assertIn("/v1/authz-diagnostics/denials/{trace_id}", paths)
+            request_payload = {
+                "principal": {
+                    "principal_type": "local_operator",
+                    "subject": "evaluated-principal-secret",
+                    "token_label": "evaluated-token-label-secret",
+                },
+                "action": "example_access.read",
+                "product": "example-product",
+                "context": "example-context",
+                "target_scope": "context",
+            }
+            try:
+                async with lifespan_client(app) as client:
+                    allowed_response = await client.post(
+                        "/v1/authz-diagnostics/effective-access/evaluate",
+                        headers={"Authorization": "Bearer admin-token"},
+                        json=request_payload,
+                    )
+                    denied_response = await client.post(
+                        "/v1/authz-diagnostics/effective-access/evaluate",
+                        headers={"Authorization": "Bearer admin-token"},
+                        json={**request_payload, "action": "example_access.write"},
+                    )
+                    instance_response = await client.post(
+                        "/v1/authz-diagnostics/effective-access/evaluate",
+                        headers={"Authorization": "Bearer admin-token"},
+                        json={
+                            **request_payload,
+                            "target_scope": "instance",
+                            "instance": "prod",
+                        },
+                    )
+                    active_records_after_reads = store.list_authz_policy_records(
+                        status="active",
+                        limit=2,
+                    )
+            finally:
+                store.close()
+
+        self.assertEqual(allowed_response.status_code, 200, allowed_response.text)
+        self.assertEqual(allowed_response.json()["evaluation"]["decision"], "allowed")
+        self.assertEqual(denied_response.status_code, 200, denied_response.text)
+        self.assertEqual(denied_response.json()["evaluation"]["decision"], "denied")
+        self.assertEqual(
+            denied_response.json()["evaluation"]["reason_code"],
+            "no_matching_grant",
+        )
+        self.assertEqual(instance_response.status_code, 200, instance_response.text)
+        self.assertEqual(instance_response.json()["request"]["target_scope"], "instance")
+        self.assertEqual(instance_response.json()["evaluation"]["decision"], "denied")
+        self.assertEqual(active_records_after_reads, (record,))
+        rendered = json.dumps(
+            {"allowed": allowed_response.json(), "denied": denied_response.json()},
+            sort_keys=True,
+        )
+        self.assertNotIn("evaluated-principal-secret", rendered)
+        self.assertNotIn("evaluated-token-label-secret", rendered)
+
+    async def test_support_reader_explains_persisted_denial_without_policy_write_authority(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            store = PostgresRecordStore(database_url=_database_url(root / "launchplane.sqlite3"))
+            store.ensure_schema()
+            policy = _support_reader_policy()
+            record = _seed_policy(store, policy)
+            app = _app(root=root, store=store, record=record)
+            try:
+                async with lifespan_client(app) as client:
+                    denied_response = await client.get(
+                        "/v1/service/runtime",
+                        headers={"Authorization": "Bearer support-token"},
+                    )
+                    denied_trace_id = denied_response.json()["trace_id"]
+                    explanation_response = await client.get(
+                        f"/v1/authz-diagnostics/denials/{denied_trace_id}",
+                        headers={"Authorization": "Bearer support-token"},
+                    )
+                    evaluate_response = await client.post(
+                        "/v1/authz-diagnostics/effective-access/evaluate",
+                        headers={"Authorization": "Bearer support-token"},
+                        json={
+                            "principal": {
+                                "principal_type": "local_operator",
+                                "subject": "support-reader",
+                                "token_label": "support-reader-label",
+                            },
+                            "action": "launchplane_service.read",
+                            "product": "launchplane",
+                            "context": "launchplane",
+                            "target_scope": "context",
+                        },
+                    )
+                    stored_record = store.read_authz_denial_record(
+                        trace_id=denied_trace_id,
+                        observed_at="2026-08-18T12:01:00+00:00",
+                    )
+            finally:
+                store.close()
+
+        self.assertEqual(denied_response.status_code, 403, denied_response.text)
+        self.assertEqual(explanation_response.status_code, 200, explanation_response.text)
+        self.assertEqual(explanation_response.json()["trace_id"], denied_trace_id)
+        self.assertEqual(
+            explanation_response.json()["reason_code"],
+            "no_matching_grant",
+        )
+        self.assertEqual(evaluate_response.status_code, 403, evaluate_response.text)
+        self.assertIsNotNone(stored_record)
+        rendered = json.dumps(explanation_response.json(), sort_keys=True)
+        self.assertNotIn("support-reader", rendered)
+        self.assertNotIn("support-reader-label", rendered)
+        self.assertNotIn("authz_policy_grant.write", rendered)
+
+    async def test_unknown_denial_trace_is_not_distinguishable_from_expired_evidence(self) -> None:
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            store = PostgresRecordStore(database_url=_database_url(root / "launchplane.sqlite3"))
+            store.ensure_schema()
+            policy = _support_reader_policy()
+            record = _seed_policy(store, policy)
+            store.write_authz_denial_record(
+                build_authz_denial_record(
+                    trace_id="expired-trace",
+                    recorded_at="2026-07-01T00:00:00+00:00",
+                    expires_at="2026-07-31T00:00:00+00:00",
+                    route_path="/v1/service/runtime",
+                    evaluation=AuthzEvaluation(
+                        decision="denied",
+                        reason_code="no_matching_grant",
+                        principal_type="local_operator",
+                        action="launchplane_service.read",
+                        product="launchplane",
+                        context="launchplane",
+                        target_scope="context",
+                        instance_specified=False,
+                    ),
+                    policy_record_id=record.record_id,
+                    policy_revision=record.revision,
+                    policy_sha256=record.policy_sha256,
+                )
+            )
+            app = _app(root=root, store=store, record=record)
+            try:
+                async with lifespan_client(app) as client:
+                    unknown_response = await client.get(
+                        "/v1/authz-diagnostics/denials/unknown-trace",
+                        headers={"Authorization": "Bearer support-token"},
+                    )
+                    expired_response = await client.get(
+                        "/v1/authz-diagnostics/denials/expired-trace",
+                        headers={"Authorization": "Bearer support-token"},
+                    )
+            finally:
+                store.close()
+
+        self.assertEqual(unknown_response.status_code, 404, unknown_response.text)
+        self.assertEqual(expired_response.status_code, 404, expired_response.text)
+        self.assertEqual(unknown_response.json()["error"], expired_response.json()["error"])
+
+    async def test_unauthorized_denial_explanation_skips_route_database_reads(self) -> None:
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            store = PostgresRecordStore(database_url=_database_url(root / "launchplane.sqlite3"))
+            store.ensure_schema()
+            record = _seed_policy(store, _support_reader_policy())
+            app = _app(root=root, store=store, record=record)
+            try:
+                async with lifespan_client(app) as client:
+                    with (
+                        patch.object(
+                            store,
+                            "list_authz_policy_records",
+                            side_effect=AssertionError("authorization must precede policy reads"),
+                        ),
+                        patch.object(
+                            store,
+                            "read_authz_denial_record",
+                            side_effect=AssertionError("authorization must precede denial reads"),
+                        ),
+                    ):
+                        response = await client.get(
+                            "/v1/authz-diagnostics/denials/unknown-trace",
+                            headers={"Authorization": "Bearer admin-token"},
+                        )
+            finally:
+                store.close()
+
+        self.assertEqual(response.status_code, 403, response.text)
+
+
+class AuthzDenialRecordStoreTests(unittest.TestCase):
+    def test_effective_access_target_scope_requires_one_exact_instance(self) -> None:
+        base_request = {
+            "principal": {
+                "principal_type": "local_operator",
+                "subject": "operator",
+                "token_label": "operator-label",
+            },
+            "action": "example_access.read",
+            "product": "example-product",
+            "context": "example-context",
+        }
+
+        with self.assertRaises(ValidationError):
+            EffectiveAccessEvaluateRequest.model_validate(
+                {**base_request, "target_scope": "instance"}
+            )
+        with self.assertRaises(ValidationError):
+            EffectiveAccessEvaluateRequest.model_validate(
+                {**base_request, "target_scope": "context", "instance": "prod"}
+            )
+        with self.assertRaises(ValidationError):
+            EffectiveAccessEvaluateRequest.model_validate(
+                {**base_request, "target_scope": "instance", "instance": "prod*"}
+            )
+
+    def test_denial_records_are_immutable_by_trace_id(self) -> None:
+        with TemporaryDirectory() as directory:
+            store = PostgresRecordStore(
+                database_url=_database_url(Path(directory) / "launchplane.sqlite3")
+            )
+            store.ensure_schema()
+            evaluation = AuthzEvaluation(
+                decision="denied",
+                reason_code="no_matching_grant",
+                principal_type="local_operator",
+                action="example_access.read",
+                product="example-product",
+                context="example-context",
+                target_scope="context",
+                instance_specified=False,
+            )
+            first_record = build_authz_denial_record(
+                trace_id="trace-immutable",
+                recorded_at="2026-08-18T12:00:00+00:00",
+                expires_at="2026-09-17T12:00:00+00:00",
+                route_path="/v1/deployments",
+                evaluation=evaluation,
+                policy_record_id="authz-policy-1",
+                policy_revision=1,
+                policy_sha256="a" * 64,
+            )
+            store.write_authz_denial_record(first_record)
+            with self.assertRaisesRegex(ValueError, "different evidence"):
+                store.write_authz_denial_record(
+                    first_record.model_copy(update={"route_path": "/v1/promotions"})
+                )
+            stored_record = store.read_authz_denial_record(
+                trace_id="trace-immutable",
+                observed_at="2026-08-18T12:01:00+00:00",
+            )
+            store.close()
+
+        self.assertEqual(stored_record, first_record)

--- a/tests/test_driver_descriptors.py
+++ b/tests/test_driver_descriptors.py
@@ -756,7 +756,7 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
 
     def test_descriptor_driver_route_rejects_duplicate_path(self) -> None:
         descriptor = _fake_native_descriptor(
-            _fake_native_action(action_id="ping"),
+            _fake_native_action(),
             _fake_native_action(action_id="pong", authz_action="fake_native.pong"),
         )
 
@@ -966,7 +966,11 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
                     for node in ast.walk(syntax_tree)
                     if isinstance(node, ast.Call)
                     and isinstance(node.func, ast.Attribute)
-                    and node.func.attr == "_native_driver_route_authorization_allows"
+                    and node.func.attr
+                    in {
+                        "_native_driver_route_authorization_allows",
+                        "native_driver_route_authorization_allows",
+                    }
                 ]
                 self.assertEqual(len(authorization_calls), 1)
                 keyword_names = {keyword.arg for keyword in authorization_calls[0].keywords}

--- a/tests/test_http_app_browser_mutation.py
+++ b/tests/test_http_app_browser_mutation.py
@@ -20,8 +20,8 @@ from tests.http_app_test_support import (
     _RejectingVerifier,
     _work_graph_read_policy,
 )
-from tests.support.auth import _identity, _StubVerifier
-from tests.support.work_graph import _work_graph_snapshot_payload
+from tests.support.auth import StubVerifier, identity
+from tests.support.work_graph import work_graph_snapshot_payload
 
 
 class FastApiBrowserMutationBoundaryTests(unittest.IsolatedAsyncioTestCase):
@@ -34,6 +34,7 @@ class FastApiBrowserMutationBoundaryTests(unittest.IsolatedAsyncioTestCase):
         expected_routes = {
             "/auth/logout",
             "/v1/agent/write-intents/evaluate",
+            "/v1/authz-diagnostics/effective-access/evaluate",
             "/v1/authz-policies/managed-rule-sets/reconcile",
             "/v1/drivers/generic-web/prod-promotion",
             "/v1/drivers/generic-web/prod-promotion-workflow",
@@ -87,9 +88,8 @@ class FastApiBrowserMutationBoundaryTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(actual_bearer_only_routes, expected_bearer_only_routes)
         self.assertEqual(unprotected_cookie_routes, set())
 
-    def _human_app(
-        self,
-    ) -> tuple[FastAPI, HumanSessionManager, LaunchplaneHumanSession]:
+    @staticmethod
+    def _human_app() -> tuple[FastAPI, HumanSessionManager, LaunchplaneHumanSession]:
         session_manager = HumanSessionManager(
             config=_github_oauth_config(),
             session_store=InMemoryHumanSessionStore(),
@@ -128,7 +128,7 @@ class FastApiBrowserMutationBoundaryTests(unittest.IsolatedAsyncioTestCase):
 
                 response = await _post_work_graph_rank(
                     app,
-                    payload={"snapshot": _work_graph_snapshot_payload(), "limit": 1},
+                    payload={"snapshot": work_graph_snapshot_payload(), "limit": 1},
                     authorization="",
                     headers=headers,
                 )
@@ -153,7 +153,7 @@ class FastApiBrowserMutationBoundaryTests(unittest.IsolatedAsyncioTestCase):
 
                 response = await _post_work_graph_rank(
                     app,
-                    payload={"snapshot": _work_graph_snapshot_payload(), "limit": 1},
+                    payload={"snapshot": work_graph_snapshot_payload(), "limit": 1},
                     authorization="",
                     headers=headers,
                 )
@@ -169,20 +169,20 @@ class FastApiBrowserMutationBoundaryTests(unittest.IsolatedAsyncioTestCase):
 
         stale_response = await _post_work_graph_rank(
             app,
-            payload={"snapshot": _work_graph_snapshot_payload(), "limit": 1},
+            payload={"snapshot": work_graph_snapshot_payload(), "limit": 1},
             authorization="",
             headers=stale_headers,
         )
         valid_headers = _browser_mutation_headers(session_manager, human_session)
         accepted_response = await _post_work_graph_rank(
             app,
-            payload={"snapshot": _work_graph_snapshot_payload(), "limit": 1},
+            payload={"snapshot": work_graph_snapshot_payload(), "limit": 1},
             authorization="",
             headers=valid_headers,
         )
         replay_response = await _post_work_graph_rank(
             app,
-            payload={"snapshot": _work_graph_snapshot_payload(), "limit": 1},
+            payload={"snapshot": work_graph_snapshot_payload(), "limit": 1},
             authorization="",
             headers=valid_headers,
         )
@@ -194,14 +194,14 @@ class FastApiBrowserMutationBoundaryTests(unittest.IsolatedAsyncioTestCase):
 
     async def test_github_actions_bearer_mutation_does_not_require_browser_headers(self) -> None:
         app = create_launchplane_fastapi_app(
-            verifier=_StubVerifier(_identity()),
+            verifier=StubVerifier(identity()),
             authz_policy=_work_graph_read_policy(),
             record_store_factory=lambda: _MissingProductReadStore(),
         )
 
         response = await _post_work_graph_rank(
             app,
-            payload={"snapshot": _work_graph_snapshot_payload(), "limit": 1},
+            payload={"snapshot": work_graph_snapshot_payload(), "limit": 1},
         )
 
         self.assertEqual(response.status_code, 202)

--- a/tests/test_schema_migration.py
+++ b/tests/test_schema_migration.py
@@ -33,7 +33,7 @@ from control_plane.storage.schema_invariants import (
     EXPECTED_ALEMBIC_HEAD_REVISION,
 )
 from control_plane.storage.schema_migration import (
-    _alembic_config,
+    alembic_config,
     migrate_schema,
     schema_migration_action,
 )
@@ -44,7 +44,7 @@ class SchemaMigrationTests(unittest.TestCase):
         with TemporaryDirectory() as temporary_directory_name:
             database_path = Path(temporary_directory_name) / "launchplane.sqlite3"
             database_url = f"sqlite+pysqlite:///{database_path}"
-            config = _alembic_config(database_url)
+            config = alembic_config(database_url)
             command.upgrade(config, "c6f8a0b2d4e6")
             engine = create_engine(database_url)
             observation_id = "public-ingress-example-site-prod-20260727t120000z"
@@ -241,7 +241,7 @@ class SchemaMigrationTests(unittest.TestCase):
         with TemporaryDirectory() as temporary_directory_name:
             database_path = Path(temporary_directory_name) / "launchplane.sqlite3"
             database_url = f"sqlite+pysqlite:///{database_path}"
-            config = _alembic_config(database_url)
+            config = alembic_config(database_url)
             command.upgrade(config, "c6f8a0b2d4e6")
             engine = create_engine(database_url)
 
@@ -313,7 +313,7 @@ class SchemaMigrationTests(unittest.TestCase):
             )
             try:
                 with engine.begin() as connection:
-                    for incident_id, payload in rows:
+                    for row_incident_id, row_payload in rows:
                         connection.execute(
                             text(
                                 "insert into launchplane_public_ingress_incidents "
@@ -323,14 +323,14 @@ class SchemaMigrationTests(unittest.TestCase):
                                 ":payload)"
                             ),
                             {
-                                "incident_id": incident_id,
+                                "incident_id": row_incident_id,
                                 "product": "example-site",
                                 "context": "example-site",
                                 "instance": "prod",
-                                "status": payload["status"],
-                                "opened_at": payload["opened_at"],
-                                "latest_observed_at": payload["latest_observed_at"],
-                                "payload": json.dumps(payload),
+                                "status": row_payload["status"],
+                                "opened_at": row_payload["opened_at"],
+                                "latest_observed_at": row_payload["latest_observed_at"],
+                                "payload": json.dumps(row_payload),
                             },
                         )
                 command.upgrade(config, EXPECTED_ALEMBIC_HEAD_REVISION)
@@ -399,7 +399,7 @@ class SchemaMigrationTests(unittest.TestCase):
         with TemporaryDirectory() as temporary_directory_name:
             database_path = Path(temporary_directory_name) / "launchplane.sqlite3"
             database_url = f"sqlite+pysqlite:///{database_path}"
-            config = _alembic_config(database_url)
+            config = alembic_config(database_url)
             command.upgrade(config, "b3d5f7a9c1e4")
             engine = create_engine(database_url)
             profile_payload = {
@@ -570,7 +570,7 @@ class SchemaMigrationTests(unittest.TestCase):
         database_url = "postgresql+psycopg://launchplane:p%40ssword@postgres/launchplane"
 
         self.assertEqual(
-            _alembic_config(database_url).get_main_option("sqlalchemy.url"),
+            alembic_config(database_url).get_main_option("sqlalchemy.url"),
             database_url,
         )
 
@@ -578,7 +578,7 @@ class SchemaMigrationTests(unittest.TestCase):
         with TemporaryDirectory() as temporary_directory_name:
             database_path = Path(temporary_directory_name) / "launchplane.sqlite3"
             database_url = f"sqlite+pysqlite:///{database_path}"
-            config = _alembic_config(database_url)
+            config = alembic_config(database_url)
             command.upgrade(config, "a1c3e5f7b9d2")
             engine = create_engine(database_url)
             try:
@@ -643,7 +643,7 @@ class SchemaMigrationTests(unittest.TestCase):
         with TemporaryDirectory() as temporary_directory_name:
             database_path = Path(temporary_directory_name) / "launchplane.sqlite3"
             database_url = f"sqlite+pysqlite:///{database_path}"
-            command.upgrade(_alembic_config(database_url), EXPECTED_ALEMBIC_HEAD_REVISION)
+            command.upgrade(alembic_config(database_url), EXPECTED_ALEMBIC_HEAD_REVISION)
             policy = LaunchplaneAuthzPolicy()
             first_record = LaunchplaneAuthzPolicyRecord(
                 record_id="authz-sqlite-first",
@@ -703,7 +703,7 @@ class SchemaMigrationTests(unittest.TestCase):
         with TemporaryDirectory() as temporary_directory_name:
             database_path = Path(temporary_directory_name) / "launchplane.sqlite3"
             database_url = f"sqlite+pysqlite:///{database_path}"
-            config = _alembic_config(database_url)
+            config = alembic_config(database_url)
 
             command.upgrade(config, EXPECTED_ALEMBIC_HEAD_REVISION)
             engine = create_engine(database_url)
@@ -813,7 +813,7 @@ class SchemaMigrationTests(unittest.TestCase):
         with TemporaryDirectory() as temporary_directory_name:
             database_path = Path(temporary_directory_name) / "launchplane.sqlite3"
             database_url = f"sqlite+pysqlite:///{database_path}"
-            config = _alembic_config(database_url)
+            config = alembic_config(database_url)
 
             command.upgrade(config, EXPECTED_ALEMBIC_HEAD_REVISION)
             engine = create_engine(database_url)
@@ -861,7 +861,9 @@ class SchemaMigrationTests(unittest.TestCase):
                 }
                 owner_indexes: dict[str, dict[str, Mapping[str, object]]] = {
                     table_name: {
-                        str(index["name"]): index for index in inspector.get_indexes(table_name)
+                        index_name: index
+                        for index in inspector.get_indexes(table_name)
+                        if isinstance(index_name := index.get("name"), str)
                     }
                     for table_name in owner_table_names
                 }
@@ -1008,7 +1010,7 @@ class SchemaMigrationTests(unittest.TestCase):
         with TemporaryDirectory() as temporary_directory_name:
             database_path = Path(temporary_directory_name) / "launchplane.sqlite3"
             database_url = f"sqlite+pysqlite:///{database_path}"
-            config = _alembic_config(database_url)
+            config = alembic_config(database_url)
             command.upgrade(config, "e9b1d3f5a7c0")
             legacy_payloads = []
             previous_record_id: str | None = None
@@ -1193,7 +1195,7 @@ class SchemaMigrationTests(unittest.TestCase):
         with TemporaryDirectory() as temporary_directory_name:
             database_path = Path(temporary_directory_name) / "launchplane.sqlite3"
             database_url = f"sqlite+pysqlite:///{database_path}"
-            config = _alembic_config(database_url)
+            config = alembic_config(database_url)
 
             command.upgrade(config, "f3a5c7e9b1d4")
             engine = create_engine(database_url)
@@ -1261,7 +1263,7 @@ class SchemaMigrationTests(unittest.TestCase):
         with TemporaryDirectory() as temporary_directory_name:
             database_path = Path(temporary_directory_name) / "launchplane.sqlite3"
             database_url = f"sqlite+pysqlite:///{database_path}"
-            config = _alembic_config(database_url)
+            config = alembic_config(database_url)
             command.upgrade(config, "a4c6e8f0b2d5")
             engine = create_engine(database_url)
             legacy_rows = [
@@ -1402,7 +1404,7 @@ class SchemaMigrationTests(unittest.TestCase):
         with TemporaryDirectory() as temporary_directory_name:
             database_path = Path(temporary_directory_name) / "launchplane.sqlite3"
             database_url = f"sqlite+pysqlite:///{database_path}"
-            config = _alembic_config(database_url)
+            config = alembic_config(database_url)
             command.upgrade(config, "b5d7f9a1c3e6")
             engine = create_engine(database_url)
             legacy_payload = {
@@ -1489,7 +1491,29 @@ class SchemaMigrationTests(unittest.TestCase):
             for primary_key in CRITICAL_PRIMARY_KEYS
         }
 
-        self.assertEqual(EXPECTED_ALEMBIC_HEAD_REVISION, "f0a2c4e6b8d1")
+        self.assertEqual(EXPECTED_ALEMBIC_HEAD_REVISION, "a2c4e6f8b0d3")
+        self.assertEqual(
+            column_types[("launchplane_authz_denials", "payload")],
+            ("jsonb",),
+        )
+        self.assertEqual(
+            indexes[
+                (
+                    "launchplane_authz_denials",
+                    "launchplane_authz_denials_recorded_idx",
+                )
+            ].column_names,
+            ("recorded_at",),
+        )
+        self.assertEqual(
+            indexes[
+                (
+                    "launchplane_authz_denials",
+                    "launchplane_authz_denials_expires_idx",
+                )
+            ].column_names,
+            ("expires_at",),
+        )
         self.assertEqual(
             column_types[("launchplane_merge_admissions", "payload")],
             ("jsonb",),

--- a/tests/test_service_auth.py
+++ b/tests/test_service_auth.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta, timezone
 import hashlib
 import json
 from types import SimpleNamespace
+from typing import Any
 import unittest
 from unittest.mock import Mock, patch
 
@@ -26,6 +27,8 @@ from control_plane.service_auth import (
     action_safety,
     agent_authz_audit,
     agent_consumer_subject,
+    clear_authz_evaluation,
+    current_authz_evaluation,
     limited_remote_user_action_allowed,
     migrate_authz_policy_to_schema_v2,
     parse_authz_policy_toml,
@@ -39,8 +42,8 @@ from control_plane.service_human_auth import (
 )
 
 
-def _actions_identity(**overrides: object) -> GitHubActionsIdentity:
-    claims: dict[str, object] = {
+def _actions_identity(**overrides: Any) -> GitHubActionsIdentity:
+    claims: dict[str, Any] = {
         "repository": "cbusillo/verireel",
         "repository_owner": "cbusillo",
         "repository_id": "1001",
@@ -72,8 +75,8 @@ def _actions_identity(**overrides: object) -> GitHubActionsIdentity:
     )
 
 
-def _human_identity(**overrides: object) -> GitHubHumanIdentity:
-    values: dict[str, object] = {
+def _human_identity(**overrides: Any) -> GitHubHumanIdentity:
+    values: dict[str, Any] = {
         "login": "alice",
         "github_id": 123,
         "name": "Alice Example",
@@ -85,17 +88,17 @@ def _human_identity(**overrides: object) -> GitHubHumanIdentity:
     values.update(overrides)
     return GitHubHumanIdentity(
         login=str(values["login"]),
-        github_id=values["github_id"],  # type: ignore[arg-type]
+        github_id=values["github_id"],
         name=str(values["name"]),
         email=str(values["email"]),
-        organizations=values["organizations"],  # type: ignore[arg-type]
-        teams=values["teams"],  # type: ignore[arg-type]
-        role=values["role"],  # type: ignore[arg-type]
+        organizations=values["organizations"],
+        teams=values["teams"],
+        role=values["role"],
     )
 
 
-def _terminal_agent_identity(**overrides: object) -> TerminalAgentIdentity:
-    values: dict[str, object] = {
+def _terminal_agent_identity(**overrides: Any) -> TerminalAgentIdentity:
+    values: dict[str, Any] = {
         "subject": "local-owner-agent",
         "token_label": "local-owner-read",
     }
@@ -106,8 +109,8 @@ def _terminal_agent_identity(**overrides: object) -> TerminalAgentIdentity:
     )
 
 
-def _local_operator_identity(**overrides: object) -> LocalOperatorIdentity:
-    values: dict[str, object] = {
+def _local_operator_identity(**overrides: Any) -> LocalOperatorIdentity:
+    values: dict[str, Any] = {
         "subject": "local-owner-agent",
         "token_label": "local-owner-write",
     }
@@ -118,8 +121,8 @@ def _local_operator_identity(**overrides: object) -> LocalOperatorIdentity:
     )
 
 
-def _local_admin_identity(**overrides: object) -> LocalAdminIdentity:
-    values: dict[str, object] = {
+def _local_admin_identity(**overrides: Any) -> LocalAdminIdentity:
+    values: dict[str, Any] = {
         "subject": "local-owner-admin",
         "token_label": "local-owner-admin",
     }
@@ -201,8 +204,8 @@ class GitHubOidcVerifierBoundaryTests(unittest.TestCase):
                     "repository_id": "1001",
                     "repository_owner_id": "2001",
                     "workflow_ref": "cbusillo/verireel/.github/workflows/preview.yml@refs/heads/main",
+                    missing_claim: "",
                 }
-                claims[missing_claim] = ""
 
                 with patch("control_plane.service_auth.jwt.decode", return_value=claims):
                     verifier = GitHubOidcVerifier(
@@ -214,6 +217,41 @@ class GitHubOidcVerifierBoundaryTests(unittest.TestCase):
 
 
 class LaunchplaneAuthzPolicyBoundaryTests(unittest.TestCase):
+    def test_evaluate_records_only_bounded_reason_categories(self) -> None:
+        policy = LaunchplaneAuthzPolicy.model_validate(
+            {
+                "schema_version": 2,
+                "local_operators": [
+                    {
+                        "subjects": ["local-owner-agent"],
+                        "token_labels": ["local-owner-write"],
+                        "products": ["example-product"],
+                        "contexts": ["example-context"],
+                        "actions": ["example_access.read"],
+                    }
+                ],
+            }
+        )
+        clear_authz_evaluation()
+        self.addCleanup(clear_authz_evaluation)
+
+        allowed = policy.evaluate(
+            identity=_local_operator_identity(),
+            action="example_access.read",
+            product="example-product",
+            context="example-context",
+        )
+        denied = policy.evaluate(
+            identity=_local_operator_identity(),
+            action="example_access.write",
+            product="example-product",
+            context="example-context",
+        )
+
+        self.assertEqual(allowed.reason_code, "allowed")
+        self.assertEqual(denied.reason_code, "no_matching_grant")
+        self.assertEqual(current_authz_evaluation(), denied)
+
     def test_agent_consumer_subject_classifies_terminal_agent_as_read_only_context(self) -> None:
         subject = agent_consumer_subject(
             identity=_terminal_agent_identity(),
@@ -1030,7 +1068,8 @@ class LaunchplaneAuthzPolicyBoundaryTests(unittest.TestCase):
 
 
 class HumanSessionBoundaryTests(unittest.TestCase):
-    def _session_manager(self) -> tuple[HumanSessionManager, InMemoryHumanSessionStore]:
+    @staticmethod
+    def _session_manager() -> tuple[HumanSessionManager, InMemoryHumanSessionStore]:
         config = GitHubOAuthConfig(
             client_id="client-id",
             client_secret="client-secret",
@@ -1136,7 +1175,7 @@ class LaunchplaneAuthzPolicyCompatibilityTests(unittest.TestCase):
         legacy_payload.pop("local_operators", None)
         legacy_payload.pop("local_admins", None)
         legacy_sha256 = hashlib.sha256(
-            json.dumps(legacy_payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+            json.dumps(legacy_payload, sort_keys=True, separators=(",", ":")).encode()
         ).hexdigest()
 
         self.assertEqual(authz_policy_sha256(policy), legacy_sha256)
@@ -1163,7 +1202,7 @@ class LaunchplaneAuthzPolicyCompatibilityTests(unittest.TestCase):
         self.assertEqual(
             authz_policy_sha256(policy),
             hashlib.sha256(
-                json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+                json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
             ).hexdigest(),
         )
 


### PR DESCRIPTION
## Summary

- add a separately authorized, read-only effective-access evaluation endpoint for one explicit principal/action/product/context/target query
- add bounded, redacted denial explanation by trace ID with dedicated 30-day DB records and no list surface
- preserve request-local authorization context and immutable policy provenance without mutating production policy or provider/runtime state
- update authorization, operations, records, schema migration, generated OpenAPI, and focused regression coverage

## Validation

- focused authz/service-auth suite: 62 tests passed
- full unittest gate: 12/12 shards passed, 2,991 targets
- Ruff on all changed/new Python files: passed
- Ruff format on all changed/new Python files: passed
- mypy: 737 source files passed
- PyCharm changed-files inspection: GREEN, zero findings
- frontend validate: 62 tests, OpenAPI drift, typecheck, and production build passed
- config-authority audit: status `ok`
- final independent reviews: Opus READY; Gemini READY

## Safety Boundary

- no production authorization grant or policy write
- no provider/runtime mutation
- no bootstrap retirement
- no `#2167` recovery apply
- production authorization remains frozen

Refs #2180
