### PR TITLE
Add read-only authorization policy health summaries

### DIFF
--- a/control_plane/authz_grant_service.py
+++ b/control_plane/authz_grant_service.py
@@ -20,6 +20,17 @@ from control_plane.contracts.authz_policy_record import (
     authz_policy_sha256,
     build_authz_policy_record_id,
 )
+from control_plane.contracts.authz_access_read import (
+    AuthzManagedSetCollectionSummary,
+    AuthzManagedSetSummary,
+    AuthzPolicyHealthReasonCode,
+    AuthzPolicyHealthSnapshot,
+    AuthzPolicyHealthState,
+    AuthzPolicyHealthSummary,
+    AuthzPolicyRecordSummary,
+    AuthzPrincipalRuleCounts,
+    AuthzReachableAdministratorSummary,
+)
 from control_plane.contracts.owner_acceptance import (
     OWNER_ACCEPTANCE_EVENT_WRITE_ACTION,
     OWNER_ACCEPTANCE_READ_ACTION,
@@ -99,6 +110,7 @@ _AUTHZ_PRINCIPAL_TYPES: tuple[AuthzPrincipalType, ...] = (
     "local_operators",
     "local_admins",
 )
+_AUTHZ_POLICY_HEALTH_MANAGED_SET_LIMIT = 100
 
 
 @dataclass(frozen=True)
@@ -109,6 +121,12 @@ class AuthzRuleLocation:
 
 @dataclass(frozen=True)
 class AuthzManagedRuleEntry:
+    principal_type: AuthzPrincipalType
+    rule: AuthzPolicyRule
+
+
+@dataclass(frozen=True)
+class AuthzPolicyRuleEntry:
     principal_type: AuthzPrincipalType
     rule: AuthzPolicyRule
 
@@ -577,6 +595,139 @@ def summarize_active_authz_policy_record(
         for rule in record.policy.github_actions
     )
     return summary
+
+
+def _authz_principal_rule_counts(
+    entries: list[AuthzPolicyRuleEntry],
+) -> AuthzPrincipalRuleCounts:
+    counts = {principal_type: 0 for principal_type in _AUTHZ_PRINCIPAL_TYPES}
+    for entry in entries:
+        counts[entry.principal_type] += 1
+    return AuthzPrincipalRuleCounts(**counts)
+
+
+def summarize_active_authz_policy_health_record(
+    *,
+    record: LaunchplaneAuthzPolicyRecord,
+    caller_identity: AuthzApplyingIdentity,
+) -> AuthzPolicyHealthSnapshot:
+    rules_by_principal = _authz_policy_rule_collections(record.policy)
+    rule_entries = [
+        AuthzPolicyRuleEntry(principal_type=principal_type, rule=rule)
+        for principal_type, rules in rules_by_principal
+        for rule in rules
+    ]
+    managed_entries = [entry for entry in rule_entries if entry.rule.managed_set_id is not None]
+    unmanaged_rule_count = len(rule_entries) - len(managed_entries)
+
+    managed_sets: dict[str, list[AuthzPolicyRuleEntry]] = {}
+    for entry in managed_entries:
+        managed_set_id = entry.rule.managed_set_id
+        if managed_set_id is None:
+            continue
+        managed_sets.setdefault(managed_set_id, []).append(entry)
+    sorted_managed_set_ids = sorted(managed_sets)
+    returned_managed_set_ids = sorted_managed_set_ids[:_AUTHZ_POLICY_HEALTH_MANAGED_SET_LIMIT]
+    managed_set_items = tuple(
+        AuthzManagedSetSummary(
+            managed_set_id=managed_set_id,
+            rule_count=len(managed_sets[managed_set_id]),
+            principal_rule_counts=_authz_principal_rule_counts(managed_sets[managed_set_id]),
+        )
+        for managed_set_id in returned_managed_set_ids
+    )
+
+    administrator_entries = [
+        entry for entry in rule_entries if _authz_rule_grants_policy_administration(entry.rule)
+    ]
+    caller_administrator_rule_count = sum(
+        _authz_rule_allows_identity(
+            rule=entry.rule,
+            identity=caller_identity,
+            schema_version=record.policy.schema_version,
+        )
+        for entry in administrator_entries
+    )
+    independent_administrator_rule_count = (
+        len(administrator_entries) - caller_administrator_rule_count
+    )
+    managed_administrator_rule_count = sum(
+        entry.rule.managed_set_id is not None for entry in administrator_entries
+    )
+
+    immutable_repository_rule_count = sum(
+        1 for rule in record.policy.github_actions if rule.repository_id
+    )
+    legacy_name_only_rule_count = (
+        len(record.policy.github_actions) - immutable_repository_rule_count
+    )
+    privileged_unpinned_rule_count = sum(
+        _github_rule_requires_immutable_workflow(rule)
+        and (
+            not rule.job_workflow_refs
+            or any(
+                _IMMUTABLE_JOB_WORKFLOW_REF_PATTERN.fullmatch(job_workflow_ref) is None
+                for job_workflow_ref in rule.job_workflow_refs
+            )
+        )
+        for rule in record.policy.github_actions
+    )
+
+    reason_codes: list[AuthzPolicyHealthReasonCode] = []
+    if not administrator_entries:
+        reason_codes.append("authz_policy_admin_unreachable")
+    elif not independent_administrator_rule_count:
+        reason_codes.append("authz_policy_independent_admin_unreachable")
+    if record.policy.schema_version == 1:
+        reason_codes.append("policy_schema_legacy")
+    if unmanaged_rule_count:
+        reason_codes.append("unmanaged_rules_present")
+    if legacy_name_only_rule_count:
+        reason_codes.append("github_actions_legacy_name_only_rules_present")
+    if privileged_unpinned_rule_count:
+        reason_codes.append("github_actions_privileged_unpinned_reusable_rules_present")
+
+    health_state: AuthzPolicyHealthState
+    if "authz_policy_admin_unreachable" in reason_codes:
+        health_state = "blocked"
+    elif reason_codes:
+        health_state = "attention_required"
+    else:
+        health_state = "healthy"
+
+    return AuthzPolicyHealthSnapshot(
+        policy=AuthzPolicyRecordSummary(
+            record_id=record.record_id,
+            revision=record.revision,
+            policy_sha256=record.policy_sha256,
+            updated_at=record.updated_at,
+            schema_version=record.policy.schema_version,
+        ),
+        health=AuthzPolicyHealthSummary(
+            state=health_state,
+            reason_codes=tuple(reason_codes),
+            managed_rule_count=len(managed_entries),
+            unmanaged_rule_count=unmanaged_rule_count,
+            github_actions_legacy_name_only_rule_count=legacy_name_only_rule_count,
+            github_actions_privileged_unpinned_reusable_rule_count=privileged_unpinned_rule_count,
+        ),
+        managed_sets=AuthzManagedSetCollectionSummary(
+            total_count=len(sorted_managed_set_ids),
+            returned_count=len(managed_set_items),
+            truncated=len(sorted_managed_set_ids) > len(managed_set_items),
+            items=managed_set_items,
+        ),
+        reachable_administrators=AuthzReachableAdministratorSummary(
+            policy_reachable=bool(administrator_entries),
+            rule_count=len(administrator_entries),
+            managed_rule_count=managed_administrator_rule_count,
+            unmanaged_rule_count=(len(administrator_entries) - managed_administrator_rule_count),
+            principal_rule_counts=_authz_principal_rule_counts(administrator_entries),
+            caller_has_policy_administration=bool(caller_administrator_rule_count),
+            independent_from_caller_reachable=bool(independent_administrator_rule_count),
+            independent_from_caller_rule_count=independent_administrator_rule_count,
+        ),
+    )
 
 
 def authz_policy_operator_payload(identity: AuthzApplyingIdentity) -> dict[str, object]:

--- a/control_plane/contracts/authz_access_read.py
+++ b/control_plane/contracts/authz_access_read.py
@@ -17,6 +17,7 @@ from control_plane.service_auth import (
 
 EFFECTIVE_ACCESS_READ_ACTION = "authz_policy_effective_access.read"
 AUTHZ_DENIAL_EXPLANATION_READ_ACTION = "authz_denial_explanation.read"
+AUTHZ_POLICY_HEALTH_READ_ACTION = "authz_policy_health.read"
 
 
 class GitHubActionsAccessPrincipal(BaseModel):
@@ -271,3 +272,89 @@ class AuthzDenialExplanationResponse(BaseModel):
     policy_record_id: str
     policy_revision: int = Field(ge=1)
     policy_sha256: str
+
+
+AuthzPolicyHealthState: TypeAlias = Literal["healthy", "attention_required", "blocked"]
+AuthzPolicyHealthReasonCode: TypeAlias = Literal[
+    "authz_policy_admin_unreachable",
+    "authz_policy_independent_admin_unreachable",
+    "policy_schema_legacy",
+    "unmanaged_rules_present",
+    "github_actions_legacy_name_only_rules_present",
+    "github_actions_privileged_unpinned_reusable_rules_present",
+]
+
+
+class AuthzPrincipalRuleCounts(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    github_actions: int = Field(ge=0)
+    github_humans: int = Field(ge=0)
+    terminal_agents: int = Field(ge=0)
+    local_operators: int = Field(ge=0)
+    local_admins: int = Field(ge=0)
+
+
+class AuthzPolicyRecordSummary(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    record_id: str
+    revision: int = Field(ge=1)
+    policy_sha256: str
+    updated_at: str
+    schema_version: Literal[1, 2]
+
+
+class AuthzPolicyHealthSummary(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    state: AuthzPolicyHealthState
+    reason_codes: tuple[AuthzPolicyHealthReasonCode, ...]
+    managed_rule_count: int = Field(ge=0)
+    unmanaged_rule_count: int = Field(ge=0)
+    github_actions_legacy_name_only_rule_count: int = Field(ge=0)
+    github_actions_privileged_unpinned_reusable_rule_count: int = Field(ge=0)
+
+
+class AuthzManagedSetSummary(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    managed_set_id: str
+    rule_count: int = Field(ge=1)
+    principal_rule_counts: AuthzPrincipalRuleCounts
+
+
+class AuthzManagedSetCollectionSummary(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    total_count: int = Field(ge=0)
+    returned_count: int = Field(ge=0)
+    truncated: bool
+    items: tuple[AuthzManagedSetSummary, ...]
+
+
+class AuthzReachableAdministratorSummary(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    policy_reachable: bool
+    rule_count: int = Field(ge=0)
+    managed_rule_count: int = Field(ge=0)
+    unmanaged_rule_count: int = Field(ge=0)
+    principal_rule_counts: AuthzPrincipalRuleCounts
+    caller_has_policy_administration: bool
+    independent_from_caller_reachable: bool
+    independent_from_caller_rule_count: int = Field(ge=0)
+
+
+class AuthzPolicyHealthSnapshot(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    policy: AuthzPolicyRecordSummary
+    health: AuthzPolicyHealthSummary
+    managed_sets: AuthzManagedSetCollectionSummary
+    reachable_administrators: AuthzReachableAdministratorSummary
+
+
+class AuthzPolicyHealthResponse(AuthzPolicyHealthSnapshot):
+    status: Literal["ok"] = "ok"
+    trace_id: str

--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -76,8 +76,10 @@ from control_plane.contracts.generic_web_deploy_recovery import (
 )
 from control_plane.contracts.authz_access_read import (
     AUTHZ_DENIAL_EXPLANATION_READ_ACTION,
+    AUTHZ_POLICY_HEALTH_READ_ACTION,
     EFFECTIVE_ACCESS_READ_ACTION,
     AuthzDenialExplanationResponse,
+    AuthzPolicyHealthResponse,
     EffectiveAccessDecision,
     EffectiveAccessEvaluateRequest,
     EffectiveAccessEvaluateResponse,
@@ -1021,6 +1023,7 @@ _MERGE_TRAIN_POLICY_IMPORT_ROUTE = "/v1/merge-train/policies/import"
 _AUTHZ_POLICY_ACTIVE_ROUTE = "/v1/authz-policies/active"
 _AUTHZ_DIAGNOSTIC_EVALUATE_ROUTE = "/v1/authz-diagnostics/github-actions/evaluate"
 _AUTHZ_EFFECTIVE_ACCESS_EVALUATE_ROUTE = "/v1/authz-diagnostics/effective-access/evaluate"
+_AUTHZ_POLICY_HEALTH_ROUTE = "/v1/authz-diagnostics/active-policy/health"
 _AUTHZ_DENIAL_EXPLANATION_ROUTE = "/v1/authz-diagnostics/denials/{trace_id}"
 _AUTHZ_POLICY_MANAGED_RECONCILE_ROUTE = "/v1/authz-policies/managed-rule-sets/reconcile"
 _GENERIC_WEB_PREVIEW_AUTHZ_PLAN_ROUTE = (
@@ -14507,6 +14510,58 @@ def create_launchplane_fastapi_app(
             )
         return active_records[0]
 
+    async def read_authz_policy_health(
+        identity: Annotated[LaunchplaneIdentity, Depends(read_identity)],
+        record_store: Annotated[object, Depends(get_record_store)],
+    ) -> AuthzPolicyHealthResponse:
+        trace_id = next_trace_id()
+        is_administrator = isinstance(identity, LocalAdminIdentity) or (
+            isinstance(identity, GitHubHumanIdentity) and identity.role == "admin"
+        )
+        preflight_authorized = resolved_authz_policy_runtime.policy.allows(
+            identity=identity,
+            action=AUTHZ_POLICY_HEALTH_READ_ACTION,
+            product="launchplane",
+            context=_LAUNCHPLANE_SERVICE_CONTEXT,
+        )
+        if not is_administrator or not preflight_authorized:
+            raise _launchplane_http_error(
+                status_code=403,
+                trace_id=trace_id,
+                code="authorization_denied",
+                message="Identity cannot read Launchplane authz policy health.",
+            )
+        database_store = require_authz_policy_database_store(
+            record_store=record_store,
+            trace_id=trace_id,
+            message="Authz policy health reads require Launchplane database storage.",
+        )
+        active_record = read_single_active_authz_policy_record(
+            database_store=database_store,
+            trace_id=trace_id,
+        )
+        if not active_record.policy.allows(
+            identity=identity,
+            action=AUTHZ_POLICY_HEALTH_READ_ACTION,
+            product="launchplane",
+            context=_LAUNCHPLANE_SERVICE_CONTEXT,
+        ):
+            raise _launchplane_http_error(
+                status_code=403,
+                trace_id=trace_id,
+                code="authorization_denied",
+                message="Identity cannot read Launchplane authz policy health.",
+                authz_policy_provenance=AuthzPolicyProvenance.from_record(active_record),
+            )
+        snapshot = control_plane_authz_grant_service.summarize_active_authz_policy_health_record(
+            record=active_record,
+            caller_identity=identity,
+        )
+        return AuthzPolicyHealthResponse(
+            trace_id=trace_id,
+            **snapshot.model_dump(),
+        )
+
     async def evaluate_effective_access(
         evaluation_request: EffectiveAccessEvaluateRequest,
         identity: Annotated[LaunchplaneIdentity, Depends(read_browser_mutation_identity)],
@@ -22314,6 +22369,20 @@ def create_launchplane_fastapi_app(
             403: {"model": LaunchplaneErrorResponse},
             409: {"model": LaunchplaneErrorResponse},
             503: {"model": LaunchplaneErrorResponse},
+        },
+    )
+
+    app.add_api_route(
+        _AUTHZ_POLICY_HEALTH_ROUTE,
+        read_authz_policy_health,
+        methods=["GET"],
+        response_model=AuthzPolicyHealthResponse,
+        response_model_exclude_none=True,
+        operation_id="read_authz_policy_health",
+        summary="Read bounded active authorization policy health",
+        responses={
+            **authz_diagnostic_route_responses,
+            409: {"model": LaunchplaneErrorResponse},
         },
     )
 

--- a/docs/authorization-authority.md
+++ b/docs/authorization-authority.md
@@ -92,6 +92,23 @@ The first DB-native read-only slice keeps those capabilities separate:
 - denial records contain no principal identifier or token label, expire after
   30 days, and return the same not-found response when absent or expired.
 
+The next read-only administration slice adds `authz_policy_health.read` for an
+authenticated GitHub administrator or local administrator. It reads the exact
+active DB policy record and returns only immutable policy provenance, bounded
+health reason codes, managed-set rule counts, and policy-administrator rule
+counts. Managed summaries may identify a managed set but never expose managed
+rule IDs, rule hashes, selectors, actions, repositories, workflows, logins,
+GitHub IDs, subjects, token labels, or raw policy payloads. "Reachable
+administrator" means a rule satisfies the existing policy-administration safety
+predicate; it does not prove that an external credential or identity provider
+is currently available.
+
+The health read checks the caller against both the current runtime policy and
+the freshly loaded active DB record, rejects non-administrator principal types,
+and fails closed when active policy state is missing or ambiguous. It performs
+no policy, provider, runtime, bootstrap, secret, or deployment mutation. Landing
+the action and route does not grant production access to them.
+
 Landing these read contracts does not authorize their production grants and
 does not relax the active freeze. Production policy changes still require the
 separate reviewed administration and recovery gates owned by `#2058`/`#2061`.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -592,6 +592,7 @@ Current implementation scope:
 - `POST /v1/authz-policies/managed-rule-sets/generic-web-preview/plan`
 - `POST /v1/authz-policies/managed-rule-sets/reconcile`
 - `POST /v1/authz-diagnostics/github-actions/evaluate`
+- `GET /v1/authz-diagnostics/active-policy/health`
 - `GET /v1/route-bindings/records/current`
 - `POST /v1/route-bindings/reconcile`
 - `POST /v1/route-bindings/odoo-testing/controller/run-once`
@@ -658,6 +659,16 @@ single active DB policy record, delegates the decision to the ordinary policy
 evaluator, and returns only the supplied scope, allowed/denied decision, one
 bounded reason code, and active record/revision/digest. It does not return rule
 matches, selector values, managed IDs, principal values, or permission lists.
+
+`GET /v1/authz-diagnostics/active-policy/health` is the separately authorized
+DB-native administrator health read. The caller must be a GitHub administrator
+or local administrator with `authz_policy_health.read`. The route authorizes
+against the runtime policy, reloads the single active DB policy record, and
+authorizes again before returning immutable policy provenance, bounded health
+reason codes, managed-set rule counts, and reachable policy-administrator rule
+counts. It never returns managed rule IDs, rule hashes, selectors, actions, or
+principal identities. Missing or multiple active records fail closed, and the
+read does not authorize a policy write or production grant.
 
 Standard `authorization_denied` HTTP failures with a captured policy evaluation
 write a redacted `launchplane_authz_denials` audit record on a best-effort basis.

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -303,6 +303,7 @@ cleanup scope so the store is always closed.
     and optional `Idempotency-Key` replay/conflict handling)
 - authz policy administration routes:
   - `GET /v1/authz-policies/active`
+  - `GET /v1/authz-diagnostics/active-policy/health`
   - `POST /v1/authz-policies/managed-rule-sets/reconcile`
     (native FastAPI for bearer-token and signed-in GitHub human-session
     callers and DB-backed policy records; managed-rule-set dry-runs return a
@@ -717,6 +718,18 @@ returns full workflow refs or principal selectors. Its removal readiness fields
 include managed and unmanaged rule totals, unmanaged counts by principal type,
 and the count of privileged GitHub Actions rules that still lack an immutable
 reusable-workflow identity.
+
+`GET /v1/authz-diagnostics/active-policy/health` is a separate read-only
+administrator contract. It requires a GitHub administrator or local
+administrator with `authz_policy_health.read`, reloads the exact active DB
+policy after preflight authorization, and reauthorizes against that record. The
+response contains active-record identity, revision, digest, schema version,
+bounded health reason codes, at most 100 lexically ordered managed-set summaries
+with rule and principal-type counts, and policy-administrator rule counts. It
+does not expose managed rule IDs, rule hashes, selectors, actions, repositories,
+workflows, or principal identifiers. Missing active state returns `503`, and
+multiple active records return `409`; the service never falls back to cached
+policy state for the response.
 
 New managed GitHub Actions rules require immutable GitHub `repository_id` and
 `repository_owner_id` selectors. Production-capable, destructive,

--- a/frontend/generated/openapi-canonical.json
+++ b/frontend/generated/openapi-canonical.json
@@ -1383,6 +1383,289 @@
         "title": "AuthzDiagnosticRuleEvaluation",
         "type": "object"
       },
+      "AuthzManagedSetCollectionSummary": {
+        "additionalProperties": false,
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/AuthzManagedSetSummary"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "returned_count": {
+            "minimum": 0.0,
+            "title": "Returned Count",
+            "type": "integer"
+          },
+          "total_count": {
+            "minimum": 0.0,
+            "title": "Total Count",
+            "type": "integer"
+          },
+          "truncated": {
+            "title": "Truncated",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "total_count",
+          "returned_count",
+          "truncated",
+          "items"
+        ],
+        "title": "AuthzManagedSetCollectionSummary",
+        "type": "object"
+      },
+      "AuthzManagedSetSummary": {
+        "additionalProperties": false,
+        "properties": {
+          "managed_set_id": {
+            "title": "Managed Set Id",
+            "type": "string"
+          },
+          "principal_rule_counts": {
+            "$ref": "#/components/schemas/AuthzPrincipalRuleCounts"
+          },
+          "rule_count": {
+            "minimum": 1.0,
+            "title": "Rule Count",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "managed_set_id",
+          "rule_count",
+          "principal_rule_counts"
+        ],
+        "title": "AuthzManagedSetSummary",
+        "type": "object"
+      },
+      "AuthzPolicyHealthResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "health": {
+            "$ref": "#/components/schemas/AuthzPolicyHealthSummary"
+          },
+          "managed_sets": {
+            "$ref": "#/components/schemas/AuthzManagedSetCollectionSummary"
+          },
+          "policy": {
+            "$ref": "#/components/schemas/AuthzPolicyRecordSummary"
+          },
+          "reachable_administrators": {
+            "$ref": "#/components/schemas/AuthzReachableAdministratorSummary"
+          },
+          "status": {
+            "const": "ok",
+            "default": "ok",
+            "title": "Status",
+            "type": "string"
+          },
+          "trace_id": {
+            "title": "Trace Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "policy",
+          "health",
+          "managed_sets",
+          "reachable_administrators",
+          "trace_id"
+        ],
+        "title": "AuthzPolicyHealthResponse",
+        "type": "object"
+      },
+      "AuthzPolicyHealthSummary": {
+        "additionalProperties": false,
+        "properties": {
+          "github_actions_legacy_name_only_rule_count": {
+            "minimum": 0.0,
+            "title": "Github Actions Legacy Name Only Rule Count",
+            "type": "integer"
+          },
+          "github_actions_privileged_unpinned_reusable_rule_count": {
+            "minimum": 0.0,
+            "title": "Github Actions Privileged Unpinned Reusable Rule Count",
+            "type": "integer"
+          },
+          "managed_rule_count": {
+            "minimum": 0.0,
+            "title": "Managed Rule Count",
+            "type": "integer"
+          },
+          "reason_codes": {
+            "items": {
+              "enum": [
+                "authz_policy_admin_unreachable",
+                "authz_policy_independent_admin_unreachable",
+                "policy_schema_legacy",
+                "unmanaged_rules_present",
+                "github_actions_legacy_name_only_rules_present",
+                "github_actions_privileged_unpinned_reusable_rules_present"
+              ],
+              "type": "string"
+            },
+            "title": "Reason Codes",
+            "type": "array"
+          },
+          "state": {
+            "enum": [
+              "healthy",
+              "attention_required",
+              "blocked"
+            ],
+            "title": "State",
+            "type": "string"
+          },
+          "unmanaged_rule_count": {
+            "minimum": 0.0,
+            "title": "Unmanaged Rule Count",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "state",
+          "reason_codes",
+          "managed_rule_count",
+          "unmanaged_rule_count",
+          "github_actions_legacy_name_only_rule_count",
+          "github_actions_privileged_unpinned_reusable_rule_count"
+        ],
+        "title": "AuthzPolicyHealthSummary",
+        "type": "object"
+      },
+      "AuthzPolicyRecordSummary": {
+        "additionalProperties": false,
+        "properties": {
+          "policy_sha256": {
+            "title": "Policy Sha256",
+            "type": "string"
+          },
+          "record_id": {
+            "title": "Record Id",
+            "type": "string"
+          },
+          "revision": {
+            "minimum": 1.0,
+            "title": "Revision",
+            "type": "integer"
+          },
+          "schema_version": {
+            "enum": [
+              1,
+              2
+            ],
+            "title": "Schema Version",
+            "type": "integer"
+          },
+          "updated_at": {
+            "title": "Updated At",
+            "type": "string"
+          }
+        },
+        "required": [
+          "record_id",
+          "revision",
+          "policy_sha256",
+          "updated_at",
+          "schema_version"
+        ],
+        "title": "AuthzPolicyRecordSummary",
+        "type": "object"
+      },
+      "AuthzPrincipalRuleCounts": {
+        "additionalProperties": false,
+        "properties": {
+          "github_actions": {
+            "minimum": 0.0,
+            "title": "Github Actions",
+            "type": "integer"
+          },
+          "github_humans": {
+            "minimum": 0.0,
+            "title": "Github Humans",
+            "type": "integer"
+          },
+          "local_admins": {
+            "minimum": 0.0,
+            "title": "Local Admins",
+            "type": "integer"
+          },
+          "local_operators": {
+            "minimum": 0.0,
+            "title": "Local Operators",
+            "type": "integer"
+          },
+          "terminal_agents": {
+            "minimum": 0.0,
+            "title": "Terminal Agents",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "github_actions",
+          "github_humans",
+          "terminal_agents",
+          "local_operators",
+          "local_admins"
+        ],
+        "title": "AuthzPrincipalRuleCounts",
+        "type": "object"
+      },
+      "AuthzReachableAdministratorSummary": {
+        "additionalProperties": false,
+        "properties": {
+          "caller_has_policy_administration": {
+            "title": "Caller Has Policy Administration",
+            "type": "boolean"
+          },
+          "independent_from_caller_reachable": {
+            "title": "Independent From Caller Reachable",
+            "type": "boolean"
+          },
+          "independent_from_caller_rule_count": {
+            "minimum": 0.0,
+            "title": "Independent From Caller Rule Count",
+            "type": "integer"
+          },
+          "managed_rule_count": {
+            "minimum": 0.0,
+            "title": "Managed Rule Count",
+            "type": "integer"
+          },
+          "policy_reachable": {
+            "title": "Policy Reachable",
+            "type": "boolean"
+          },
+          "principal_rule_counts": {
+            "$ref": "#/components/schemas/AuthzPrincipalRuleCounts"
+          },
+          "rule_count": {
+            "minimum": 0.0,
+            "title": "Rule Count",
+            "type": "integer"
+          },
+          "unmanaged_rule_count": {
+            "minimum": 0.0,
+            "title": "Unmanaged Rule Count",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "policy_reachable",
+          "rule_count",
+          "managed_rule_count",
+          "unmanaged_rule_count",
+          "principal_rule_counts",
+          "caller_has_policy_administration",
+          "independent_from_caller_reachable",
+          "independent_from_caller_rule_count"
+        ],
+        "title": "AuthzReachableAdministratorSummary",
+        "type": "object"
+      },
       "BackupGateEvidence": {
         "additionalProperties": false,
         "properties": {
@@ -35255,6 +35538,96 @@
           }
         },
         "summary": "Read human auth session"
+      }
+    },
+    "/v1/authz-diagnostics/active-policy/health": {
+      "get": {
+        "operationId": "read_authz_policy_health",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Authorization",
+            "required": false,
+            "schema": {
+              "default": "",
+              "title": "Authorization",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "Cookie",
+            "required": false,
+            "schema": {
+              "default": "",
+              "title": "Cookie",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthzPolicyHealthResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "summary": "Read bounded active authorization policy health"
       }
     },
     "/v1/authz-diagnostics/denials/{trace_id}": {

--- a/tests/test_authz_access_read.py
+++ b/tests/test_authz_access_read.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import datetime, timezone
 import json
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -11,6 +12,7 @@ from pydantic import ValidationError
 
 from control_plane.contracts.authz_access_read import (
     AUTHZ_DENIAL_EXPLANATION_READ_ACTION,
+    AUTHZ_POLICY_HEALTH_READ_ACTION,
     EFFECTIVE_ACCESS_READ_ACTION,
     EffectiveAccessEvaluateRequest,
 )
@@ -27,6 +29,7 @@ from control_plane.service_auth import (
     GitHubActionsIdentity,
     LaunchplaneAuthzPolicy,
 )
+from control_plane.storage.filesystem import FilesystemRecordStore
 from control_plane.storage.postgres import PostgresRecordStore
 from tests.support.http import lifespan_client
 
@@ -38,6 +41,22 @@ class _RejectingVerifier:
 
 def _database_url(path: Path) -> str:
     return f"sqlite+pysqlite:///{path}"
+
+
+def _nested_mapping_keys(value: object) -> set[str]:
+    if isinstance(value, dict):
+        return set(value) | {
+            nested_key
+            for nested_value in value.values()
+            for nested_key in _nested_mapping_keys(nested_value)
+        }
+    if isinstance(value, list):
+        return {
+            nested_key
+            for nested_value in value
+            for nested_key in _nested_mapping_keys(nested_value)
+        }
+    return set()
 
 
 def _seed_policy(
@@ -78,7 +97,7 @@ def _support_reader_policy() -> LaunchplaneAuthzPolicy:
 def _app(
     *,
     root: Path,
-    store: PostgresRecordStore,
+    store: object,
     record: LaunchplaneAuthzPolicyRecord,
 ) -> FastAPI:
     return create_launchplane_fastapi_app(
@@ -106,6 +125,416 @@ def _app(
 
 
 class AuthzAccessReadHttpTests(unittest.IsolatedAsyncioTestCase):
+    async def test_administrator_reads_bounded_policy_health_without_selector_leakage(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            store = PostgresRecordStore(database_url=_database_url(root / "launchplane.sqlite3"))
+            store.ensure_schema()
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "schema_version": 2,
+                    "local_admins": [
+                        {
+                            "managed_set_id": "operator.authz-health",
+                            "managed_rule_id": "reader",
+                            "subjects": ["authz-admin"],
+                            "token_labels": ["authz-admin-label"],
+                            "products": ["launchplane"],
+                            "contexts": ["launchplane"],
+                            "actions": [
+                                AUTHZ_POLICY_HEALTH_READ_ACTION,
+                                "authz_policy_grant.write",
+                            ],
+                        },
+                        {
+                            "managed_set_id": "operator.recovery",
+                            "managed_rule_id": "independent-admin",
+                            "subjects": ["independent-admin-secret"],
+                            "token_labels": ["independent-token-secret"],
+                            "products": ["launchplane"],
+                            "contexts": ["launchplane"],
+                            "actions": ["authz_policy_grant.write"],
+                        },
+                    ],
+                }
+            )
+            record = _seed_policy(store, policy)
+            app = _app(root=root, store=store, record=record)
+            records_before_read = store.list_authz_policy_records()
+            try:
+                async with lifespan_client(app) as client:
+                    with patch.object(
+                        store,
+                        "write_authz_denial_record",
+                        side_effect=AssertionError("successful health reads must not write"),
+                    ):
+                        response = await client.get(
+                            "/v1/authz-diagnostics/active-policy/health",
+                            headers={"Authorization": "Bearer admin-token"},
+                        )
+                records_after_read = store.list_authz_policy_records()
+            finally:
+                store.close()
+
+        self.assertEqual(response.status_code, 200, response.text)
+        self.assertEqual(records_after_read, records_before_read)
+        payload = response.json()
+        self.assertEqual(payload["policy"]["record_id"], record.record_id)
+        self.assertEqual(payload["policy"]["revision"], record.revision)
+        self.assertEqual(payload["policy"]["policy_sha256"], record.policy_sha256)
+        self.assertEqual(payload["health"]["state"], "healthy")
+        self.assertEqual(payload["health"]["reason_codes"], [])
+        self.assertEqual(payload["managed_sets"]["total_count"], 2)
+        self.assertEqual(
+            [item["managed_set_id"] for item in payload["managed_sets"]["items"]],
+            ["operator.authz-health", "operator.recovery"],
+        )
+        self.assertTrue(payload["reachable_administrators"]["policy_reachable"])
+        self.assertTrue(payload["reachable_administrators"]["caller_has_policy_administration"])
+        self.assertTrue(payload["reachable_administrators"]["independent_from_caller_reachable"])
+        serialized = json.dumps(payload, sort_keys=True)
+        for secret_value in (
+            "authz-admin",
+            "authz-admin-label",
+            "independent-admin-secret",
+            "independent-token-secret",
+        ):
+            self.assertNotIn(secret_value, serialized)
+        self.assertTrue(
+            {
+                "managed_rule_id",
+                "subjects",
+                "token_labels",
+                "actions",
+                "products",
+                "contexts",
+            }.isdisjoint(_nested_mapping_keys(payload))
+        )
+        route = app.openapi()["paths"]["/v1/authz-diagnostics/active-policy/health"]
+        self.assertEqual(route["get"]["operationId"], "read_authz_policy_health")
+
+    async def test_policy_health_reports_missing_reachable_policy_administrator(self) -> None:
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            store = PostgresRecordStore(database_url=_database_url(root / "launchplane.sqlite3"))
+            store.ensure_schema()
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "schema_version": 2,
+                    "local_admins": [
+                        {
+                            "managed_set_id": "operator.authz-health",
+                            "managed_rule_id": "reader",
+                            "subjects": ["authz-admin"],
+                            "token_labels": ["authz-admin-label"],
+                            "products": ["launchplane"],
+                            "contexts": ["launchplane"],
+                            "actions": [AUTHZ_POLICY_HEALTH_READ_ACTION],
+                        }
+                    ],
+                }
+            )
+            record = _seed_policy(store, policy)
+            app = _app(root=root, store=store, record=record)
+            try:
+                async with lifespan_client(app) as client:
+                    response = await client.get(
+                        "/v1/authz-diagnostics/active-policy/health",
+                        headers={"Authorization": "Bearer admin-token"},
+                    )
+                    active_policy_response = await client.get(
+                        "/v1/authz-policies/active",
+                        headers={"Authorization": "Bearer admin-token"},
+                    )
+            finally:
+                store.close()
+
+        self.assertEqual(response.status_code, 200, response.text)
+        payload = response.json()
+        self.assertEqual(payload["health"]["state"], "blocked")
+        self.assertIn("authz_policy_admin_unreachable", payload["health"]["reason_codes"])
+        self.assertFalse(payload["reachable_administrators"]["policy_reachable"])
+        self.assertEqual(payload["reachable_administrators"]["rule_count"], 0)
+        self.assertEqual(active_policy_response.status_code, 403, active_policy_response.text)
+
+    async def test_policy_health_reports_when_caller_is_only_policy_administrator(self) -> None:
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            store = PostgresRecordStore(database_url=_database_url(root / "launchplane.sqlite3"))
+            store.ensure_schema()
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "schema_version": 2,
+                    "local_admins": [
+                        {
+                            "managed_set_id": "operator.authz-health",
+                            "managed_rule_id": "sole-administrator",
+                            "subjects": ["authz-admin"],
+                            "token_labels": ["authz-admin-label"],
+                            "products": ["launchplane"],
+                            "contexts": ["launchplane"],
+                            "actions": [
+                                AUTHZ_POLICY_HEALTH_READ_ACTION,
+                                "authz_policy_grant.write",
+                            ],
+                        }
+                    ],
+                }
+            )
+            record = _seed_policy(store, policy)
+            app = _app(root=root, store=store, record=record)
+            try:
+                async with lifespan_client(app) as client:
+                    response = await client.get(
+                        "/v1/authz-diagnostics/active-policy/health",
+                        headers={"Authorization": "Bearer admin-token"},
+                    )
+            finally:
+                store.close()
+
+        self.assertEqual(response.status_code, 200, response.text)
+        payload = response.json()
+        self.assertEqual(payload["health"]["state"], "attention_required")
+        self.assertEqual(
+            payload["health"]["reason_codes"],
+            ["authz_policy_independent_admin_unreachable"],
+        )
+        self.assertTrue(payload["reachable_administrators"]["caller_has_policy_administration"])
+        self.assertFalse(payload["reachable_administrators"]["independent_from_caller_reachable"])
+        self.assertEqual(
+            payload["reachable_administrators"]["independent_from_caller_rule_count"],
+            0,
+        )
+
+    async def test_unauthorized_policy_health_skips_route_database_reads(self) -> None:
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            store = PostgresRecordStore(database_url=_database_url(root / "launchplane.sqlite3"))
+            store.ensure_schema()
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "schema_version": 2,
+                    "local_operators": [
+                        {
+                            "subjects": ["support-reader"],
+                            "token_labels": ["support-reader-label"],
+                            "products": ["launchplane"],
+                            "contexts": ["launchplane"],
+                            "actions": [AUTHZ_POLICY_HEALTH_READ_ACTION],
+                        }
+                    ],
+                }
+            )
+            record = _seed_policy(store, policy)
+            app = _app(root=root, store=store, record=record)
+            try:
+                async with lifespan_client(app) as client:
+                    with patch.object(
+                        store,
+                        "list_authz_policy_records",
+                        side_effect=AssertionError("authorization must precede policy reads"),
+                    ):
+                        response = await client.get(
+                            "/v1/authz-diagnostics/active-policy/health",
+                            headers={"Authorization": "Bearer support-token"},
+                        )
+            finally:
+                store.close()
+
+        self.assertEqual(response.status_code, 403, response.text)
+
+    async def test_policy_health_rechecks_authorization_against_active_database_policy(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            store = PostgresRecordStore(database_url=_database_url(root / "launchplane.sqlite3"))
+            store.ensure_schema()
+            runtime_policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "schema_version": 2,
+                    "local_admins": [
+                        {
+                            "subjects": ["authz-admin"],
+                            "token_labels": ["authz-admin-label"],
+                            "products": ["launchplane"],
+                            "contexts": ["launchplane"],
+                            "actions": [AUTHZ_POLICY_HEALTH_READ_ACTION],
+                        }
+                    ],
+                }
+            )
+            runtime_record = _seed_policy(store, runtime_policy)
+            denied_policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "schema_version": 2,
+                    "local_admins": [
+                        {
+                            "subjects": ["independent-admin"],
+                            "token_labels": ["independent-label"],
+                            "products": ["launchplane"],
+                            "contexts": ["launchplane"],
+                            "actions": [AUTHZ_POLICY_HEALTH_READ_ACTION],
+                        }
+                    ],
+                }
+            )
+            denied_digest = authz_policy_sha256(denied_policy)
+            denied_record = LaunchplaneAuthzPolicyRecord(
+                record_id=build_authz_policy_record_id(
+                    revision=2,
+                    policy_sha256=denied_digest,
+                ),
+                revision=2,
+                status="active",
+                source="test:authz-policy-health-recheck",
+                updated_at="2026-08-20T12:00:00+00:00",
+                policy_sha256=denied_digest,
+                policy=denied_policy,
+            )
+            app = _app(root=root, store=store, record=runtime_record)
+            try:
+                async with lifespan_client(app) as client:
+                    with patch.object(
+                        store,
+                        "list_authz_policy_records",
+                        return_value=(denied_record,),
+                    ):
+                        response = await client.get(
+                            "/v1/authz-diagnostics/active-policy/health",
+                            headers={"Authorization": "Bearer admin-token"},
+                        )
+                    denial_record = store.read_authz_denial_record(
+                        trace_id=response.json()["trace_id"],
+                        observed_at=datetime.now(timezone.utc).isoformat(),
+                    )
+            finally:
+                store.close()
+
+        self.assertEqual(response.status_code, 403, response.text)
+        self.assertIsNotNone(denial_record)
+        assert denial_record is not None
+        self.assertEqual(denial_record.policy_record_id, denied_record.record_id)
+        self.assertEqual(denial_record.policy_revision, denied_record.revision)
+        self.assertEqual(denial_record.policy_sha256, denied_record.policy_sha256)
+
+    async def test_policy_health_requires_authentication_and_database_storage(self) -> None:
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "schema_version": 2,
+                    "local_admins": [
+                        {
+                            "subjects": ["authz-admin"],
+                            "token_labels": ["authz-admin-label"],
+                            "products": ["launchplane"],
+                            "contexts": ["launchplane"],
+                            "actions": [AUTHZ_POLICY_HEALTH_READ_ACTION],
+                        }
+                    ],
+                }
+            )
+            digest = authz_policy_sha256(policy)
+            record = LaunchplaneAuthzPolicyRecord(
+                record_id=build_authz_policy_record_id(revision=1, policy_sha256=digest),
+                revision=1,
+                status="active",
+                source="test:authz-policy-health-database-required",
+                updated_at="2026-08-20T12:00:00+00:00",
+                policy_sha256=digest,
+                policy=policy,
+            )
+            app = _app(
+                root=root,
+                store=FilesystemRecordStore(root / "filesystem-state"),
+                record=record,
+            )
+            async with lifespan_client(app) as client:
+                unauthenticated_response = await client.get(
+                    "/v1/authz-diagnostics/active-policy/health"
+                )
+                database_required_response = await client.get(
+                    "/v1/authz-diagnostics/active-policy/health",
+                    headers={"Authorization": "Bearer admin-token"},
+                )
+
+        self.assertEqual(unauthenticated_response.status_code, 401)
+        self.assertEqual(
+            unauthenticated_response.json()["error"]["code"],
+            "authentication_required",
+        )
+        self.assertEqual(database_required_response.status_code, 503)
+        self.assertEqual(
+            database_required_response.json()["error"]["code"],
+            "database_required",
+        )
+
+    async def test_policy_health_fails_closed_for_missing_or_ambiguous_active_policy(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            store = PostgresRecordStore(database_url=_database_url(root / "launchplane.sqlite3"))
+            store.ensure_schema()
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "schema_version": 2,
+                    "local_admins": [
+                        {
+                            "subjects": ["authz-admin"],
+                            "token_labels": ["authz-admin-label"],
+                            "products": ["launchplane"],
+                            "contexts": ["launchplane"],
+                            "actions": [AUTHZ_POLICY_HEALTH_READ_ACTION],
+                        }
+                    ],
+                }
+            )
+            record = _seed_policy(store, policy)
+            second_record = record.model_copy(
+                update={
+                    "record_id": f"{record.record_id}-duplicate",
+                    "revision": record.revision + 1,
+                }
+            )
+            app = _app(root=root, store=store, record=record)
+            try:
+                async with lifespan_client(app) as client:
+                    with patch.object(
+                        store,
+                        "list_authz_policy_records",
+                        return_value=(),
+                    ):
+                        missing_response = await client.get(
+                            "/v1/authz-diagnostics/active-policy/health",
+                            headers={"Authorization": "Bearer admin-token"},
+                        )
+                    with patch.object(
+                        store,
+                        "list_authz_policy_records",
+                        return_value=(record, second_record),
+                    ):
+                        ambiguous_response = await client.get(
+                            "/v1/authz-diagnostics/active-policy/health",
+                            headers={"Authorization": "Bearer admin-token"},
+                        )
+            finally:
+                store.close()
+
+        self.assertEqual(missing_response.status_code, 503, missing_response.text)
+        self.assertEqual(
+            missing_response.json()["error"]["code"],
+            "authz_policy_unavailable",
+        )
+        self.assertEqual(ambiguous_response.status_code, 409, ambiguous_response.text)
+        self.assertEqual(
+            ambiguous_response.json()["error"]["code"],
+            "active_authz_policy_ambiguous",
+        )
+
     async def test_administrator_evaluates_one_explicit_principal_without_selector_leakage(
         self,
     ) -> None:

--- a/tests/test_authz_grant_service.py
+++ b/tests/test_authz_grant_service.py
@@ -16,6 +16,7 @@ from control_plane.authz_grant_service import (
     execute_managed_authz_policy_reconcile,
     plan_managed_authz_policy_reconcile,
     summarize_active_authz_policy_record,
+    summarize_active_authz_policy_health_record,
 )
 from control_plane.contracts.authz_policy_record import (
     LaunchplaneAuthzPolicyRecord,
@@ -26,6 +27,7 @@ from control_plane.service_auth import (
     GitHubActionsIdentity,
     GitHubActionsPolicyRule,
     LaunchplaneAuthzPolicy,
+    LocalAdminIdentity,
     LocalAdminPolicyRule,
     LocalOperatorPolicyRule,
     TerminalAgentPolicyRule,
@@ -2228,3 +2230,84 @@ class AuthzManagedPolicyServiceTests(unittest.TestCase):
             summary["github_actions_privileged_unpinned_reusable_rule_count"],
             1,
         )
+
+    def test_policy_health_summary_bounds_and_sorts_managed_sets(self) -> None:
+        policy = LaunchplaneAuthzPolicy(
+            schema_version=2,
+            local_operators=tuple(
+                LocalOperatorPolicyRule(
+                    managed_set_id=f"operator.set-{index:03d}",
+                    managed_rule_id="reader",
+                    subjects=(f"operator-{index:03d}",),
+                    token_labels=(f"token-{index:03d}",),
+                    products=("launchplane",),
+                    contexts=("launchplane",),
+                    actions=("product_profile.read",),
+                )
+                for index in range(100)
+            ),
+            local_admins=(
+                LocalAdminPolicyRule(
+                    managed_set_id="operator.admin",
+                    managed_rule_id="policy-admin",
+                    subjects=("authz-admin",),
+                    token_labels=("authz-admin-label",),
+                    products=("launchplane",),
+                    contexts=("launchplane",),
+                    actions=("authz_policy_grant.write",),
+                ),
+            ),
+        )
+        summary = summarize_active_authz_policy_health_record(
+            record=_active_record_for_policy(policy),
+            caller_identity=LocalAdminIdentity(
+                subject="authz-admin",
+                token_label="authz-admin-label",
+            ),
+        )
+
+        self.assertEqual(summary.managed_sets.total_count, 101)
+        self.assertEqual(summary.managed_sets.returned_count, 100)
+        self.assertTrue(summary.managed_sets.truncated)
+        returned_ids = tuple(item.managed_set_id for item in summary.managed_sets.items)
+        self.assertEqual(returned_ids, tuple(sorted(returned_ids)))
+        self.assertEqual(returned_ids[0], "operator.admin")
+        self.assertEqual(returned_ids[-1], "operator.set-098")
+
+    def test_policy_health_summary_reports_legacy_unmanaged_github_risks(self) -> None:
+        policy = LaunchplaneAuthzPolicy(
+            schema_version=1,
+            github_actions=(
+                GitHubActionsPolicyRule(
+                    repository="example/repository",
+                    workflow_refs=(
+                        "example/repository/.github/workflows/caller.yml@refs/heads/main",
+                    ),
+                    products=("launchplane",),
+                    contexts=("launchplane",),
+                    actions=("authz_policy_grant.write",),
+                ),
+            ),
+        )
+        summary = summarize_active_authz_policy_health_record(
+            record=_active_record_for_policy(policy),
+            caller_identity=LocalAdminIdentity(
+                subject="authz-admin",
+                token_label="authz-admin-label",
+            ),
+        )
+
+        self.assertEqual(summary.health.state, "attention_required")
+        self.assertEqual(
+            summary.health.reason_codes,
+            (
+                "policy_schema_legacy",
+                "unmanaged_rules_present",
+                "github_actions_legacy_name_only_rules_present",
+                "github_actions_privileged_unpinned_reusable_rules_present",
+            ),
+        )
+        self.assertEqual(summary.health.managed_rule_count, 0)
+        self.assertEqual(summary.health.unmanaged_rule_count, 1)
+        self.assertTrue(summary.reachable_administrators.policy_reachable)
+        self.assertTrue(summary.reachable_administrators.independent_from_caller_reachable)

--- a/tests/test_service_auth.py
+++ b/tests/test_service_auth.py
@@ -339,6 +339,7 @@ class LaunchplaneAuthzPolicyBoundaryTests(unittest.TestCase):
             "preview_destroy.execute": "destructive",
             "odoo_prod_backup_restore_apply.execute": "destructive",
             "secret_binding.apply": "secret_backed",
+            "authz_policy_health.read": "policy_admin",
             "authz_policy_grant.write": "policy_admin",
         }
 


### PR DESCRIPTION
## Summary
- add an administrator-only active authorization policy health endpoint
- return immutable DB-policy provenance and bounded, redacted managed-set and reachable-administrator summaries
- fail closed for unauthorized, unsupported-store, missing-active, and multiple-active states while preserving exact denial provenance
- update OpenAPI and authorization/operator documentation

## Validation
- `uv run --extra dev python -m unittest tests.test_authz_access_read tests.test_authz_grant_service tests.test_service_auth`
- `uv run --extra dev launchplane ci unittest-shard local` (3,028 targets)
- `uv run --extra dev ruff format --check ...`
- `uv run --extra dev ruff check ...`
- `uv run --extra dev mypy control_plane tests`
- `pnpm --dir frontend validate`
- `uv run launchplane service audit-config-authority --control-plane-root .`
- JetBrains changed-files inspection: GREEN, 0 findings
- final independent Opus review: APPROVE
- final independent Gemini review: APPROVE

No schema migration, policy write, production grant, workflow change, bootstrap/static-token retirement, provider mutation, or runtime mutation is included.

Closes #2196
Refs #2180