### PR TITLE
Pin fixed GitHub CLI module dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,15 +21,18 @@ ARG GITHUB_CLI_X_TEXT_VERSION=v0.39.0
 ENV CGO_ENABLED=0 \
     GOTOOLCHAIN=local
 
-RUN mkdir -p /tmp/github-cli-build \
+RUN github_cli_x_mod_version=v0.40.0 \
+    && mkdir -p /tmp/github-cli-build \
     && cd /tmp/github-cli-build \
     && go mod init launchplane.local/github-cli-build \
     && go get "github.com/cli/cli/v2/cmd/gh@${GITHUB_CLI_VERSION}" \
     && go get "google.golang.org/grpc@${GITHUB_CLI_GRPC_VERSION}" \
+    && go get "golang.org/x/mod@${github_cli_x_mod_version}" \
     && go get "golang.org/x/text@${GITHUB_CLI_X_TEXT_VERSION}" \
     && go build -trimpath -o /go/bin/gh github.com/cli/cli/v2/cmd/gh \
     && go version -m /go/bin/gh | grep -F "github.com/cli/cli/v2" | grep -F "${GITHUB_CLI_VERSION}" \
     && go version -m /go/bin/gh | grep -F "google.golang.org/grpc" | grep -F "${GITHUB_CLI_GRPC_VERSION}" \
+    && go version -m /go/bin/gh | grep -F "golang.org/x/mod" | grep -F "${github_cli_x_mod_version}" \
     && go version -m /go/bin/gh | grep -F "golang.org/x/text" | grep -F "${GITHUB_CLI_X_TEXT_VERSION}"
 
 FROM mirror.gcr.io/library/python:3.13-slim

--- a/tests/test_service_image_contract.py
+++ b/tests/test_service_image_contract.py
@@ -19,6 +19,9 @@ GITHUB_CLI_MODULE_CONTRACTS = {
         "GITHUB_CLI_X_TEXT_VERSION",
     ),
 }
+GITHUB_CLI_INTERNAL_MODULE_CONTRACTS = {
+    "golang.org/x/mod": ("golang.org/x/mod", "github_cli_x_mod_version"),
+}
 RUNTIME_SECURITY_UPGRADE_PACKAGES = {
     "bsdutils",
     "libblkid1",
@@ -39,8 +42,9 @@ ARG_PATTERN = re.compile(r"^ARG\s+(?P<name>[A-Z0-9_]+)=(?P<value>\S+)\s*$", re.M
 GO_GET_PATTERN = re.compile(r'\bgo\s+get\s+"(?P<module>[^"@\s]+)@(?P<reference>[^"\s]+)"')
 GO_PROVENANCE_PATTERN = re.compile(
     r'\bgo\s+version\s+-m\s+/go/bin/gh\s+\|\s+grep\s+-F\s+"'
-    r'(?P<module>[^"\s]+)"\s+\|\s+grep\s+-F\s+"\$\{(?P<argument>[A-Z0-9_]+)\}"'
+    r'(?P<module>[^"\s]+)"\s+\|\s+grep\s+-F\s+"\$\{(?P<argument>[A-Za-z_][A-Za-z0-9_]*)\}"'
 )
+SHELL_VERSION_PATTERN = re.compile(r"\b(?P<name>[a-z][a-z0-9_]*)=(?P<value>v\S+)\s+\\")
 
 
 class ServiceImageContractTests(unittest.TestCase):
@@ -70,6 +74,18 @@ class ServiceImageContractTests(unittest.TestCase):
         for argument_name in expected_argument_names:
             self.assertRegex(arguments[argument_name], GO_VERSION_PATTERN)
 
+        shell_versions = {
+            match.group("name"): match.group("value")
+            for match in SHELL_VERSION_PATTERN.finditer(build_stage_text)
+        }
+        expected_shell_version_names = {
+            version_name for _, version_name in GITHUB_CLI_INTERNAL_MODULE_CONTRACTS.values()
+        }
+
+        self.assertTrue(expected_shell_version_names.issubset(shell_versions))
+        for version_name in expected_shell_version_names:
+            self.assertRegex(shell_versions[version_name], GO_VERSION_PATTERN)
+
         go_gets = {
             match.group("module"): match.group("reference")
             for match in GO_GET_PATTERN.finditer(build_stage_text)
@@ -78,6 +94,12 @@ class ServiceImageContractTests(unittest.TestCase):
             package_path: f"${{{argument_name}}}"
             for package_path, (_, argument_name) in GITHUB_CLI_MODULE_CONTRACTS.items()
         }
+        expected_go_gets.update(
+            {
+                package_path: f"${{{version_name}}}"
+                for package_path, (_, version_name) in GITHUB_CLI_INTERNAL_MODULE_CONTRACTS.items()
+            }
+        )
 
         self.assertEqual(go_gets, expected_go_gets)
         self.assertNotRegex(build_stage_text, r"\bgo\s+install\b")
@@ -96,6 +118,7 @@ class ServiceImageContractTests(unittest.TestCase):
             (module_path, argument_name)
             for _, (module_path, argument_name) in GITHUB_CLI_MODULE_CONTRACTS.items()
         }
+        expected_provenance.update(GITHUB_CLI_INTERNAL_MODULE_CONTRACTS.values())
 
         self.assertEqual(provenance, expected_provenance)
 


### PR DESCRIPTION
## Summary
- pin `golang.org/x/mod` `v0.40.0` inside the custom GitHub CLI build
- verify the compiled `gh` binary records the fixed module version
- keep the pin internal to the image build rather than adding a new config-authority surface

## Why
Trivy began reporting `CVE-2026-56864` and `CVE-2026-56865` against `golang.org/x/mod v0.37.0` in the runtime image on August 19, 2026. Both are fixed in `v0.40.0`.

## Validation
- exact Go build completed with `github.com/cli/cli/v2 v2.96.0` and `golang.org/x/mod v0.40.0`
- service image contract tests
- changed-files config-authority gate
- PyCharm changed-files inspection: zero findings

Local Docker was unavailable; CI container build and Trivy scan are the authoritative image proof.