### PR TITLE
Add exact provider evidence for deploy recovery

### DIFF
--- a/.github/workflows/reusable-generic-web-stable-deploy.yml
+++ b/.github/workflows/reusable-generic-web-stable-deploy.yml
@@ -184,6 +184,9 @@ jobs:
       provider_status: ${{ steps.recovery.outputs.provider_status }}
       retry_safe: ${{ steps.recovery.outputs.retry_safe }}
       observed_at: ${{ steps.recovery.outputs.observed_at }}
+      provider_evidence: ${{ steps.provider_evidence.outputs.provider_evidence }}
+      provider_read_error_class: >-
+        ${{ steps.provider_evidence.outputs.provider_read_error_class }}
     runs-on: ubuntu-latest
     steps:
       - name: Download staged recovery request
@@ -279,6 +282,72 @@ jobs:
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
+      - name: Resolve provider evidence request
+        id: provider_evidence_request
+        continue-on-error: true
+        env:
+          RECOVERY_REQUEST: ${{ steps.request.outputs.request }}
+        run: |
+          set -euo pipefail
+
+          launchplane_url="$(jq -er '.launchplane_url | select(type == "string" and length > 0)' <<< "$RECOVERY_REQUEST")"
+          product="$(jq -er '.product | select(type == "string" and length > 0)' <<< "$RECOVERY_REQUEST")"
+          instance="$(jq -er '.instance | select(type == "string" and length > 0)' <<< "$RECOVERY_REQUEST")"
+          artifact_id="$(jq -er '.artifact_id | select(type == "string" and length > 0)' <<< "$RECOVERY_REQUEST")"
+          source_git_ref="$(jq -er '.source_git_ref | select(type == "string" and length > 0)' <<< "$RECOVERY_REQUEST")"
+          original_run_id="$(jq -er '.original_run_id | select(type == "string" and test("^[1-9][0-9]*$"))' <<< "$RECOVERY_REQUEST")"
+          original_run_attempt="$(jq -er '.original_run_attempt | select(type == "string" and test("^[1-9][0-9]*$"))' <<< "$RECOVERY_REQUEST")"
+          reason="$(jq -er '.reason | select(type == "string" and length > 0)' <<< "$RECOVERY_REQUEST")"
+          payload="$(jq -cn \
+            --arg product "$product" \
+            --arg instance "$instance" \
+            --arg artifact_id "$artifact_id" \
+            --arg source_git_ref "$source_git_ref" \
+            --arg reason "$reason" \
+            '{
+              schema_version: 1,
+              product: $product,
+              instance: $instance,
+              original_deploy: {
+                schema_version: 1,
+                product: $product,
+                deploy: {
+                  schema_version: 1,
+                  product: $product,
+                  instance: $instance,
+                  artifact_id: $artifact_id,
+                  source_git_ref: $source_git_ref
+                }
+              },
+              reason: $reason
+            }')"
+          idempotency_key="generic-web-stable-deploy:${product}:${instance}:${original_run_id}:${original_run_attempt}"
+
+          {
+            echo "launchplane_url=$launchplane_url"
+            echo "idempotency_key=$idempotency_key"
+            echo "payload<<EOF"
+            echo "$payload"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Inspect exact provider evidence
+        id: provider_evidence
+        continue-on-error: true
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@dcfe6fb13cdd5f7c66428ce9ef108ebbe215fff5 # launchplane-request
+        with:
+          launchplane-url: ${{ steps.provider_evidence_request.outputs.launchplane_url }}
+          audience: ${{ inputs.launchplane_audience }}
+          route-path: /v1/admin/generic-web/deploy-recovery/provider-evidence
+          payload: ${{ steps.provider_evidence_request.outputs.payload }}
+          idempotency-key: ${{ steps.provider_evidence_request.outputs.idempotency_key }}
+          timeout-ms: ${{ inputs['timeout-ms'] }}
+          fail-result-paths: ""
+          output-paths: >-
+            provider_evidence=provider_evidence,
+            provider_read_error_class=provider_read_error_class
+          log-response-body: false
+
       - name: Request Launchplane recovery dry run
         id: recovery
         uses: cbusillo/launchplane/.github/actions/generic-web-deploy-recovery-dry-run@b2055d2944626234664390d6fcd96975ded38511 # main
@@ -295,6 +364,10 @@ jobs:
           PROVIDER_STATUS: ${{ steps.recovery.outputs.provider_status }}
           RETRY_SAFE: ${{ steps.recovery.outputs.retry_safe }}
           OBSERVED_AT: ${{ steps.recovery.outputs.observed_at }}
+          PROVIDER_EVIDENCE: ${{ steps.provider_evidence.outputs.provider_evidence }}
+          PROVIDER_READ_ERROR_CLASS: >-
+            ${{ steps.provider_evidence.outputs.provider_read_error_class }}
+          PROVIDER_EVIDENCE_STEP_OUTCOME: ${{ steps.provider_evidence.outcome }}
         run: |
           set -euo pipefail
 
@@ -308,4 +381,7 @@ jobs:
             echo "- Provider status: \`$PROVIDER_STATUS\`"
             echo "- Retry safe: \`$RETRY_SAFE\`"
             echo "- Observed at: \`$OBSERVED_AT\`"
+            echo "- Exact provider evidence: \`${PROVIDER_EVIDENCE:-unavailable}\`"
+            echo "- Provider read error class: \`${PROVIDER_READ_ERROR_CLASS:-}\`"
+            echo "- Provider evidence step: \`$PROVIDER_EVIDENCE_STEP_OUTCOME\`"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/control_plane/authz_scope.py
+++ b/control_plane/authz_scope.py
@@ -7,6 +7,7 @@ _NON_DESCRIPTOR_INSTANCE_SCOPED_AUTHZ_ACTIONS = frozenset(
     {
         "backup_gate.write",
         "deployment.read",
+        "generic_web_deploy_recovery_provider_evidence.read",
         "inventory.read",
         "product_profile.health_monitoring.apply",
         "product_profile.health_monitoring.plan",

--- a/control_plane/contracts/generic_web_deploy_recovery.py
+++ b/control_plane/contracts/generic_web_deploy_recovery.py
@@ -22,6 +22,19 @@ GenericWebDeployRecoveryProviderOutcome = Literal[
     "unknown",
     "not_inspected",
 ]
+GenericWebDeployProviderEvidenceClassification = Literal[
+    "deployment_present",
+    "deployment_absent_before_effect",
+    "deployment_absent_after_effect",
+    "provider_status_unknown",
+    "provider_read_failed",
+    "not_inspected",
+]
+GenericWebDeployProviderReadErrorClass = Literal[
+    "",
+    "target_resolution_failed",
+    "provider_request_failed",
+]
 
 
 class GenericWebDeployRecoveryDryRunRequest(BaseModel):
@@ -85,6 +98,23 @@ class GenericWebDeployRecoveryDryRunResponse(BaseModel):
     recovery_digest: str = Field(pattern=r"^[0-9a-f]{64}$")
 
 
+class GenericWebDeployRecoveryProviderEvidenceResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: Literal[1] = 1
+    status: Literal["ok"] = "ok"
+    mode: Literal["provider-evidence"] = "provider-evidence"
+    reservation_state: Literal["running", "completed", "reconcile_required"]
+    reservation_attempt: int = Field(ge=1)
+    observed_at: str
+    reconciliation_key_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    provider_target_key_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    provider_effect_phase: str = Field(max_length=128)
+    provider_evidence: GenericWebDeployProviderEvidenceClassification
+    provider_status: str = Field(default="", max_length=128)
+    provider_read_error_class: GenericWebDeployProviderReadErrorClass = ""
+
+
 class GenericWebDeployRecoveryApplyResponse(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -105,7 +135,9 @@ class GenericWebDeployRecoveryApplyResponse(BaseModel):
 
 
 def generic_web_deploy_recovery_identifier_sha256(value: str) -> str:
-    return hashlib.sha256(value.strip().encode("utf-8")).hexdigest()
+    digest = hashlib.sha256()
+    digest.update(value.strip().encode())
+    return digest.hexdigest()
 
 
 def build_generic_web_deploy_recovery_digest(payload: dict[str, object]) -> str:
@@ -115,4 +147,6 @@ def build_generic_web_deploy_recovery_digest(payload: dict[str, object]) -> str:
         separators=(",", ":"),
         sort_keys=True,
     )
-    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+    digest = hashlib.sha256()
+    digest.update(canonical.encode())
+    return digest.hexdigest()

--- a/control_plane/generic_web_deploy_provider_adapter.py
+++ b/control_plane/generic_web_deploy_provider_adapter.py
@@ -1,10 +1,14 @@
 import hashlib
 from dataclasses import dataclass
 from pathlib import Path
-from typing import cast
+from typing import Protocol, cast
 
 import click
 
+from control_plane.contracts.generic_web_deploy_recovery import (
+    GenericWebDeployProviderEvidenceClassification,
+    GenericWebDeployProviderReadErrorClass,
+)
 from control_plane.contracts.product_profile_record import (
     LaunchplaneProductProfileRecord,
     ProductLaneProfile,
@@ -49,6 +53,15 @@ __all__ = [
 ]
 
 
+def _string_field(payload: dict[str, object], key: str) -> str:
+    value = payload.get(key)
+    return value.strip() if isinstance(value, str) else ""
+
+
+class _DeploymentRecordReader(Protocol):
+    def read_deployment_record(self, record_id: str) -> object: ...
+
+
 @dataclass(frozen=True, slots=True)
 class _GenericWebDeployProviderInspection:
     observation: GenericWebProviderDeploymentObservation
@@ -56,6 +69,8 @@ class _GenericWebDeployProviderInspection:
     retry_safe: bool = False
     identity_matches: bool = True
     post_deploy_unobserved: bool = False
+    provider_evidence: GenericWebDeployProviderEvidenceClassification = "not_inspected"
+    provider_read_error_class: GenericWebDeployProviderReadErrorClass = ""
 
 
 class GenericWebDeployProviderMutationAdapter:
@@ -150,7 +165,7 @@ class GenericWebDeployProviderMutationAdapter:
             )
         except (FileNotFoundError, ValueError, click.ClickException):
             return ProviderObservation(outcome="unknown")
-        terminal_failure = str(driver_result.get("deploy_status", "")).strip() == "fail"
+        terminal_failure = _string_field(driver_result, "deploy_status") == "fail"
         return ProviderObservation(
             outcome="present",
             response_status_code=502 if terminal_failure else 202,
@@ -162,6 +177,79 @@ class GenericWebDeployProviderMutationAdapter:
         )
 
     def inspect(
+        self,
+        *,
+        provider_operation_key: str,
+        provider_effect_phase: str,
+        reconciliation_key: str,
+        expected_provider_target_key: str = "",
+    ) -> _GenericWebDeployProviderInspection:
+        evidence = self.inspect_evidence(
+            provider_operation_key=provider_operation_key,
+            provider_effect_phase=provider_effect_phase,
+            reconciliation_key=reconciliation_key,
+            expected_provider_target_key=expected_provider_target_key,
+        )
+        if not evidence.identity_matches:
+            return evidence
+        observation = evidence.observation
+        resolved_target = evidence.resolved_deploy_target
+        if observation.outcome != "present":
+            if observation.outcome == "absent" and provider_effect_phase == "deploy_trigger":
+                return _GenericWebDeployProviderInspection(
+                    observation=GenericWebProviderDeploymentObservation(outcome="unknown"),
+                    resolved_deploy_target=resolved_target,
+                    provider_evidence=evidence.provider_evidence,
+                    provider_read_error_class=evidence.provider_read_error_class,
+                )
+            return _GenericWebDeployProviderInspection(
+                observation=observation,
+                resolved_deploy_target=resolved_target,
+                retry_safe=(
+                    observation.outcome == "absent"
+                    and provider_effect_phase in {"", "target_update"}
+                ),
+                provider_evidence=evidence.provider_evidence,
+                provider_read_error_class=evidence.provider_read_error_class,
+            )
+        if resolved_target is None:
+            return _GenericWebDeployProviderInspection(
+                observation=GenericWebProviderDeploymentObservation(outcome="unknown"),
+                provider_evidence="provider_read_failed",
+                provider_read_error_class="target_resolution_failed",
+            )
+        post_deploy_unobserved = (
+            generic_web_provider_deployment_succeeded(observation.deployment_status)
+            and generic_web_post_deploy_executor_for_driver_id(self._profile.driver_id) is not None
+        )
+        deployment_record_id = self._deployment_record_id(provider_operation_key)
+        if provider_effect_phase.startswith("post_deploy_"):
+            read_deployment_record_value = getattr(
+                self._record_store, "read_deployment_record", None
+            )
+            if not callable(read_deployment_record_value):
+                return _GenericWebDeployProviderInspection(
+                    observation=GenericWebProviderDeploymentObservation(outcome="unknown"),
+                    provider_evidence=evidence.provider_evidence,
+                )
+            record_reader = cast(_DeploymentRecordReader, self._record_store)
+            try:
+                record_reader.read_deployment_record(deployment_record_id)
+            except FileNotFoundError:
+                return _GenericWebDeployProviderInspection(
+                    observation=GenericWebProviderDeploymentObservation(outcome="unknown"),
+                    provider_evidence=evidence.provider_evidence,
+                )
+            post_deploy_unobserved = False
+        return _GenericWebDeployProviderInspection(
+            observation=observation,
+            resolved_deploy_target=resolved_target,
+            post_deploy_unobserved=post_deploy_unobserved,
+            provider_evidence=evidence.provider_evidence,
+            provider_read_error_class=evidence.provider_read_error_class,
+        )
+
+    def inspect_evidence(
         self,
         *,
         provider_operation_key: str,
@@ -192,8 +280,17 @@ class GenericWebDeployProviderMutationAdapter:
                 return _GenericWebDeployProviderInspection(
                     observation=GenericWebProviderDeploymentObservation(outcome="unknown"),
                     identity_matches=False,
+                    provider_evidence="provider_read_failed",
+                    provider_read_error_class="target_resolution_failed",
                 )
             self._resolved_deploy_target = resolved_target
+        except (FileNotFoundError, ValueError, click.ClickException):
+            return _GenericWebDeployProviderInspection(
+                observation=GenericWebProviderDeploymentObservation(outcome="unknown"),
+                provider_evidence="provider_read_failed",
+                provider_read_error_class="target_resolution_failed",
+            )
+        try:
             observation = self._deploy_provider.observe_artifact_deploy(
                 control_plane_root=self._control_plane_root,
                 resolved_deploy_target=resolved_target,
@@ -201,46 +298,31 @@ class GenericWebDeployProviderMutationAdapter:
             )
         except (FileNotFoundError, ValueError, click.ClickException):
             return _GenericWebDeployProviderInspection(
-                observation=GenericWebProviderDeploymentObservation(outcome="unknown")
+                observation=GenericWebProviderDeploymentObservation(outcome="unknown"),
+                resolved_deploy_target=resolved_target,
+                provider_evidence="provider_read_failed",
+                provider_read_error_class="provider_request_failed",
             )
-        if observation.outcome != "present":
-            if observation.outcome == "absent" and provider_effect_phase == "deploy_trigger":
-                return _GenericWebDeployProviderInspection(
-                    observation=GenericWebProviderDeploymentObservation(outcome="unknown")
-                )
-            return _GenericWebDeployProviderInspection(
-                observation=observation,
-                retry_safe=(
-                    observation.outcome == "absent"
-                    and provider_effect_phase in {"", "target_update"}
-                ),
+        if observation.outcome == "present":
+            provider_evidence: GenericWebDeployProviderEvidenceClassification = "deployment_present"
+        elif observation.outcome == "absent":
+            provider_evidence = (
+                "deployment_absent_before_effect"
+                if provider_effect_phase in {"", "target_update"}
+                else "deployment_absent_after_effect"
             )
-        post_deploy_unobserved = (
-            generic_web_provider_deployment_succeeded(observation.deployment_status)
-            and generic_web_post_deploy_executor_for_driver_id(self._profile.driver_id) is not None
-        )
-        deployment_record_id = self._deployment_record_id(provider_operation_key)
-        if provider_effect_phase.startswith("post_deploy_"):
-            read_deployment_record = getattr(self._record_store, "read_deployment_record", None)
-            if not callable(read_deployment_record):
-                return _GenericWebDeployProviderInspection(
-                    observation=GenericWebProviderDeploymentObservation(outcome="unknown")
-                )
-            try:
-                read_deployment_record(deployment_record_id)
-            except FileNotFoundError:
-                return _GenericWebDeployProviderInspection(
-                    observation=GenericWebProviderDeploymentObservation(outcome="unknown")
-                )
-            post_deploy_unobserved = False
+        else:
+            provider_evidence = "provider_status_unknown"
         return _GenericWebDeployProviderInspection(
             observation=observation,
             resolved_deploy_target=resolved_target,
-            post_deploy_unobserved=post_deploy_unobserved,
+            provider_evidence=provider_evidence,
         )
 
     def _deployment_record_id(self, provider_operation_key: str) -> str:
-        operation_digest = hashlib.sha256(provider_operation_key.encode("utf-8")).hexdigest()[:24]
+        digest = hashlib.sha256()
+        digest.update(provider_operation_key.encode())
+        operation_digest = digest.hexdigest()[:24]
         return (
             f"deployment-provider-operation-{operation_digest}-"
             f"{self._lane.context}-{self._lane.instance}"
@@ -267,9 +349,9 @@ class GenericWebDeployProviderMutationAdapter:
         except click.ClickException as error:
             raise ProviderMutationUnknownError(str(error)) from error
         provider_effect_attempted = result.pop("provider_effect_attempted", False) is True
-        if str(result.get("deploy_status", "")).strip() == "fail" and provider_effect_attempted:
+        if _string_field(result, "deploy_status") == "fail" and provider_effect_attempted:
             raise ProviderMutationUnknownError(
-                str(result.get("error_message", "")).strip()
+                _string_field(result, "error_message")
                 or "Generic web provider outcome requires reconciliation."
             )
         return ProviderMutationOutcome(

--- a/control_plane/generic_web_deploy_recovery_http.py
+++ b/control_plane/generic_web_deploy_recovery_http.py
@@ -1,7 +1,7 @@
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Annotated, Any, cast
+from typing import Annotated, Any
 
 import click
 from fastapi import Depends, Header, Request
@@ -13,6 +13,7 @@ from control_plane.contracts.generic_web_deploy_recovery import (
     GenericWebDeployRecoveryApplyResponse,
     GenericWebDeployRecoveryDryRunRequest,
     GenericWebDeployRecoveryDryRunResponse,
+    GenericWebDeployRecoveryProviderEvidenceResponse,
     GenericWebDeployRecoveryProviderOutcome,
     build_generic_web_deploy_recovery_digest,
     generic_web_deploy_recovery_identifier_sha256,
@@ -52,14 +53,23 @@ from control_plane.workflows.generic_web_deploy_provider import (
 
 
 GENERIC_WEB_DEPLOY_RECOVERY_DRY_RUN_ROUTE = "/v1/admin/generic-web/deploy-recovery/dry-run"
+GENERIC_WEB_DEPLOY_RECOVERY_PROVIDER_EVIDENCE_ROUTE = (
+    "/v1/admin/generic-web/deploy-recovery/provider-evidence"
+)
 GENERIC_WEB_DEPLOY_RECOVERY_APPLY_ROUTE = "/v1/admin/generic-web/deploy-recovery/apply"
+GENERIC_WEB_DEPLOY_RECOVERY_PROVIDER_EVIDENCE_READ_ACTION = (
+    "generic_web_deploy_recovery_provider_evidence.read"
+)
 
 __all__ = [
     "GENERIC_WEB_DEPLOY_RECOVERY_DRY_RUN_ROUTE",
+    "GENERIC_WEB_DEPLOY_RECOVERY_PROVIDER_EVIDENCE_ROUTE",
+    "GENERIC_WEB_DEPLOY_RECOVERY_PROVIDER_EVIDENCE_READ_ACTION",
     "GENERIC_WEB_DEPLOY_RECOVERY_APPLY_ROUTE",
     "GenericWebDeployRecoveryDependencies",
     "build_generic_web_deploy_recovery_apply_handler",
     "build_generic_web_deploy_recovery_dry_run_handler",
+    "build_generic_web_deploy_recovery_provider_evidence_handler",
 ]
 
 
@@ -75,7 +85,29 @@ class GenericWebDeployRecoveryDependencies:
 
 
 def _bounded_recovery_value(value: object, *, limit: int = 128) -> str:
-    return str(value or "").strip()[:limit]
+    return value.strip()[:limit] if isinstance(value, str) else ""
+
+
+def _recovery_authorization_allows(
+    *,
+    dependencies: GenericWebDeployRecoveryDependencies,
+    identity: LaunchplaneIdentity,
+    actions: tuple[str, ...],
+    product: str,
+    context: str,
+    instance: str,
+) -> bool:
+    target = AuthorizationTarget(scope="instance", instances=(instance,))
+    return any(
+        dependencies.authorization_allows(
+            identity=identity,
+            action=action,
+            product=product,
+            context=context,
+            target=target,
+        )
+        for action in actions
+    )
 
 
 @dataclass(frozen=True, slots=True)
@@ -200,20 +232,19 @@ def _stored_recovery_metadata(
         return None
     digest = str(stored_recovery.get("recovery_digest") or "").strip()
     action = str(stored_recovery.get("recovery_action") or "").strip()
-    if (
-        len(digest) != 64
-        or any(character not in "0123456789abcdef" for character in digest)
-        or action
-        not in {
-            "replay_completed",
-            "wait_for_active_lease",
-            "adopt_observed",
-            "retry_original_operation",
-            "hold_unknown",
-        }
-    ):
+    if len(digest) != 64 or any(character not in "0123456789abcdef" for character in digest):
         return None
-    return digest, cast(GenericWebDeployRecoveryAction, action)
+    match action:
+        case (
+            "replay_completed"
+            | "wait_for_active_lease"
+            | "adopt_observed"
+            | "retry_original_operation"
+            | "hold_unknown"
+        ):
+            return digest, action
+        case _:
+            return None
 
 
 def _recovery_metadata(
@@ -329,6 +360,7 @@ async def _inspect_generic_web_deploy_recovery(
     idempotency_key: str,
     trace_id: str,
     dependencies: GenericWebDeployRecoveryDependencies,
+    authorization_actions: tuple[str, ...] = ("generic_web_deploy.execute",),
 ) -> _GenericWebDeployRecoveryInspection:
     try:
         profile, lane = resolve_generic_web_deploy_lane(
@@ -357,12 +389,13 @@ async def _inspect_generic_web_deploy_recovery(
             code="invalid_request",
             message="Request could not be completed.",
         ) from error
-    if not dependencies.authorization_allows(
+    if not _recovery_authorization_allows(
+        dependencies=dependencies,
         identity=identity,
-        action="generic_web_deploy.execute",
+        actions=authorization_actions,
         product=profile.product,
         context=lane.context,
-        target=AuthorizationTarget(scope="instance", instances=(lane.instance,)),
+        instance=lane.instance,
     ):
         raise dependencies.http_error(
             status_code=403,
@@ -399,7 +432,7 @@ async def _inspect_generic_web_deploy_recovery(
         )
     original_fingerprint = dependencies.idempotency_request_fingerprint(
         route_path=GENERIC_WEB_DEPLOY_ROUTE,
-        payload=cast(dict[str, object], original_payload),
+        payload=original_payload,
     )
     lookup = record_store.lookup_existing_mutation_reservation(
         route_path=GENERIC_WEB_DEPLOY_ROUTE,
@@ -454,7 +487,7 @@ async def _inspect_generic_web_deploy_recovery(
     provider_operation_key = ""
     provider_observation_payload: dict[str, object] = {"outcome": provider_outcome}
     operation_product = recovery_request.original_deploy.product.strip()
-    operation_context = ""
+    operation_context: str
     operation_instance = recovery_request.original_deploy.deploy.instance.strip()
     authoritative_lane = lane
 
@@ -559,12 +592,13 @@ async def _inspect_generic_web_deploy_recovery(
                 message="Stored generic web deploy recovery target identity conflicts.",
             )
 
-    if not dependencies.authorization_allows(
+    if not _recovery_authorization_allows(
+        dependencies=dependencies,
         identity=identity,
-        action="generic_web_deploy.execute",
+        actions=authorization_actions,
         product=operation_product,
         context=operation_context,
-        target=AuthorizationTarget(scope="instance", instances=(operation_instance,)),
+        instance=operation_instance,
     ):
         raise dependencies.http_error(
             status_code=403,
@@ -691,6 +725,60 @@ def build_generic_web_deploy_recovery_dry_run_handler(
         return inspection.dry_run_response()
 
     return dry_run_generic_web_deploy_recovery
+
+
+def build_generic_web_deploy_recovery_provider_evidence_handler(
+    *, dependencies: GenericWebDeployRecoveryDependencies
+) -> Callable[..., Any]:
+    async def inspect_generic_web_deploy_recovery_provider_evidence(
+        request: Request,
+        recovery_request: GenericWebDeployRecoveryDryRunRequest,
+        identity: Annotated[LaunchplaneIdentity, Depends(dependencies.read_write_identity)],
+        record_store: Annotated[object, Depends(dependencies.get_record_store)],
+        idempotency_key: Annotated[str, Header(alias="Idempotency-Key")],
+    ) -> GenericWebDeployRecoveryProviderEvidenceResponse:
+        trace_id = dependencies.next_trace_id()
+        inspection = await _inspect_generic_web_deploy_recovery(
+            request=request,
+            recovery_request=recovery_request,
+            identity=identity,
+            record_store=record_store,
+            idempotency_key=idempotency_key,
+            trace_id=trace_id,
+            dependencies=dependencies,
+            authorization_actions=(
+                GENERIC_WEB_DEPLOY_RECOVERY_PROVIDER_EVIDENCE_READ_ACTION,
+                "generic_web_deploy.execute",
+            ),
+        )
+        provider_inspection = inspection.provider_inspection
+        return GenericWebDeployRecoveryProviderEvidenceResponse(
+            reservation_state=inspection.reservation.state,
+            reservation_attempt=inspection.reservation.attempt,
+            observed_at=inspection.observed_at,
+            reconciliation_key_sha256=generic_web_deploy_recovery_identifier_sha256(
+                inspection.reservation.reconciliation_key
+            ),
+            provider_target_key_sha256=generic_web_deploy_recovery_identifier_sha256(
+                inspection.reservation.provider_target_key
+            ),
+            provider_effect_phase=_bounded_recovery_value(
+                inspection.reservation.provider_effect_phase
+            ),
+            provider_evidence=(
+                provider_inspection.provider_evidence
+                if provider_inspection is not None
+                else "not_inspected"
+            ),
+            provider_status=inspection.provider_status,
+            provider_read_error_class=(
+                provider_inspection.provider_read_error_class
+                if provider_inspection is not None
+                else ""
+            ),
+        )
+
+    return inspect_generic_web_deploy_recovery_provider_evidence
 
 
 def build_generic_web_deploy_recovery_apply_handler(

--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -71,6 +71,9 @@ from control_plane import live_target_runtime as control_plane_live_target_runti
 from control_plane.change_impact_github import GitHubChangeImpactRepositoryEvidenceProvider
 from control_plane.change_impact_service import ChangeImpactRepositoryEvidenceProvider
 from control_plane.contracts.change_impact import ChangeImpactTargetReference
+from control_plane.contracts.generic_web_deploy_recovery import (
+    GenericWebDeployRecoveryProviderEvidenceResponse,
+)
 from control_plane.contracts.authz_access_read import (
     AUTHZ_DENIAL_EXPLANATION_READ_ACTION,
     EFFECTIVE_ACCESS_READ_ACTION,
@@ -174,6 +177,11 @@ from control_plane.http_routes import (
     replay_idempotent_response,
     request_fingerprint as build_request_fingerprint,
     require_product_profile_read_store,
+)
+from control_plane.generic_web_deploy_recovery_http import (
+    GENERIC_WEB_DEPLOY_RECOVERY_PROVIDER_EVIDENCE_ROUTE,
+    GenericWebDeployRecoveryDependencies,
+    build_generic_web_deploy_recovery_provider_evidence_handler,
 )
 from control_plane.contracts.authz_policy_record import (
     LaunchplaneAuthzPolicyRecord,
@@ -20012,6 +20020,38 @@ def create_launchplane_fastapi_app(
         app,
         dependencies=generic_web_write_route_dependencies,
         handlers=generic_web_write_route_handlers,
+    )
+    inspect_generic_web_deploy_recovery_provider_evidence = (
+        build_generic_web_deploy_recovery_provider_evidence_handler(
+            dependencies=GenericWebDeployRecoveryDependencies(
+                read_write_identity=generic_web_write_route_dependencies.read_write_identity,
+                get_record_store=generic_web_write_route_dependencies.get_record_store,
+                next_trace_id=generic_web_write_route_dependencies.next_trace_id,
+                authorization_allows=generic_web_write_route_dependencies.authorization_allows,
+                http_error=generic_web_write_route_dependencies.http_error,
+                control_plane_root=generic_web_write_route_dependencies.control_plane_root,
+                idempotency_request_fingerprint=(
+                    generic_web_write_route_dependencies.idempotency_request_fingerprint
+                ),
+            )
+        )
+    )
+    app.add_api_route(
+        GENERIC_WEB_DEPLOY_RECOVERY_PROVIDER_EVIDENCE_ROUTE,
+        inspect_generic_web_deploy_recovery_provider_evidence,
+        methods=["POST"],
+        response_model=GenericWebDeployRecoveryProviderEvidenceResponse,
+        response_model_exclude_none=True,
+        operation_id="inspect_generic_web_deploy_recovery_provider_evidence",
+        summary="Inspect exact provider evidence for a generic web deploy reservation",
+        responses={
+            400: {"model": LaunchplaneErrorResponse},
+            401: {"model": LaunchplaneErrorResponse},
+            403: {"model": LaunchplaneErrorResponse},
+            404: {"model": LaunchplaneErrorResponse},
+            409: {"model": LaunchplaneErrorResponse},
+            503: {"model": LaunchplaneErrorResponse},
+        },
     )
 
     app.add_api_route(

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -427,6 +427,42 @@ triggering run, enforces a single-file and size bound, and passes the compact
 request through the same bounded dry-run action. This mode also skips stable
 deploy and exposes no apply path.
 
+The same protected recovery job performs an advisory exact-provider evidence
+read before the authoritative dry-run. It calls
+`POST /v1/admin/generic-web/deploy-recovery/provider-evidence` with the identical
+request and original `Idempotency-Key`. The route derives provider operation and
+target identity only from the exact stored reservation and reconciliation
+snapshot. It reports one bounded classification:
+
+- `deployment_present` when the exact titled provider deployment has complete
+  terminal evidence;
+- `deployment_absent_before_effect` when no exact deployment is visible before
+  the provider effect started;
+- `deployment_absent_after_effect` when no exact deployment is visible after
+  the provider effect started;
+- `provider_status_unknown` when the exact deployment is present but pending or
+  has an unrecognized status;
+- `provider_read_failed` with only a bounded target-resolution or provider-read
+  error category; or
+- `not_inspected` for completed reservations and active leases.
+
+This diagnostic never returns or changes `retry_safe`, `proposed_action`, or the
+recovery digest. In particular, `deployment_absent_after_effect` is not proof
+that the original provider effect never occurred and cannot make recovery
+retryable automatically. The response omits raw scope, idempotency key,
+reconciliation key, provider target or operation identity, deployment id,
+provider timestamps, URL, payload, logs, credentials, and exception messages.
+It performs no reservation, deployment, inventory, provider-operation, outbox,
+or provider mutation writes.
+
+Authorization checks the dedicated
+`generic_web_deploy_recovery_provider_evidence.read` action first and accepts
+`generic_web_deploy.execute` as the more-privileged compatibility path. The
+compatibility path avoids a new production grant for the existing protected
+recovery workflow while authorization redesign issue `#2058` remains open. It
+must be removed under `#2167` once DB-native policy administration can grant the
+dedicated read action to the exact workflow identity.
+
 Stage 2 apply is explicit and digest-gated. Operators call
 `POST /v1/admin/generic-web/deploy-recovery/apply` with the same request body as
 the dry-run plus `expected_recovery_digest`. The service recomputes a fresh

--- a/frontend/generated/openapi-canonical.json
+++ b/frontend/generated/openapi-canonical.json
@@ -7094,6 +7094,101 @@
         "title": "GenericWebDeployRecoveryDryRunResponse",
         "type": "object"
       },
+      "GenericWebDeployRecoveryProviderEvidenceResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "mode": {
+            "const": "provider-evidence",
+            "default": "provider-evidence",
+            "title": "Mode",
+            "type": "string"
+          },
+          "observed_at": {
+            "title": "Observed At",
+            "type": "string"
+          },
+          "provider_effect_phase": {
+            "maxLength": 128,
+            "title": "Provider Effect Phase",
+            "type": "string"
+          },
+          "provider_evidence": {
+            "enum": [
+              "deployment_present",
+              "deployment_absent_before_effect",
+              "deployment_absent_after_effect",
+              "provider_status_unknown",
+              "provider_read_failed",
+              "not_inspected"
+            ],
+            "title": "Provider Evidence",
+            "type": "string"
+          },
+          "provider_read_error_class": {
+            "default": "",
+            "enum": [
+              "",
+              "target_resolution_failed",
+              "provider_request_failed"
+            ],
+            "title": "Provider Read Error Class",
+            "type": "string"
+          },
+          "provider_status": {
+            "default": "",
+            "maxLength": 128,
+            "title": "Provider Status",
+            "type": "string"
+          },
+          "provider_target_key_sha256": {
+            "pattern": "^[0-9a-f]{64}$",
+            "title": "Provider Target Key Sha256",
+            "type": "string"
+          },
+          "reconciliation_key_sha256": {
+            "pattern": "^[0-9a-f]{64}$",
+            "title": "Reconciliation Key Sha256",
+            "type": "string"
+          },
+          "reservation_attempt": {
+            "minimum": 1.0,
+            "title": "Reservation Attempt",
+            "type": "integer"
+          },
+          "reservation_state": {
+            "enum": [
+              "running",
+              "completed",
+              "reconcile_required"
+            ],
+            "title": "Reservation State",
+            "type": "string"
+          },
+          "schema_version": {
+            "const": 1,
+            "default": 1,
+            "title": "Schema Version",
+            "type": "integer"
+          },
+          "status": {
+            "const": "ok",
+            "default": "ok",
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "reservation_state",
+          "reservation_attempt",
+          "observed_at",
+          "reconciliation_key_sha256",
+          "provider_target_key_sha256",
+          "provider_effect_phase",
+          "provider_evidence"
+        ],
+        "title": "GenericWebDeployRecoveryProviderEvidenceResponse",
+        "type": "object"
+      },
       "GenericWebDeployRequest": {
         "additionalProperties": false,
         "properties": {
@@ -34588,6 +34683,115 @@
           }
         },
         "summary": "Inspect an existing generic web deploy reservation without writing"
+      }
+    },
+    "/v1/admin/generic-web/deploy-recovery/provider-evidence": {
+      "post": {
+        "operationId": "inspect_generic_web_deploy_recovery_provider_evidence",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Idempotency-Key",
+            "required": true,
+            "schema": {
+              "title": "Idempotency-Key",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "Authorization",
+            "required": false,
+            "schema": {
+              "default": "",
+              "title": "Authorization",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GenericWebDeployRecoveryDryRunRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GenericWebDeployRecoveryProviderEvidenceResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "summary": "Inspect exact provider evidence for a generic web deploy reservation"
       }
     },
     "/v1/agent/context": {

--- a/tests/support/auth.py
+++ b/tests/support/auth.py
@@ -52,7 +52,7 @@ _StubVerifier = StubVerifier
 _identity = identity
 
 
-def _local_operator_policy(
+def local_operator_policy(
     *,
     actions: tuple[str, ...],
     products: tuple[str, ...] = ("*",),
@@ -71,3 +71,6 @@ def _local_operator_policy(
             ),
         )
     )
+
+
+_local_operator_policy = local_operator_policy

--- a/tests/support/profiles.py
+++ b/tests/support/profiles.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import cast
 
 
-def _product_profile_payload(product: str = "sellyouroutboard") -> dict[str, object]:
+def product_profile_payload(product: str = "sellyouroutboard") -> dict[str, object]:
     return {
         "schema_version": 1,
         "product": product,
@@ -29,6 +29,9 @@ def _product_profile_payload(product: str = "sellyouroutboard") -> dict[str, obj
         "updated_at": "2026-04-30T21:30:00Z",
         "source": "test",
     }
+
+
+_product_profile_payload = product_profile_payload
 
 
 def _odoo_preview_profile_payload(product: str = "odoo-tenant-cm") -> dict[str, object]:

--- a/tests/support/stores.py
+++ b/tests/support/stores.py
@@ -17,8 +17,11 @@ from control_plane.contracts.runtime_key_safety_policy import (
 from control_plane.storage.postgres import PostgresRecordStore
 
 
-def _sqlite_database_url(database_path: Path) -> str:
+def sqlite_database_url(database_path: Path) -> str:
     return f"sqlite+pysqlite:///{database_path}"
+
+
+_sqlite_database_url = sqlite_database_url
 
 
 def _write_odoo_preview_template_runtime_environment(

--- a/tests/test_generic_web_deploy_recovery.py
+++ b/tests/test_generic_web_deploy_recovery.py
@@ -14,7 +14,11 @@ from control_plane.contracts.product_profile_record import LaunchplaneProductPro
 from control_plane.contracts.promotion_record import HealthcheckEvidence
 from control_plane.contracts.ship_request import ShipRequest
 from control_plane.http_app import idempotency_request_fingerprint
-from control_plane.service_auth import BearerIdentityConfig
+from control_plane.service_auth import (
+    BearerIdentityConfig,
+    LaunchplaneAuthzPolicy,
+    LocalOperatorPolicyRule,
+)
 from control_plane.storage.postgres import (
     ExistingMutationReservationLookupResult,
     PostgresRecordStore,
@@ -26,13 +30,14 @@ from control_plane.workflows.generic_web_deploy_provider import (
     build_generic_web_provider_reconciliation_key,
     build_generic_web_provider_target_key,
 )
-from tests.support.auth import _StubVerifier, _identity, _local_operator_policy
-from tests.support.profiles import _product_profile_payload
-from tests.support.stores import _sqlite_database_url
+from tests.support.auth import StubVerifier, identity, local_operator_policy
+from tests.support.profiles import product_profile_payload as _product_profile_payload
+from tests.support.stores import sqlite_database_url as _sqlite_database_url
 from tests.test_service import _invoke_app, create_launchplane_fastapi_test_app
 
 
 _RECOVERY_ROUTE = "/v1/admin/generic-web/deploy-recovery/dry-run"
+_PROVIDER_EVIDENCE_ROUTE = "/v1/admin/generic-web/deploy-recovery/provider-evidence"
 _RECOVERY_APPLY_ROUTE = "/v1/admin/generic-web/deploy-recovery/apply"
 _OPERATOR_TOKEN = "local-operator-token"
 
@@ -43,12 +48,14 @@ def _create_recovery_app(
     store: PostgresRecordStore,
     actions: tuple[str, ...] = ("generic_web_deploy.execute",),
     contexts: tuple[str, ...] = ("sellyouroutboard-testing",),
+    authz_policy: LaunchplaneAuthzPolicy | None = None,
 ) -> Any:
     return create_launchplane_fastapi_test_app(
         local_record_store_for_tests=store,
         state_dir=root / "state",
-        verifier=_StubVerifier(_identity()),
-        authz_policy=_local_operator_policy(
+        verifier=StubVerifier(identity()),
+        authz_policy=authz_policy
+        or local_operator_policy(
             actions=actions,
             products=("sellyouroutboard",),
             contexts=contexts,
@@ -105,6 +112,29 @@ def _invoke_recovery_apply(
             "original_deploy": original_deploy,
             "reason": reason,
             "expected_recovery_digest": expected_recovery_digest,
+        },
+        headers={"Idempotency-Key": idempotency_key},
+    )
+
+
+def _invoke_provider_evidence(
+    app: Any,
+    *,
+    original_deploy: dict[str, object],
+    idempotency_key: str,
+    reason: str,
+) -> tuple[int, dict[str, Any]]:
+    return _invoke_app(
+        app,
+        method="POST",
+        path=_PROVIDER_EVIDENCE_ROUTE,
+        authorization=f"Bearer {_OPERATOR_TOKEN}",
+        payload={
+            "schema_version": 1,
+            "product": "sellyouroutboard",
+            "instance": "testing",
+            "original_deploy": original_deploy,
+            "reason": reason,
         },
         headers={"Idempotency-Key": idempotency_key},
     )
@@ -195,7 +225,7 @@ def _legacy_generic_web_reconciliation_key(
         "deploy_timeout_seconds": target.deploy_timeout_seconds,
     }
     encoded = base64.urlsafe_b64encode(
-        json.dumps(legacy_snapshot, separators=(",", ":")).encode("utf-8")
+        json.dumps(legacy_snapshot, separators=(",", ":")).encode()
     ).decode("ascii")
     return f"generic-web-provider-target:{encoded.rstrip('=')}"
 
@@ -250,7 +280,6 @@ def _write_generic_web_recovery_reservation(
         idempotency_key=reservation.idempotency_key,
         request_fingerprint=reservation.request_fingerprint,
         lease_owner=reservation.lease_owner,
-        lease_seconds=300,
         reconciliation_key=reservation.reconciliation_key,
         provider_target_key=reservation.provider_target_key,
     ).record
@@ -258,7 +287,6 @@ def _write_generic_web_recovery_reservation(
         checkpointed = store.checkpoint_mutation_provider_effect(
             reservation=reserved,
             effect_phase=reservation.provider_effect_phase,
-            lease_seconds=300,
         )
         assert checkpointed.record is not None
         reserved = checkpointed.record
@@ -486,7 +514,6 @@ class GenericWebDeployRecoveryHttpTests(unittest.TestCase):
                             else stored_fingerprint
                         ),
                         lease_owner=f"worker-{index}",
-                        lease_seconds=300,
                     )
                 app = _create_recovery_app(root=root, store=store)
                 status_code, payload = _invoke_app(
@@ -656,18 +683,18 @@ class GenericWebDeployRecoveryHttpTests(unittest.TestCase):
                         return_value=provider,
                     ),
                     patch.object(store, "reserve_mutation", side_effect=AssertionError("reserve")),
-                    patch.object(
-                        store,
+                    patch(
+                        "control_plane.storage.postgres.PostgresRecordStore."
                         "write_deployment_record",
                         side_effect=AssertionError("deployment write"),
                     ),
-                    patch.object(
-                        store,
+                    patch(
+                        "control_plane.storage.postgres.PostgresRecordStore."
                         "write_environment_inventory",
                         side_effect=AssertionError("inventory write"),
                     ),
-                    patch.object(
-                        store,
+                    patch(
+                        "control_plane.storage.postgres.PostgresRecordStore."
                         "write_idempotency_record",
                         side_effect=AssertionError("idempotency write"),
                     ),
@@ -756,6 +783,290 @@ class GenericWebDeployRecoveryHttpTests(unittest.TestCase):
         self.assertEqual(payload["provider_outcome"], "unknown")
         self.assertEqual(payload["proposed_action"], "hold_unknown")
         self.assertEqual(provider.observation_calls, 1)
+
+    def test_provider_evidence_distinguishes_bounded_observations_without_writes(
+        self,
+    ) -> None:
+        present = GenericWebProviderDeploymentObservation(
+            outcome="present",
+            deployment_status="success",
+            deployment_id="deployment-secret",
+            started_at="2026-08-15T12:00:00Z",
+            finished_at="2026-08-15T12:05:00Z",
+            error_message="provider-secret-message",
+        )
+        cases = (
+            (present, "target_update", "deployment_present", "success"),
+            (
+                GenericWebProviderDeploymentObservation(outcome="absent"),
+                "target_update",
+                "deployment_absent_before_effect",
+                "",
+            ),
+            (
+                GenericWebProviderDeploymentObservation(outcome="absent"),
+                "deploy_trigger",
+                "deployment_absent_after_effect",
+                "",
+            ),
+            (
+                GenericWebProviderDeploymentObservation(
+                    outcome="unknown", deployment_status="running"
+                ),
+                "deploy_trigger",
+                "provider_status_unknown",
+                "running",
+            ),
+        )
+        expected_keys = {
+            "schema_version",
+            "status",
+            "mode",
+            "reservation_state",
+            "reservation_attempt",
+            "observed_at",
+            "reconciliation_key_sha256",
+            "provider_target_key_sha256",
+            "provider_effect_phase",
+            "provider_evidence",
+            "provider_status",
+            "provider_read_error_class",
+        }
+        for observation, effect_phase, expected_evidence, expected_status in cases:
+            with (
+                self.subTest(expected_evidence=expected_evidence),
+                TemporaryDirectory() as temporary_directory_name,
+            ):
+                root = Path(temporary_directory_name)
+                store = PostgresRecordStore(
+                    database_url=_sqlite_database_url(root / "launchplane.sqlite3")
+                )
+                store.ensure_schema()
+                store.write_product_profile_record(
+                    LaunchplaneProductProfileRecord.model_validate(_product_profile_payload())
+                )
+                original_deploy = _generic_web_recovery_original_deploy()
+                reservation = _write_generic_web_recovery_reservation(
+                    store,
+                    _generic_web_recovery_reservation(
+                        original_deploy=original_deploy,
+                        idempotency_key=f"provider-evidence-{expected_evidence}",
+                        provider_effect_phase=effect_phase,
+                    ),
+                )
+                provider = _RecoveryObservationProvider(observation)
+                app = _create_recovery_app(root=root, store=store)
+                with (
+                    patch(
+                        "control_plane.generic_web_deploy_provider_adapter."
+                        "default_generic_web_deploy_provider",
+                        return_value=provider,
+                    ),
+                    patch.object(store, "reserve_mutation", side_effect=AssertionError("reserve")),
+                    patch(
+                        "control_plane.storage.postgres.PostgresRecordStore."
+                        "write_deployment_record",
+                        side_effect=AssertionError("deployment write"),
+                    ),
+                    patch(
+                        "control_plane.storage.postgres.PostgresRecordStore."
+                        "write_environment_inventory",
+                        side_effect=AssertionError("inventory write"),
+                    ),
+                    patch(
+                        "control_plane.storage.postgres.PostgresRecordStore."
+                        "write_idempotency_record",
+                        side_effect=AssertionError("idempotency write"),
+                    ),
+                ):
+                    status_code, payload = _invoke_provider_evidence(
+                        app,
+                        original_deploy=original_deploy,
+                        idempotency_key=reservation.idempotency_key,
+                        reason="Inspect exact provider evidence without mutation.",
+                    )
+                store.close()
+
+            self.assertEqual(status_code, 200)
+            self.assertEqual(set(payload), expected_keys)
+            self.assertEqual(payload["provider_evidence"], expected_evidence)
+            self.assertEqual(payload["provider_status"], expected_status)
+            self.assertEqual(payload["provider_read_error_class"], "")
+            self.assertNotIn("retry_safe", payload)
+            self.assertNotIn("recovery_digest", payload)
+            serialized = json.dumps(payload, sort_keys=True)
+            self.assertNotIn("deployment-secret", serialized)
+            self.assertNotIn("provider-secret-message", serialized)
+            self.assertNotIn(reservation.idempotency_key, serialized)
+            self.assertNotIn(reservation.scope, serialized)
+            self.assertEqual(provider.observation_calls, 1)
+
+    def test_provider_evidence_reports_bounded_provider_read_failure(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(root / "launchplane.sqlite3")
+            )
+            store.ensure_schema()
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_product_profile_payload())
+            )
+            original_deploy = _generic_web_recovery_original_deploy()
+            reservation = _write_generic_web_recovery_reservation(
+                store,
+                _generic_web_recovery_reservation(
+                    original_deploy=original_deploy,
+                    idempotency_key="provider-evidence-read-failure",
+                    provider_effect_phase="deploy_trigger",
+                ),
+            )
+            provider = _FailingRecoveryObservationProvider(
+                GenericWebProviderDeploymentObservation(outcome="unknown")
+            )
+            app = _create_recovery_app(root=root, store=store)
+            with patch(
+                "control_plane.generic_web_deploy_provider_adapter."
+                "default_generic_web_deploy_provider",
+                return_value=provider,
+            ):
+                status_code, payload = _invoke_provider_evidence(
+                    app,
+                    original_deploy=original_deploy,
+                    idempotency_key=reservation.idempotency_key,
+                    reason="Classify provider read failure without exposing details.",
+                )
+            store.close()
+
+        self.assertEqual(status_code, 200)
+        self.assertEqual(payload["provider_evidence"], "provider_read_failed")
+        self.assertEqual(payload["provider_read_error_class"], "provider_request_failed")
+        self.assertNotIn("provider read failed", json.dumps(payload, sort_keys=True))
+
+    def test_provider_evidence_supports_dedicated_and_execute_authorization(self) -> None:
+        for actions in (
+            ("generic_web_deploy_recovery_provider_evidence.read",),
+            ("generic_web_deploy.execute",),
+        ):
+            with (
+                self.subTest(actions=actions),
+                TemporaryDirectory() as temporary_directory_name,
+            ):
+                root = Path(temporary_directory_name)
+                store = PostgresRecordStore(
+                    database_url=_sqlite_database_url(root / "launchplane.sqlite3")
+                )
+                store.ensure_schema()
+                store.write_product_profile_record(
+                    LaunchplaneProductProfileRecord.model_validate(_product_profile_payload())
+                )
+                original_deploy = _generic_web_recovery_original_deploy()
+                reservation = _write_generic_web_recovery_reservation(
+                    store,
+                    _generic_web_recovery_reservation(
+                        original_deploy=original_deploy,
+                        idempotency_key=f"provider-evidence-authz-{actions[0]}",
+                    ),
+                )
+                app = _create_recovery_app(root=root, store=store, actions=actions)
+                with patch(
+                    "control_plane.generic_web_deploy_provider_adapter."
+                    "default_generic_web_deploy_provider",
+                    return_value=_RecoveryObservationProvider(
+                        GenericWebProviderDeploymentObservation(outcome="absent")
+                    ),
+                ):
+                    status_code, _payload = _invoke_provider_evidence(
+                        app,
+                        original_deploy=original_deploy,
+                        idempotency_key=reservation.idempotency_key,
+                        reason="Verify provider evidence authorization compatibility.",
+                    )
+                store.close()
+
+            self.assertEqual(status_code, 200)
+
+    def test_provider_evidence_dedicated_authorization_supports_schema_v2(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(root / "launchplane.sqlite3")
+            )
+            store.ensure_schema()
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_product_profile_payload())
+            )
+            original_deploy = _generic_web_recovery_original_deploy()
+            reservation = _write_generic_web_recovery_reservation(
+                store,
+                _generic_web_recovery_reservation(
+                    original_deploy=original_deploy,
+                    idempotency_key="provider-evidence-authz-schema-v2",
+                ),
+            )
+            app = _create_recovery_app(
+                root=root,
+                store=store,
+                authz_policy=LaunchplaneAuthzPolicy(
+                    schema_version=2,
+                    local_operators=(
+                        LocalOperatorPolicyRule(
+                            subjects=("local-owner-agent",),
+                            token_labels=("local-owner-write",),
+                            products=("sellyouroutboard",),
+                            contexts=("sellyouroutboard-testing",),
+                            instances=("testing",),
+                            actions=("generic_web_deploy_recovery_provider_evidence.read",),
+                        ),
+                    ),
+                ),
+            )
+            with patch(
+                "control_plane.generic_web_deploy_provider_adapter."
+                "default_generic_web_deploy_provider",
+                return_value=_RecoveryObservationProvider(
+                    GenericWebProviderDeploymentObservation(outcome="absent")
+                ),
+            ):
+                status_code, _payload = _invoke_provider_evidence(
+                    app,
+                    original_deploy=original_deploy,
+                    idempotency_key=reservation.idempotency_key,
+                    reason="Verify schema-v2 dedicated provider evidence authorization.",
+                )
+            store.close()
+
+        self.assertEqual(status_code, 200)
+
+    def test_provider_evidence_denies_before_reservation_lookup(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(root / "launchplane.sqlite3")
+            )
+            store.ensure_schema()
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_product_profile_payload())
+            )
+            app = _create_recovery_app(
+                root=root,
+                store=store,
+                actions=("generic_web_preview.execute",),
+            )
+            with patch.object(
+                store,
+                "lookup_existing_mutation_reservation",
+                side_effect=AssertionError("lookup disclosure"),
+            ):
+                status_code, payload = _invoke_provider_evidence(
+                    app,
+                    original_deploy=_generic_web_recovery_original_deploy(),
+                    idempotency_key="provider-evidence-denied",
+                    reason="Verify denial before reservation lookup.",
+                )
+            store.close()
+
+        self.assertEqual(status_code, 403)
+        self.assertEqual(payload["error"]["code"], "authorization_denied")
 
     def test_generic_web_deploy_recovery_digest_ignores_observed_at(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
@@ -1126,28 +1437,28 @@ class GenericWebDeployRecoveryHttpTests(unittest.TestCase):
             original_mark_reconcile = store.mark_mutation_reconcile_required
             original_retry_reconciled = store.retry_reconciled_mutation
 
-            def mark_reconcile_side_effect(
-                *,
-                reservation: LaunchplaneIdempotencyRecord,
-                reconciliation_key: str,
-            ) -> object:
+            def mark_reconcile_side_effect(**call_kwargs: object) -> object:
                 transitions.append("mark")
                 return original_mark_reconcile(
-                    reservation=reservation,
-                    reconciliation_key=reconciliation_key,
+                    reservation=cast(LaunchplaneIdempotencyRecord, call_kwargs["reservation"]),
+                    reconciliation_key=cast(str, call_kwargs["reconciliation_key"]),
                 )
 
-            def retry_reconciled_side_effect(
-                *,
-                reservation: LaunchplaneIdempotencyRecord,
-                lease_owner: str,
-                lease_seconds: int = 300,
-            ) -> object:
+            def retry_reconciled_side_effect(**call_kwargs: object) -> object:
                 transitions.append("retry")
+                candidate_reservation = cast(
+                    LaunchplaneIdempotencyRecord, call_kwargs["reservation"]
+                )
+                lease_owner = cast(str, call_kwargs["lease_owner"])
+                if "lease_seconds" not in call_kwargs:
+                    return original_retry_reconciled(
+                        reservation=candidate_reservation,
+                        lease_owner=lease_owner,
+                    )
                 return original_retry_reconciled(
-                    reservation=reservation,
+                    reservation=candidate_reservation,
                     lease_owner=lease_owner,
-                    lease_seconds=lease_seconds,
+                    lease_seconds=cast(int, call_kwargs["lease_seconds"]),
                 )
 
             with (

--- a/tests/test_generic_web_deploy_recovery_action.py
+++ b/tests/test_generic_web_deploy_recovery_action.py
@@ -218,6 +218,12 @@ import('./{ACTION_ENTRYPOINT.as_posix()}');
             "RECOVERY_ARTIFACT_RUN_ID: ${{ github.event.workflow_run.id }}",
             "Recovery request artifact must contain exactly one file.",
             "Recovery request artifact exceeds the size limit.",
+            "name: Resolve provider evidence request",
+            "name: Inspect exact provider evidence",
+            "route-path: /v1/admin/generic-web/deploy-recovery/provider-evidence",
+            "provider_evidence=provider_evidence",
+            "provider_read_error_class=provider_read_error_class",
+            "continue-on-error: true",
             "name: Request Launchplane recovery dry run",
             "uses: cbusillo/launchplane/.github/actions/"
             "generic-web-deploy-recovery-dry-run@b2055d2944626234664390d6fcd96975ded38511",
@@ -225,6 +231,8 @@ import('./{ACTION_ENTRYPOINT.as_posix()}');
             "Recovery digest:",
             "Proposed action:",
             "Reservation state:",
+            "Exact provider evidence:",
+            "Provider read error class:",
         )
         for fragment in required_fragments:
             with self.subTest(fragment=fragment):

--- a/tests/test_http_write_route_registrars.py
+++ b/tests/test_http_write_route_registrars.py
@@ -4,13 +4,13 @@ from fastapi.routing import APIRoute
 
 from control_plane.http_app import create_launchplane_fastapi_app
 from control_plane.service_auth import LaunchplaneAuthzPolicy
-from tests.support.auth import _identity, _StubVerifier
+from tests.support.auth import identity, StubVerifier
 
 
 class FastApiWriteRouteRegistrarTests(unittest.TestCase):
     def setUp(self) -> None:
         app = create_launchplane_fastapi_app(
-            verifier=_StubVerifier(_identity()),
+            verifier=StubVerifier(identity()),
             authz_policy=LaunchplaneAuthzPolicy(),
             record_store_factory=object,
         )
@@ -59,6 +59,32 @@ class FastApiWriteRouteRegistrarTests(unittest.TestCase):
         for status_code in ("400", "401", "403", "404", "409", "503"):
             self.assertIn(status_code, route["responses"])
 
+    def test_generic_web_deploy_recovery_provider_evidence_openapi_contract(self) -> None:
+        route = self.app.openapi()["paths"][
+            "/v1/admin/generic-web/deploy-recovery/provider-evidence"
+        ]["post"]
+
+        self.assertEqual(
+            route["operationId"],
+            "inspect_generic_web_deploy_recovery_provider_evidence",
+        )
+        self.assertEqual(
+            route["requestBody"]["content"]["application/json"]["schema"]["$ref"],
+            "#/components/schemas/GenericWebDeployRecoveryDryRunRequest",
+        )
+        self.assertEqual(
+            route["responses"]["200"]["content"]["application/json"]["schema"]["$ref"],
+            "#/components/schemas/GenericWebDeployRecoveryProviderEvidenceResponse",
+        )
+        idempotency_header = next(
+            parameter
+            for parameter in route["parameters"]
+            if parameter["in"] == "header" and parameter["name"] == "Idempotency-Key"
+        )
+        self.assertTrue(idempotency_header["required"])
+        for status_code in ("400", "401", "403", "404", "409", "503"):
+            self.assertIn(status_code, route["responses"])
+
     def test_evidence_write_routes_preserve_contracts_and_ownership(self) -> None:
         expected_routes = (
             ("/v1/evidence/backup-gates", "write_backup_gate_evidence"),
@@ -89,7 +115,10 @@ class FastApiWriteRouteRegistrarTests(unittest.TestCase):
         for route, (_, operation_id) in zip(extracted_routes, expected_routes, strict=True):
             self.assertEqual(route.operation_id, operation_id)
             self.assertEqual(route.response_model.__name__, "AcceptedEvidenceResponse")
-            self.assertEqual(route.endpoint.__module__, "control_plane.http_routes.evidence")
+            self.assertEqual(
+                getattr(route.endpoint, "__module__", ""),
+                "control_plane.http_routes.evidence",
+            )
 
     def test_evidence_write_routes_preserve_interleaved_route_order(self) -> None:
         route_keys = [(next(iter(route.methods or set())), route.path) for route in self.api_routes]
@@ -170,6 +199,11 @@ class FastApiWriteRouteRegistrarTests(unittest.TestCase):
                 "AcceptedEvidenceResponse",
             ),
             (
+                "/v1/admin/generic-web/deploy-recovery/provider-evidence",
+                "inspect_generic_web_deploy_recovery_provider_evidence",
+                "GenericWebDeployRecoveryProviderEvidenceResponse",
+            ),
+            (
                 "/v1/drivers/generic-web/prod-rollback-plan",
                 "write_generic_web_rollback_plan",
                 "AcceptedEvidenceResponse",
@@ -201,7 +235,7 @@ class FastApiWriteRouteRegistrarTests(unittest.TestCase):
                 if route.path.startswith("/v1/admin/generic-web/deploy-recovery/")
                 else "control_plane.http_routes.generic_web"
             )
-            self.assertEqual(route.endpoint.__module__, expected_module)
+            self.assertEqual(getattr(route.endpoint, "__module__", ""), expected_module)
 
     def test_generic_web_write_routes_preserve_interleaved_route_order(self) -> None:
         route_keys = [(next(iter(route.methods or set())), route.path) for route in self.api_routes]
@@ -219,6 +253,7 @@ class FastApiWriteRouteRegistrarTests(unittest.TestCase):
             ("POST", "/v1/drivers/generic-web/prod-promotion-workflow"),
             ("POST", "/v1/drivers/generic-web/stable-verification"),
             ("POST", "/v1/drivers/generic-web/preview-verification"),
+            ("POST", "/v1/admin/generic-web/deploy-recovery/provider-evidence"),
             ("POST", "/v1/drivers/verireel/testing-deploy"),
         ]
         expected_rollback = [


### PR DESCRIPTION
## Summary

- add a separate read-only provider-evidence endpoint for exact generic-web deploy recovery reservations
- classify exact provider evidence without changing dry-run/apply digest or retry semantics
- expose the bounded diagnostic through the protected recovery workflow during rollout
- register the dedicated read action as instance-scoped while retaining `generic_web_deploy.execute` as the compatibility authorization path

## Safety contract

- no provider, reservation, deployment, inventory, outbox, or policy mutation
- no raw provider IDs, deployment IDs, URLs, logs, payloads, credentials, timestamps, or exception messages
- `deployment_absent_after_effect` never implies retry safety
- recovery apply remains separately digest-gated and is not introduced by this workflow
- the diagnostic path and request-resolution prelude are advisory with `continue-on-error`

## Validation

- `uv run --extra dev launchplane ci unittest-shard local` — 3,014 targets across 12 shards passed
- `uv run --extra dev python -m unittest tests.test_generic_web_deploy_recovery tests.test_generic_web_deploy_recovery_action tests.test_http_write_route_registrars tests.test_service_auth` — 92 passed
- `pnpm --dir frontend validate` — passed
- `uv run launchplane service audit-config-authority --control-plane-root .` — status `ok`
- scoped Ruff and format checks — passed
- `uv run --extra dev mypy control_plane tests` — 737 files clean
- actionlint — passed
- PyCharm 2026.2.1 changed-files closeout — zero findings
- independent Opus and Gemini final contract reviews — READY

Closes the missing provider-evidence implementation slice under #2167.
