### PR TITLE
Correlate legacy generic-web deploy recovery

### DIFF
--- a/control_plane/contracts/generic_web_deploy_recovery.py
+++ b/control_plane/contracts/generic_web_deploy_recovery.py
@@ -24,6 +24,7 @@ GenericWebDeployRecoveryProviderOutcome = Literal[
 ]
 GenericWebDeployProviderEvidenceClassification = Literal[
     "deployment_present",
+    "deployment_correlated_legacy",
     "deployment_absent_before_effect",
     "deployment_absent_after_effect",
     "provider_status_unknown",

--- a/control_plane/generic_web_deploy_provider_adapter.py
+++ b/control_plane/generic_web_deploy_provider_adapter.py
@@ -33,7 +33,9 @@ from control_plane.workflows.generic_web_deploy import (
     record_observed_generic_web_deploy,
 )
 from control_plane.workflows.generic_web_deploy_provider import (
+    GenericWebDeployLegacyCorrelationProvider,
     GenericWebDeployProvider,
+    GenericWebLegacyDeploymentCorrelation,
     GenericWebProviderDeploymentObservation,
     GenericWebResolvedDeployTarget,
     build_generic_web_provider_reconciliation_key,
@@ -71,6 +73,7 @@ class _GenericWebDeployProviderInspection:
     post_deploy_unobserved: bool = False
     provider_evidence: GenericWebDeployProviderEvidenceClassification = "not_inspected"
     provider_read_error_class: GenericWebDeployProviderReadErrorClass = ""
+    legacy_correlation_digest_evidence: dict[str, object] | None = None
 
 
 class GenericWebDeployProviderMutationAdapter:
@@ -183,6 +186,7 @@ class GenericWebDeployProviderMutationAdapter:
         provider_effect_phase: str,
         reconciliation_key: str,
         expected_provider_target_key: str = "",
+        legacy_provider_effect_started_at: str = "",
     ) -> _GenericWebDeployProviderInspection:
         evidence = self.inspect_evidence(
             provider_operation_key=provider_operation_key,
@@ -196,22 +200,41 @@ class GenericWebDeployProviderMutationAdapter:
         resolved_target = evidence.resolved_deploy_target
         if observation.outcome != "present":
             if observation.outcome == "absent" and provider_effect_phase == "deploy_trigger":
-                return _GenericWebDeployProviderInspection(
-                    observation=GenericWebProviderDeploymentObservation(outcome="unknown"),
+                (
+                    legacy_correlation,
+                    legacy_provider_evidence,
+                    legacy_read_error_class,
+                ) = self._inspect_legacy_artifact_deploy(
+                    resolved_target=resolved_target,
+                    provider_effect_started_at=legacy_provider_effect_started_at,
+                )
+                if legacy_correlation is None:
+                    return _GenericWebDeployProviderInspection(
+                        observation=GenericWebProviderDeploymentObservation(outcome="unknown"),
+                        resolved_deploy_target=resolved_target,
+                        provider_evidence=legacy_provider_evidence,
+                        provider_read_error_class=legacy_read_error_class,
+                    )
+                observation = legacy_correlation.observation
+                evidence = _GenericWebDeployProviderInspection(
+                    observation=observation,
                     resolved_deploy_target=resolved_target,
+                    provider_evidence="deployment_correlated_legacy",
+                    legacy_correlation_digest_evidence=(
+                        legacy_correlation.digest_evidence.model_dump(mode="json")
+                    ),
+                )
+            else:
+                return _GenericWebDeployProviderInspection(
+                    observation=observation,
+                    resolved_deploy_target=resolved_target,
+                    retry_safe=(
+                        observation.outcome == "absent"
+                        and provider_effect_phase in {"", "target_update"}
+                    ),
                     provider_evidence=evidence.provider_evidence,
                     provider_read_error_class=evidence.provider_read_error_class,
                 )
-            return _GenericWebDeployProviderInspection(
-                observation=observation,
-                resolved_deploy_target=resolved_target,
-                retry_safe=(
-                    observation.outcome == "absent"
-                    and provider_effect_phase in {"", "target_update"}
-                ),
-                provider_evidence=evidence.provider_evidence,
-                provider_read_error_class=evidence.provider_read_error_class,
-            )
         if resolved_target is None:
             return _GenericWebDeployProviderInspection(
                 observation=GenericWebProviderDeploymentObservation(outcome="unknown"),
@@ -247,7 +270,41 @@ class GenericWebDeployProviderMutationAdapter:
             post_deploy_unobserved=post_deploy_unobserved,
             provider_evidence=evidence.provider_evidence,
             provider_read_error_class=evidence.provider_read_error_class,
+            legacy_correlation_digest_evidence=evidence.legacy_correlation_digest_evidence,
         )
+
+    def _inspect_legacy_artifact_deploy(
+        self,
+        *,
+        resolved_target: GenericWebResolvedDeployTarget | None,
+        provider_effect_started_at: str,
+    ) -> tuple[
+        GenericWebLegacyDeploymentCorrelation | None,
+        GenericWebDeployProviderEvidenceClassification,
+        GenericWebDeployProviderReadErrorClass,
+    ]:
+        normalized_effect_started_at = provider_effect_started_at.strip()
+        if resolved_target is None or not normalized_effect_started_at:
+            return None, "deployment_absent_after_effect", ""
+        if not isinstance(
+            self._deploy_provider,
+            GenericWebDeployLegacyCorrelationProvider,
+        ):
+            return None, "deployment_absent_after_effect", ""
+        try:
+            return (
+                self._deploy_provider.observe_legacy_artifact_deploy(
+                    control_plane_root=self._control_plane_root,
+                    resolved_deploy_target=resolved_target,
+                    provider_effect_started_at=normalized_effect_started_at,
+                ),
+                "deployment_correlated_legacy",
+                "",
+            )
+        except ValueError:
+            return None, "provider_status_unknown", ""
+        except (FileNotFoundError, click.ClickException):
+            return None, "provider_read_failed", "provider_request_failed"
 
     def inspect_evidence(
         self,

--- a/control_plane/generic_web_deploy_recovery_http.py
+++ b/control_plane/generic_web_deploy_recovery_http.py
@@ -126,6 +126,7 @@ class _GenericWebDeployRecoveryInspection:
     retry_safe: bool
     proposed_action: GenericWebDeployRecoveryAction
     provider_observation_payload: dict[str, object]
+    legacy_correlation_digest_evidence: dict[str, object] | None = None
     adapter: GenericWebDeployProviderMutationAdapter | None = None
     provider_inspection: Any | None = None
 
@@ -134,7 +135,7 @@ class _GenericWebDeployRecoveryInspection:
         return build_generic_web_deploy_recovery_digest(self.digest_payload())
 
     def digest_payload(self) -> dict[str, object]:
-        return {
+        payload: dict[str, object] = {
             "schema_version": 1,
             "request": self.request.model_dump(
                 mode="json",
@@ -149,6 +150,9 @@ class _GenericWebDeployRecoveryInspection:
             "retry_safe": self.retry_safe,
             "proposed_action": self.proposed_action,
         }
+        if self.legacy_correlation_digest_evidence is not None:
+            payload["legacy_correlation"] = self.legacy_correlation_digest_evidence
+        return payload
 
     def dry_run_response(self) -> GenericWebDeployRecoveryDryRunResponse:
         return GenericWebDeployRecoveryDryRunResponse(
@@ -490,6 +494,7 @@ async def _inspect_generic_web_deploy_recovery(
     operation_context: str
     operation_instance = recovery_request.original_deploy.deploy.instance.strip()
     authoritative_lane = lane
+    legacy_provider_effect_started_at = ""
 
     if reservation.state == "completed":
         stored_result = reservation.response_payload.get("result")
@@ -591,6 +596,19 @@ async def _inspect_generic_web_deploy_recovery(
                 code="reservation_target_conflict",
                 message="Stored generic web deploy recovery target identity conflicts.",
             )
+        if (
+            legacy_snapshot_without_product
+            and reservation.provider_effect_phase == "deploy_trigger"
+        ):
+            try:
+                parse_launchplane_mutation_timestamp(
+                    reservation.provider_effect_started_at,
+                    field_name="provider_effect_started_at",
+                )
+            except ValueError:
+                legacy_provider_effect_started_at = ""
+            else:
+                legacy_provider_effect_started_at = reservation.provider_effect_started_at
 
     if not _recovery_authorization_allows(
         dependencies=dependencies,
@@ -661,6 +679,7 @@ async def _inspect_generic_web_deploy_recovery(
                 provider_effect_phase=reservation.provider_effect_phase,
                 reconciliation_key=reservation.reconciliation_key,
                 expected_provider_target_key=reservation.provider_target_key,
+                legacy_provider_effect_started_at=legacy_provider_effect_started_at,
             )
             if not provider_inspection.identity_matches:
                 raise dependencies.http_error(
@@ -674,7 +693,18 @@ async def _inspect_generic_web_deploy_recovery(
                 provider_inspection.observation.deployment_status
             )
             retry_safe = provider_inspection.retry_safe
-            provider_observation_payload = provider_inspection.observation.model_dump(mode="json")
+            legacy_correlation_digest_evidence = (
+                provider_inspection.legacy_correlation_digest_evidence
+            )
+            if legacy_correlation_digest_evidence is None:
+                provider_observation_payload = provider_inspection.observation.model_dump(
+                    mode="json"
+                )
+            else:
+                provider_observation_payload = {
+                    "outcome": provider_outcome,
+                    "deployment_status": provider_status,
+                }
             if provider_outcome == "present":
                 proposed_action = "adopt_observed"
             elif provider_outcome == "absent" and retry_safe:
@@ -697,6 +727,11 @@ async def _inspect_generic_web_deploy_recovery(
         retry_safe=retry_safe,
         proposed_action=proposed_action,
         provider_observation_payload=provider_observation_payload,
+        legacy_correlation_digest_evidence=(
+            provider_inspection.legacy_correlation_digest_evidence
+            if provider_inspection is not None
+            else None
+        ),
         adapter=adapter,
         provider_inspection=provider_inspection,
     )

--- a/control_plane/workflows/dokploy_deploy.py
+++ b/control_plane/workflows/dokploy_deploy.py
@@ -15,6 +15,19 @@ from control_plane.contracts.ship_request import ShipRequest
 from control_plane.dokploy import api as dokploy_api
 
 
+def dokploy_deploy_artifact_reference(
+    *,
+    ship_request: ShipRequest,
+    target_type: str,
+) -> str:
+    if target_type == "application":
+        return provider_image_reference(
+            artifact_id=ship_request.artifact_id,
+            deploy_reference=ship_request.deploy_reference,
+        )
+    return ship_request.artifact_id.strip()
+
+
 def update_dokploy_target_artifact(
     *,
     host: str,
@@ -209,12 +222,10 @@ def execute_dokploy_artifact_deploy(
         target_type=resolved_target.target_type,
         target_id=resolved_target.target_id,
     )
-    deploy_reference = ship_request.artifact_id
-    if resolved_target.target_type == "application":
-        deploy_reference = provider_image_reference(
-            artifact_id=ship_request.artifact_id,
-            deploy_reference=ship_request.deploy_reference,
-        )
+    deploy_reference = dokploy_deploy_artifact_reference(
+        ship_request=ship_request,
+        target_type=resolved_target.target_type,
+    )
     update_dokploy_target_artifact(
         host=host,
         token=token,

--- a/control_plane/workflows/generic_web_deploy_provider.py
+++ b/control_plane/workflows/generic_web_deploy_provider.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 import base64
 from collections.abc import Callable
+from datetime import datetime, timedelta
 import hashlib
 from pathlib import Path
-from typing import Literal, Protocol, cast
+from typing import Literal, Protocol, cast, runtime_checkable
 
 import click
 from pydantic import BaseModel, ConfigDict, Field, model_validator
@@ -21,6 +22,7 @@ from control_plane.contracts.deploy_reference import validate_provider_deploy_re
 from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
 from control_plane.contracts.dokploy_target_record import DokployTargetRecord
 from control_plane.contracts.deployment_record import ResolvedTargetEvidence
+from control_plane.contracts.idempotency_record import parse_launchplane_mutation_timestamp
 from control_plane.contracts.product_profile_record import (
     LaunchplaneProductProfileRecord,
     ProductLaneProfile,
@@ -29,7 +31,10 @@ from control_plane.contracts.runtime_environment_record import RuntimeEnvironmen
 from control_plane.contracts.promotion_record import HealthcheckEvidence
 from control_plane.contracts.runtime_identity import RuntimeIdentity
 from control_plane.contracts.ship_request import ShipRequest
-from control_plane.workflows.dokploy_deploy import execute_dokploy_artifact_deploy
+from control_plane.workflows.dokploy_deploy import (
+    dokploy_deploy_artifact_reference,
+    execute_dokploy_artifact_deploy,
+)
 from control_plane.dokploy import api as dokploy_api
 from control_plane.dokploy import source as dokploy_source
 
@@ -84,7 +89,7 @@ def build_generic_web_provider_target_key(
             resolved_deploy_target.resolved_target.target_id,
         )
     )
-    return f"generic-web-provider-target:{hashlib.sha256(identity.encode('utf-8')).hexdigest()}"
+    return f"generic-web-provider-target:{hashlib.sha256(identity.encode()).hexdigest()}"
 
 
 def build_generic_web_provider_reconciliation_key(
@@ -107,7 +112,7 @@ def build_generic_web_provider_reconciliation_key(
         provider_deploy_mode=ship_request.provider_deploy_mode,
         deploy_timeout_seconds=resolved_deploy_target.deploy_timeout_seconds,
     )
-    encoded = base64.urlsafe_b64encode(snapshot.model_dump_json().encode("utf-8")).decode("ascii")
+    encoded = base64.urlsafe_b64encode(snapshot.model_dump_json().encode()).decode("ascii")
     return f"{_GENERIC_WEB_RECONCILIATION_KEY_PREFIX}{encoded.rstrip('=')}"
 
 
@@ -217,6 +222,31 @@ class GenericWebProviderDeploymentObservation(BaseModel):
         return self
 
 
+class GenericWebLegacyDeploymentCorrelationEvidence(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: Literal[1] = 1
+    deployment_id_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    deployment_title_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    deployment_created_at: str
+    deployment_started_at: str
+    deployment_finished_at: str
+    artifact_reference_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+
+
+class GenericWebLegacyDeploymentCorrelation(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    observation: GenericWebProviderDeploymentObservation
+    digest_evidence: GenericWebLegacyDeploymentCorrelationEvidence
+
+    @model_validator(mode="after")
+    def _validate_observation(self) -> "GenericWebLegacyDeploymentCorrelation":
+        if self.observation.outcome != "present":
+            raise ValueError("Legacy deployment correlation requires a present observation.")
+        return self
+
+
 class DokployGenericWebDeployStore(control_plane_secrets.SecretReadStore, Protocol):
     def read_provider_target_record(
         self, *, context_name: str, instance_name: str
@@ -275,9 +305,25 @@ class GenericWebDeployProvider(Protocol):
     ) -> GenericWebProviderDeploymentObservation: ...
 
 
+@runtime_checkable
+class GenericWebDeployLegacyCorrelationProvider(Protocol):
+    def observe_legacy_artifact_deploy(
+        self,
+        *,
+        control_plane_root: Path,
+        resolved_deploy_target: GenericWebResolvedDeployTarget,
+        provider_effect_started_at: str,
+    ) -> GenericWebLegacyDeploymentCorrelation: ...
+
+
 class DokployGenericWebDeployProvider:
     provider_id = "dokploy"
     delegated_executor = "control-plane.dokploy"
+
+    def _read_provider_config(self, *, control_plane_root: Path) -> tuple[str, str]:
+        if self.provider_id != "dokploy":
+            raise RuntimeError("Dokploy provider identity is invalid.")
+        return dokploy_source.read_dokploy_config(control_plane_root=control_plane_root)
 
     def resolve_deploy_target(
         self,
@@ -294,7 +340,7 @@ class DokployGenericWebDeployProvider:
         fallback_target_name: str,
         request_deploy_reference: str = "",
     ) -> GenericWebResolvedDeployTarget:
-        del request_artifact_id, profile
+        del control_plane_root, request_artifact_id, profile
         dokploy_store = _require_dokploy_deploy_store(record_store)
         context_name = lane.context.strip()
         instance_name = lane.instance.strip()
@@ -394,7 +440,7 @@ class DokployGenericWebDeployProvider:
         before_provider_mutation: Callable[[str], None],
         effect_started: Callable[[], None],
     ) -> None:
-        host, token = dokploy_source.read_dokploy_config(control_plane_root=control_plane_root)
+        host, token = self._read_provider_config(control_plane_root=control_plane_root)
         execute_dokploy_artifact_deploy(
             host=host,
             token=token,
@@ -414,7 +460,7 @@ class DokployGenericWebDeployProvider:
         resolved_deploy_target: GenericWebResolvedDeployTarget,
         deployment_title: str,
     ) -> GenericWebProviderDeploymentObservation:
-        host, token = dokploy_source.read_dokploy_config(control_plane_root=control_plane_root)
+        host, token = self._read_provider_config(control_plane_root=control_plane_root)
         target = resolved_deploy_target.resolved_target
         deployment = dokploy_api.deployment_for_target_by_title(
             host=host,
@@ -465,6 +511,261 @@ class DokployGenericWebDeployProvider:
                 deployment.get("errorMessage") or deployment.get("error_message") or ""
             ).strip(),
         )
+
+    def observe_legacy_artifact_deploy(
+        self,
+        *,
+        control_plane_root: Path,
+        resolved_deploy_target: GenericWebResolvedDeployTarget,
+        provider_effect_started_at: str,
+    ) -> GenericWebLegacyDeploymentCorrelation:
+        host, token = self._read_provider_config(control_plane_root=control_plane_root)
+        target = resolved_deploy_target.resolved_target
+        deployments = dokploy_api.list_deployments_for_target(
+            host=host,
+            token=token,
+            target_type=target.target_type,
+            target_id=target.target_id,
+        )
+        target_payload = dokploy_api.fetch_dokploy_target_payload(
+            host=host,
+            token=token,
+            target_type=target.target_type,
+            target_id=target.target_id,
+        )
+        return correlate_legacy_dokploy_deployment(
+            deployments=deployments,
+            target_payload=target_payload,
+            target_type=target.target_type,
+            target_id=target.target_id,
+            provider_effect_started_at=provider_effect_started_at,
+            expected_artifact_reference=dokploy_deploy_artifact_reference(
+                ship_request=resolved_deploy_target.ship_request,
+                target_type=target.target_type,
+            ),
+        )
+
+
+def correlate_legacy_dokploy_deployment(
+    *,
+    deployments: list[dokploy_api.JsonObject],
+    target_payload: dokploy_api.JsonObject,
+    target_type: str,
+    target_id: str,
+    provider_effect_started_at: str,
+    expected_artifact_reference: str,
+) -> GenericWebLegacyDeploymentCorrelation:
+    effect_started_at, _ = _parse_legacy_provider_timestamp(
+        provider_effect_started_at,
+        field_name="provider_effect_started_at",
+    )
+    window_started_at = effect_started_at - timedelta(seconds=5)
+    window_finished_at = effect_started_at + timedelta(seconds=65)
+    parsed_deployments: list[tuple[dokploy_api.JsonObject, datetime, dict[str, str]]] = []
+    for deployment in deployments:
+        parsed_timestamps = _parse_all_legacy_deployment_timestamps(deployment)
+        created_at = _required_legacy_deployment_timestamp(
+            parsed_timestamps,
+            deployment,
+            aliases=("createdAt", "created_at"),
+            field_name="created_at",
+        )[0]
+        parsed_deployments.append((deployment, created_at, parsed_timestamps))
+    if not any(created_at < window_started_at for _, created_at, _ in parsed_deployments):
+        raise ValueError("Legacy deployment correlation requires older retained history.")
+    candidates = [
+        parsed
+        for parsed in parsed_deployments
+        if window_started_at <= parsed[1] <= window_finished_at
+    ]
+    if len(candidates) != 1:
+        raise ValueError("Legacy deployment correlation requires exactly one window candidate.")
+    candidate, candidate_created_at, candidate_timestamps = candidates[0]
+    if candidate_created_at != max(created_at for _, created_at, _ in parsed_deployments):
+        raise ValueError("Legacy deployment correlation candidate is not newest overall.")
+    title = _required_legacy_deployment_string(candidate, "title")
+    normalized_title = title.casefold()
+    if normalized_title.startswith(("launchplane operation ", "launchplane post-deploy ")):
+        raise ValueError("Legacy deployment correlation candidate has a Launchplane title.")
+    status = dokploy_api.deployment_status(candidate)
+    if not generic_web_provider_deployment_succeeded(status):
+        raise ValueError("Legacy deployment correlation candidate is not successful.")
+    deployment_id = dokploy_api.deployment_key(candidate).strip()
+    if not deployment_id:
+        raise ValueError("Legacy deployment correlation candidate has no deployment id.")
+    started_at, normalized_started_at = _required_legacy_deployment_timestamp(
+        candidate_timestamps,
+        candidate,
+        aliases=("startedAt", "started_at"),
+        field_name="started_at",
+    )
+    finished_at, normalized_finished_at = _required_legacy_deployment_timestamp(
+        candidate_timestamps,
+        candidate,
+        aliases=("finishedAt", "finished_at"),
+        field_name="finished_at",
+    )
+    if finished_at < started_at:
+        raise ValueError("Legacy deployment correlation candidate timestamps are inconsistent.")
+    normalized_target_id = target_id.strip()
+    if (
+        not normalized_target_id
+        or _dokploy_deployment_target_id(
+            deployment=candidate,
+            target_type=target_type,
+        )
+        != normalized_target_id
+        or _dokploy_target_payload_id(
+            target_payload=target_payload,
+            target_type=target_type,
+        )
+        != normalized_target_id
+    ):
+        raise ValueError("Legacy deployment correlation target identity is not exact.")
+    expected_reference = expected_artifact_reference.strip()
+    if (
+        not expected_reference
+        or _dokploy_target_artifact_reference(
+            target_payload=target_payload,
+            target_type=target_type,
+        )
+        != expected_reference
+    ):
+        raise ValueError("Legacy deployment correlation artifact reference does not match.")
+    normalized_created_at = _normalized_legacy_deployment_timestamp(
+        candidate_timestamps,
+        candidate,
+        aliases=("createdAt", "created_at"),
+        field_name="created_at",
+    )
+    return GenericWebLegacyDeploymentCorrelation(
+        observation=GenericWebProviderDeploymentObservation(
+            outcome="present",
+            deployment_status=status,
+            deployment_id=deployment_id,
+            started_at=normalized_started_at,
+            finished_at=normalized_finished_at,
+        ),
+        digest_evidence=GenericWebLegacyDeploymentCorrelationEvidence(
+            deployment_id_sha256=_legacy_correlation_sha256(deployment_id),
+            deployment_title_sha256=_legacy_correlation_sha256(title),
+            deployment_created_at=normalized_created_at,
+            deployment_started_at=normalized_started_at,
+            deployment_finished_at=normalized_finished_at,
+            artifact_reference_sha256=_legacy_correlation_sha256(expected_reference),
+        ),
+    )
+
+
+def _parse_all_legacy_deployment_timestamps(
+    deployment: dokploy_api.JsonObject,
+) -> dict[str, str]:
+    parsed_timestamps: dict[str, str] = {}
+    for field_name, value in deployment.items():
+        if not (field_name.endswith("At") or field_name.endswith("_at")):
+            continue
+        if value is None or value == "":
+            continue
+        if not isinstance(value, str):
+            raise ValueError("Legacy deployment timestamps must be strings.")
+        _, normalized = _parse_legacy_provider_timestamp(value, field_name=field_name)
+        parsed_timestamps[field_name] = normalized
+    return parsed_timestamps
+
+
+def _required_legacy_deployment_timestamp(
+    parsed_timestamps: dict[str, str],
+    deployment: dokploy_api.JsonObject,
+    *,
+    aliases: tuple[str, ...],
+    field_name: str,
+) -> tuple[datetime, str]:
+    normalized = _normalized_legacy_deployment_timestamp(
+        parsed_timestamps,
+        deployment,
+        aliases=aliases,
+        field_name=field_name,
+    )
+    return _parse_legacy_provider_timestamp(normalized, field_name=field_name)
+
+
+def _normalized_legacy_deployment_timestamp(
+    parsed_timestamps: dict[str, str],
+    deployment: dokploy_api.JsonObject,
+    *,
+    aliases: tuple[str, ...],
+    field_name: str,
+) -> str:
+    values = {
+        parsed_timestamps[alias]
+        for alias in aliases
+        if alias in deployment and alias in parsed_timestamps
+    }
+    if len(values) != 1:
+        raise ValueError(f"Legacy deployment correlation requires exact {field_name} evidence.")
+    return values.pop()
+
+
+def _parse_legacy_provider_timestamp(value: str, *, field_name: str) -> tuple[datetime, str]:
+    utc_timestamp = parse_launchplane_mutation_timestamp(value, field_name=field_name)
+    return (
+        utc_timestamp,
+        utc_timestamp.isoformat(timespec="microseconds").replace("+00:00", "Z"),
+    )
+
+
+def _required_legacy_deployment_string(
+    deployment: dokploy_api.JsonObject,
+    field_name: str,
+) -> str:
+    value = deployment.get(field_name)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"Legacy deployment correlation requires {field_name}.")
+    return value.strip()
+
+
+def _dokploy_target_payload_id(*, target_payload: dokploy_api.JsonObject, target_type: str) -> str:
+    field_name = {"application": "applicationId", "compose": "composeId"}.get(target_type)
+    if field_name is None:
+        raise ValueError("Legacy deployment correlation target type is unsupported.")
+    value = target_payload.get(field_name)
+    return value.strip() if isinstance(value, str) else ""
+
+
+def _dokploy_deployment_target_id(*, deployment: dokploy_api.JsonObject, target_type: str) -> str:
+    field_name = {"application": "applicationId", "compose": "composeId"}.get(target_type)
+    if field_name is None:
+        raise ValueError("Legacy deployment correlation target type is unsupported.")
+    value = deployment.get(field_name)
+    return value.strip() if isinstance(value, str) else ""
+
+
+def _dokploy_target_artifact_reference(
+    *, target_payload: dokploy_api.JsonObject, target_type: str
+) -> str:
+    if target_type == "application":
+        value = target_payload.get("dockerImage")
+        return value.strip() if isinstance(value, str) else ""
+    if target_type == "compose":
+        raw_env = target_payload.get("env")
+        if not isinstance(raw_env, str):
+            return ""
+        references: list[str] = []
+        for raw_line in raw_env.splitlines():
+            line = raw_line.strip()
+            if not line or line.startswith("#"):
+                continue
+            if line.startswith("export "):
+                line = line[7:].strip()
+            key, separator, value = line.partition("=")
+            if separator and key.strip() == "DOCKER_IMAGE_REFERENCE":
+                references.append(value.strip())
+        return references[0] if len(references) == 1 else ""
+    raise ValueError("Legacy deployment correlation target type is unsupported.")
+
+
+def _legacy_correlation_sha256(value: str) -> str:
+    return hashlib.sha256(value.strip().encode()).hexdigest()
 
 
 def _resolve_dokploy_deploy_mode(*, configured_ship_mode: str, target_type: str) -> str:
@@ -571,13 +872,15 @@ def _dokploy_target_definition_for_lane(
 def _dokploy_target_type_from_provider_target(
     *, provider_target: ProviderTargetRecord
 ) -> DeployTargetCompatibilityType:
-    if provider_target.provider_target_type not in {"application", "compose"}:
-        raise click.ClickException(
-            "Provider-target type mismatch for "
-            f"{provider_target.context}/{provider_target.instance}: "
-            "Dokploy execution only supports provider-target type 'application' or 'compose'."
-        )
-    return cast(DeployTargetCompatibilityType, provider_target.provider_target_type)
+    if provider_target.provider_target_type == "application":
+        return "application"
+    if provider_target.provider_target_type == "compose":
+        return "compose"
+    raise click.ClickException(
+        "Provider-target type mismatch for "
+        f"{provider_target.context}/{provider_target.instance}: "
+        "Dokploy execution only supports provider-target type 'application' or 'compose'."
+    )
 
 
 def _validate_dokploy_provider_target(

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -436,6 +436,9 @@ snapshot. It reports one bounded classification:
 
 - `deployment_present` when the exact titled provider deployment has complete
   terminal evidence;
+- `deployment_correlated_legacy` only when the exact title is absent and a
+  legacy generic-web reservation can be correlated from bounded read-only
+  provider evidence;
 - `deployment_absent_before_effect` when no exact deployment is visible before
   the provider effect started;
 - `deployment_absent_after_effect` when no exact deployment is visible after
@@ -446,14 +449,42 @@ snapshot. It reports one bounded classification:
   error category; or
 - `not_inspected` for completed reservations and active leases.
 
-This diagnostic never returns or changes `retry_safe`, `proposed_action`, or the
-recovery digest. In particular, `deployment_absent_after_effect` is not proof
-that the original provider effect never occurred and cannot make recovery
-retryable automatically. The response omits raw scope, idempotency key,
-reconciliation key, provider target or operation identity, deployment id,
-provider timestamps, URL, payload, logs, credentials, and exception messages.
-It performs no reservation, deployment, inventory, provider-operation, outbox,
-or provider mutation writes.
+The legacy fallback is available only for an actionable reservation under the
+existing lease rules, an exact stored target identity, `deploy_trigger` with an
+authoritative `provider_effect_started_at`, and a legacy reconciliation snapshot
+that predates the stored product field. Exact provider-operation title
+observation always runs first. Dokploy correlation then reads only retained
+deployment history and the current exact target payload. It parses every
+retained deployment timestamp and requires all of the following:
+
+- at least one older deployment before the correlation window;
+- exactly one deployment created in the inclusive window from five seconds
+  before through 65 seconds after the provider-effect checkpoint;
+- that candidate is the newest retained deployment overall and does not use a
+  Launchplane operation title;
+- terminal successful status plus deployment id, start time, and finish time;
+- an exact current artifact match: `DOCKER_IMAGE_REFERENCE` for compose targets
+  or the application image field for application targets, using the same
+  normalized provider image reference as deploy execution.
+
+Zero, multiple, stale, malformed, incomplete, conflicting, or provider-error
+evidence remains `unknown` / `hold_unknown` with `retry_safe=false`. A successful
+legacy correlation is adoption-only and never enables provider retry. Where the
+product driver has a post-deploy phase, adoption records that post-deploy work
+as unobserved rather than claiming it completed.
+
+The bounded provider-evidence route reports failed correlation invariants as
+`provider_status_unknown`; provider request failures remain `provider_read_failed`
+with only the existing bounded read-error class.
+
+The diagnostic never returns `retry_safe`, `proposed_action`, or raw evidence.
+The response omits raw scope, idempotency key, reconciliation key, provider
+target or operation identity, deployment title or id, provider timestamps,
+target environment, URL, payload, logs, credentials, and exception messages. It
+performs no reservation, deployment, inventory, provider-operation, outbox, or
+provider mutation writes. In particular, ordinary
+`deployment_absent_after_effect` remains non-retryable and is not proof that the
+original provider effect never occurred.
 
 Authorization checks the dedicated
 `generic_web_deploy_recovery_provider_evidence.read` action first and accepts
@@ -470,7 +501,11 @@ inspection and requires an exact digest match before it writes anything. The
 digest intentionally excludes `observed_at`, so routine database observation
 time changes do not stale a reviewed recovery; all reservation identity,
 provider classification, action, request, and bounded provider observation
-inputs remain part of the digest.
+inputs remain part of the digest. Non-legacy digest inputs are unchanged. Only a
+successful legacy correlation adds normalized timestamps and hashes of the
+deployment identity, title, and exact artifact reference. Apply reinspects the
+provider, so any change to that derived evidence stales the reviewed digest
+before adoption.
 
 Apply never creates a new reservation, releases a reservation, or supersedes a
 provider target. If the reviewed reservation is an expired `running` mutation,

--- a/frontend/generated/openapi-canonical.json
+++ b/frontend/generated/openapi-canonical.json
@@ -7115,6 +7115,7 @@
           "provider_evidence": {
             "enum": [
               "deployment_present",
+              "deployment_correlated_legacy",
               "deployment_absent_before_effect",
               "deployment_absent_after_effect",
               "provider_status_unknown",

--- a/tests/test_generic_web_deploy.py
+++ b/tests/test_generic_web_deploy.py
@@ -11,7 +11,7 @@ from control_plane.contracts.dokploy_target_id_record import DokployTargetIdReco
 from control_plane.contracts.dokploy_target_record import DokployTargetRecord
 from control_plane.contracts.deployment_record import DeploymentRecord, ResolvedTargetEvidence
 from control_plane.contracts.environment_inventory import EnvironmentInventory
-from control_plane.contracts.promotion_record import PostDeployUpdateEvidence
+from control_plane.contracts.promotion_record import HealthcheckEvidence, PostDeployUpdateEvidence
 from control_plane.contracts.product_profile_record import (
     LaunchplaneProductProfileRecord,
     ProductImageProfile,
@@ -31,6 +31,7 @@ from control_plane.contracts.secret_record import (
 )
 from control_plane.contracts.ship_request import ShipRequest
 from control_plane.dokploy import DokploySourceOfTruth, DokployTargetDefinition
+from control_plane.dokploy import api as dokploy_api
 from control_plane import secrets as control_plane_secrets
 from control_plane.generic_web_deploy_http import GenericWebDeployEnvelope
 from control_plane.generic_web_deploy_provider_adapter import (
@@ -48,11 +49,14 @@ from control_plane.workflows.generic_web_deploy import (
 )
 from control_plane.workflows.generic_web_deploy_provider import DokployGenericWebDeployProvider
 from control_plane.workflows.generic_web_deploy_provider import (
+    GenericWebLegacyDeploymentCorrelation,
+    GenericWebLegacyDeploymentCorrelationEvidence,
     GenericWebProviderDeploymentObservation,
 )
 from control_plane.workflows.generic_web_deploy_provider import (
     GenericWebResolvedDeployTarget,
     build_generic_web_provider_reconciliation_key,
+    correlate_legacy_dokploy_deployment,
     resolve_generic_web_provider_reconciliation_target,
 )
 from control_plane.workflows.ship import build_deployment_record
@@ -239,7 +243,8 @@ class _DokployGenericWebDeployStore(_GenericWebDeployStore):
         )
         return bindings[:limit] if limit is not None else bindings
 
-    def list_secret_audit_events(self, *, secret_id: str) -> tuple[SecretAuditEvent, ...]:
+    @staticmethod
+    def list_secret_audit_events(*, secret_id: str) -> tuple[SecretAuditEvent, ...]:
         del secret_id
         return ()
 
@@ -316,7 +321,11 @@ def _runtime_secret_record(
 def _runtime_secret_version(
     *, secret_id: str, version_id: str, plaintext_value: str
 ) -> SecretVersion:
-    ciphertext, key_id = control_plane_secrets._encrypt_secret_value(plaintext_value)
+    encrypt_secret_value = cast(
+        Callable[[str], tuple[str, str]],
+        getattr(control_plane_secrets, "_encrypt_secret_value"),
+    )
+    ciphertext, key_id = encrypt_secret_value(plaintext_value)
     return SecretVersion(
         version_id=version_id,
         secret_id=secret_id,
@@ -472,9 +481,37 @@ class _FakeGenericWebDeployProvider:
         return self.observation
 
 
+class _LegacyFakeGenericWebDeployProvider(_FakeGenericWebDeployProvider):
+    def __init__(self) -> None:
+        super().__init__(observation=GenericWebProviderDeploymentObservation(outcome="absent"))
+        self.legacy_observation_calls = 0
+
+    def observe_legacy_artifact_deploy(
+        self, **_kwargs: object
+    ) -> GenericWebLegacyDeploymentCorrelation:
+        self.legacy_observation_calls += 1
+        return GenericWebLegacyDeploymentCorrelation(
+            observation=GenericWebProviderDeploymentObservation(
+                outcome="present",
+                deployment_status="done",
+                deployment_id="deployment-legacy",
+                started_at="2026-08-15T12:00:02.000000Z",
+                finished_at="2026-08-15T12:00:20.000000Z",
+            ),
+            digest_evidence=GenericWebLegacyDeploymentCorrelationEvidence(
+                deployment_id_sha256="1" * 64,
+                deployment_title_sha256="2" * 64,
+                deployment_created_at="2026-08-15T12:00:01.000000Z",
+                deployment_started_at="2026-08-15T12:00:02.000000Z",
+                deployment_finished_at="2026-08-15T12:00:20.000000Z",
+                artifact_reference_sha256="3" * 64,
+            ),
+        )
+
+
 class GenericWebDeployTests(unittest.TestCase):
+    @staticmethod
     def _provider_mutation_adapter(
-        self,
         *,
         profile: LaunchplaneProductProfileRecord,
         store: _GenericWebDeployStore,
@@ -1488,6 +1525,33 @@ class GenericWebDeployTests(unittest.TestCase):
         self.assertEqual(observation.outcome, "unknown")
         self.assertEqual(store.deployments, [])
 
+    def test_provider_adapter_legacy_correlation_is_adoption_only_and_marks_post_deploy(
+        self,
+    ) -> None:
+        profile = _profile(driver_id="odoo")
+        store = _GenericWebDeployStore(profile)
+        provider = _LegacyFakeGenericWebDeployProvider()
+        adapter = self._provider_mutation_adapter(
+            profile=profile,
+            store=store,
+            provider=provider,
+        )
+
+        inspection = adapter.inspect(
+            provider_operation_key="provider-operation:legacy-correlation",
+            provider_effect_phase="deploy_trigger",
+            reconciliation_key=adapter.reconciliation_key(),
+            legacy_provider_effect_started_at="2026-08-15T12:00:00Z",
+        )
+
+        self.assertEqual(inspection.observation.outcome, "present")
+        self.assertEqual(inspection.provider_evidence, "deployment_correlated_legacy")
+        self.assertFalse(inspection.retry_safe)
+        self.assertTrue(inspection.post_deploy_unobserved)
+        self.assertIsNotNone(inspection.legacy_correlation_digest_evidence)
+        self.assertEqual(len(provider.observed_target_ids), 1)
+        self.assertEqual(provider.legacy_observation_calls, 1)
+
     def test_present_provider_observation_requires_exact_terminal_evidence(self) -> None:
         with self.assertRaisesRegex(ValueError, "deployment_id, started_at, finished_at"):
             GenericWebProviderDeploymentObservation(
@@ -1647,6 +1711,332 @@ class GenericWebDeployTests(unittest.TestCase):
             )
 
         self.assertEqual(observation.outcome, "absent")
+
+    def test_legacy_dokploy_correlation_accepts_exact_application_and_compose_evidence(
+        self,
+    ) -> None:
+        success_cases: tuple[tuple[str, dokploy_api.JsonObject, str, str], ...] = (
+            (
+                "application",
+                {
+                    "applicationId": "target-123",
+                    "dockerImage": "ghcr.io/example/app:sha-abc123",
+                },
+                "ghcr.io/example/app:sha-abc123",
+                "2026-08-15T11:59:55Z",
+            ),
+            (
+                "compose",
+                {
+                    "composeId": "target-123",
+                    "env": "OTHER=value\nDOCKER_IMAGE_REFERENCE=ghcr.io/example/app@sha256:abc123\n",
+                },
+                "ghcr.io/example/app@sha256:abc123",
+                "2026-08-15T12:01:05Z",
+            ),
+        )
+        for target_type, target_payload, expected_reference, candidate_created_at in success_cases:
+            with self.subTest(target_type=target_type):
+                target_field = "applicationId" if target_type == "application" else "composeId"
+                correlation = correlate_legacy_dokploy_deployment(
+                    deployments=[
+                        {
+                            "deploymentId": "deployment-old",
+                            target_field: "target-123",
+                            "title": "older deployment",
+                            "status": "done",
+                            "createdAt": "2026-08-15T11:59:54Z",
+                            "startedAt": "2026-08-15T11:59:54Z",
+                            "finishedAt": "2026-08-15T11:59:54.500Z",
+                        },
+                        {
+                            "deploymentId": "deployment-candidate",
+                            target_field: "target-123",
+                            "title": "abc123",
+                            "status": "done",
+                            "createdAt": candidate_created_at,
+                            "startedAt": candidate_created_at,
+                            "finishedAt": "2026-08-15T12:01:06Z",
+                        },
+                    ],
+                    target_payload=target_payload,
+                    target_type=target_type,
+                    target_id="target-123",
+                    provider_effect_started_at="2026-08-15T12:00:00Z",
+                    expected_artifact_reference=expected_reference,
+                )
+
+            self.assertEqual(correlation.observation.outcome, "present")
+            self.assertEqual(correlation.observation.deployment_status, "done")
+            self.assertEqual(
+                correlation.digest_evidence.deployment_created_at,
+                candidate_created_at.replace("Z", ".000000Z")
+                if "." not in candidate_created_at
+                else candidate_created_at,
+            )
+            self.assertNotIn(
+                "deployment-candidate",
+                correlation.digest_evidence.model_dump_json(),
+            )
+            self.assertNotIn("abc123", correlation.digest_evidence.model_dump_json())
+
+    def test_legacy_dokploy_correlation_rejects_every_ambiguous_invariant(self) -> None:
+        candidate: dokploy_api.JsonObject = {
+            "deploymentId": "deployment-candidate",
+            "applicationId": "target-123",
+            "title": "abc123",
+            "status": "done",
+            "createdAt": "2026-08-15T12:00:01Z",
+            "startedAt": "2026-08-15T12:00:02Z",
+            "finishedAt": "2026-08-15T12:00:20Z",
+        }
+        older: dokploy_api.JsonObject = {
+            "deploymentId": "deployment-old",
+            "applicationId": "target-123",
+            "title": "older",
+            "status": "done",
+            "createdAt": "2026-08-15T11:59:54Z",
+            "startedAt": "2026-08-15T11:59:54Z",
+            "finishedAt": "2026-08-15T11:59:54.500Z",
+        }
+        target_payload: dokploy_api.JsonObject = {
+            "applicationId": "target-123",
+            "dockerImage": "ghcr.io/example/app:sha-abc123",
+        }
+
+        cases: list[
+            tuple[
+                str,
+                list[dokploy_api.JsonObject],
+                dokploy_api.JsonObject,
+                str,
+                str,
+            ]
+        ] = [
+            (
+                "no older history",
+                [dict(candidate)],
+                dict(target_payload),
+                "application",
+                "target-123",
+            ),
+            (
+                "no window candidate",
+                [dict(older), {**candidate, "createdAt": "2026-08-15T12:01:06Z"}],
+                dict(target_payload),
+                "application",
+                "target-123",
+            ),
+            (
+                "multiple window candidates",
+                [dict(older), dict(candidate), {**candidate, "deploymentId": "deployment-second"}],
+                dict(target_payload),
+                "application",
+                "target-123",
+            ),
+            (
+                "candidate not newest",
+                [
+                    dict(older),
+                    dict(candidate),
+                    {
+                        **candidate,
+                        "deploymentId": "deployment-newer",
+                        "createdAt": "2026-08-15T12:01:06Z",
+                    },
+                ],
+                dict(target_payload),
+                "application",
+                "target-123",
+            ),
+            (
+                "launchplane title",
+                [dict(older), {**candidate, "title": "Launchplane operation abcdef"}],
+                dict(target_payload),
+                "application",
+                "target-123",
+            ),
+            (
+                "launchplane post-deploy title",
+                [dict(older), {**candidate, "title": "Launchplane post-deploy abcdef"}],
+                dict(target_payload),
+                "application",
+                "target-123",
+            ),
+            (
+                "non-success status",
+                [dict(older), {**candidate, "status": "failed"}],
+                dict(target_payload),
+                "application",
+                "target-123",
+            ),
+            (
+                "missing deployment id",
+                [
+                    dict(older),
+                    {key: value for key, value in candidate.items() if key != "deploymentId"},
+                ],
+                dict(target_payload),
+                "application",
+                "target-123",
+            ),
+            (
+                "missing started at",
+                [
+                    dict(older),
+                    {key: value for key, value in candidate.items() if key != "startedAt"},
+                ],
+                dict(target_payload),
+                "application",
+                "target-123",
+            ),
+            (
+                "missing finished at",
+                [
+                    dict(older),
+                    {key: value for key, value in candidate.items() if key != "finishedAt"},
+                ],
+                dict(target_payload),
+                "application",
+                "target-123",
+            ),
+            (
+                "invalid retained timestamp",
+                [{**older, "updatedAt": "not-a-time"}, dict(candidate)],
+                dict(target_payload),
+                "application",
+                "target-123",
+            ),
+            (
+                "target identity mismatch",
+                [dict(older), {**candidate, "applicationId": "target-other"}],
+                dict(target_payload),
+                "application",
+                "target-123",
+            ),
+            (
+                "artifact mismatch",
+                [dict(older), dict(candidate)],
+                {**target_payload, "dockerImage": "ghcr.io/example/app:sha-other"},
+                "application",
+                "target-123",
+            ),
+            (
+                "ambiguous compose artifact",
+                [
+                    {**older, "composeId": "target-123"},
+                    {**candidate, "composeId": "target-123"},
+                ],
+                {
+                    "composeId": "target-123",
+                    "env": (
+                        "DOCKER_IMAGE_REFERENCE=ghcr.io/example/app:sha-abc123\n"
+                        "DOCKER_IMAGE_REFERENCE=ghcr.io/example/app:sha-other\n"
+                    ),
+                },
+                "compose",
+                "target-123",
+            ),
+        ]
+        for name, deployments, payload, target_type, target_id in cases:
+            with self.subTest(name=name), self.assertRaises(ValueError):
+                correlate_legacy_dokploy_deployment(
+                    deployments=deployments,
+                    target_payload=payload,
+                    target_type=target_type,
+                    target_id=target_id,
+                    provider_effect_started_at="2026-08-15T12:00:00Z",
+                    expected_artifact_reference="ghcr.io/example/app:sha-abc123",
+                )
+
+    def test_dokploy_legacy_observation_uses_only_history_and_current_target_reads(self) -> None:
+        provider = DokployGenericWebDeployProvider()
+        resolved = GenericWebResolvedDeployTarget(
+            ship_request=ShipRequest(
+                artifact_id=f"ghcr.io/example/app@sha256:{'a' * 64}",
+                deploy_reference="ghcr.io/example/app:sha-abc123",
+                context="example-testing",
+                instance="testing",
+                source_git_ref="abc123",
+                target_name="example",
+                target_type="application",
+                provider_id="dokploy",
+                target_category="application",
+                provider_target_type="application",
+                deploy_mode="dokploy-application-api",
+                provider_deploy_mode="dokploy-application-api",
+                destination_health=HealthcheckEvidence(status="skipped"),
+            ),
+            resolved_target=ResolvedTargetEvidence(
+                target_type="application",
+                target_id="target-123",
+                target_name="example",
+            ),
+            deploy_timeout_seconds=45,
+        )
+        with (
+            patch(
+                "control_plane.workflows.generic_web_deploy_provider."
+                "dokploy_source.read_dokploy_config",
+                return_value=("https://dokploy.example", "token"),
+            ),
+            patch(
+                "control_plane.workflows.generic_web_deploy_provider."
+                "dokploy_api.list_deployments_for_target",
+                return_value=[
+                    {
+                        "deploymentId": "deployment-old",
+                        "applicationId": "target-123",
+                        "title": "older",
+                        "status": "done",
+                        "createdAt": "2026-08-15T11:59:54Z",
+                        "startedAt": "2026-08-15T11:59:54Z",
+                        "finishedAt": "2026-08-15T11:59:54.500Z",
+                    },
+                    {
+                        "deploymentId": "deployment-candidate",
+                        "applicationId": "target-123",
+                        "title": "abc123",
+                        "status": "done",
+                        "createdAt": "2026-08-15T12:00:01Z",
+                        "startedAt": "2026-08-15T12:00:02Z",
+                        "finishedAt": "2026-08-15T12:00:20Z",
+                    },
+                ],
+            ) as history_read,
+            patch(
+                "control_plane.workflows.generic_web_deploy_provider."
+                "dokploy_api.fetch_dokploy_target_payload",
+                return_value={
+                    "applicationId": "target-123",
+                    "dockerImage": "ghcr.io/example/app:sha-abc123",
+                },
+            ) as target_read,
+            patch(
+                "control_plane.workflows.generic_web_deploy_provider."
+                "dokploy_api.trigger_deployment",
+                side_effect=AssertionError("provider write"),
+            ),
+        ):
+            correlation = provider.observe_legacy_artifact_deploy(
+                control_plane_root=Path("."),
+                resolved_deploy_target=resolved,
+                provider_effect_started_at="2026-08-15T12:00:00Z",
+            )
+
+        self.assertEqual(correlation.observation.outcome, "present")
+        history_read.assert_called_once_with(
+            host="https://dokploy.example",
+            token="token",
+            target_type="application",
+            target_id="target-123",
+        )
+        target_read.assert_called_once_with(
+            host="https://dokploy.example",
+            token="token",
+            target_type="application",
+            target_id="target-123",
+        )
 
     def test_reconciliation_key_reconstructs_original_target_after_authority_change(
         self,

--- a/tests/test_generic_web_deploy_recovery.py
+++ b/tests/test_generic_web_deploy_recovery.py
@@ -25,6 +25,8 @@ from control_plane.storage.postgres import (
 )
 from control_plane.workflows.generic_web_deploy import GenericWebDeployResult
 from control_plane.workflows.generic_web_deploy_provider import (
+    GenericWebLegacyDeploymentCorrelation,
+    GenericWebLegacyDeploymentCorrelationEvidence,
     GenericWebProviderDeploymentObservation,
     GenericWebResolvedDeployTarget,
     build_generic_web_provider_reconciliation_key,
@@ -239,11 +241,16 @@ def _generic_web_recovery_reservation(
     lease_expires_at: str = "2099-08-16T18:00:00Z",
     provider_effect_phase: str = "target_update",
     provider_target_key: str | None = None,
+    legacy_snapshot_without_product: bool = False,
 ) -> LaunchplaneIdempotencyRecord:
     target = _generic_web_recovery_target(context=context)
-    reconciliation_key = build_generic_web_provider_reconciliation_key(
-        target,
-        product="sellyouroutboard",
+    reconciliation_key = (
+        _legacy_generic_web_reconciliation_key(target)
+        if legacy_snapshot_without_product
+        else build_generic_web_provider_reconciliation_key(
+            target,
+            product="sellyouroutboard",
+        )
     )
     return LaunchplaneIdempotencyRecord(
         record_id=f"idempotency-{idempotency_key}",
@@ -317,6 +324,54 @@ class _FailingRecoveryObservationProvider(_RecoveryObservationProvider):
     def observe_artifact_deploy(self, **_kwargs: object) -> GenericWebProviderDeploymentObservation:
         self.observation_calls += 1
         raise ClickException("provider read failed")
+
+
+def _legacy_correlation(
+    *,
+    deployment_id_sha256: str = "1" * 64,
+    deployment_title_sha256: str = "2" * 64,
+    artifact_reference_sha256: str = "3" * 64,
+) -> GenericWebLegacyDeploymentCorrelation:
+    return GenericWebLegacyDeploymentCorrelation(
+        observation=GenericWebProviderDeploymentObservation(
+            outcome="present",
+            deployment_status="done",
+            deployment_id="provider-legacy-deployment-secret",
+            started_at="2026-08-15T12:00:02.000000Z",
+            finished_at="2026-08-15T12:00:20.000000Z",
+        ),
+        digest_evidence=GenericWebLegacyDeploymentCorrelationEvidence(
+            deployment_id_sha256=deployment_id_sha256,
+            deployment_title_sha256=deployment_title_sha256,
+            deployment_created_at="2026-08-15T12:00:01.000000Z",
+            deployment_started_at="2026-08-15T12:00:02.000000Z",
+            deployment_finished_at="2026-08-15T12:00:20.000000Z",
+            artifact_reference_sha256=artifact_reference_sha256,
+        ),
+    )
+
+
+class _LegacyRecoveryObservationProvider(_RecoveryObservationProvider):
+    def __init__(
+        self,
+        correlations: tuple[GenericWebLegacyDeploymentCorrelation | BaseException, ...],
+    ) -> None:
+        super().__init__(GenericWebProviderDeploymentObservation(outcome="absent"))
+        self.correlations = list(correlations)
+        self.legacy_observation_calls = 0
+
+    def observe_legacy_artifact_deploy(
+        self, **_kwargs: object
+    ) -> GenericWebLegacyDeploymentCorrelation:
+        if self.observation_calls != self.legacy_observation_calls + 1:
+            raise AssertionError("legacy observation ran before exact-title observation")
+        self.legacy_observation_calls += 1
+        if not self.correlations:
+            raise AssertionError("unexpected legacy observation")
+        correlation = self.correlations.pop(0)
+        if isinstance(correlation, BaseException):
+            raise correlation
+        return correlation
 
 
 class GenericWebDeployRecoveryHttpTests(unittest.TestCase):
@@ -941,6 +996,374 @@ class GenericWebDeployRecoveryHttpTests(unittest.TestCase):
         self.assertEqual(payload["provider_evidence"], "provider_read_failed")
         self.assertEqual(payload["provider_read_error_class"], "provider_request_failed")
         self.assertNotIn("provider read failed", json.dumps(payload, sort_keys=True))
+
+    def test_legacy_correlation_is_bounded_read_only_and_adoption_only(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(root / "launchplane.sqlite3")
+            )
+            store.ensure_schema()
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_product_profile_payload())
+            )
+            original_deploy = _generic_web_recovery_original_deploy()
+            reservation = _write_generic_web_recovery_reservation(
+                store,
+                _generic_web_recovery_reservation(
+                    original_deploy=original_deploy,
+                    idempotency_key="legacy-correlation-bounded",
+                    provider_effect_phase="deploy_trigger",
+                    legacy_snapshot_without_product=True,
+                ),
+            )
+            provider = _LegacyRecoveryObservationProvider(
+                (_legacy_correlation(), _legacy_correlation())
+            )
+            app = _create_recovery_app(root=root, store=store)
+            with (
+                patch(
+                    "control_plane.generic_web_deploy_provider_adapter."
+                    "default_generic_web_deploy_provider",
+                    return_value=provider,
+                ),
+                patch.object(store, "reserve_mutation", side_effect=AssertionError("reserve")),
+                patch(
+                    "control_plane.storage.postgres.PostgresRecordStore.write_deployment_record",
+                    side_effect=AssertionError("deployment write"),
+                ),
+                patch(
+                    "control_plane.storage.postgres.PostgresRecordStore."
+                    "write_environment_inventory",
+                    side_effect=AssertionError("inventory write"),
+                ),
+                patch(
+                    "control_plane.storage.postgres.PostgresRecordStore.write_idempotency_record",
+                    side_effect=AssertionError("idempotency write"),
+                ),
+            ):
+                evidence_status, evidence_payload = _invoke_provider_evidence(
+                    app,
+                    original_deploy=original_deploy,
+                    idempotency_key=reservation.idempotency_key,
+                    reason="Inspect bounded legacy correlation evidence.",
+                )
+                dry_status, dry_payload = _invoke_recovery(
+                    app,
+                    original_deploy=original_deploy,
+                    idempotency_key=reservation.idempotency_key,
+                    reason="Inspect bounded legacy correlation evidence.",
+                )
+            store.close()
+
+        self.assertEqual(evidence_status, 200)
+        self.assertEqual(evidence_payload["provider_evidence"], "deployment_correlated_legacy")
+        self.assertEqual(evidence_payload["provider_status"], "done")
+        self.assertEqual(dry_status, 200)
+        self.assertEqual(dry_payload["provider_outcome"], "present")
+        self.assertEqual(dry_payload["proposed_action"], "adopt_observed")
+        self.assertFalse(dry_payload["retry_safe"])
+        self.assertEqual(provider.observation_calls, 2)
+        self.assertEqual(provider.legacy_observation_calls, 2)
+        serialized = json.dumps(
+            {"evidence": evidence_payload, "dry_run": dry_payload},
+            sort_keys=True,
+        )
+        self.assertNotIn("provider-legacy-deployment-secret", serialized)
+        self.assertNotIn("2026-08-15T12:00:01", serialized)
+        self.assertNotIn("legacy/github-actions/scope", serialized)
+
+    def test_legacy_fallback_requires_legacy_snapshot_and_actionable_lease(self) -> None:
+        for name, legacy_snapshot, state, lease_expires_at, expected_exact_calls in (
+            ("modern snapshot", False, "reconcile_required", "", 1),
+            ("active lease", True, "running", "2099-08-16T18:00:00Z", 0),
+        ):
+            with (
+                self.subTest(name=name),
+                TemporaryDirectory() as temporary_directory_name,
+            ):
+                root = Path(temporary_directory_name)
+                store = PostgresRecordStore(
+                    database_url=_sqlite_database_url(root / "launchplane.sqlite3")
+                )
+                store.ensure_schema()
+                store.write_product_profile_record(
+                    LaunchplaneProductProfileRecord.model_validate(_product_profile_payload())
+                )
+                original_deploy = _generic_web_recovery_original_deploy()
+                reservation = _write_generic_web_recovery_reservation(
+                    store,
+                    _generic_web_recovery_reservation(
+                        original_deploy=original_deploy,
+                        idempotency_key=f"legacy-gate-{name}",
+                        state=cast(Literal["running", "reconcile_required"], state),
+                        lease_expires_at=lease_expires_at,
+                        provider_effect_phase="deploy_trigger",
+                        legacy_snapshot_without_product=legacy_snapshot,
+                    ),
+                )
+                provider = _LegacyRecoveryObservationProvider((_legacy_correlation(),))
+                app = _create_recovery_app(root=root, store=store)
+                with patch(
+                    "control_plane.generic_web_deploy_provider_adapter."
+                    "default_generic_web_deploy_provider",
+                    return_value=provider,
+                ):
+                    status_code, payload = _invoke_recovery(
+                        app,
+                        original_deploy=original_deploy,
+                        idempotency_key=reservation.idempotency_key,
+                        reason="Verify legacy fallback gating.",
+                    )
+                store.close()
+
+            self.assertEqual(status_code, 200)
+            self.assertEqual(
+                payload["proposed_action"],
+                "hold_unknown" if name == "modern snapshot" else "wait_for_active_lease",
+            )
+            self.assertEqual(provider.observation_calls, expected_exact_calls)
+            self.assertEqual(provider.legacy_observation_calls, 0)
+
+    def test_legacy_correlation_error_holds_unknown(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(root / "launchplane.sqlite3")
+            )
+            store.ensure_schema()
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_product_profile_payload())
+            )
+            original_deploy = _generic_web_recovery_original_deploy()
+            reservation = _write_generic_web_recovery_reservation(
+                store,
+                _generic_web_recovery_reservation(
+                    original_deploy=original_deploy,
+                    idempotency_key="legacy-correlation-ambiguous",
+                    provider_effect_phase="deploy_trigger",
+                    legacy_snapshot_without_product=True,
+                ),
+            )
+            provider = _LegacyRecoveryObservationProvider(
+                (
+                    ValueError("raw provider ambiguity secret"),
+                    ValueError("raw provider ambiguity secret"),
+                )
+            )
+            app = _create_recovery_app(root=root, store=store)
+            with patch(
+                "control_plane.generic_web_deploy_provider_adapter."
+                "default_generic_web_deploy_provider",
+                return_value=provider,
+            ):
+                evidence_status, evidence_payload = _invoke_provider_evidence(
+                    app,
+                    original_deploy=original_deploy,
+                    idempotency_key=reservation.idempotency_key,
+                    reason="Hold ambiguous legacy evidence.",
+                )
+                status_code, payload = _invoke_recovery(
+                    app,
+                    original_deploy=original_deploy,
+                    idempotency_key=reservation.idempotency_key,
+                    reason="Hold ambiguous legacy evidence.",
+                )
+            store.close()
+
+        self.assertEqual(evidence_status, 200)
+        self.assertEqual(evidence_payload["provider_evidence"], "provider_status_unknown")
+        self.assertEqual(status_code, 200)
+        self.assertEqual(payload["provider_outcome"], "unknown")
+        self.assertEqual(payload["proposed_action"], "hold_unknown")
+        self.assertFalse(payload["retry_safe"])
+        self.assertNotIn("raw provider ambiguity secret", json.dumps(payload, sort_keys=True))
+
+    def test_optional_legacy_capability_does_not_change_nonlegacy_recovery_digest(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(root / "launchplane.sqlite3")
+            )
+            store.ensure_schema()
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_product_profile_payload())
+            )
+            original_deploy = _generic_web_recovery_original_deploy()
+            reservation = _write_generic_web_recovery_reservation(
+                store,
+                _generic_web_recovery_reservation(
+                    original_deploy=original_deploy,
+                    idempotency_key="nonlegacy-digest-stability",
+                ),
+            )
+            without_capability = _RecoveryObservationProvider(
+                GenericWebProviderDeploymentObservation(outcome="absent")
+            )
+            with_capability = _LegacyRecoveryObservationProvider((_legacy_correlation(),))
+            app = _create_recovery_app(root=root, store=store)
+            with patch(
+                "control_plane.generic_web_deploy_provider_adapter."
+                "default_generic_web_deploy_provider",
+                return_value=without_capability,
+            ):
+                first_status, first_payload = _invoke_recovery(
+                    app,
+                    original_deploy=original_deploy,
+                    idempotency_key=reservation.idempotency_key,
+                    reason="Verify nonlegacy digest stability.",
+                )
+            with patch(
+                "control_plane.generic_web_deploy_provider_adapter."
+                "default_generic_web_deploy_provider",
+                return_value=with_capability,
+            ):
+                second_status, second_payload = _invoke_recovery(
+                    app,
+                    original_deploy=original_deploy,
+                    idempotency_key=reservation.idempotency_key,
+                    reason="Verify nonlegacy digest stability.",
+                )
+            store.close()
+
+        self.assertEqual(first_status, 200)
+        self.assertEqual(second_status, 200)
+        self.assertEqual(first_payload["recovery_digest"], second_payload["recovery_digest"])
+        self.assertEqual(with_capability.legacy_observation_calls, 0)
+
+    def test_legacy_apply_reinspection_stales_changed_correlation_evidence(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(root / "launchplane.sqlite3")
+            )
+            store.ensure_schema()
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_product_profile_payload())
+            )
+            original_deploy = _generic_web_recovery_original_deploy()
+            reservation = _write_generic_web_recovery_reservation(
+                store,
+                _generic_web_recovery_reservation(
+                    original_deploy=original_deploy,
+                    idempotency_key="legacy-stale-apply",
+                    provider_effect_phase="deploy_trigger",
+                    legacy_snapshot_without_product=True,
+                ),
+            )
+            provider = _LegacyRecoveryObservationProvider(
+                (
+                    _legacy_correlation(),
+                    _legacy_correlation(deployment_id_sha256="4" * 64),
+                )
+            )
+            app = _create_recovery_app(root=root, store=store)
+            with patch(
+                "control_plane.generic_web_deploy_provider_adapter."
+                "default_generic_web_deploy_provider",
+                return_value=provider,
+            ):
+                dry_status, dry_payload = _invoke_recovery(
+                    app,
+                    original_deploy=original_deploy,
+                    idempotency_key=reservation.idempotency_key,
+                    reason="Review legacy correlation evidence.",
+                )
+                apply_status, apply_payload = _invoke_recovery_apply(
+                    app,
+                    original_deploy=original_deploy,
+                    idempotency_key=reservation.idempotency_key,
+                    reason="Review legacy correlation evidence.",
+                    expected_recovery_digest=dry_payload["recovery_digest"],
+                )
+            stored = store.read_idempotency_record(
+                scope=reservation.scope,
+                route_path=reservation.route_path,
+                idempotency_key=reservation.idempotency_key,
+            )
+            store.close()
+
+        self.assertEqual(dry_status, 200)
+        self.assertEqual(apply_status, 409)
+        self.assertEqual(apply_payload["error"]["code"], "stale_recovery_digest")
+        self.assertIsNotNone(stored)
+        assert stored is not None
+        self.assertEqual(stored.state, "reconcile_required")
+
+    def test_legacy_apply_adopts_without_retrying_provider_effect(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(root / "launchplane.sqlite3")
+            )
+            store.ensure_schema()
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_product_profile_payload())
+            )
+            original_deploy = _generic_web_recovery_original_deploy()
+            reservation = _write_generic_web_recovery_reservation(
+                store,
+                _generic_web_recovery_reservation(
+                    original_deploy=original_deploy,
+                    idempotency_key="legacy-adoption-only",
+                    provider_effect_phase="deploy_trigger",
+                    legacy_snapshot_without_product=True,
+                ),
+            )
+            provider = _LegacyRecoveryObservationProvider(
+                (_legacy_correlation(), _legacy_correlation())
+            )
+            app = _create_recovery_app(root=root, store=store)
+            with patch(
+                "control_plane.generic_web_deploy_provider_adapter."
+                "default_generic_web_deploy_provider",
+                return_value=provider,
+            ):
+                reason = "Adopt exact bounded legacy correlation evidence."
+                dry_status, dry_payload = _invoke_recovery(
+                    app,
+                    original_deploy=original_deploy,
+                    idempotency_key=reservation.idempotency_key,
+                    reason=reason,
+                )
+            with (
+                patch(
+                    "control_plane.generic_web_deploy_provider_adapter."
+                    "default_generic_web_deploy_provider",
+                    return_value=provider,
+                ),
+                patch(
+                    "control_plane.generic_web_deploy_provider_adapter."
+                    "GenericWebDeployProviderMutationAdapter.apply",
+                    side_effect=AssertionError("provider retry"),
+                ),
+            ):
+                apply_status, apply_payload = _invoke_recovery_apply(
+                    app,
+                    original_deploy=original_deploy,
+                    idempotency_key=reservation.idempotency_key,
+                    reason=reason,
+                    expected_recovery_digest=dry_payload["recovery_digest"],
+                )
+            stored = store.read_idempotency_record(
+                scope=reservation.scope,
+                route_path=reservation.route_path,
+                idempotency_key=reservation.idempotency_key,
+            )
+            store.close()
+
+        self.assertEqual(dry_status, 200)
+        self.assertEqual(dry_payload["proposed_action"], "adopt_observed")
+        self.assertFalse(dry_payload["retry_safe"])
+        self.assertEqual(apply_status, 202)
+        self.assertEqual(apply_payload["recovery_action"], "adopt_observed")
+        self.assertFalse(apply_payload["retry_safe"])
+        self.assertIsNotNone(stored)
+        assert stored is not None
+        self.assertEqual(stored.state, "completed")
+        serialized = json.dumps(apply_payload, sort_keys=True)
+        self.assertNotIn("provider-legacy-deployment-secret", serialized)
+        self.assertNotIn("2026-08-15T12:00:02", serialized)
 
     def test_provider_evidence_supports_dedicated_and_execute_authorization(self) -> None:
         for actions in (


### PR DESCRIPTION
## Summary

- preserve exact provider-operation title lookup as the primary recovery signal
- add a bounded read-only fallback for structurally legacy reservations whose deployment predates exact Launchplane titles
- require complete retained history, one unique newest successful candidate in a tight provider-effect window, exact target identity, and exact current immutable artifact reference
- produce adoption-only recovery evidence with `retry_safe=false`; ambiguous or conflicting evidence remains `hold_unknown`

## Safety contract

- fallback engages only for legacy snapshots missing the stored product field, `deploy_trigger`, and an authoritative provider-effect timestamp
- no provider, reservation, policy, deployment, inventory, or outbox mutation during inspection
- no raw deployment title, provider ID, deployment ID, target environment, logs, timestamps, or exception text in HTTP responses
- correlation evidence is hashed/normalized and included only in the legacy recovery digest
- apply re-inspects provider state and rejects stale evidence before adoption
- no retry path is enabled by legacy correlation

## Production evidence motivating the slice

Read-only evidence for the exact RepairShopr reservation shows the provider effect checkpoint and one successful provider deployment 1.364 seconds apart, complete older history, no later deployment, a legacy non-Launchplane title matching the source commit, and the exact immutable artifact currently configured and running healthy. No production state was mutated while collecting this evidence.

## Validation

- `uv run --extra dev launchplane ci unittest-shard local` — 3,024 targets across 12 shards passed
- focused recovery/provider/OpenAPI tests — 84 passed
- `pnpm --dir frontend validate` — passed after locked dependency install
- `uv run launchplane service audit-config-authority --control-plane-root .` — status `ok`
- scoped Ruff dry-run/check/format — passed
- `uv run --extra dev mypy control_plane tests` — 737 files clean
- PyCharm changed-files closeout — zero findings
- independent Opus and Gemini contract/implementation reviews — READY after live API payload confirmation

Implements #2187 under parent recovery plan #2167.
