### PR TITLE
Add artifact-backed recovery apply action

### DIFF
--- a/.github/actions/generic-web-deploy-recovery-dry-run/action.yml
+++ b/.github/actions/generic-web-deploy-recovery-dry-run/action.yml
@@ -11,9 +11,28 @@ inputs:
     default: ""
   request-json:
     description: >-
-      Exact legacy deploy coordinates and operator reason as JSON. Supplying a
-      reviewed expected_recovery_digest selects digest-bound apply mode.
-    required: true
+      Optional exact legacy deploy coordinates and operator reason as JSON.
+      Supplying a reviewed expected_recovery_digest selects digest-bound apply
+      mode. When omitted, the action downloads and validates the approved
+      recovery apply artifact for the current workflow_run event.
+    required: false
+    default: ""
+  expected-product:
+    description: Expected Launchplane product for artifact-backed apply mode.
+    required: false
+    default: ""
+  expected-instance:
+    description: Expected Launchplane instance for artifact-backed apply mode.
+    required: false
+    default: ""
+  workflow-run-id:
+    description: Source workflow run containing the approved apply request artifact.
+    required: false
+    default: ${{ github.event.workflow_run.id }}
+  github-token:
+    description: GitHub token used only to download the source workflow artifact.
+    required: false
+    default: ${{ github.token }}
   audience:
     description: Optional GitHub OIDC audience. Defaults to the service URL host.
     required: false

--- a/.github/actions/generic-web-deploy-recovery-dry-run/action.yml
+++ b/.github/actions/generic-web-deploy-recovery-dry-run/action.yml
@@ -11,10 +11,9 @@ inputs:
     default: ""
   request-json:
     description: >-
-      Optional exact legacy deploy coordinates and operator reason as JSON.
-      Supplying a reviewed expected_recovery_digest selects digest-bound apply
-      mode. When omitted, the action downloads and validates the approved
-      recovery apply artifact for the current workflow_run event.
+      Optional exact legacy deploy coordinates and operator reason as JSON for
+      dry-run mode only. When omitted, the action downloads and validates the
+      approved digest-bound apply artifact for the current workflow_run event.
     required: false
     default: ""
   expected-product:

--- a/.github/actions/generic-web-deploy-recovery-dry-run/dist/download-artifact.mjs
+++ b/.github/actions/generic-web-deploy-recovery-dry-run/dist/download-artifact.mjs
@@ -1,0 +1,96 @@
+import { Buffer } from "node:buffer";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import process from "node:process";
+
+const requestFileName = "launchplane-recovery-apply-request.json";
+
+function requiredEnvironment(name) {
+  const value = String(process.env[name] ?? "").trim();
+  if (!value) {
+    throw new Error(`${name} is required.`);
+  }
+  return value;
+}
+
+function positiveRunId(value) {
+  if (!/^[1-9][0-9]*$/.test(value)) {
+    throw new Error("workflow-run-id must be a positive integer.");
+  }
+  return value;
+}
+
+async function githubRequest(url, token) {
+  const response = await fetch(url, {
+    headers: {
+      Accept: "application/vnd.github+json",
+      Authorization: `Bearer ${token}`,
+      "X-GitHub-Api-Version": "2022-11-28",
+    },
+  });
+  if (!response.ok) {
+    throw new Error(`GitHub artifact request failed with ${response.status}.`);
+  }
+  return response;
+}
+
+export async function downloadArtifact(token, workflowRunId) {
+  const runId = positiveRunId(workflowRunId);
+  const repository = requiredEnvironment("GITHUB_REPOSITORY");
+  const apiUrl = requiredEnvironment("GITHUB_API_URL");
+  const artifactName = `launchplane-recovery-apply-request-${runId}`;
+  const artifactsResponse = await githubRequest(
+    `${apiUrl}/repos/${repository}/actions/runs/${runId}/artifacts?per_page=100`,
+    token,
+  );
+  const artifactsPayload = await artifactsResponse.json();
+  const artifacts = Array.isArray(artifactsPayload.artifacts) ? artifactsPayload.artifacts : [];
+  const matchingArtifacts = artifacts.filter(
+    artifact => artifact.name === artifactName && artifact.expired !== true,
+  );
+  if (matchingArtifacts.length !== 1) {
+    throw new Error("Recovery apply source run must contain exactly one matching artifact.");
+  }
+  const matchingArtifact = matchingArtifacts[0];
+  const archiveSize = Reflect.get(matchingArtifact, "size_in_bytes");
+  if (!Number.isSafeInteger(archiveSize) || archiveSize <= 0 || archiveSize > 32768) {
+    throw new Error("Recovery apply source artifact archive is invalid or too large.");
+  }
+
+  const archiveDownloadUrl = String(Reflect.get(matchingArtifact, "archive_download_url") ?? "");
+  if (!archiveDownloadUrl) {
+    throw new Error("Recovery apply source artifact download URL is missing.");
+  }
+  const archiveResponse = await githubRequest(archiveDownloadUrl, token);
+  const destinationDirectory = join(
+    requiredEnvironment("RUNNER_TEMP"),
+    `launchplane-recovery-apply-${requiredEnvironment("GITHUB_RUN_ID")}-${requiredEnvironment("GITHUB_RUN_ATTEMPT")}`,
+  );
+  mkdirSync(destinationDirectory, { recursive: true });
+  const archivePath = join(destinationDirectory, "request.zip");
+  const archive = Buffer.from(await archiveResponse.arrayBuffer());
+  if (archive.length === 0 || archive.length > 32768) {
+    throw new Error("Recovery apply downloaded archive is invalid or too large.");
+  }
+  writeFileSync(archivePath, archive, { mode: 0o600 });
+  try {
+    const entries = execFileSync("unzip", ["-Z1", archivePath], { encoding: "utf8" })
+      .split(/\r?\n/)
+      .filter(Boolean);
+    if (entries.length !== 1 || entries[0] !== requestFileName) {
+      throw new Error("Recovery apply artifact must contain exactly one regular file.");
+    }
+    const request = execFileSync("unzip", ["-p", archivePath, requestFileName], {
+      maxBuffer: 8193,
+    });
+    if (request.length === 0 || request.length > 8192) {
+      throw new Error("Recovery apply artifact exceeds the size limit.");
+    }
+    const requestPath = join(destinationDirectory, requestFileName);
+    writeFileSync(requestPath, request, { mode: 0o600 });
+    return requestPath;
+  } finally {
+    rmSync(archivePath, { force: true });
+  }
+}

--- a/.github/actions/generic-web-deploy-recovery-dry-run/dist/download-artifact.mjs
+++ b/.github/actions/generic-web-deploy-recovery-dry-run/dist/download-artifact.mjs
@@ -1,10 +1,158 @@
 import { Buffer } from "node:buffer";
-import { execFileSync } from "node:child_process";
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import process from "node:process";
+import { inflateRawSync } from "node:zlib";
 
 const requestFileName = "launchplane-recovery-apply-request.json";
+const maximumArchiveSize = 32768;
+const maximumRequestSize = 8192;
+const endOfCentralDirectorySignature = 0x06054b50;
+const centralDirectorySignature = 0x02014b50;
+const localFileSignature = 0x04034b50;
+
+function crc32(value) {
+  let checksum = 0xffffffff;
+  for (const byte of value) {
+    checksum ^= byte;
+    for (let bit = 0; bit < 8; bit += 1) {
+      checksum = checksum >>> 1 ^ 0xedb88320 & -(checksum & 1);
+    }
+  }
+  return (checksum ^ 0xffffffff) >>> 0;
+}
+
+function findEndOfCentralDirectory(archive) {
+  for (let offset = archive.length - 22; offset >= 0; offset -= 1) {
+    if (archive.readUInt32LE(offset) === endOfCentralDirectorySignature) {
+      return offset;
+    }
+  }
+  throw new Error("Recovery apply artifact is not a valid ZIP archive.");
+}
+
+function extractRequest(archive) {
+  const endOffset = findEndOfCentralDirectory(archive);
+  const commentLength = archive.readUInt16LE(endOffset + 20);
+  if (endOffset + 22 + commentLength !== archive.length) {
+    throw new Error("Recovery apply artifact ZIP footer is invalid.");
+  }
+  const diskNumber = archive.readUInt16LE(endOffset + 4);
+  const centralDirectoryDisk = archive.readUInt16LE(endOffset + 6);
+  const diskEntries = archive.readUInt16LE(endOffset + 8);
+  const totalEntries = archive.readUInt16LE(endOffset + 10);
+  const centralDirectorySize = archive.readUInt32LE(endOffset + 12);
+  const centralDirectoryOffset = archive.readUInt32LE(endOffset + 16);
+  if (
+    diskNumber !== 0 ||
+    centralDirectoryDisk !== 0 ||
+    diskEntries !== 1 ||
+    totalEntries !== 1 ||
+    centralDirectoryOffset + centralDirectorySize !== endOffset
+  ) {
+    throw new Error("Recovery apply artifact must contain exactly one regular file.");
+  }
+  if (
+    centralDirectoryOffset + 46 > endOffset ||
+    archive.readUInt32LE(centralDirectoryOffset) !== centralDirectorySignature
+  ) {
+    throw new Error("Recovery apply artifact central directory is invalid.");
+  }
+
+  const versionMadeBy = archive.readUInt16LE(centralDirectoryOffset + 4);
+  const flags = archive.readUInt16LE(centralDirectoryOffset + 8);
+  const compressionMethod = archive.readUInt16LE(centralDirectoryOffset + 10);
+  const expectedChecksum = archive.readUInt32LE(centralDirectoryOffset + 16);
+  const compressedSize = archive.readUInt32LE(centralDirectoryOffset + 20);
+  const uncompressedSize = archive.readUInt32LE(centralDirectoryOffset + 24);
+  const fileNameLength = archive.readUInt16LE(centralDirectoryOffset + 28);
+  const extraLength = archive.readUInt16LE(centralDirectoryOffset + 30);
+  const fileCommentLength = archive.readUInt16LE(centralDirectoryOffset + 32);
+  const fileDisk = archive.readUInt16LE(centralDirectoryOffset + 34);
+  const externalAttributes = archive.readUInt32LE(centralDirectoryOffset + 38);
+  const localHeaderOffset = archive.readUInt32LE(centralDirectoryOffset + 42);
+  const centralEntryEnd =
+    centralDirectoryOffset + 46 + fileNameLength + extraLength + fileCommentLength;
+  const fileName = archive
+    .subarray(centralDirectoryOffset + 46, centralDirectoryOffset + 46 + fileNameLength)
+    .toString("utf8");
+  const unixFileType = externalAttributes >>> 16 & 0o170000;
+  if (
+    centralEntryEnd !== endOffset ||
+    fileDisk !== 0 ||
+    fileName !== requestFileName ||
+    (flags & 1) !== 0 ||
+    ![0, 8].includes(compressionMethod) ||
+    uncompressedSize === 0 ||
+    uncompressedSize > maximumRequestSize ||
+    (externalAttributes & 0x10) !== 0 ||
+    versionMadeBy >>> 8 === 3 && unixFileType !== 0 && unixFileType !== 0o100000
+  ) {
+    throw new Error("Recovery apply artifact must contain exactly one regular file.");
+  }
+
+  if (
+    localHeaderOffset + 30 > centralDirectoryOffset ||
+    archive.readUInt32LE(localHeaderOffset) !== localFileSignature
+  ) {
+    throw new Error("Recovery apply artifact local file header is invalid.");
+  }
+  const localFlags = archive.readUInt16LE(localHeaderOffset + 6);
+  const localCompressionMethod = archive.readUInt16LE(localHeaderOffset + 8);
+  const localFileNameLength = archive.readUInt16LE(localHeaderOffset + 26);
+  const localExtraLength = archive.readUInt16LE(localHeaderOffset + 28);
+  const dataOffset = localHeaderOffset + 30 + localFileNameLength + localExtraLength;
+  const dataEnd = dataOffset + compressedSize;
+  const localFileName = archive
+    .subarray(localHeaderOffset + 30, localHeaderOffset + 30 + localFileNameLength)
+    .toString("utf8");
+  if (
+    localFileName !== requestFileName ||
+    localFlags !== flags ||
+    localCompressionMethod !== compressionMethod ||
+    dataOffset > centralDirectoryOffset ||
+    dataEnd > centralDirectoryOffset
+  ) {
+    throw new Error("Recovery apply artifact local file header is invalid.");
+  }
+  const usesDataDescriptor = (flags & 8) !== 0;
+  if (!usesDataDescriptor && dataEnd !== centralDirectoryOffset) {
+    throw new Error("Recovery apply artifact contains unreferenced ZIP data.");
+  }
+  if (usesDataDescriptor) {
+    const descriptorHasSignature =
+      dataEnd + 4 <= centralDirectoryOffset && archive.readUInt32LE(dataEnd) === 0x08074b50;
+    const descriptorOffset = dataEnd + (descriptorHasSignature ? 4 : 0);
+    if (
+      descriptorOffset + 12 !== centralDirectoryOffset ||
+      archive.readUInt32LE(descriptorOffset) !== expectedChecksum ||
+      archive.readUInt32LE(descriptorOffset + 4) !== compressedSize ||
+      archive.readUInt32LE(descriptorOffset + 8) !== uncompressedSize
+    ) {
+      throw new Error("Recovery apply artifact data descriptor is invalid.");
+    }
+  }
+
+  const compressedRequest = archive.subarray(dataOffset, dataEnd);
+  let request;
+  try {
+    request =
+      compressionMethod === 0
+        ? compressedRequest
+        : inflateRawSync(compressedRequest, { maxOutputLength: maximumRequestSize + 1 });
+  } catch {
+    throw new Error("Recovery apply artifact request data is invalid.");
+  }
+  if (
+    request.length !== uncompressedSize ||
+    request.length === 0 ||
+    request.length > maximumRequestSize ||
+    crc32(request) !== expectedChecksum
+  ) {
+    throw new Error("Recovery apply artifact request data is invalid.");
+  }
+  return request;
+}
 
 function requiredEnvironment(name) {
   const value = String(process.env[name] ?? "").trim();
@@ -41,7 +189,7 @@ export async function downloadArtifact(token, workflowRunId) {
   const apiUrl = requiredEnvironment("GITHUB_API_URL");
   const artifactName = `launchplane-recovery-apply-request-${runId}`;
   const artifactsResponse = await githubRequest(
-    `${apiUrl}/repos/${repository}/actions/runs/${runId}/artifacts?per_page=100`,
+    `${apiUrl}/repos/${repository}/actions/runs/${runId}/artifacts?name=${encodeURIComponent(artifactName)}&per_page=100`,
     token,
   );
   const artifactsPayload = await artifactsResponse.json();
@@ -49,12 +197,12 @@ export async function downloadArtifact(token, workflowRunId) {
   const matchingArtifacts = artifacts.filter(
     artifact => artifact.name === artifactName && artifact.expired !== true,
   );
-  if (matchingArtifacts.length !== 1) {
+  if (artifactsPayload.total_count !== artifacts.length || matchingArtifacts.length !== 1) {
     throw new Error("Recovery apply source run must contain exactly one matching artifact.");
   }
   const matchingArtifact = matchingArtifacts[0];
   const archiveSize = Reflect.get(matchingArtifact, "size_in_bytes");
-  if (!Number.isSafeInteger(archiveSize) || archiveSize <= 0 || archiveSize > 32768) {
+  if (!Number.isSafeInteger(archiveSize) || archiveSize <= 0 || archiveSize > maximumArchiveSize) {
     throw new Error("Recovery apply source artifact archive is invalid or too large.");
   }
 
@@ -67,30 +215,14 @@ export async function downloadArtifact(token, workflowRunId) {
     requiredEnvironment("RUNNER_TEMP"),
     `launchplane-recovery-apply-${requiredEnvironment("GITHUB_RUN_ID")}-${requiredEnvironment("GITHUB_RUN_ATTEMPT")}`,
   );
+  rmSync(destinationDirectory, { recursive: true, force: true });
   mkdirSync(destinationDirectory, { recursive: true });
-  const archivePath = join(destinationDirectory, "request.zip");
   const archive = Buffer.from(await archiveResponse.arrayBuffer());
-  if (archive.length === 0 || archive.length > 32768) {
+  if (archive.length === 0 || archive.length > maximumArchiveSize) {
     throw new Error("Recovery apply downloaded archive is invalid or too large.");
   }
-  writeFileSync(archivePath, archive, { mode: 0o600 });
-  try {
-    const entries = execFileSync("unzip", ["-Z1", archivePath], { encoding: "utf8" })
-      .split(/\r?\n/)
-      .filter(Boolean);
-    if (entries.length !== 1 || entries[0] !== requestFileName) {
-      throw new Error("Recovery apply artifact must contain exactly one regular file.");
-    }
-    const request = execFileSync("unzip", ["-p", archivePath, requestFileName], {
-      maxBuffer: 8193,
-    });
-    if (request.length === 0 || request.length > 8192) {
-      throw new Error("Recovery apply artifact exceeds the size limit.");
-    }
-    const requestPath = join(destinationDirectory, requestFileName);
-    writeFileSync(requestPath, request, { mode: 0o600 });
-    return requestPath;
-  } finally {
-    rmSync(archivePath, { force: true });
-  }
+  const request = extractRequest(archive);
+  const requestPath = join(destinationDirectory, requestFileName);
+  writeFileSync(requestPath, request, { mode: 0o600 });
+  return requestPath;
 }

--- a/.github/actions/generic-web-deploy-recovery-dry-run/dist/index.mjs
+++ b/.github/actions/generic-web-deploy-recovery-dry-run/dist/index.mjs
@@ -1,5 +1,22 @@
+import { existsSync, lstatSync, readFileSync, readdirSync } from "node:fs";
+import { basename, dirname } from "node:path";
+import { setTimeout as sleep } from "node:timers/promises";
+
+import { downloadArtifact } from "./download-artifact.mjs";
+
 const runtime = Reflect.get(globalThis, "process");
 const environment = runtime.env;
+const artifactRequestKeys = new Set([
+  "artifact_id",
+  "expected_recovery_digest",
+  "instance",
+  "original_run_attempt",
+  "original_run_id",
+  "product",
+  "reason",
+  "schema_version",
+  "source_git_ref",
+]);
 const requestKeys = new Set([
   "artifact_id",
   "expected_recovery_digest",
@@ -81,8 +98,180 @@ function parseRequest(value) {
   return request;
 }
 
-function configureRequestAction() {
-  const request = parseRequest(requiredInput("request-json"));
+function validateWorkflowRunEvent(workflowRunId) {
+  if (environment.GITHUB_EVENT_NAME !== "workflow_run") {
+    throw new Error("Artifact-backed recovery apply requires a workflow_run event.");
+  }
+  const eventPath = String(environment.GITHUB_EVENT_PATH ?? "").trim();
+  if (!eventPath) {
+    throw new Error("GITHUB_EVENT_PATH is required for artifact-backed recovery apply.");
+  }
+  const event = JSON.parse(readFileSync(eventPath, "utf8"));
+  const workflowRun = event.workflow_run;
+  const repository = String(environment.GITHUB_REPOSITORY ?? "").trim();
+  if (
+    !workflowRun ||
+    String(workflowRun.id) !== workflowRunId ||
+    workflowRun.name !== "Launchplane Recovery Apply Request" ||
+    workflowRun.path !== ".github/workflows/launchplane-recovery-apply-request.yml" ||
+    workflowRun.conclusion !== "success" ||
+    workflowRun.event !== "workflow_dispatch" ||
+    workflowRun.head_branch !== "main" ||
+    !/^[0-9a-f]{40}$/.test(String(workflowRun.head_sha ?? "")) ||
+    workflowRun.head_repository?.full_name !== repository
+  ) {
+    throw new Error("Recovery apply source workflow provenance is invalid.");
+  }
+}
+
+async function loadRequest() {
+  const explicitRequest = input("request-json");
+  if (explicitRequest) {
+    const request = parseRequest(explicitRequest);
+    if (optionalRequestDigest(request)) {
+      throw new Error("Digest-bound recovery apply requires workflow-run artifact provenance.");
+    }
+    return request;
+  }
+
+  const workflowRunId = requiredInput("workflow-run-id");
+  if (!/^[1-9][0-9]*$/.test(workflowRunId)) {
+    throw new Error("workflow-run-id must be a positive integer.");
+  }
+  validateWorkflowRunEvent(workflowRunId);
+
+  const requestFile = await downloadArtifact(requiredInput("github-token"), workflowRunId);
+  const requestDirectory = dirname(requestFile);
+  const entries = readdirSync(requestDirectory, { withFileTypes: true });
+  if (
+    entries.length !== 1 ||
+    entries[0].name !== basename(requestFile) ||
+    !entries[0].isFile()
+  ) {
+    throw new Error("Recovery apply artifact must contain exactly one regular file.");
+  }
+  const requestFileStat = lstatSync(requestFile);
+  if (!requestFileStat.isFile() || requestFileStat.isSymbolicLink()) {
+    throw new Error("Recovery apply artifact request file is invalid.");
+  }
+  if (requestFileStat.size === 0 || requestFileStat.size > 8192) {
+    throw new Error("Recovery apply artifact exceeds the size limit.");
+  }
+
+  const request = parseRequest(readFileSync(requestFile, "utf8"));
+  const requestKeyList = Object.keys(request).sort();
+  const expectedKeyList = [...artifactRequestKeys].sort();
+  if (JSON.stringify(requestKeyList) !== JSON.stringify(expectedKeyList)) {
+    throw new Error("Recovery apply artifact has an invalid schema.");
+  }
+
+  const product = requestString(request, "product");
+  const instance = requestString(request, "instance");
+  if (product !== requiredInput("expected-product") || instance !== requiredInput("expected-instance")) {
+    throw new Error("Recovery apply target does not match the expected product and instance.");
+  }
+  if (!/^[^\s]+@sha256:[0-9a-f]{64}$/.test(requestString(request, "artifact_id"))) {
+    throw new Error("Recovery apply artifact identity must be immutable.");
+  }
+  if (!/^[0-9a-f]{40}$/.test(requestString(request, "source_git_ref"))) {
+    throw new Error("Recovery apply source commit is invalid.");
+  }
+  requestPositiveInteger(request, "original_run_id");
+  requestPositiveInteger(request, "original_run_attempt");
+  if (!optionalRequestDigest(request)) {
+    throw new Error("Recovery apply artifact must include a reviewed recovery digest.");
+  }
+  if (requestString(request, "reason").length > 1000) {
+    throw new Error("Recovery apply reason is too long.");
+  }
+  return request;
+}
+
+function readGitHubOutputs() {
+  const outputPath = String(environment.GITHUB_OUTPUT ?? "").trim();
+  if (!outputPath) {
+    throw new Error("GITHUB_OUTPUT is required to verify recovery apply evidence.");
+  }
+  const lines = readFileSync(outputPath, "utf8").split(/\r?\n/);
+  const outputs = new Map();
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+    const heredocIndex = line.indexOf("<<");
+    if (heredocIndex > 0) {
+      const name = line.slice(0, heredocIndex);
+      const delimiter = line.slice(heredocIndex + 2);
+      const values = [];
+      index += 1;
+      while (index < lines.length && lines[index] !== delimiter) {
+        values.push(lines[index]);
+        index += 1;
+      }
+      outputs.set(name, values.join("\n"));
+      continue;
+    }
+    const equalsIndex = line.indexOf("=");
+    if (equalsIndex > 0) {
+      outputs.set(line.slice(0, equalsIndex), line.slice(equalsIndex + 1));
+    }
+  }
+  return outputs;
+}
+
+function verifyApplyOutputs(outputs, expectedRecoveryDigest) {
+  const reservationAttempt = outputs.get("reservation_attempt") ?? "";
+  const traceId = outputs.get("trace_id") ?? "";
+  if (
+    outputs.get("status") !== "accepted" ||
+    outputs.get("mode") !== "apply" ||
+    outputs.get("reservation_state") !== "completed" ||
+    outputs.get("recovery_action") !== "adopt_observed" ||
+    outputs.get("recovery_digest") !== expectedRecoveryDigest ||
+    outputs.get("provider_outcome") !== "present" ||
+    outputs.get("provider_status") !== "done" ||
+    outputs.get("retry_safe") !== "false" ||
+    !/^[1-9][0-9]*$/.test(reservationAttempt) ||
+    !traceId.trim()
+  ) {
+    throw new Error("Launchplane recovery apply did not return adoption-only evidence.");
+  }
+}
+
+async function waitForApplyOutputs(expectedRecoveryDigest) {
+  const outputPath = String(environment.GITHUB_OUTPUT ?? "").trim();
+  const timeoutMilliseconds = Number.parseInt(input("timeout-ms", "120000"), 10);
+  const deadline = Date.now() + (Number.isFinite(timeoutMilliseconds) ? timeoutMilliseconds : 120000);
+  const requiredOutputs = [
+    "status",
+    "mode",
+    "trace_id",
+    "reservation_state",
+    "reservation_attempt",
+    "recovery_action",
+    "recovery_digest",
+    "provider_outcome",
+    "provider_status",
+    "retry_safe",
+  ];
+  while (Date.now() <= deadline) {
+    if (runtime.exitCode) {
+      throw new Error("Launchplane recovery apply request failed before evidence was available.");
+    }
+    if (outputPath && existsSync(outputPath)) {
+      const outputs = readGitHubOutputs();
+      if (requiredOutputs.every(name => outputs.has(name))) {
+        verifyApplyOutputs(outputs, expectedRecoveryDigest);
+        if (runtime.exitCode) {
+          throw new Error("Launchplane recovery apply request failed after producing evidence.");
+        }
+        return;
+      }
+    }
+    await sleep(50);
+  }
+  throw new Error("Timed out waiting for Launchplane recovery apply evidence.");
+}
+
+function configureRequestAction(request) {
   const launchplaneUrl = input("launchplane-url") || requestString(request, "launchplane_url");
   const product = requestString(request, "product");
   const instance = requestString(request, "instance");
@@ -156,11 +345,15 @@ function configureRequestAction() {
       "observed_at=observed_at",
     ].join(",");
   }
+  return expectedRecoveryDigest;
 }
 
 try {
-  configureRequestAction();
+  const expectedRecoveryDigest = configureRequestAction(await loadRequest());
   await import(new URL("../../launchplane-request/dist/index.js", import.meta.url));
+  if (expectedRecoveryDigest) {
+    await waitForApplyOutputs(expectedRecoveryDigest);
+  }
 } catch (error) {
   console.error(error instanceof Error ? error.message : String(error));
   runtime.exitCode = 1;

--- a/tests/test_generic_web_deploy_recovery_action.py
+++ b/tests/test_generic_web_deploy_recovery_action.py
@@ -1,4 +1,5 @@
 import base64
+from collections.abc import Callable
 from io import BytesIO
 import json
 import os
@@ -19,6 +20,39 @@ REUSABLE_WORKFLOW = Path(".github/workflows/reusable-generic-web-stable-deploy.y
 
 
 class GenericWebDeployRecoveryActionTests(unittest.TestCase):
+    @staticmethod
+    def apply_request_and_workflow_run() -> tuple[dict[str, object], dict[str, object]]:
+        return (
+            {
+                "schema_version": 1,
+                "product": "repairshopr-sync",
+                "instance": "prod",
+                "artifact_id": "ghcr.io/cbusillo/repairshopr_api@sha256:" + "b" * 64,
+                "source_git_ref": "2d66fb6b2708f975b1645ac912a5b576a9282853",
+                "original_run_id": "29609495343",
+                "original_run_attempt": "1",
+                "expected_recovery_digest": "a" * 64,
+                "reason": "Adopt the reviewed legacy deploy effect.",
+            },
+            {
+                "id": 32213365281,
+                "name": "Launchplane Recovery Apply Request",
+                "path": ".github/workflows/launchplane-recovery-apply-request.yml",
+                "conclusion": "success",
+                "event": "workflow_dispatch",
+                "head_branch": "main",
+                "head_sha": "7bbfa12578cea62cedb23f1770f9f5b7d9e288b2",
+                "head_repository": {"full_name": "cbusillo/repairshopr_api"},
+            },
+        )
+
+    def test_action_extracts_artifacts_without_external_zip_tools(self) -> None:
+        source = DOWNLOAD_ENTRYPOINT.read_text(encoding="utf-8")
+
+        self.assertNotIn("node:child_process", source)
+        self.assertNotIn("execFileSync", source)
+        self.assertNotIn('"unzip"', source)
+
     def run_action(
         self,
         *,
@@ -28,6 +62,9 @@ class GenericWebDeployRecoveryActionTests(unittest.TestCase):
         request_file: Path | None = None,
         workflow_run: dict[str, object] | None = None,
         response_overrides: dict[str, object] | None = None,
+        archive_compression: int = zipfile.ZIP_STORED,
+        archive_transform: Callable[[bytes], bytes] | None = None,
+        artifact_total_count: int = 1,
     ) -> subprocess.CompletedProcess[str]:
         if shutil.which("node") is None:
             self.skipTest("node is required to test the recovery dry-run action")
@@ -48,12 +85,15 @@ class GenericWebDeployRecoveryActionTests(unittest.TestCase):
         if request_file is not None:
             effective_request = json.loads(request_file.read_text(encoding="utf-8"))
             archive = BytesIO()
-            with zipfile.ZipFile(archive, "w") as zip_file:
+            with zipfile.ZipFile(archive, "w", compression=archive_compression) as zip_file:
                 zip_file.writestr(
                     "launchplane-recovery-apply-request.json",
                     json.dumps(effective_request),
                 )
-            artifact_archive_data = base64.b64encode(archive.getvalue()).decode("ascii")
+            archive_bytes = archive.getvalue()
+            if archive_transform is not None:
+                archive_bytes = archive_transform(archive_bytes)
+            artifact_archive_data = base64.b64encode(archive_bytes).decode("ascii")
             event_path = output_path.parent / "event.json"
             event_path.write_text(
                 json.dumps({"workflow_run": workflow_run}),
@@ -113,6 +153,7 @@ global.fetch = async (url, init) => {{
   calls.push({{url, init}});
   if (url.includes('/actions/runs/32213365281/artifacts?')) {{
     return new Response(JSON.stringify({{
+      total_count: {artifact_total_count},
       artifacts: [{{
         id: 42,
         name: 'launchplane-recovery-apply-request-32213365281',
@@ -299,6 +340,138 @@ await import('./{ACTION_ENTRYPOINT.as_posix()}');
             "https://launchplane.example/v1/admin/generic-web/deploy-recovery/apply",
         )
 
+    def test_action_accepts_deflated_workflow_run_artifact(self) -> None:
+        request, workflow_run = self.apply_request_and_workflow_run()
+        with TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            request_file = root / "request.json"
+            request_file.write_text(json.dumps(request), encoding="utf-8")
+            result = self.run_action(
+                request=None,
+                request_file=request_file,
+                workflow_run=workflow_run,
+                output_path=root / "github-output.txt",
+                archive_compression=zipfile.ZIP_DEFLATED,
+            )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_action_accepts_signed_zip_data_descriptor(self) -> None:
+        request, workflow_run = self.apply_request_and_workflow_run()
+
+        def add_data_descriptor(archive: bytes) -> bytes:
+            end_offset = archive.rfind(b"PK\x05\x06")
+            central_offset = int.from_bytes(archive[end_offset + 16 : end_offset + 20], "little")
+            checksum_and_sizes = archive[central_offset + 16 : central_offset + 28]
+            descriptor = b"PK\x07\x08" + checksum_and_sizes
+            mutated = bytearray(
+                archive[:central_offset] + descriptor + archive[central_offset:]
+            )
+            mutated[6:8] = (int.from_bytes(mutated[6:8], "little") | 8).to_bytes(2, "little")
+            mutated[14:26] = b"\0" * 12
+            moved_central_offset = central_offset + len(descriptor)
+            mutated[moved_central_offset + 8 : moved_central_offset + 10] = (
+                int.from_bytes(
+                    mutated[moved_central_offset + 8 : moved_central_offset + 10],
+                    "little",
+                )
+                | 8
+            ).to_bytes(2, "little")
+            moved_end_offset = end_offset + len(descriptor)
+            mutated[moved_end_offset + 16 : moved_end_offset + 20] = moved_central_offset.to_bytes(
+                4,
+                "little",
+            )
+            return bytes(mutated)
+
+        with TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            request_file = root / "request.json"
+            request_file.write_text(json.dumps(request), encoding="utf-8")
+            result = self.run_action(
+                request=None,
+                request_file=request_file,
+                workflow_run=workflow_run,
+                output_path=root / "github-output.txt",
+                archive_transform=add_data_descriptor,
+            )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_action_rejects_hidden_zip_data_before_central_directory(self) -> None:
+        request, workflow_run = self.apply_request_and_workflow_run()
+
+        def add_hidden_data(archive: bytes) -> bytes:
+            end_offset = archive.rfind(b"PK\x05\x06")
+            central_offset = int.from_bytes(archive[end_offset + 16 : end_offset + 20], "little")
+            hidden_data = b"hidden"
+            mutated = bytearray(
+                archive[:central_offset] + hidden_data + archive[central_offset:]
+            )
+            moved_end_offset = end_offset + len(hidden_data)
+            mutated[moved_end_offset + 16 : moved_end_offset + 20] = (
+                central_offset + len(hidden_data)
+            ).to_bytes(4, "little")
+            return bytes(mutated)
+
+        with TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            request_file = root / "request.json"
+            request_file.write_text(json.dumps(request), encoding="utf-8")
+            result = self.run_action(
+                request=None,
+                request_file=request_file,
+                workflow_run=workflow_run,
+                output_path=root / "github-output.txt",
+                archive_transform=add_hidden_data,
+            )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("contains unreferenced ZIP data", result.stderr)
+
+    def test_action_rejects_artifact_with_invalid_crc(self) -> None:
+        request, workflow_run = self.apply_request_and_workflow_run()
+
+        def corrupt_request(archive: bytes) -> bytes:
+            mutated = bytearray(archive)
+            file_name_length = int.from_bytes(mutated[26:28], "little")
+            extra_length = int.from_bytes(mutated[28:30], "little")
+            data_offset = 30 + file_name_length + extra_length
+            mutated[data_offset] ^= 1
+            return bytes(mutated)
+
+        with TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            request_file = root / "request.json"
+            request_file.write_text(json.dumps(request), encoding="utf-8")
+            result = self.run_action(
+                request=None,
+                request_file=request_file,
+                workflow_run=workflow_run,
+                output_path=root / "github-output.txt",
+                archive_transform=corrupt_request,
+            )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("request data is invalid", result.stderr)
+
+    def test_action_rejects_truncated_artifact_listing(self) -> None:
+        request, workflow_run = self.apply_request_and_workflow_run()
+        with TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            request_file = root / "request.json"
+            request_file.write_text(json.dumps(request), encoding="utf-8")
+            result = self.run_action(
+                request=None,
+                request_file=request_file,
+                workflow_run=workflow_run,
+                output_path=root / "github-output.txt",
+                artifact_total_count=101,
+            )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("exactly one matching artifact", result.stderr)
+
     def test_action_downloads_exact_source_run_artifact(self) -> None:
         request = {
             "schema_version": 1,
@@ -326,6 +499,7 @@ global.fetch = async (url, init) => {{
   calls.push({{url, headers: init.headers}});
   if (url.includes('/artifacts?')) {{
     return new Response(JSON.stringify({{
+      total_count: 1,
       artifacts: [{{
         id: 42,
         name: 'launchplane-recovery-apply-request-32213365281',
@@ -363,6 +537,10 @@ console.log(JSON.stringify({{
         self.assertEqual(
             evidence["calls"][0]["headers"]["Authorization"],
             "Bearer github-token",
+        )
+        self.assertIn(
+            "?name=launchplane-recovery-apply-request-32213365281&per_page=100",
+            evidence["calls"][0]["url"],
         )
 
     def test_action_rejects_invalid_workflow_run_provenance_before_oidc(self) -> None:

--- a/tests/test_generic_web_deploy_recovery_action.py
+++ b/tests/test_generic_web_deploy_recovery_action.py
@@ -1,3 +1,5 @@
+import base64
+from io import BytesIO
 import json
 import os
 import shutil
@@ -5,9 +7,13 @@ import subprocess
 from pathlib import Path
 from tempfile import TemporaryDirectory
 import unittest
+import zipfile
 
 
 ACTION_ENTRYPOINT = Path(".github/actions/generic-web-deploy-recovery-dry-run/dist/index.mjs")
+DOWNLOAD_ENTRYPOINT = Path(
+    ".github/actions/generic-web-deploy-recovery-dry-run/dist/download-artifact.mjs"
+)
 ACTION_METADATA = Path(".github/actions/generic-web-deploy-recovery-dry-run/action.yml")
 REUSABLE_WORKFLOW = Path(".github/workflows/reusable-generic-web-stable-deploy.yml")
 
@@ -16,9 +22,12 @@ class GenericWebDeployRecoveryActionTests(unittest.TestCase):
     def run_action(
         self,
         *,
-        request: dict[str, object],
+        request: dict[str, object] | None,
         output_path: Path,
         launchplane_url: str = "https://launchplane.example",
+        request_file: Path | None = None,
+        workflow_run: dict[str, object] | None = None,
+        response_overrides: dict[str, object] | None = None,
     ) -> subprocess.CompletedProcess[str]:
         if shutil.which("node") is None:
             self.skipTest("node is required to test the recovery dry-run action")
@@ -29,12 +38,44 @@ class GenericWebDeployRecoveryActionTests(unittest.TestCase):
                 "ACTIONS_ID_TOKEN_REQUEST_TOKEN": "request-token",
                 "ACTIONS_ID_TOKEN_REQUEST_URL": "https://oidc.example/token",
                 "GITHUB_OUTPUT": str(output_path),
-                "INPUT_REQUEST-JSON": json.dumps(request),
+                "INPUT_REQUEST-JSON": json.dumps(request) if request is not None else "",
             }
         )
         if launchplane_url:
             env["INPUT_LAUNCHPLANE-URL"] = launchplane_url
-        if "expected_recovery_digest" in request:
+        effective_request = request
+        artifact_archive_data = ""
+        if request_file is not None:
+            effective_request = json.loads(request_file.read_text(encoding="utf-8"))
+            archive = BytesIO()
+            with zipfile.ZipFile(archive, "w") as zip_file:
+                zip_file.writestr(
+                    "launchplane-recovery-apply-request.json",
+                    json.dumps(effective_request),
+                )
+            artifact_archive_data = base64.b64encode(archive.getvalue()).decode("ascii")
+            event_path = output_path.parent / "event.json"
+            event_path.write_text(
+                json.dumps({"workflow_run": workflow_run}),
+                encoding="utf-8",
+            )
+            env.update(
+                {
+                    "GITHUB_EVENT_NAME": "workflow_run",
+                    "GITHUB_EVENT_PATH": str(event_path),
+                    "GITHUB_API_URL": "https://api.github.example",
+                    "GITHUB_REPOSITORY": "cbusillo/repairshopr_api",
+                    "GITHUB_RUN_ATTEMPT": "1",
+                    "GITHUB_RUN_ID": "400",
+                    "INPUT_GITHUB-TOKEN": "github-token",
+                    "INPUT_EXPECTED-INSTANCE": "prod",
+                    "INPUT_EXPECTED-PRODUCT": "repairshopr-sync",
+                    "INPUT_WORKFLOW-RUN-ID": "32213365281",
+                    "RUNNER_TEMP": str(output_path.parent),
+                }
+            )
+        assert effective_request is not None
+        if "expected_recovery_digest" in effective_request:
             response_status = 202
             response_payload = {
                 "schema_version": 1,
@@ -63,10 +104,27 @@ class GenericWebDeployRecoveryActionTests(unittest.TestCase):
                 "retry_safe": True,
                 "observed_at": "2026-08-16T22:00:00Z",
             }
+        if response_overrides:
+            response_payload.update(response_overrides)
         script = f"""
 const calls = [];
+const artifactArchive = Buffer.from('{artifact_archive_data}', 'base64');
 global.fetch = async (url, init) => {{
   calls.push({{url, init}});
+  if (url.includes('/actions/runs/32213365281/artifacts?')) {{
+    return new Response(JSON.stringify({{
+      artifacts: [{{
+        id: 42,
+        name: 'launchplane-recovery-apply-request-32213365281',
+        expired: false,
+        size_in_bytes: artifactArchive.length,
+        archive_download_url: 'https://artifacts.example/request.zip'
+      }}]
+    }}), {{status: 200}});
+  }}
+  if (url === 'https://artifacts.example/request.zip') {{
+    return new Response(artifactArchive, {{status: 200}});
+  }}
   if (url.startsWith('https://oidc.example/token')) {{
     return new Response(JSON.stringify({{value: 'oidc-token'}}), {{status: 200}});
   }}
@@ -80,10 +138,10 @@ process.on('beforeExit', () => {{
     body: call.init.body || ''
   }}))));
 }});
-import('./{ACTION_ENTRYPOINT.as_posix()}');
+await import('./{ACTION_ENTRYPOINT.as_posix()}');
 """
         return subprocess.run(
-            ["node", "-e", script],
+            ["node", "--input-type=module", "-e", script],
             capture_output=True,
             env=env,
             text=True,
@@ -93,6 +151,11 @@ import('./{ACTION_ENTRYPOINT.as_posix()}');
         metadata = ACTION_METADATA.read_text(encoding="utf-8")
 
         self.assertIn("using: node24", metadata)
+        self.assertIn("  expected-product:\n", metadata)
+        self.assertIn("  expected-instance:\n", metadata)
+        self.assertIn("default: ${{ github.event.workflow_run.id }}", metadata)
+        self.assertIn("default: ${{ github.token }}", metadata)
+        self.assertIn("main: dist/index.mjs", metadata)
         for output_name in (
             "status",
             "mode",
@@ -102,8 +165,6 @@ import('./{ACTION_ENTRYPOINT.as_posix()}');
             "reservation_state",
             "reservation_attempt",
             "recovery_action",
-            "provider_outcome",
-            "provider_status",
             "retry_safe",
             "observed_at",
         ):
@@ -172,7 +233,7 @@ import('./{ACTION_ENTRYPOINT.as_posix()}');
                     self.assertIn(f"{output_name}<<", outputs)
                     self.assertIn(f"\n{output_value}\n", outputs)
 
-    def test_action_reconstructs_digest_bound_apply_and_projects_result(self) -> None:
+    def test_action_rejects_explicit_digest_bound_apply_before_oidc(self) -> None:
         request = {
             "schema_version": 1,
             "product": "repairshopr-sync",
@@ -185,59 +246,242 @@ import('./{ACTION_ENTRYPOINT.as_posix()}');
             "reason": "Adopt the reviewed legacy deploy effect.",
         }
         with TemporaryDirectory() as temporary_directory:
-            output_path = Path(temporary_directory) / "github-output.txt"
-            result = self.run_action(request=request, output_path=output_path)
+            result = self.run_action(
+                request=request,
+                output_path=Path(temporary_directory) / "github-output.txt",
+            )
 
-            self.assertEqual(result.returncode, 0, result.stderr)
-            calls = json.loads(result.stderr.splitlines()[-1])
-            self.assertEqual(len(calls), 2)
-            launchplane_call = calls[1]
-            self.assertEqual(
-                launchplane_call["url"],
-                "https://launchplane.example/v1/admin/generic-web/deploy-recovery/apply",
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("requires workflow-run artifact provenance", result.stderr)
+        calls = json.loads(result.stderr.splitlines()[-1])
+        self.assertEqual(calls, [])
+
+    def test_action_validates_workflow_run_artifact_before_apply(self) -> None:
+        request = {
+            "schema_version": 1,
+            "product": "repairshopr-sync",
+            "instance": "prod",
+            "artifact_id": "ghcr.io/cbusillo/repairshopr_api@sha256:" + "b" * 64,
+            "source_git_ref": "2d66fb6b2708f975b1645ac912a5b576a9282853",
+            "original_run_id": "29609495343",
+            "original_run_attempt": "1",
+            "expected_recovery_digest": "a" * 64,
+            "reason": "Adopt the reviewed legacy deploy effect.",
+        }
+        workflow_run = {
+            "id": 32213365281,
+            "name": "Launchplane Recovery Apply Request",
+            "path": ".github/workflows/launchplane-recovery-apply-request.yml",
+            "conclusion": "success",
+            "event": "workflow_dispatch",
+            "head_branch": "main",
+            "head_sha": "7bbfa12578cea62cedb23f1770f9f5b7d9e288b2",
+            "head_repository": {"full_name": "cbusillo/repairshopr_api"},
+        }
+        with TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            request_directory = root / "request"
+            request_directory.mkdir()
+            request_file = request_directory / "launchplane-recovery-apply-request.json"
+            request_file.write_text(json.dumps(request), encoding="utf-8")
+            result = self.run_action(
+                request=None,
+                request_file=request_file,
+                workflow_run=workflow_run,
+                output_path=root / "github-output.txt",
             )
-            self.assertEqual(launchplane_call["method"], "POST")
-            self.assertEqual(
-                launchplane_call["headers"]["Idempotency-Key"],
-                "generic-web-stable-deploy:repairshopr-sync:prod:29609495343:1",
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        calls = json.loads(result.stderr.splitlines()[-1])
+        self.assertEqual(len(calls), 4)
+        self.assertEqual(
+            calls[-1]["url"],
+            "https://launchplane.example/v1/admin/generic-web/deploy-recovery/apply",
+        )
+
+    def test_action_downloads_exact_source_run_artifact(self) -> None:
+        request = {
+            "schema_version": 1,
+            "product": "repairshopr-sync",
+            "instance": "prod",
+            "artifact_id": "ghcr.io/cbusillo/repairshopr_api@sha256:" + "b" * 64,
+            "source_git_ref": "2d66fb6b2708f975b1645ac912a5b576a9282853",
+            "original_run_id": "29609495343",
+            "original_run_attempt": "1",
+            "expected_recovery_digest": "a" * 64,
+            "reason": "Adopt the reviewed legacy deploy effect.",
+        }
+        archive = BytesIO()
+        with zipfile.ZipFile(archive, "w") as zip_file:
+            zip_file.writestr(
+                "launchplane-recovery-apply-request.json",
+                json.dumps(request),
             )
-            self.assertEqual(
-                json.loads(launchplane_call["body"]),
-                {
-                    "schema_version": 1,
-                    "product": "repairshopr-sync",
-                    "instance": "prod",
-                    "original_deploy": {
-                        "schema_version": 1,
-                        "product": "repairshopr-sync",
-                        "deploy": {
-                            "schema_version": 1,
-                            "product": "repairshopr-sync",
-                            "instance": "prod",
-                            "artifact_id": request["artifact_id"],
-                            "source_git_ref": request["source_git_ref"],
-                        },
-                    },
-                    "reason": request["reason"],
-                    "expected_recovery_digest": request["expected_recovery_digest"],
-                },
+        archive_data = base64.b64encode(archive.getvalue()).decode("ascii")
+        with TemporaryDirectory() as temporary_directory:
+            script = f"""
+const calls = [];
+const archive = Buffer.from('{archive_data}', 'base64');
+global.fetch = async (url, init) => {{
+  calls.push({{url, headers: init.headers}});
+  if (url.includes('/artifacts?')) {{
+    return new Response(JSON.stringify({{
+      artifacts: [{{
+        id: 42,
+        name: 'launchplane-recovery-apply-request-32213365281',
+        expired: false,
+        size_in_bytes: archive.length,
+        archive_download_url: 'https://artifacts.example/request.zip'
+      }}]
+    }}), {{status: 200}});
+  }}
+  return new Response(archive, {{status: 200}});
+}};
+process.env.GITHUB_API_URL = 'https://api.github.example';
+process.env.GITHUB_REPOSITORY = 'cbusillo/repairshopr_api';
+process.env.GITHUB_RUN_ATTEMPT = '1';
+process.env.GITHUB_RUN_ID = '400';
+process.env.RUNNER_TEMP = '{temporary_directory}';
+const module = await import('./{DOWNLOAD_ENTRYPOINT.as_posix()}');
+const requestPath = await module.downloadArtifact('github-token', '32213365281');
+console.log(JSON.stringify({{
+  calls,
+  requestPath,
+  request: JSON.parse(await (await import('node:fs/promises')).readFile(requestPath, 'utf8'))
+}}));
+"""
+            result = subprocess.run(
+                ["node", "--input-type=module", "-e", script],
+                capture_output=True,
+                text=True,
             )
-            outputs = output_path.read_text(encoding="utf-8")
-            for output_name, output_value in (
-                ("status", "accepted"),
-                ("mode", "apply"),
-                ("trace_id", "recovery-apply-trace"),
-                ("reservation_state", "completed"),
-                ("reservation_attempt", "1"),
-                ("recovery_action", "adopt_observed"),
-                ("recovery_digest", "a" * 64),
-                ("provider_outcome", "present"),
-                ("provider_status", "done"),
-                ("retry_safe", "false"),
-            ):
-                with self.subTest(output_name=output_name):
-                    self.assertIn(f"{output_name}<<", outputs)
-                    self.assertIn(f"\n{output_value}\n", outputs)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        evidence = json.loads(result.stdout)
+        self.assertEqual(evidence["request"], request)
+        self.assertEqual(len(evidence["calls"]), 2)
+        self.assertEqual(
+            evidence["calls"][0]["headers"]["Authorization"],
+            "Bearer github-token",
+        )
+
+    def test_action_rejects_invalid_workflow_run_provenance_before_oidc(self) -> None:
+        request = {
+            "schema_version": 1,
+            "product": "repairshopr-sync",
+            "instance": "prod",
+            "artifact_id": "ghcr.io/cbusillo/repairshopr_api@sha256:" + "b" * 64,
+            "source_git_ref": "2d66fb6b2708f975b1645ac912a5b576a9282853",
+            "original_run_id": "29609495343",
+            "original_run_attempt": "1",
+            "expected_recovery_digest": "a" * 64,
+            "reason": "Adopt the reviewed legacy deploy effect.",
+        }
+        workflow_run = {
+            "id": 32213365281,
+            "name": "Launchplane Recovery Apply Request",
+            "path": ".github/workflows/untrusted.yml",
+            "conclusion": "success",
+            "event": "workflow_dispatch",
+            "head_branch": "main",
+            "head_sha": "7bbfa12578cea62cedb23f1770f9f5b7d9e288b2",
+            "head_repository": {"full_name": "cbusillo/repairshopr_api"},
+        }
+        with TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            request_directory = root / "request"
+            request_directory.mkdir()
+            request_file = request_directory / "launchplane-recovery-apply-request.json"
+            request_file.write_text(json.dumps(request), encoding="utf-8")
+            result = self.run_action(
+                request=None,
+                request_file=request_file,
+                workflow_run=workflow_run,
+                output_path=root / "github-output.txt",
+            )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("source workflow provenance is invalid", result.stderr)
+        calls = json.loads(result.stderr.splitlines()[-1])
+        self.assertEqual(calls, [])
+
+    def test_action_rejects_apply_response_with_mismatched_digest(self) -> None:
+        request = {
+            "schema_version": 1,
+            "product": "repairshopr-sync",
+            "instance": "prod",
+            "artifact_id": "ghcr.io/cbusillo/repairshopr_api@sha256:" + "b" * 64,
+            "source_git_ref": "2d66fb6b2708f975b1645ac912a5b576a9282853",
+            "original_run_id": "29609495343",
+            "original_run_attempt": "1",
+            "expected_recovery_digest": "a" * 64,
+            "reason": "Adopt the reviewed legacy deploy effect.",
+        }
+        workflow_run = {
+            "id": 32213365281,
+            "name": "Launchplane Recovery Apply Request",
+            "path": ".github/workflows/launchplane-recovery-apply-request.yml",
+            "conclusion": "success",
+            "event": "workflow_dispatch",
+            "head_branch": "main",
+            "head_sha": "7bbfa12578cea62cedb23f1770f9f5b7d9e288b2",
+            "head_repository": {"full_name": "cbusillo/repairshopr_api"},
+        }
+        with TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            request_directory = root / "request"
+            request_directory.mkdir()
+            request_file = request_directory / "launchplane-recovery-apply-request.json"
+            request_file.write_text(json.dumps(request), encoding="utf-8")
+            result = self.run_action(
+                request=None,
+                request_file=request_file,
+                workflow_run=workflow_run,
+                output_path=root / "github-output.txt",
+                response_overrides={"recovery_digest": "c" * 64},
+            )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("did not return adoption-only evidence", result.stderr)
+
+    def test_action_rejects_apply_response_that_allows_provider_retry(self) -> None:
+        request = {
+            "schema_version": 1,
+            "product": "repairshopr-sync",
+            "instance": "prod",
+            "artifact_id": "ghcr.io/cbusillo/repairshopr_api@sha256:" + "b" * 64,
+            "source_git_ref": "2d66fb6b2708f975b1645ac912a5b576a9282853",
+            "original_run_id": "29609495343",
+            "original_run_attempt": "1",
+            "expected_recovery_digest": "a" * 64,
+            "reason": "Adopt the reviewed legacy deploy effect.",
+        }
+        workflow_run = {
+            "id": 32213365281,
+            "name": "Launchplane Recovery Apply Request",
+            "path": ".github/workflows/launchplane-recovery-apply-request.yml",
+            "conclusion": "success",
+            "event": "workflow_dispatch",
+            "head_branch": "main",
+            "head_sha": "7bbfa12578cea62cedb23f1770f9f5b7d9e288b2",
+            "head_repository": {"full_name": "cbusillo/repairshopr_api"},
+        }
+        with TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            request_directory = root / "request"
+            request_directory.mkdir()
+            request_file = request_directory / "launchplane-recovery-apply-request.json"
+            request_file.write_text(json.dumps(request), encoding="utf-8")
+            result = self.run_action(
+                request=None,
+                request_file=request_file,
+                workflow_run=workflow_run,
+                output_path=root / "github-output.txt",
+                response_overrides={"retry_safe": True},
+            )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("did not return adoption-only evidence", result.stderr)
 
     def test_action_rejects_invalid_apply_digest_before_oidc(self) -> None:
         request = {


### PR DESCRIPTION
## Summary
- let the established generic-web recovery action download the exact source workflow artifact using its internal `github.token` default
- require exact workflow-run provenance, strict request schema, target binding, immutable artifact identity, source commit, and reviewed digest before OIDC
- allow digest-bound apply only through artifact-backed provenance; explicit JSON remains dry-run-only
- verify adoption-only outputs and reject any provider-retry-safe response

## Validation
- focused recovery action and GitHub Actions security tests
- full 3,024-target unittest gate at six-way concurrency
- full mypy across 737 files
- changed-files config-authority gate
- PyCharm changed-files inspection: zero findings
- independent multi-model risk review, with all blockers resolved

Refs #2167