### PR TITLE
Use effect timestamp during provider reconciliation

### DIFF
--- a/control_plane/generic_web_deploy_provider_adapter.py
+++ b/control_plane/generic_web_deploy_provider_adapter.py
@@ -132,10 +132,25 @@ class GenericWebDeployProviderMutationAdapter:
         provider_effect_phase: str,
         reconciliation_key: str,
     ) -> ProviderObservation:
+        return self.observe_with_effect_started_at(
+            provider_operation_key,
+            provider_effect_phase,
+            reconciliation_key,
+            "",
+        )
+
+    def observe_with_effect_started_at(
+        self,
+        provider_operation_key: str,
+        provider_effect_phase: str,
+        reconciliation_key: str,
+        provider_effect_started_at: str,
+    ) -> ProviderObservation:
         inspection = self.inspect(
             provider_operation_key=provider_operation_key,
             provider_effect_phase=provider_effect_phase,
             reconciliation_key=reconciliation_key,
+            legacy_provider_effect_started_at=provider_effect_started_at,
         )
         return self.provider_observation_from_inspection(
             provider_operation_key=provider_operation_key,

--- a/control_plane/generic_web_deploy_recovery_http.py
+++ b/control_plane/generic_web_deploy_recovery_http.py
@@ -208,6 +208,20 @@ class _GenericWebRecoveryApplyAdapter:
             reconciliation_key,
         )
 
+    def observe_with_effect_started_at(
+        self,
+        provider_operation_key: str,
+        provider_effect_phase: str,
+        reconciliation_key: str,
+        provider_effect_started_at: str,
+    ) -> ProviderObservation:
+        return self._delegate.observe_with_effect_started_at(
+            provider_operation_key,
+            provider_effect_phase,
+            reconciliation_key,
+            provider_effect_started_at,
+        )
+
     def apply(
         self, provider_operation_key: str, lease: ProviderOperationLease
     ) -> ProviderMutationOutcome:

--- a/control_plane/provider_operations.py
+++ b/control_plane/provider_operations.py
@@ -144,6 +144,18 @@ class DurableProviderMutationAdapter(Protocol):
         """Perform the provider mutation and return its terminal evidence."""
 
 
+@runtime_checkable
+class ProviderEffectTimestampObserver(Protocol):
+    def observe_with_effect_started_at(
+        self,
+        provider_operation_key: str,
+        provider_effect_phase: str,
+        reconciliation_key: str,
+        provider_effect_started_at: str,
+    ) -> ProviderObservation:
+        """Observe a provider effect using its authoritative checkpoint time."""
+
+
 class DurableProviderOperationStore(Protocol):
     def reserve_mutation(
         self,
@@ -255,14 +267,14 @@ def build_provider_operation_key(
     )
     if not all(identity.split("\x1f")):
         raise ValueError("Provider operation keys require complete durable identity.")
-    return f"provider-operation:{hashlib.sha256(identity.encode('utf-8')).hexdigest()}"
+    return f"provider-operation:{hashlib.sha256(identity.encode()).hexdigest()}"
 
 
 def provider_operation_title(provider_operation_key: str) -> str:
     normalized_key = provider_operation_key.strip()
     if not normalized_key:
         raise ValueError("Provider operation titles require an operation key.")
-    digest = hashlib.sha256(normalized_key.encode("utf-8")).hexdigest()[:24]
+    digest = hashlib.sha256(normalized_key.encode()).hexdigest()[:24]
     return f"Launchplane operation {digest}"
 
 
@@ -360,6 +372,23 @@ class _ReservationHeartbeat:
                 continue
 
 
+def _resolve_heartbeat_interval(
+    *,
+    lease_seconds: int,
+    heartbeat_interval_seconds: float | None,
+) -> float:
+    if lease_seconds < 1:
+        raise ValueError("Durable provider operation leases must be positive.")
+    resolved_interval = heartbeat_interval_seconds
+    if resolved_interval is None:
+        resolved_interval = max(0.1, min(30.0, lease_seconds / 3))
+    if resolved_interval <= 0:
+        raise ValueError("Durable provider operation heartbeat intervals must be positive.")
+    if resolved_interval >= lease_seconds:
+        raise ValueError("Durable provider operation heartbeats must run before lease expiry.")
+    return resolved_interval
+
+
 def run_durable_provider_operation(
     *,
     store: DurableProviderOperationStore,
@@ -374,15 +403,10 @@ def run_durable_provider_operation(
     heartbeat_interval_seconds: float | None = None,
     target_supersession: ProviderTargetSupersession | None = None,
 ) -> DurableProviderOperationResult:
-    if lease_seconds < 1:
-        raise ValueError("Durable provider operation leases must be positive.")
-    resolved_heartbeat_interval = heartbeat_interval_seconds
-    if resolved_heartbeat_interval is None:
-        resolved_heartbeat_interval = max(0.1, min(30.0, lease_seconds / 3))
-    if resolved_heartbeat_interval <= 0:
-        raise ValueError("Durable provider operation heartbeat intervals must be positive.")
-    if resolved_heartbeat_interval >= lease_seconds:
-        raise ValueError("Durable provider operation heartbeats must run before lease expiry.")
+    resolved_heartbeat_interval = _resolve_heartbeat_interval(
+        lease_seconds=lease_seconds,
+        heartbeat_interval_seconds=heartbeat_interval_seconds,
+    )
     if target_supersession is not None and target_supersession.minimum_expired_seconds < 0:
         raise ValueError("Provider target supersession delays cannot be negative.")
     provider_target_key = adapter.target_key().strip()
@@ -506,15 +530,10 @@ def resume_acquired_provider_operation(
     normalized_response_trace_id = response_trace_id.strip()
     if not normalized_response_trace_id:
         raise ValueError("Provider operation resume requires a response trace id.")
-    if lease_seconds < 1:
-        raise ValueError("Durable provider operation leases must be positive.")
-    resolved_heartbeat_interval = heartbeat_interval_seconds
-    if resolved_heartbeat_interval is None:
-        resolved_heartbeat_interval = max(0.1, min(30.0, lease_seconds / 3))
-    if resolved_heartbeat_interval <= 0:
-        raise ValueError("Durable provider operation heartbeat intervals must be positive.")
-    if resolved_heartbeat_interval >= lease_seconds:
-        raise ValueError("Durable provider operation heartbeats must run before lease expiry.")
+    resolved_heartbeat_interval = _resolve_heartbeat_interval(
+        lease_seconds=lease_seconds,
+        heartbeat_interval_seconds=heartbeat_interval_seconds,
+    )
     provider_operation_key = build_provider_operation_key(
         scope=reservation.scope,
         route_path=reservation.route_path,
@@ -645,6 +664,35 @@ def _apply_acquired(
     )
 
 
+def _adopt_reconciled_result(
+    *,
+    store: DurableProviderOperationStore,
+    reservation: LaunchplaneIdempotencyRecord,
+    response_status_code: int,
+    response_trace_id: str,
+    response_payload: dict[str, object],
+) -> tuple[DurableProviderOperationResult | None, LaunchplaneIdempotencyRecord | None]:
+    adoption = store.adopt_reconciled_mutation(
+        reservation=reservation,
+        response_status_code=response_status_code,
+        response_trace_id=response_trace_id,
+        response_payload=response_payload,
+    )
+    if adoption.status == "adopted":
+        return (
+            DurableProviderOperationResult(
+                "adopted",
+                adoption.record,
+                response_status_code,
+                response_payload,
+            ),
+            adoption.record,
+        )
+    if adoption.status == "replayed":
+        return _replayed_result(adoption.record), adoption.record
+    return None, adoption.record
+
+
 def _complete_or_adopt_outcome(
     *,
     store: DurableProviderOperationStore,
@@ -670,21 +718,15 @@ def _complete_or_adopt_outcome(
     if completion_result.status == "replayed":
         return _replayed_result(completion_result.record)
     if completion_result.status == "reconcile_required":
-        adoption = store.adopt_reconciled_mutation(
+        adoption_result, _ = _adopt_reconciled_result(
+            store=store,
             reservation=reservation,
             response_status_code=outcome.response_status_code,
             response_trace_id=response_trace_id,
             response_payload=outcome.response_payload,
         )
-        if adoption.status == "adopted":
-            return DurableProviderOperationResult(
-                "adopted",
-                adoption.record,
-                outcome.response_status_code,
-                outcome.response_payload,
-            )
-        if adoption.status == "replayed":
-            return _replayed_result(adoption.record)
+        if adoption_result is not None:
+            return adoption_result
     return DurableProviderOperationResult(
         "reconcile_required",
         completion_result.record,
@@ -723,11 +765,22 @@ def _reconcile(
     provider_effect_phase = (
         fallback_record.provider_effect_phase if fallback_record is not None else ""
     )
-    observation = adapter.observe(
-        provider_operation_key,
-        provider_effect_phase,
-        bound_reconciliation_key,
+    provider_effect_started_at = (
+        fallback_record.provider_effect_started_at if fallback_record is not None else ""
     )
+    if isinstance(adapter, ProviderEffectTimestampObserver):
+        observation = adapter.observe_with_effect_started_at(
+            provider_operation_key,
+            provider_effect_phase,
+            bound_reconciliation_key,
+            provider_effect_started_at,
+        )
+    else:
+        observation = adapter.observe(
+            provider_operation_key,
+            provider_effect_phase,
+            bound_reconciliation_key,
+        )
     provider_effect_started = bool(
         fallback_record is not None and fallback_record.provider_effect_started_at
     )
@@ -771,24 +824,18 @@ def _reconcile(
             409,
             {},
         )
-    adoption = store.adopt_reconciled_mutation(
+    adoption_result, adoption_record = _adopt_reconciled_result(
+        store=store,
         reservation=fallback_record,
         response_status_code=observation.response_status_code,
         response_trace_id=response_trace_id,
         response_payload=observation.response_payload,
     )
-    if adoption.status == "adopted":
-        return DurableProviderOperationResult(
-            "adopted",
-            adoption.record,
-            observation.response_status_code,
-            observation.response_payload,
-        )
-    if adoption.status == "replayed":
-        return _replayed_result(adoption.record)
+    if adoption_result is not None:
+        return adoption_result
     return DurableProviderOperationResult(
         "reconcile_required",
-        adoption.record or fallback_record,
+        adoption_record or fallback_record,
         409,
         {},
     )

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -332,6 +332,11 @@ former replaces the previous process-local apply lock. Both require an
   marker after a deployment-trigger checkpoint remains unknown. Genuinely
   unknown state stays `reconcile_required`; adapters are the only place
   provider-specific reconciliation lives.
+- Reconciliation supplies the stored provider-effect start timestamp to the
+  adapter. Generic-web deploys use it only as a bounded fallback when Dokploy
+  did not retain the deterministic operation title, requiring one newest,
+  successful deployment in the exact time window plus exact target and artifact
+  identity before adoption.
 - Migrated Dokploy adapters attach a deterministic, per-request operation title
   to the provider deployment. Both the initial deployment wait and restart
   reconciliation search for that exact marker; desired state or another recent
@@ -395,6 +400,10 @@ or provider state. The bounded response reports only reservation state and
 timestamps, hashed identifiers, provider outcome/status, retry safety, one of
 `replay_completed`, `wait_for_active_lease`, `adopt_observed`,
 `retry_original_operation`, or `hold_unknown`, and a canonical recovery digest.
+Recovery apply recomputes that evidence and rejects a stale digest. After a
+Launchplane deployment changes provider observation or reconciliation behavior,
+run a fresh dry-run and review the new bounded evidence instead of reusing a
+pre-deployment digest.
 Raw scopes, idempotency keys, reconciliation keys, provider-target keys,
 original payloads, target URLs, and provider payloads are never returned.
 Product repositories that need an OIDC-authenticated inspection should use the

--- a/tests/test_generic_web_deploy.py
+++ b/tests/test_generic_web_deploy.py
@@ -1552,6 +1552,28 @@ class GenericWebDeployTests(unittest.TestCase):
         self.assertEqual(len(provider.observed_target_ids), 1)
         self.assertEqual(provider.legacy_observation_calls, 1)
 
+    def test_provider_adapter_observe_uses_effect_start_for_legacy_correlation(self) -> None:
+        profile = _profile()
+        store = _GenericWebDeployStore(profile)
+        provider = _LegacyFakeGenericWebDeployProvider()
+        adapter = self._provider_mutation_adapter(
+            profile=profile,
+            store=store,
+            provider=provider,
+        )
+
+        observation = adapter.observe_with_effect_started_at(
+            "provider-operation:legacy-correlation",
+            "deploy_trigger",
+            adapter.reconciliation_key(),
+            "2026-08-15T12:00:00Z",
+        )
+
+        self.assertEqual(observation.outcome, "present")
+        self.assertEqual(observation.response_status_code, 202)
+        self.assertEqual(provider.legacy_observation_calls, 1)
+        self.assertEqual(len(store.deployments), 1)
+
     def test_present_provider_observation_requires_exact_terminal_evidence(self) -> None:
         with self.assertRaisesRegex(ValueError, "deployment_id, started_at, finished_at"):
             GenericWebProviderDeploymentObservation(

--- a/tests/test_provider_effect_timestamp_observer.py
+++ b/tests/test_provider_effect_timestamp_observer.py
@@ -1,0 +1,52 @@
+from tempfile import TemporaryDirectory
+import unittest
+
+from control_plane.provider_operations import (
+    ProviderMutationUnknownError,
+    ProviderObservation,
+)
+from tests.test_provider_operations import _FakeAdapter, _StoreFixture
+
+
+class _TimestampObserver(_FakeAdapter):
+    def __init__(self) -> None:
+        super().__init__(observation=ProviderObservation(outcome="unknown"))
+        self.provider_effect_started_at = ""
+
+    def observe_with_effect_started_at(
+        self,
+        provider_operation_key: str,
+        provider_effect_phase: str,
+        reconciliation_key: str,
+        provider_effect_started_at: str,
+    ) -> ProviderObservation:
+        self.provider_effect_started_at = provider_effect_started_at
+        return super().observe(
+            provider_operation_key,
+            provider_effect_phase,
+            reconciliation_key,
+        )
+
+
+class ProviderEffectTimestampObserverTests(unittest.TestCase):
+    def test_reconciliation_forwards_stored_effect_timestamp(self) -> None:
+        with TemporaryDirectory() as directory:
+            fixture = _StoreFixture(directory)
+            first_attempt = _FakeAdapter(
+                apply_error=ProviderMutationUnknownError("provider outcome unknown"),
+                checkpoint_before_rejection=True,
+            )
+
+            first_result = fixture.run(first_attempt)
+            expected_started_at = fixture.stored().provider_effect_started_at
+            observer = _TimestampObserver()
+            recovery_result = fixture.run(observer, lease_owner="instance-b")
+
+        self.assertEqual(first_result.status, "reconcile_required")
+        self.assertTrue(expected_started_at)
+        self.assertEqual(recovery_result.status, "reconcile_required")
+        self.assertEqual(observer.provider_effect_started_at, expected_started_at)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- forward the durable provider-effect checkpoint time only to adapters that opt into timestamp-aware observation
- let generic-web reconciliation use the existing bounded legacy Dokploy correlation when an operation title was not retained
- keep other provider adapters on the unchanged observation protocol and document stale-digest refresh behavior

## Validation
- `uv run --extra dev launchplane ci unittest-shard local --jobs 6` (3,026 targets)
- `uv run --extra dev mypy control_plane tests`
- changed-file Ruff checks
- config-authority audit: status `ok`
- PyCharm changed-files inspection: zero findings

Closes the current deployment blocker tracked under #2167.