### PR TITLE
Add read-only authorization candidate-policy preview

### DIFF
--- a/control_plane/authz_grant_service.py
+++ b/control_plane/authz_grant_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections import Counter
 from collections.abc import Callable
 from dataclasses import dataclass
 from fnmatch import fnmatchcase
@@ -23,13 +24,24 @@ from control_plane.contracts.authz_policy_record import (
 from control_plane.contracts.authz_access_read import (
     AuthzManagedSetCollectionSummary,
     AuthzManagedSetSummary,
+    AuthzPolicyCandidatePreviewRequest,
+    AuthzPolicyCandidatePreviewResponse,
+    AuthzPolicyCandidateProbeDelta,
+    AuthzPolicyCandidateProbeResult,
+    AuthzPolicyCandidateReadinessReason,
+    AuthzPolicyCandidateReadinessSummary,
+    AuthzPolicyCandidateStructuralDiff,
+    AuthzPolicyCandidateSummary,
     AuthzPolicyHealthReasonCode,
     AuthzPolicyHealthSnapshot,
     AuthzPolicyHealthState,
     AuthzPolicyHealthSummary,
     AuthzPolicyRecordSummary,
     AuthzPrincipalRuleCounts,
+    AuthzPolicyPrincipalType,
     AuthzReachableAdministratorSummary,
+    EffectiveAccessDecision,
+    EffectiveAccessRequestSummary,
 )
 from control_plane.contracts.owner_acceptance import (
     OWNER_ACCEPTANCE_EVENT_WRITE_ACTION,
@@ -42,6 +54,7 @@ from control_plane.contracts.product_owner import (
     PRODUCT_OWNER_REQUIREMENT_WRITE_ACTION,
 )
 from control_plane.service_auth import (
+    AuthorizationTarget,
     AuthzInstanceSelectors,
     GitHubActionsIdentity,
     GitHubActionsPolicyRule,
@@ -96,13 +109,7 @@ AuthzApplyingIdentity: TypeAlias = (
     | LocalOperatorIdentity
     | LocalAdminIdentity
 )
-AuthzPrincipalType: TypeAlias = Literal[
-    "github_actions",
-    "github_humans",
-    "terminal_agents",
-    "local_operators",
-    "local_admins",
-]
+AuthzPrincipalType: TypeAlias = AuthzPolicyPrincipalType
 _AUTHZ_PRINCIPAL_TYPES: tuple[AuthzPrincipalType, ...] = (
     "github_actions",
     "github_humans",
@@ -447,7 +454,8 @@ class AuthzManagedCompatibilityRetirement(BaseModel):
     )
 
 
-AuthzOperationalReadinessBlockerCode: TypeAlias = Literal[
+AuthzOperationalReadinessBlockerCode: TypeAlias = AuthzPolicyCandidateReadinessReason
+_AUTHZ_OPERATIONAL_READINESS_BLOCKER_CODES: tuple[AuthzOperationalReadinessBlockerCode, ...] = (
     "repository_not_exact",
     "workflow_refs_not_singleton",
     "workflow_ref_not_exact",
@@ -461,7 +469,7 @@ AuthzOperationalReadinessBlockerCode: TypeAlias = Literal[
     "context_not_exact",
     "instances_not_singleton",
     "instance_not_exact",
-]
+)
 
 
 class AuthzManagedOperationalReadinessBlocker(BaseModel):
@@ -606,12 +614,16 @@ def _authz_principal_rule_counts(
     return AuthzPrincipalRuleCounts(**counts)
 
 
-def summarize_active_authz_policy_health_record(
+def summarize_authz_policy_health(
     *,
-    record: LaunchplaneAuthzPolicyRecord,
+    policy: LaunchplaneAuthzPolicy,
     caller_identity: AuthzApplyingIdentity,
-) -> AuthzPolicyHealthSnapshot:
-    rules_by_principal = _authz_policy_rule_collections(record.policy)
+) -> tuple[
+    AuthzPolicyHealthSummary,
+    AuthzManagedSetCollectionSummary,
+    AuthzReachableAdministratorSummary,
+]:
+    rules_by_principal = _authz_policy_rule_collections(policy)
     rule_entries = [
         AuthzPolicyRuleEntry(principal_type=principal_type, rule=rule)
         for principal_type, rules in rules_by_principal
@@ -644,7 +656,7 @@ def summarize_active_authz_policy_health_record(
         _authz_rule_allows_identity(
             rule=entry.rule,
             identity=caller_identity,
-            schema_version=record.policy.schema_version,
+            schema_version=policy.schema_version,
         )
         for entry in administrator_entries
     )
@@ -655,12 +667,8 @@ def summarize_active_authz_policy_health_record(
         entry.rule.managed_set_id is not None for entry in administrator_entries
     )
 
-    immutable_repository_rule_count = sum(
-        1 for rule in record.policy.github_actions if rule.repository_id
-    )
-    legacy_name_only_rule_count = (
-        len(record.policy.github_actions) - immutable_repository_rule_count
-    )
+    immutable_repository_rule_count = sum(1 for rule in policy.github_actions if rule.repository_id)
+    legacy_name_only_rule_count = len(policy.github_actions) - immutable_repository_rule_count
     privileged_unpinned_rule_count = sum(
         _github_rule_requires_immutable_workflow(rule)
         and (
@@ -670,7 +678,7 @@ def summarize_active_authz_policy_health_record(
                 for job_workflow_ref in rule.job_workflow_refs
             )
         )
-        for rule in record.policy.github_actions
+        for rule in policy.github_actions
     )
 
     reason_codes: list[AuthzPolicyHealthReasonCode] = []
@@ -678,7 +686,7 @@ def summarize_active_authz_policy_health_record(
         reason_codes.append("authz_policy_admin_unreachable")
     elif not independent_administrator_rule_count:
         reason_codes.append("authz_policy_independent_admin_unreachable")
-    if record.policy.schema_version == 1:
+    if policy.schema_version == 1:
         reason_codes.append("policy_schema_legacy")
     if unmanaged_rule_count:
         reason_codes.append("unmanaged_rules_present")
@@ -695,15 +703,8 @@ def summarize_active_authz_policy_health_record(
     else:
         health_state = "healthy"
 
-    return AuthzPolicyHealthSnapshot(
-        policy=AuthzPolicyRecordSummary(
-            record_id=record.record_id,
-            revision=record.revision,
-            policy_sha256=record.policy_sha256,
-            updated_at=record.updated_at,
-            schema_version=record.policy.schema_version,
-        ),
-        health=AuthzPolicyHealthSummary(
+    return (
+        AuthzPolicyHealthSummary(
             state=health_state,
             reason_codes=tuple(reason_codes),
             managed_rule_count=len(managed_entries),
@@ -711,13 +712,13 @@ def summarize_active_authz_policy_health_record(
             github_actions_legacy_name_only_rule_count=legacy_name_only_rule_count,
             github_actions_privileged_unpinned_reusable_rule_count=privileged_unpinned_rule_count,
         ),
-        managed_sets=AuthzManagedSetCollectionSummary(
+        AuthzManagedSetCollectionSummary(
             total_count=len(sorted_managed_set_ids),
             returned_count=len(managed_set_items),
             truncated=len(sorted_managed_set_ids) > len(managed_set_items),
             items=managed_set_items,
         ),
-        reachable_administrators=AuthzReachableAdministratorSummary(
+        AuthzReachableAdministratorSummary(
             policy_reachable=bool(administrator_entries),
             rule_count=len(administrator_entries),
             managed_rule_count=managed_administrator_rule_count,
@@ -727,6 +728,29 @@ def summarize_active_authz_policy_health_record(
             independent_from_caller_reachable=bool(independent_administrator_rule_count),
             independent_from_caller_rule_count=independent_administrator_rule_count,
         ),
+    )
+
+
+def summarize_active_authz_policy_health_record(
+    *,
+    record: LaunchplaneAuthzPolicyRecord,
+    caller_identity: AuthzApplyingIdentity,
+) -> AuthzPolicyHealthSnapshot:
+    health, managed_sets, reachable_administrators = summarize_authz_policy_health(
+        policy=record.policy,
+        caller_identity=caller_identity,
+    )
+    return AuthzPolicyHealthSnapshot(
+        policy=AuthzPolicyRecordSummary(
+            record_id=record.record_id,
+            revision=record.revision,
+            policy_sha256=record.policy_sha256,
+            updated_at=record.updated_at,
+            schema_version=record.policy.schema_version,
+        ),
+        health=health,
+        managed_sets=managed_sets,
+        reachable_administrators=reachable_administrators,
     )
 
 
@@ -913,6 +937,323 @@ def _managed_operational_readiness_blockers(
             )
         )
     return tuple(blockers)
+
+
+def _candidate_managed_set_policies(
+    policy: LaunchplaneAuthzPolicy,
+) -> dict[str, LaunchplaneAuthzPolicy]:
+    grouped: dict[str, dict[AuthzPrincipalType, list[AuthzPolicyRule]]] = {}
+    for principal_type, rules in _authz_policy_rule_collections(policy):
+        for rule in rules:
+            if rule.managed_set_id is None:
+                continue
+            collections = grouped.setdefault(
+                rule.managed_set_id,
+                {candidate_type: [] for candidate_type in _AUTHZ_PRINCIPAL_TYPES},
+            )
+            collections[principal_type].append(rule)
+    return {
+        managed_set_id: LaunchplaneAuthzPolicy.model_validate(
+            {
+                "schema_version": 2,
+                **{
+                    principal_type: tuple(collections[principal_type])
+                    for principal_type in _AUTHZ_PRINCIPAL_TYPES
+                },
+            }
+        )
+        for managed_set_id, collections in grouped.items()
+    }
+
+
+def validate_authz_candidate_policy(
+    policy: LaunchplaneAuthzPolicy,
+) -> LaunchplaneAuthzPolicy:
+    if policy.schema_version != 2:
+        raise ValueError("Authorization candidate policy preview requires schema version 2.")
+    normalized_policy = _normalize_desired_authz_policy(policy)
+    for managed_set_id, managed_set_policy in sorted(
+        _candidate_managed_set_policies(normalized_policy).items()
+    ):
+        AuthzManagedPolicyReconcileEnvelope(
+            product="launchplane",
+            managed_set_id=managed_set_id,
+            desired_policy=managed_set_policy,
+        )
+    return normalized_policy
+
+
+def _authz_policy_rule_count(policy: LaunchplaneAuthzPolicy) -> int:
+    return sum(len(rules) for _, rules in _authz_policy_rule_collections(policy))
+
+
+def _authz_policy_principal_rule_counts(
+    policy: LaunchplaneAuthzPolicy,
+) -> AuthzPrincipalRuleCounts:
+    return AuthzPrincipalRuleCounts(
+        **{
+            principal_type: len(rules)
+            for principal_type, rules in _authz_policy_rule_collections(policy)
+        }
+    )
+
+
+def _authz_policy_managed_rule_entries(
+    policy: LaunchplaneAuthzPolicy,
+) -> dict[tuple[str, str], AuthzPolicyRuleEntry]:
+    return {
+        (rule.managed_set_id, rule.managed_rule_id): AuthzPolicyRuleEntry(
+            principal_type=principal_type,
+            rule=rule,
+        )
+        for principal_type, rules in _authz_policy_rule_collections(policy)
+        for rule in rules
+        if rule.managed_set_id is not None and rule.managed_rule_id is not None
+    }
+
+
+def _authz_policy_unmanaged_rule_hashes(
+    policy: LaunchplaneAuthzPolicy,
+) -> dict[AuthzPrincipalType, Counter[str]]:
+    rule_hashes: dict[AuthzPrincipalType, Counter[str]] = {
+        "github_actions": Counter(),
+        "github_humans": Counter(),
+        "terminal_agents": Counter(),
+        "local_operators": Counter(),
+        "local_admins": Counter(),
+    }
+    for principal_type, rules in _authz_policy_rule_collections(policy):
+        for rule in rules:
+            if rule.managed_set_id is None:
+                rule_hashes[principal_type][_authz_rule_sha256(rule)] += 1
+    return rule_hashes
+
+
+def build_authz_candidate_policy_structural_diff(
+    *,
+    active_policy: LaunchplaneAuthzPolicy,
+    candidate_policy: LaunchplaneAuthzPolicy,
+) -> AuthzPolicyCandidateStructuralDiff:
+    active_managed = _authz_policy_managed_rule_entries(active_policy)
+    candidate_managed = _authz_policy_managed_rule_entries(candidate_policy)
+    active_unmanaged = _authz_policy_unmanaged_rule_hashes(active_policy)
+    candidate_unmanaged = _authz_policy_unmanaged_rule_hashes(candidate_policy)
+
+    managed_keys = active_managed.keys() | candidate_managed.keys()
+    added_managed_rule_count = 0
+    removed_managed_rule_count = 0
+    updated_managed_rule_count = 0
+    unchanged_managed_rule_count = 0
+    changed_principal_types: set[AuthzPrincipalType] = set()
+    for managed_key in managed_keys:
+        active_entry = active_managed.get(managed_key)
+        candidate_entry = candidate_managed.get(managed_key)
+        if active_entry is None:
+            assert candidate_entry is not None
+            added_managed_rule_count += 1
+            changed_principal_types.add(candidate_entry.principal_type)
+            continue
+        if candidate_entry is None:
+            removed_managed_rule_count += 1
+            changed_principal_types.add(active_entry.principal_type)
+            continue
+        if active_entry.principal_type == candidate_entry.principal_type and _authz_rule_sha256(
+            active_entry.rule
+        ) == _authz_rule_sha256(candidate_entry.rule):
+            unchanged_managed_rule_count += 1
+            continue
+        updated_managed_rule_count += 1
+        changed_principal_types.update(
+            (active_entry.principal_type, candidate_entry.principal_type)
+        )
+
+    added_unmanaged_rule_count = 0
+    removed_unmanaged_rule_count = 0
+    unchanged_unmanaged_rule_count = 0
+    for principal_type in _AUTHZ_PRINCIPAL_TYPES:
+        active_hashes = active_unmanaged[principal_type]
+        candidate_hashes = candidate_unmanaged[principal_type]
+        for rule_sha256 in active_hashes.keys() | candidate_hashes.keys():
+            active_count = active_hashes[rule_sha256]
+            candidate_count = candidate_hashes[rule_sha256]
+            unchanged_unmanaged_rule_count += min(active_count, candidate_count)
+            if candidate_count > active_count:
+                added_unmanaged_rule_count += candidate_count - active_count
+                changed_principal_types.add(principal_type)
+            elif active_count > candidate_count:
+                removed_unmanaged_rule_count += active_count - candidate_count
+                changed_principal_types.add(principal_type)
+
+    active_managed_sets = {managed_set_id for managed_set_id, _ in active_managed}
+    candidate_managed_sets = {managed_set_id for managed_set_id, _ in candidate_managed}
+    added_rule_count = added_managed_rule_count + added_unmanaged_rule_count
+    removed_rule_count = removed_managed_rule_count + removed_unmanaged_rule_count
+    schema_changed = active_policy.schema_version != candidate_policy.schema_version
+    changed = bool(
+        schema_changed or added_rule_count or updated_managed_rule_count or removed_rule_count
+    )
+    return AuthzPolicyCandidateStructuralDiff(
+        changed=changed,
+        schema_changed=schema_changed,
+        active_rule_count=_authz_policy_rule_count(active_policy),
+        candidate_rule_count=_authz_policy_rule_count(candidate_policy),
+        added_rule_count=added_rule_count,
+        updated_rule_count=updated_managed_rule_count,
+        removed_rule_count=removed_rule_count,
+        unchanged_rule_count=(unchanged_managed_rule_count + unchanged_unmanaged_rule_count),
+        active_managed_rule_count=len(active_managed),
+        candidate_managed_rule_count=len(candidate_managed),
+        active_unmanaged_rule_count=sum(
+            sum(rule_hashes.values()) for rule_hashes in active_unmanaged.values()
+        ),
+        candidate_unmanaged_rule_count=sum(
+            sum(rule_hashes.values()) for rule_hashes in candidate_unmanaged.values()
+        ),
+        added_managed_set_count=len(candidate_managed_sets - active_managed_sets),
+        removed_managed_set_count=len(active_managed_sets - candidate_managed_sets),
+        retained_managed_set_count=len(active_managed_sets & candidate_managed_sets),
+        changed_principal_types=tuple(
+            principal_type
+            for principal_type in _AUTHZ_PRINCIPAL_TYPES
+            if principal_type in changed_principal_types
+        ),
+        active_principal_rule_counts=_authz_policy_principal_rule_counts(active_policy),
+        candidate_principal_rule_counts=_authz_policy_principal_rule_counts(candidate_policy),
+    )
+
+
+def _candidate_policy_readiness(
+    policy: LaunchplaneAuthzPolicy,
+) -> AuthzPolicyCandidateReadinessSummary:
+    blockers = tuple(
+        blocker
+        for managed_set_id, managed_set_policy in sorted(
+            _candidate_managed_set_policies(policy).items()
+        )
+        for blocker in _managed_operational_readiness_blockers(
+            desired_policy=managed_set_policy,
+            managed_set_id=managed_set_id,
+        )
+    )
+    reason_codes: set[AuthzPolicyCandidateReadinessReason] = {
+        reason_code for blocker in blockers for reason_code in blocker.reason_codes
+    }
+    return AuthzPolicyCandidateReadinessSummary(
+        blocked_rule_count=len(blockers),
+        reason_codes=tuple(
+            reason_code
+            for reason_code in _AUTHZ_OPERATIONAL_READINESS_BLOCKER_CODES
+            if reason_code in reason_codes
+        ),
+    )
+
+
+def preview_authz_candidate_policy(
+    *,
+    active_record: LaunchplaneAuthzPolicyRecord,
+    caller_identity: AuthzApplyingIdentity,
+    request: AuthzPolicyCandidatePreviewRequest,
+    trace_id: str,
+) -> AuthzPolicyCandidatePreviewResponse:
+    submitted_candidate_sha256 = authz_policy_sha256(request.candidate_policy)
+    candidate_policy = validate_authz_candidate_policy(request.candidate_policy)
+    evaluated_candidate_sha256 = authz_policy_sha256(candidate_policy)
+    normalized_active_policy = _normalize_desired_authz_policy(active_record.policy)
+    _validate_github_managed_workflow_transition(
+        current_rules=active_record.policy.github_actions,
+        desired_rules=tuple(
+            rule for rule in candidate_policy.github_actions if rule.managed_set_id is not None
+        ),
+    )
+    active_health, _, active_reachable_administrators = summarize_authz_policy_health(
+        policy=active_record.policy,
+        caller_identity=caller_identity,
+    )
+    candidate_health, _, candidate_reachable_administrators = summarize_authz_policy_health(
+        policy=candidate_policy,
+        caller_identity=caller_identity,
+    )
+    probe_results: list[AuthzPolicyCandidateProbeResult] = []
+    for probe in request.probes:
+        target = (
+            AuthorizationTarget(scope="instance", instances=(probe.instance,))
+            if probe.target_scope == "instance"
+            else AuthorizationTarget(scope="context")
+        )
+        active_evaluation = active_record.policy.evaluate(
+            identity=probe.identity(),
+            action=probe.action,
+            product=probe.product,
+            context=probe.context,
+            target=target,
+            record_context=False,
+        )
+        candidate_evaluation = candidate_policy.evaluate(
+            identity=probe.identity(),
+            action=probe.action,
+            product=probe.product,
+            context=probe.context,
+            target=target,
+            record_context=False,
+        )
+        delta: AuthzPolicyCandidateProbeDelta
+        if active_evaluation.decision == candidate_evaluation.decision:
+            delta = (
+                "unchanged"
+                if active_evaluation.reason_code == candidate_evaluation.reason_code
+                else "reason_changed"
+            )
+        elif candidate_evaluation.decision == "allowed":
+            delta = "granted"
+        else:
+            delta = "revoked"
+        probe_results.append(
+            AuthzPolicyCandidateProbeResult(
+                request=EffectiveAccessRequestSummary(
+                    principal_type=probe.principal.principal_type,
+                    action=probe.action,
+                    product=probe.product,
+                    context=probe.context,
+                    target_scope=probe.target_scope,
+                    instance=probe.instance,
+                ),
+                active_evaluation=EffectiveAccessDecision(
+                    decision=active_evaluation.decision,
+                    reason_code=active_evaluation.reason_code,
+                ),
+                candidate_evaluation=EffectiveAccessDecision(
+                    decision=candidate_evaluation.decision,
+                    reason_code=candidate_evaluation.reason_code,
+                ),
+                delta=delta,
+            )
+        )
+    return AuthzPolicyCandidatePreviewResponse(
+        trace_id=trace_id,
+        active_policy=AuthzPolicyRecordSummary(
+            record_id=active_record.record_id,
+            revision=active_record.revision,
+            policy_sha256=active_record.policy_sha256,
+            updated_at=active_record.updated_at,
+            schema_version=active_record.policy.schema_version,
+        ),
+        candidate_policy=AuthzPolicyCandidateSummary(
+            submitted_policy_sha256=submitted_candidate_sha256,
+            evaluated_policy_sha256=evaluated_candidate_sha256,
+            normalized=submitted_candidate_sha256 != evaluated_candidate_sha256,
+            rule_count=_authz_policy_rule_count(candidate_policy),
+        ),
+        diff=build_authz_candidate_policy_structural_diff(
+            active_policy=normalized_active_policy,
+            candidate_policy=candidate_policy,
+        ),
+        active_health=active_health,
+        candidate_health=candidate_health,
+        active_reachable_administrators=active_reachable_administrators,
+        candidate_reachable_administrators=candidate_reachable_administrators,
+        candidate_readiness=_candidate_policy_readiness(candidate_policy),
+        probes=tuple(probe_results),
+    )
 
 
 def _github_transition_selector_payload(rule: GitHubActionsPolicyRule) -> dict[str, Any]:

--- a/control_plane/contracts/authz_access_read.py
+++ b/control_plane/contracts/authz_access_read.py
@@ -11,6 +11,7 @@ from control_plane.service_auth import (
     LaunchplaneIdentity,
     LocalAdminIdentity,
     LocalOperatorIdentity,
+    LaunchplaneAuthzPolicy,
     TerminalAgentIdentity,
 )
 
@@ -18,6 +19,31 @@ from control_plane.service_auth import (
 EFFECTIVE_ACCESS_READ_ACTION = "authz_policy_effective_access.read"
 AUTHZ_DENIAL_EXPLANATION_READ_ACTION = "authz_denial_explanation.read"
 AUTHZ_POLICY_HEALTH_READ_ACTION = "authz_policy_health.read"
+AUTHZ_POLICY_CANDIDATE_PREVIEW_READ_ACTION = "authz_policy_candidate_preview.read"
+AUTHZ_POLICY_CANDIDATE_PREVIEW_MAX_PROBES = 25
+AUTHZ_POLICY_CANDIDATE_PREVIEW_MAX_RULES = 500
+AuthzPolicyPrincipalType: TypeAlias = Literal[
+    "github_actions",
+    "github_humans",
+    "terminal_agents",
+    "local_operators",
+    "local_admins",
+]
+AuthzPolicyCandidateReadinessReason: TypeAlias = Literal[
+    "repository_not_exact",
+    "workflow_refs_not_singleton",
+    "workflow_ref_not_exact",
+    "job_workflow_refs_not_singleton",
+    "job_workflow_ref_not_immutable",
+    "actions_not_singleton",
+    "action_not_exact",
+    "products_not_singleton",
+    "product_not_exact",
+    "contexts_not_singleton",
+    "context_not_exact",
+    "instances_not_singleton",
+    "instance_not_exact",
+]
 
 
 class GitHubActionsAccessPrincipal(BaseModel):
@@ -253,6 +279,37 @@ class EffectiveAccessEvaluateResponse(BaseModel):
     evaluation: EffectiveAccessDecision
 
 
+class AuthzPolicyCandidatePreviewRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    candidate_policy: LaunchplaneAuthzPolicy
+    probes: tuple[EffectiveAccessEvaluateRequest, ...] = Field(
+        default=(),
+        max_length=AUTHZ_POLICY_CANDIDATE_PREVIEW_MAX_PROBES,
+    )
+
+    @model_validator(mode="after")
+    def _validate_candidate(self) -> "AuthzPolicyCandidatePreviewRequest":
+        if self.candidate_policy.schema_version != 2:
+            raise ValueError("Authorization candidate policy preview requires schema version 2.")
+        rule_count = sum(
+            len(rules)
+            for rules in (
+                self.candidate_policy.github_actions,
+                self.candidate_policy.github_humans,
+                self.candidate_policy.terminal_agents,
+                self.candidate_policy.local_operators,
+                self.candidate_policy.local_admins,
+            )
+        )
+        if rule_count > AUTHZ_POLICY_CANDIDATE_PREVIEW_MAX_RULES:
+            raise ValueError("Authorization candidate policy preview contains too many rules.")
+        probe_keys = tuple(probe.model_dump_json() for probe in self.probes)
+        if len(set(probe_keys)) != len(probe_keys):
+            raise ValueError("Authorization candidate policy preview probes must be unique.")
+        return self
+
+
 class AuthzDenialExplanationResponse(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -356,5 +413,81 @@ class AuthzPolicyHealthSnapshot(BaseModel):
 
 
 class AuthzPolicyHealthResponse(AuthzPolicyHealthSnapshot):
+    status: Literal["ok"] = "ok"
+    trace_id: str
+
+
+class AuthzPolicyCandidateSummary(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    submitted_policy_sha256: str
+    evaluated_policy_sha256: str
+    normalized: bool
+    schema_version: Literal[2] = 2
+    rule_count: int = Field(ge=0)
+
+
+class AuthzPolicyCandidateStructuralDiff(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    changed: bool
+    schema_changed: bool
+    active_rule_count: int = Field(ge=0)
+    candidate_rule_count: int = Field(ge=0)
+    added_rule_count: int = Field(ge=0)
+    updated_rule_count: int = Field(ge=0)
+    removed_rule_count: int = Field(ge=0)
+    unchanged_rule_count: int = Field(ge=0)
+    active_managed_rule_count: int = Field(ge=0)
+    candidate_managed_rule_count: int = Field(ge=0)
+    active_unmanaged_rule_count: int = Field(ge=0)
+    candidate_unmanaged_rule_count: int = Field(ge=0)
+    added_managed_set_count: int = Field(ge=0)
+    removed_managed_set_count: int = Field(ge=0)
+    retained_managed_set_count: int = Field(ge=0)
+    changed_principal_types: tuple[AuthzPolicyPrincipalType, ...]
+    active_principal_rule_counts: AuthzPrincipalRuleCounts
+    candidate_principal_rule_counts: AuthzPrincipalRuleCounts
+
+
+class AuthzPolicyCandidateReadinessSummary(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    blocked_rule_count: int = Field(ge=0)
+    reason_codes: tuple[AuthzPolicyCandidateReadinessReason, ...]
+
+
+AuthzPolicyCandidateProbeDelta: TypeAlias = Literal[
+    "unchanged",
+    "granted",
+    "revoked",
+    "reason_changed",
+]
+
+
+class AuthzPolicyCandidateProbeResult(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    request: EffectiveAccessRequestSummary
+    active_evaluation: EffectiveAccessDecision
+    candidate_evaluation: EffectiveAccessDecision
+    delta: AuthzPolicyCandidateProbeDelta
+
+
+class AuthzPolicyCandidatePreviewSnapshot(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    active_policy: AuthzPolicyRecordSummary
+    candidate_policy: AuthzPolicyCandidateSummary
+    diff: AuthzPolicyCandidateStructuralDiff
+    active_health: AuthzPolicyHealthSummary
+    candidate_health: AuthzPolicyHealthSummary
+    active_reachable_administrators: AuthzReachableAdministratorSummary
+    candidate_reachable_administrators: AuthzReachableAdministratorSummary
+    candidate_readiness: AuthzPolicyCandidateReadinessSummary
+    probes: tuple[AuthzPolicyCandidateProbeResult, ...]
+
+
+class AuthzPolicyCandidatePreviewResponse(AuthzPolicyCandidatePreviewSnapshot):
     status: Literal["ok"] = "ok"
     trace_id: str

--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -76,9 +76,12 @@ from control_plane.contracts.generic_web_deploy_recovery import (
 )
 from control_plane.contracts.authz_access_read import (
     AUTHZ_DENIAL_EXPLANATION_READ_ACTION,
+    AUTHZ_POLICY_CANDIDATE_PREVIEW_READ_ACTION,
     AUTHZ_POLICY_HEALTH_READ_ACTION,
     EFFECTIVE_ACCESS_READ_ACTION,
     AuthzDenialExplanationResponse,
+    AuthzPolicyCandidatePreviewRequest,
+    AuthzPolicyCandidatePreviewResponse,
     AuthzPolicyHealthResponse,
     EffectiveAccessDecision,
     EffectiveAccessEvaluateRequest,
@@ -1024,6 +1027,7 @@ _AUTHZ_POLICY_ACTIVE_ROUTE = "/v1/authz-policies/active"
 _AUTHZ_DIAGNOSTIC_EVALUATE_ROUTE = "/v1/authz-diagnostics/github-actions/evaluate"
 _AUTHZ_EFFECTIVE_ACCESS_EVALUATE_ROUTE = "/v1/authz-diagnostics/effective-access/evaluate"
 _AUTHZ_POLICY_HEALTH_ROUTE = "/v1/authz-diagnostics/active-policy/health"
+_AUTHZ_POLICY_CANDIDATE_PREVIEW_ROUTE = "/v1/authz-diagnostics/candidate-policy/preview"
 _AUTHZ_DENIAL_EXPLANATION_ROUTE = "/v1/authz-diagnostics/denials/{trace_id}"
 _AUTHZ_POLICY_MANAGED_RECONCILE_ROUTE = "/v1/authz-policies/managed-rule-sets/reconcile"
 _GENERIC_WEB_PREVIEW_AUTHZ_PLAN_ROUTE = (
@@ -4031,6 +4035,33 @@ def create_launchplane_fastapi_app(
         request.state.launchplane_human_session = session
         return session.identity
 
+    def read_nonrenewing_human_session(
+        *,
+        cookie_header: str,
+    ) -> LaunchplaneHumanSession | None:
+        if human_session_manager is None:
+            return None
+        session = human_session_manager.read_cookie_without_renewal(cookie_header)
+        if session is None:
+            return None
+        if not enforce_human_policy_revalidation:
+            return session
+        if not human_session_manager.authorization_claims_are_current(session):
+            return None
+        current_role = human_session_manager.authorized_role(
+            identity=session.identity,
+            authz_policy=resolved_authz_policy_runtime.policy,
+        )
+        if current_role not in {"admin", "read_only"}:
+            return None
+        resolved_role: Literal["read_only", "admin"] = current_role
+        if resolved_role == session.identity.role:
+            return session
+        return replace(
+            session,
+            identity=replace(session.identity, role=resolved_role),
+        )
+
     def human_identity_response(identity: GitHubHumanIdentity) -> GitHubHumanIdentityResponse:
         return GitHubHumanIdentityResponse(
             login=identity.login,
@@ -4283,6 +4314,32 @@ def create_launchplane_fastapi_app(
             reject_browser_mutation()
         consume_browser_mutation_request(request=request, session=session)
         return identity
+
+    def read_nonpersisting_sensitive_identity(
+        request: Request,
+        authorization: Annotated[str, Header(alias="Authorization")] = "",
+        cookie: Annotated[str, Header(alias="Cookie")] = "",
+    ) -> LaunchplaneIdentity:
+        bearer_identity = resolve_bearer_identity(authorization)
+        if bearer_identity is not None:
+            return bearer_identity
+        session = read_nonrenewing_human_session(cookie_header=cookie)
+        if session is None or human_session_manager is None:
+            raise _authentication_required_error("Authorization header is required.")
+        try:
+            csrf_token = validate_browser_mutation_request_headers(
+                expected_origin=human_session_manager.public_origin,
+                origin_values=tuple(request.headers.getlist("Origin")),
+                sec_fetch_site_values=tuple(request.headers.getlist("Sec-Fetch-Site")),
+                sec_fetch_mode_values=tuple(request.headers.getlist("Sec-Fetch-Mode")),
+                sec_fetch_dest_values=tuple(request.headers.getlist("Sec-Fetch-Dest")),
+                csrf_token_values=tuple(request.headers.getlist(BROWSER_CSRF_HEADER_NAME)),
+            )
+        except (PermissionError, ValueError):
+            reject_browser_mutation()
+        if not human_session_manager.csrf_token_is_valid(session, csrf_token):
+            reject_browser_mutation()
+        return session.identity
 
     def read_work_graph_rank_identity(
         request: Request,
@@ -14562,6 +14619,80 @@ def create_launchplane_fastapi_app(
             **snapshot.model_dump(),
         )
 
+    async def preview_authz_candidate_policy(
+        preview_request: AuthzPolicyCandidatePreviewRequest,
+        identity: Annotated[
+            LaunchplaneIdentity,
+            Depends(read_nonpersisting_sensitive_identity),
+        ],
+        record_store: Annotated[object, Depends(get_record_store)],
+    ) -> AuthzPolicyCandidatePreviewResponse:
+        trace_id = next_trace_id()
+        is_administrator = isinstance(identity, LocalAdminIdentity) or (
+            isinstance(identity, GitHubHumanIdentity) and identity.role == "admin"
+        )
+        preflight_authorized = (
+            resolved_authz_policy_runtime.policy.evaluate(
+                identity=identity,
+                action=AUTHZ_POLICY_CANDIDATE_PREVIEW_READ_ACTION,
+                product="launchplane",
+                context=_LAUNCHPLANE_SERVICE_CONTEXT,
+                record_context=False,
+            ).decision
+            == "allowed"
+        )
+        if not is_administrator or not preflight_authorized:
+            raise _launchplane_http_error(
+                status_code=403,
+                trace_id=trace_id,
+                code="authorization_denied",
+                message="Identity cannot preview Launchplane authz candidate policy.",
+            )
+        database_store = require_authz_policy_database_store(
+            record_store=record_store,
+            trace_id=trace_id,
+            message="Authz candidate policy previews require Launchplane database storage.",
+        )
+        active_record = read_single_active_authz_policy_record(
+            database_store=database_store,
+            trace_id=trace_id,
+        )
+        active_policy_authorized = (
+            active_record.policy.evaluate(
+                identity=identity,
+                action=AUTHZ_POLICY_CANDIDATE_PREVIEW_READ_ACTION,
+                product="launchplane",
+                context=_LAUNCHPLANE_SERVICE_CONTEXT,
+                record_context=False,
+            ).decision
+            == "allowed"
+        )
+        if not active_policy_authorized:
+            raise _launchplane_http_error(
+                status_code=403,
+                trace_id=trace_id,
+                code="authorization_denied",
+                message="Identity cannot preview Launchplane authz candidate policy.",
+                authz_policy_provenance=AuthzPolicyProvenance.from_record(active_record),
+            )
+        try:
+            return control_plane_authz_grant_service.preview_authz_candidate_policy(
+                active_record=active_record,
+                caller_identity=identity,
+                request=preview_request,
+                trace_id=trace_id,
+            )
+        except (
+            control_plane_authz_grant_service.AuthzPolicyRequestError,
+            ValueError,
+        ) as error:
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="authz_candidate_policy_invalid",
+                message="Authorization candidate policy is invalid.",
+            ) from error
+
     async def evaluate_effective_access(
         evaluation_request: EffectiveAccessEvaluateRequest,
         identity: Annotated[LaunchplaneIdentity, Depends(read_browser_mutation_identity)],
@@ -22380,6 +22511,20 @@ def create_launchplane_fastapi_app(
         response_model_exclude_none=True,
         operation_id="read_authz_policy_health",
         summary="Read bounded active authorization policy health",
+        responses={
+            **authz_diagnostic_route_responses,
+            409: {"model": LaunchplaneErrorResponse},
+        },
+    )
+
+    app.add_api_route(
+        _AUTHZ_POLICY_CANDIDATE_PREVIEW_ROUTE,
+        preview_authz_candidate_policy,
+        methods=["POST"],
+        response_model=AuthzPolicyCandidatePreviewResponse,
+        response_model_exclude_none=True,
+        operation_id="preview_authz_candidate_policy",
+        summary="Preview one exact authorization candidate policy",
         responses={
             **authz_diagnostic_route_responses,
             409: {"model": LaunchplaneErrorResponse},

--- a/control_plane/service_human_auth.py
+++ b/control_plane/service_human_auth.py
@@ -69,6 +69,11 @@ class HumanSessionStore(Protocol):
 
     def read_session(self, session_id: str) -> LaunchplaneHumanSession | None: ...
 
+    def read_session_without_cleanup(
+        self,
+        session_id: str,
+    ) -> LaunchplaneHumanSession | None: ...
+
     def delete_session(self, session_id: str) -> None: ...
 
     def write_session_if_csrf_generation(
@@ -109,6 +114,13 @@ class InMemoryHumanSessionStore:
                 self._sessions.pop(session_id, None)
                 return None
             return session
+
+    def read_session_without_cleanup(
+        self,
+        session_id: str,
+    ) -> LaunchplaneHumanSession | None:
+        with self._lock:
+            return self._sessions.get(session_id)
 
     def delete_session(self, session_id: str) -> None:
         with self._lock:
@@ -405,6 +417,18 @@ class HumanSessionManager:
             return None
         return self._session_store.read_session(session_id)
 
+    def read_cookie_without_renewal(self, cookie_header: str) -> LaunchplaneHumanSession | None:
+        signed_session_id = _cookie_value(cookie_header, SESSION_COOKIE_NAME)
+        if not signed_session_id:
+            return None
+        session_id = self._verify_cookie_value(signed_session_id)
+        if not session_id:
+            return None
+        session = self._session_store.read_session_without_cleanup(session_id)
+        if session is None or session.expires_at <= self._now():
+            return None
+        return session
+
     def authorization_claims_are_current(self, session: LaunchplaneHumanSession) -> bool:
         now = self._now()
         return (
@@ -452,20 +476,23 @@ class HumanSessionManager:
         )
         return f"{_BROWSER_CSRF_TOKEN_VERSION}.{generation}.{signature}"
 
+    def csrf_token_is_valid(self, session: LaunchplaneHumanSession, token: str) -> bool:
+        normalized_token = token.strip()
+        if not normalized_token.isascii():
+            return False
+        generation = _csrf_token_generation(normalized_token)
+        if generation is None or generation != session.csrf_generation:
+            return False
+        return hmac.compare_digest(normalized_token, self.csrf_token(session))
+
     def consume_csrf_token(
         self,
         session: LaunchplaneHumanSession,
         token: str,
     ) -> LaunchplaneHumanSession | None:
-        normalized_token = token.strip()
-        if not normalized_token.isascii():
+        if not self.csrf_token_is_valid(session, token):
             return None
-        generation = _csrf_token_generation(normalized_token)
-        if generation is None or generation != session.csrf_generation:
-            return None
-        expected_token = self.csrf_token(session)
-        if not hmac.compare_digest(normalized_token, expected_token):
-            return None
+        generation = session.csrf_generation
         rotated_session = replace(session, csrf_generation=generation + 1)
         if not self._session_store.write_session_if_csrf_generation(
             rotated_session,

--- a/control_plane/storage/postgres.py
+++ b/control_plane/storage/postgres.py
@@ -8234,6 +8234,21 @@ class PostgresRecordStore(HumanSessionStore):
                 return None
             return human_session
 
+    def read_session_without_cleanup(
+        self,
+        session_id: str,
+    ) -> LaunchplaneHumanSession | None:
+        statement = (
+            select(LaunchplaneHumanSessionRow.payload)
+            .where(LaunchplaneHumanSessionRow.session_id == session_id)
+            .limit(1)
+        )
+        with self._session_factory() as session:
+            payload = session.scalar(statement)
+            if payload is None:
+                return None
+            return _human_session_from_payload(payload)
+
     def delete_session(self, session_id: str) -> None:
         with self._session_factory() as session:
             session.execute(

--- a/docs/authorization-authority.md
+++ b/docs/authorization-authority.md
@@ -109,6 +109,34 @@ and fails closed when active policy state is missing or ambiguous. It performs
 no policy, provider, runtime, bootstrap, secret, or deployment mutation. Landing
 the action and route does not grant production access to them.
 
+The next read-only administration slice adds
+`authz_policy_candidate_preview.read` for an authenticated GitHub administrator
+or local administrator. It accepts one complete schema-v2 candidate policy and
+at most 25 explicit effective-access probes, validates every managed set through
+the existing reconciliation contract, and compares the candidate with the exact
+single active DB policy record. The response binds to the active record ID,
+revision, and digest and contains only submitted and canonical evaluated-
+candidate digests, a normalization flag, bounded health and
+administrator counts, count/category-only structural changes, operational-
+readiness reason categories, and old/new probe decisions from the ordinary
+effective-access evaluator.
+
+The preview permission includes the bounded active-policy health and reachable-
+administrator summaries returned in the comparison; callers do not also need
+`authz_policy_health.read`. Both permissions remain restricted to authenticated
+administrators, and neither implies policy-write authority.
+
+Candidate preview responses never return raw policy, active or candidate rule
+IDs, rule hashes, selectors, repositories, workflows, actions, principal
+identifiers, token labels, secrets, or managed-set topology. Probe evaluation
+disables request-local denial recording so caller-supplied identities cannot
+contaminate support-readable denial evidence. Browser administrators use
+same-origin and CSRF verification without session renewal or token rotation;
+the preview performs no policy, session, denial-evidence, idempotency, outbox,
+provider, runtime, secret, durable-operation, or other persistence write. The
+preview does not produce an apply digest, does not prove future applying-
+administrator continuity, and does not authorize any production grant.
+
 Landing these read contracts does not authorize their production grants and
 does not relax the active freeze. Production policy changes still require the
 separate reviewed administration and recovery gates owned by `#2058`/`#2061`.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -593,6 +593,7 @@ Current implementation scope:
 - `POST /v1/authz-policies/managed-rule-sets/reconcile`
 - `POST /v1/authz-diagnostics/github-actions/evaluate`
 - `GET /v1/authz-diagnostics/active-policy/health`
+- `POST /v1/authz-diagnostics/candidate-policy/preview`
 - `GET /v1/route-bindings/records/current`
 - `POST /v1/route-bindings/reconcile`
 - `POST /v1/route-bindings/odoo-testing/controller/run-once`
@@ -669,6 +670,23 @@ reason codes, managed-set rule counts, and reachable policy-administrator rule
 counts. It never returns managed rule IDs, rule hashes, selectors, actions, or
 principal identities. Missing or multiple active records fail closed, and the
 read does not authorize a policy write or production grant.
+
+`POST /v1/authz-diagnostics/candidate-policy/preview` is the non-persisting
+administrator preview for one exact schema-v2 candidate policy. The caller must
+be a GitHub administrator or local administrator with
+`authz_policy_candidate_preview.read`; Launchplane authorizes against runtime
+policy, reloads the single active DB record, and authorizes again. The service
+validates every managed candidate set through the existing reconciliation
+contract and evaluates at most 25 caller-supplied probes against the active and
+candidate policies through the ordinary evaluator with denial-context recording
+disabled. Responses contain only active record/revision/digest, submitted and
+canonical evaluated-candidate digests, a normalization flag, bounded counts and
+reason categories, and old/new probe decisions. They expose
+no rules, managed IDs, rule hashes, selectors, actions, principal identifiers,
+tokens, secrets, or topology. Browser calls retain same-origin and CSRF checks
+without session renewal or rotation, and no policy, session, denial, audit,
+idempotency, outbox, provider, runtime, secret, or durable-operation record is
+written.
 
 Standard `authorization_denied` HTTP failures with a captured policy evaluation
 write a redacted `launchplane_authz_denials` audit record on a best-effort basis.

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -304,6 +304,7 @@ cleanup scope so the store is always closed.
 - authz policy administration routes:
   - `GET /v1/authz-policies/active`
   - `GET /v1/authz-diagnostics/active-policy/health`
+  - `POST /v1/authz-diagnostics/candidate-policy/preview`
   - `POST /v1/authz-policies/managed-rule-sets/reconcile`
     (native FastAPI for bearer-token and signed-in GitHub human-session
     callers and DB-backed policy records; managed-rule-set dry-runs return a
@@ -730,6 +731,21 @@ does not expose managed rule IDs, rule hashes, selectors, actions, repositories,
 workflows, or principal identifiers. Missing active state returns `503`, and
 multiple active records return `409`; the service never falls back to cached
 policy state for the response.
+
+`POST /v1/authz-diagnostics/candidate-policy/preview` is a separate
+administrator-read contract protected by `authz_policy_candidate_preview.read`.
+It accepts one exact schema-v2 candidate authorization policy and at most 25
+explicit probes, reloads and reauthorizes against the single active DB policy,
+and evaluates both policies through the ordinary effective-access evaluator.
+The response contains immutable active-policy provenance, submitted and
+canonical evaluated-candidate digests, a normalization flag, bounded health and
+administrator counts, count/category-only structural changes,
+operational-readiness reason categories, and old/new probe decisions. It never
+returns rule IDs or hashes, managed-set IDs, raw rules, selectors, actions,
+principal identifiers, tokens, secrets, or topology. Same-origin browser calls
+verify CSRF without renewing the session or rotating its token, and the route
+performs no policy, session, denial-evidence, idempotency, outbox, provider,
+runtime, secret, durable-operation, or other persistence write.
 
 New managed GitHub Actions rules require immutable GitHub `repository_id` and
 `repository_owner_id` selectors. Production-capable, destructive,

--- a/frontend/generated/openapi-canonical.json
+++ b/frontend/generated/openapi-canonical.json
@@ -1441,6 +1441,314 @@
         "title": "AuthzManagedSetSummary",
         "type": "object"
       },
+      "AuthzPolicyCandidatePreviewRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "candidate_policy": {
+            "$ref": "#/components/schemas/LaunchplaneAuthzPolicy"
+          },
+          "probes": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/EffectiveAccessEvaluateRequest"
+            },
+            "maxItems": 25,
+            "title": "Probes",
+            "type": "array"
+          }
+        },
+        "required": [
+          "candidate_policy"
+        ],
+        "title": "AuthzPolicyCandidatePreviewRequest",
+        "type": "object"
+      },
+      "AuthzPolicyCandidatePreviewResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "active_health": {
+            "$ref": "#/components/schemas/AuthzPolicyHealthSummary"
+          },
+          "active_policy": {
+            "$ref": "#/components/schemas/AuthzPolicyRecordSummary"
+          },
+          "active_reachable_administrators": {
+            "$ref": "#/components/schemas/AuthzReachableAdministratorSummary"
+          },
+          "candidate_health": {
+            "$ref": "#/components/schemas/AuthzPolicyHealthSummary"
+          },
+          "candidate_policy": {
+            "$ref": "#/components/schemas/AuthzPolicyCandidateSummary"
+          },
+          "candidate_reachable_administrators": {
+            "$ref": "#/components/schemas/AuthzReachableAdministratorSummary"
+          },
+          "candidate_readiness": {
+            "$ref": "#/components/schemas/AuthzPolicyCandidateReadinessSummary"
+          },
+          "diff": {
+            "$ref": "#/components/schemas/AuthzPolicyCandidateStructuralDiff"
+          },
+          "probes": {
+            "items": {
+              "$ref": "#/components/schemas/AuthzPolicyCandidateProbeResult"
+            },
+            "title": "Probes",
+            "type": "array"
+          },
+          "status": {
+            "const": "ok",
+            "default": "ok",
+            "title": "Status",
+            "type": "string"
+          },
+          "trace_id": {
+            "title": "Trace Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "active_policy",
+          "candidate_policy",
+          "diff",
+          "active_health",
+          "candidate_health",
+          "active_reachable_administrators",
+          "candidate_reachable_administrators",
+          "candidate_readiness",
+          "probes",
+          "trace_id"
+        ],
+        "title": "AuthzPolicyCandidatePreviewResponse",
+        "type": "object"
+      },
+      "AuthzPolicyCandidateProbeResult": {
+        "additionalProperties": false,
+        "properties": {
+          "active_evaluation": {
+            "$ref": "#/components/schemas/EffectiveAccessDecision"
+          },
+          "candidate_evaluation": {
+            "$ref": "#/components/schemas/EffectiveAccessDecision"
+          },
+          "delta": {
+            "enum": [
+              "unchanged",
+              "granted",
+              "revoked",
+              "reason_changed"
+            ],
+            "title": "Delta",
+            "type": "string"
+          },
+          "request": {
+            "$ref": "#/components/schemas/EffectiveAccessRequestSummary"
+          }
+        },
+        "required": [
+          "request",
+          "active_evaluation",
+          "candidate_evaluation",
+          "delta"
+        ],
+        "title": "AuthzPolicyCandidateProbeResult",
+        "type": "object"
+      },
+      "AuthzPolicyCandidateReadinessSummary": {
+        "additionalProperties": false,
+        "properties": {
+          "blocked_rule_count": {
+            "minimum": 0.0,
+            "title": "Blocked Rule Count",
+            "type": "integer"
+          },
+          "reason_codes": {
+            "items": {
+              "enum": [
+                "repository_not_exact",
+                "workflow_refs_not_singleton",
+                "workflow_ref_not_exact",
+                "job_workflow_refs_not_singleton",
+                "job_workflow_ref_not_immutable",
+                "actions_not_singleton",
+                "action_not_exact",
+                "products_not_singleton",
+                "product_not_exact",
+                "contexts_not_singleton",
+                "context_not_exact",
+                "instances_not_singleton",
+                "instance_not_exact"
+              ],
+              "type": "string"
+            },
+            "title": "Reason Codes",
+            "type": "array"
+          }
+        },
+        "required": [
+          "blocked_rule_count",
+          "reason_codes"
+        ],
+        "title": "AuthzPolicyCandidateReadinessSummary",
+        "type": "object"
+      },
+      "AuthzPolicyCandidateStructuralDiff": {
+        "additionalProperties": false,
+        "properties": {
+          "active_managed_rule_count": {
+            "minimum": 0.0,
+            "title": "Active Managed Rule Count",
+            "type": "integer"
+          },
+          "active_principal_rule_counts": {
+            "$ref": "#/components/schemas/AuthzPrincipalRuleCounts"
+          },
+          "active_rule_count": {
+            "minimum": 0.0,
+            "title": "Active Rule Count",
+            "type": "integer"
+          },
+          "active_unmanaged_rule_count": {
+            "minimum": 0.0,
+            "title": "Active Unmanaged Rule Count",
+            "type": "integer"
+          },
+          "added_managed_set_count": {
+            "minimum": 0.0,
+            "title": "Added Managed Set Count",
+            "type": "integer"
+          },
+          "added_rule_count": {
+            "minimum": 0.0,
+            "title": "Added Rule Count",
+            "type": "integer"
+          },
+          "candidate_managed_rule_count": {
+            "minimum": 0.0,
+            "title": "Candidate Managed Rule Count",
+            "type": "integer"
+          },
+          "candidate_principal_rule_counts": {
+            "$ref": "#/components/schemas/AuthzPrincipalRuleCounts"
+          },
+          "candidate_rule_count": {
+            "minimum": 0.0,
+            "title": "Candidate Rule Count",
+            "type": "integer"
+          },
+          "candidate_unmanaged_rule_count": {
+            "minimum": 0.0,
+            "title": "Candidate Unmanaged Rule Count",
+            "type": "integer"
+          },
+          "changed": {
+            "title": "Changed",
+            "type": "boolean"
+          },
+          "changed_principal_types": {
+            "items": {
+              "enum": [
+                "github_actions",
+                "github_humans",
+                "terminal_agents",
+                "local_operators",
+                "local_admins"
+              ],
+              "type": "string"
+            },
+            "title": "Changed Principal Types",
+            "type": "array"
+          },
+          "removed_managed_set_count": {
+            "minimum": 0.0,
+            "title": "Removed Managed Set Count",
+            "type": "integer"
+          },
+          "removed_rule_count": {
+            "minimum": 0.0,
+            "title": "Removed Rule Count",
+            "type": "integer"
+          },
+          "retained_managed_set_count": {
+            "minimum": 0.0,
+            "title": "Retained Managed Set Count",
+            "type": "integer"
+          },
+          "schema_changed": {
+            "title": "Schema Changed",
+            "type": "boolean"
+          },
+          "unchanged_rule_count": {
+            "minimum": 0.0,
+            "title": "Unchanged Rule Count",
+            "type": "integer"
+          },
+          "updated_rule_count": {
+            "minimum": 0.0,
+            "title": "Updated Rule Count",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "changed",
+          "schema_changed",
+          "active_rule_count",
+          "candidate_rule_count",
+          "added_rule_count",
+          "updated_rule_count",
+          "removed_rule_count",
+          "unchanged_rule_count",
+          "active_managed_rule_count",
+          "candidate_managed_rule_count",
+          "active_unmanaged_rule_count",
+          "candidate_unmanaged_rule_count",
+          "added_managed_set_count",
+          "removed_managed_set_count",
+          "retained_managed_set_count",
+          "changed_principal_types",
+          "active_principal_rule_counts",
+          "candidate_principal_rule_counts"
+        ],
+        "title": "AuthzPolicyCandidateStructuralDiff",
+        "type": "object"
+      },
+      "AuthzPolicyCandidateSummary": {
+        "additionalProperties": false,
+        "properties": {
+          "evaluated_policy_sha256": {
+            "title": "Evaluated Policy Sha256",
+            "type": "string"
+          },
+          "normalized": {
+            "title": "Normalized",
+            "type": "boolean"
+          },
+          "rule_count": {
+            "minimum": 0.0,
+            "title": "Rule Count",
+            "type": "integer"
+          },
+          "schema_version": {
+            "const": 2,
+            "default": 2,
+            "title": "Schema Version",
+            "type": "integer"
+          },
+          "submitted_policy_sha256": {
+            "title": "Submitted Policy Sha256",
+            "type": "string"
+          }
+        },
+        "required": [
+          "submitted_policy_sha256",
+          "evaluated_policy_sha256",
+          "normalized",
+          "rule_count"
+        ],
+        "title": "AuthzPolicyCandidateSummary",
+        "type": "object"
+      },
       "AuthzPolicyHealthResponse": {
         "additionalProperties": false,
         "properties": {
@@ -8879,6 +9187,124 @@
         "title": "GitHubActionsAccessPrincipal",
         "type": "object"
       },
+      "GitHubActionsPolicyRule": {
+        "additionalProperties": false,
+        "properties": {
+          "actions": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Actions",
+            "type": "array"
+          },
+          "contexts": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Contexts",
+            "type": "array"
+          },
+          "environments": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Environments",
+            "type": "array"
+          },
+          "event_names": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Event Names",
+            "type": "array"
+          },
+          "instances": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Instances",
+            "type": "array"
+          },
+          "job_workflow_refs": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Job Workflow Refs",
+            "type": "array"
+          },
+          "managed_rule_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Managed Rule Id"
+          },
+          "managed_set_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Managed Set Id"
+          },
+          "products": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Products",
+            "type": "array"
+          },
+          "refs": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Refs",
+            "type": "array"
+          },
+          "repository": {
+            "title": "Repository",
+            "type": "string"
+          },
+          "repository_id": {
+            "default": "",
+            "title": "Repository Id",
+            "type": "string"
+          },
+          "repository_owner_id": {
+            "default": "",
+            "title": "Repository Owner Id",
+            "type": "string"
+          },
+          "workflow_refs": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Workflow Refs",
+            "type": "array"
+          }
+        },
+        "required": [
+          "repository"
+        ],
+        "title": "GitHubActionsPolicyRule",
+        "type": "object"
+      },
       "GitHubHumanAccessPrincipal": {
         "additionalProperties": false,
         "properties": {
@@ -8988,6 +9414,111 @@
           "role"
         ],
         "title": "GitHubHumanIdentityResponse",
+        "type": "object"
+      },
+      "GitHubHumanPolicyRule": {
+        "additionalProperties": false,
+        "properties": {
+          "actions": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Actions",
+            "type": "array"
+          },
+          "contexts": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Contexts",
+            "type": "array"
+          },
+          "github_ids": {
+            "default": [],
+            "items": {
+              "type": "integer"
+            },
+            "title": "Github Ids",
+            "type": "array"
+          },
+          "instances": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Instances",
+            "type": "array"
+          },
+          "logins": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Logins",
+            "type": "array"
+          },
+          "managed_rule_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Managed Rule Id"
+          },
+          "managed_set_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Managed Set Id"
+          },
+          "organizations": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Organizations",
+            "type": "array"
+          },
+          "products": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Products",
+            "type": "array"
+          },
+          "roles": {
+            "default": [],
+            "items": {
+              "enum": [
+                "read_only",
+                "admin"
+              ],
+              "type": "string"
+            },
+            "title": "Roles",
+            "type": "array"
+          },
+          "teams": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Teams",
+            "type": "array"
+          }
+        },
+        "title": "GitHubHumanPolicyRule",
         "type": "object"
       },
       "GitHubIssueInboxIssue": {
@@ -10387,6 +10918,62 @@
         "title": "LaunchplaneActiveAuthzPolicyResponse",
         "type": "object"
       },
+      "LaunchplaneAuthzPolicy": {
+        "additionalProperties": false,
+        "properties": {
+          "github_actions": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/GitHubActionsPolicyRule"
+            },
+            "title": "Github Actions",
+            "type": "array"
+          },
+          "github_humans": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/GitHubHumanPolicyRule"
+            },
+            "title": "Github Humans",
+            "type": "array"
+          },
+          "local_admins": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/LocalAdminPolicyRule"
+            },
+            "title": "Local Admins",
+            "type": "array"
+          },
+          "local_operators": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/LocalOperatorPolicyRule"
+            },
+            "title": "Local Operators",
+            "type": "array"
+          },
+          "schema_version": {
+            "default": 1,
+            "enum": [
+              1,
+              2
+            ],
+            "title": "Schema Version",
+            "type": "integer"
+          },
+          "terminal_agents": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/TerminalAgentPolicyRule"
+            },
+            "title": "Terminal Agents",
+            "type": "array"
+          }
+        },
+        "title": "LaunchplaneAuthzPolicy",
+        "type": "object"
+      },
       "LaunchplaneErrorDetail": {
         "additionalProperties": false,
         "properties": {
@@ -10882,6 +11469,83 @@
         "title": "LocalAdminAccessPrincipal",
         "type": "object"
       },
+      "LocalAdminPolicyRule": {
+        "additionalProperties": false,
+        "properties": {
+          "actions": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Actions",
+            "type": "array"
+          },
+          "contexts": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Contexts",
+            "type": "array"
+          },
+          "instances": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Instances",
+            "type": "array"
+          },
+          "managed_rule_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Managed Rule Id"
+          },
+          "managed_set_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Managed Set Id"
+          },
+          "products": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Products",
+            "type": "array"
+          },
+          "subjects": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Subjects",
+            "type": "array"
+          },
+          "token_labels": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Token Labels",
+            "type": "array"
+          }
+        },
+        "title": "LocalAdminPolicyRule",
+        "type": "object"
+      },
       "LocalOperatorAccessPrincipal": {
         "additionalProperties": false,
         "properties": {
@@ -10905,6 +11569,83 @@
           "token_label"
         ],
         "title": "LocalOperatorAccessPrincipal",
+        "type": "object"
+      },
+      "LocalOperatorPolicyRule": {
+        "additionalProperties": false,
+        "properties": {
+          "actions": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Actions",
+            "type": "array"
+          },
+          "contexts": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Contexts",
+            "type": "array"
+          },
+          "instances": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Instances",
+            "type": "array"
+          },
+          "managed_rule_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Managed Rule Id"
+          },
+          "managed_set_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Managed Set Id"
+          },
+          "products": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Products",
+            "type": "array"
+          },
+          "subjects": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Subjects",
+            "type": "array"
+          },
+          "token_labels": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Token Labels",
+            "type": "array"
+          }
+        },
+        "title": "LocalOperatorPolicyRule",
         "type": "object"
       },
       "ManagerPreviewApprovalDecision": {
@@ -32116,6 +32857,83 @@
         "title": "TerminalAgentAccessPrincipal",
         "type": "object"
       },
+      "TerminalAgentPolicyRule": {
+        "additionalProperties": false,
+        "properties": {
+          "actions": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Actions",
+            "type": "array"
+          },
+          "contexts": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Contexts",
+            "type": "array"
+          },
+          "instances": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Instances",
+            "type": "array"
+          },
+          "managed_rule_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Managed Rule Id"
+          },
+          "managed_set_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Managed Set Id"
+          },
+          "products": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Products",
+            "type": "array"
+          },
+          "subjects": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Subjects",
+            "type": "array"
+          },
+          "token_labels": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Token Labels",
+            "type": "array"
+          }
+        },
+        "title": "TerminalAgentPolicyRule",
+        "type": "object"
+      },
       "TrackedTargetLogDeploymentResponse": {
         "additionalProperties": false,
         "properties": {
@@ -35628,6 +36446,106 @@
           }
         },
         "summary": "Read bounded active authorization policy health"
+      }
+    },
+    "/v1/authz-diagnostics/candidate-policy/preview": {
+      "post": {
+        "operationId": "preview_authz_candidate_policy",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Authorization",
+            "required": false,
+            "schema": {
+              "default": "",
+              "title": "Authorization",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "Cookie",
+            "required": false,
+            "schema": {
+              "default": "",
+              "title": "Cookie",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AuthzPolicyCandidatePreviewRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthzPolicyCandidatePreviewResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "summary": "Preview one exact authorization candidate policy"
       }
     },
     "/v1/authz-diagnostics/denials/{trace_id}": {

--- a/tests/test_authz_access_read.py
+++ b/tests/test_authz_access_read.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from collections.abc import Iterator
+from contextlib import contextmanager
+from datetime import datetime, timedelta, timezone
 import json
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -12,8 +14,10 @@ from pydantic import ValidationError
 
 from control_plane.contracts.authz_access_read import (
     AUTHZ_DENIAL_EXPLANATION_READ_ACTION,
+    AUTHZ_POLICY_CANDIDATE_PREVIEW_READ_ACTION,
     AUTHZ_POLICY_HEALTH_READ_ACTION,
     EFFECTIVE_ACCESS_READ_ACTION,
+    AuthzPolicyCandidatePreviewRequest,
     EffectiveAccessEvaluateRequest,
 )
 from control_plane.contracts.authz_denial_record import build_authz_denial_record
@@ -27,7 +31,15 @@ from control_plane.service_auth import (
     AuthzEvaluation,
     BearerIdentityConfig,
     GitHubActionsIdentity,
+    GitHubHumanIdentity,
     LaunchplaneAuthzPolicy,
+)
+from control_plane.service_human_auth import (
+    GitHubOAuthConfig,
+    HumanSessionManager,
+    InMemoryHumanSessionStore,
+    LaunchplaneHumanSession,
+    build_browser_mutation_request_headers,
 )
 from control_plane.storage.filesystem import FilesystemRecordStore
 from control_plane.storage.postgres import PostgresRecordStore
@@ -99,6 +111,7 @@ def _app(
     root: Path,
     store: object,
     record: LaunchplaneAuthzPolicyRecord,
+    human_session_manager: HumanSessionManager | None = None,
 ) -> FastAPI:
     return create_launchplane_fastapi_app(
         verifier=_RejectingVerifier(),
@@ -111,6 +124,7 @@ def _app(
             revision=record.revision,
         ),
         record_store_factory=lambda: store,
+        human_session_manager=human_session_manager,
         bearer_identity_config=BearerIdentityConfig(
             local_admin_token="admin-token",
             local_admin_subject="authz-admin",
@@ -122,6 +136,29 @@ def _app(
         control_plane_root_path=root,
         state_dir=root / "state",
     )
+
+
+@contextmanager
+def _database_app(
+    policy: LaunchplaneAuthzPolicy,
+    *,
+    human_session_manager: HumanSessionManager | None = None,
+) -> Iterator[tuple[PostgresRecordStore, LaunchplaneAuthzPolicyRecord, FastAPI]]:
+    with TemporaryDirectory() as directory:
+        root = Path(directory)
+        store = PostgresRecordStore(database_url=_database_url(root / "launchplane.sqlite3"))
+        store.ensure_schema()
+        record = _seed_policy(store, policy)
+        app = _app(
+            root=root,
+            store=store,
+            record=record,
+            human_session_manager=human_session_manager,
+        )
+        try:
+            yield store, record, app
+        finally:
+            store.close()
 
 
 class AuthzAccessReadHttpTests(unittest.IsolatedAsyncioTestCase):
@@ -214,6 +251,431 @@ class AuthzAccessReadHttpTests(unittest.IsolatedAsyncioTestCase):
         )
         route = app.openapi()["paths"]["/v1/authz-diagnostics/active-policy/health"]
         self.assertEqual(route["get"]["operationId"], "read_authz_policy_health")
+
+    async def test_administrator_previews_exact_candidate_policy_without_persistence_or_leakage(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            store = PostgresRecordStore(database_url=_database_url(root / "launchplane.sqlite3"))
+            store.ensure_schema()
+            active_policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "schema_version": 2,
+                    "local_admins": [
+                        {
+                            "managed_set_id": "operator.authz-preview",
+                            "managed_rule_id": "reader",
+                            "subjects": ["authz-admin"],
+                            "token_labels": ["authz-admin-label"],
+                            "products": ["launchplane"],
+                            "contexts": ["launchplane"],
+                            "actions": [
+                                AUTHZ_POLICY_CANDIDATE_PREVIEW_READ_ACTION,
+                                "authz_policy_grant.write",
+                            ],
+                        },
+                        {
+                            "managed_set_id": "operator.recovery",
+                            "managed_rule_id": "independent-admin",
+                            "subjects": ["independent-admin-secret"],
+                            "token_labels": ["independent-token-secret"],
+                            "products": ["launchplane"],
+                            "contexts": ["launchplane"],
+                            "actions": ["authz_policy_grant.write"],
+                        },
+                    ],
+                }
+            )
+            candidate_payload = active_policy.model_dump(mode="json")
+            candidate_payload["local_operators"] = [
+                {
+                    "managed_set_id": "operator.candidate-secret",
+                    "managed_rule_id": "probe-reader-secret",
+                    "subjects": ["probe-subject-secret"],
+                    "token_labels": ["probe-token-secret"],
+                    "products": ["example"],
+                    "contexts": ["testing"],
+                    "actions": ["artifact_protection.read"],
+                }
+            ]
+            candidate_policy = LaunchplaneAuthzPolicy.model_validate(candidate_payload)
+            record = _seed_policy(store, active_policy)
+            app = _app(root=root, store=store, record=record)
+            records_before_preview = store.list_authz_policy_records()
+            try:
+                async with lifespan_client(app) as client:
+                    with patch.object(
+                        store,
+                        "write_authz_denial_record",
+                        side_effect=AssertionError(
+                            "candidate previews must not persist denial rows"
+                        ),
+                    ):
+                        response = await client.post(
+                            "/v1/authz-diagnostics/candidate-policy/preview",
+                            headers={"Authorization": "Bearer admin-token"},
+                            json={
+                                "candidate_policy": candidate_policy.model_dump(mode="json"),
+                                "probes": [
+                                    {
+                                        "principal": {
+                                            "principal_type": "local_operator",
+                                            "subject": "probe-subject-secret",
+                                            "token_label": "probe-token-secret",
+                                        },
+                                        "action": "artifact_protection.read",
+                                        "product": "example",
+                                        "context": "testing",
+                                        "target_scope": "context",
+                                    }
+                                ],
+                            },
+                        )
+                records_after_preview = store.list_authz_policy_records()
+            finally:
+                store.close()
+
+        self.assertEqual(response.status_code, 200, response.text)
+        self.assertEqual(records_after_preview, records_before_preview)
+        payload = response.json()
+        self.assertEqual(payload["active_policy"]["record_id"], record.record_id)
+        self.assertEqual(payload["active_policy"]["revision"], record.revision)
+        self.assertEqual(payload["active_policy"]["policy_sha256"], record.policy_sha256)
+        self.assertTrue(payload["diff"]["changed"])
+        self.assertEqual(payload["diff"]["added_rule_count"], 1)
+        self.assertEqual(payload["probes"][0]["active_evaluation"]["decision"], "denied")
+        self.assertEqual(payload["probes"][0]["candidate_evaluation"]["decision"], "allowed")
+        self.assertEqual(payload["probes"][0]["delta"], "granted")
+        serialized = json.dumps(payload, sort_keys=True)
+        for private_value in (
+            "authz-admin",
+            "authz-admin-label",
+            "independent-admin-secret",
+            "independent-token-secret",
+            "operator.candidate-secret",
+            "probe-reader-secret",
+            "probe-subject-secret",
+            "probe-token-secret",
+        ):
+            self.assertNotIn(private_value, serialized)
+        self.assertTrue(
+            {
+                "managed_set_id",
+                "managed_rule_id",
+                "subjects",
+                "token_labels",
+                "actions",
+                "products",
+                "contexts",
+                "policy",
+                "rule_sha256",
+            }.isdisjoint(_nested_mapping_keys(payload))
+        )
+        route = app.openapi()["paths"]["/v1/authz-diagnostics/candidate-policy/preview"]
+        self.assertEqual(route["post"]["operationId"], "preview_authz_candidate_policy")
+
+    async def test_browser_administrator_preview_does_not_renew_or_rotate_session(self) -> None:
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            store = PostgresRecordStore(database_url=_database_url(root / "launchplane.sqlite3"))
+            store.ensure_schema()
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "schema_version": 2,
+                    "github_humans": [
+                        {
+                            "managed_set_id": "operator.authz-preview",
+                            "managed_rule_id": "browser-admin",
+                            "github_ids": [12345],
+                            "roles": ["admin"],
+                            "products": ["launchplane"],
+                            "contexts": ["launchplane"],
+                            "actions": [
+                                AUTHZ_POLICY_CANDIDATE_PREVIEW_READ_ACTION,
+                                "authz_policy_grant.write",
+                            ],
+                        }
+                    ],
+                    "local_admins": [
+                        {
+                            "managed_set_id": "operator.recovery",
+                            "managed_rule_id": "independent-admin",
+                            "subjects": ["independent-admin"],
+                            "token_labels": ["independent-admin-label"],
+                            "products": ["launchplane"],
+                            "contexts": ["launchplane"],
+                            "actions": ["authz_policy_grant.write"],
+                        }
+                    ],
+                }
+            )
+            record = _seed_policy(store, policy)
+            session_store = InMemoryHumanSessionStore()
+            session_manager = HumanSessionManager(
+                config=GitHubOAuthConfig(
+                    client_id="client-id",
+                    client_secret="client-secret",
+                    public_url="https://launchplane.example",
+                    session_secret="session-secret",
+                    cookie_secure=False,
+                ),
+                session_store=session_store,
+            )
+            session = session_manager.issue(
+                GitHubHumanIdentity(
+                    login="browser-admin",
+                    github_id=12345,
+                    name="Browser Admin",
+                    email="browser-admin@example.test",
+                    organizations=frozenset(),
+                    teams=frozenset(),
+                    role="admin",
+                )
+            )
+            app = _app(
+                root=root,
+                store=store,
+                record=record,
+                human_session_manager=session_manager,
+            )
+            csrf_token = session_manager.csrf_token(session)
+            headers = build_browser_mutation_request_headers(
+                origin="https://launchplane.example",
+                csrf_token=csrf_token,
+            )
+            headers["Cookie"] = session_manager.session_cookie_header(session).split(";", 1)[0]
+            session_before_preview = session_store.read_session(session.session_id)
+            try:
+                async with lifespan_client(app) as client:
+                    response = await client.post(
+                        "/v1/authz-diagnostics/candidate-policy/preview",
+                        headers=headers,
+                        json={"candidate_policy": policy.model_dump(mode="json")},
+                    )
+                    rejected_headers = dict(headers)
+                    rejected_headers.pop("X-CSRF-Token")
+                    rejected_response = await client.post(
+                        "/v1/authz-diagnostics/candidate-policy/preview",
+                        headers=rejected_headers,
+                        json={"candidate_policy": policy.model_dump(mode="json")},
+                    )
+                session_after_preview = session_store.read_session(session.session_id)
+            finally:
+                store.close()
+
+        self.assertEqual(response.status_code, 200, response.text)
+        self.assertEqual(session_after_preview, session_before_preview)
+        self.assertTrue(session_manager.csrf_token_is_valid(session, csrf_token))
+        self.assertNotIn("set-cookie", response.headers)
+        self.assertEqual(rejected_response.status_code, 403, rejected_response.text)
+        self.assertEqual(
+            rejected_response.json()["error"]["code"],
+            "browser_mutation_denied",
+        )
+
+    async def test_unauthorized_candidate_preview_skips_route_database_reads(self) -> None:
+        policy = LaunchplaneAuthzPolicy.model_validate(
+            {
+                "schema_version": 2,
+                "local_admins": [
+                    {
+                        "subjects": ["authz-admin"],
+                        "token_labels": ["authz-admin-label"],
+                        "products": ["launchplane"],
+                        "contexts": ["launchplane"],
+                        "actions": [AUTHZ_POLICY_HEALTH_READ_ACTION],
+                    }
+                ],
+            }
+        )
+        with _database_app(policy) as (store, _record, app):
+            async with lifespan_client(app) as client:
+                with (
+                    patch.object(
+                        store,
+                        "list_authz_policy_records",
+                        create=True,
+                        side_effect=AssertionError("unauthorized preview must not read DB policy"),
+                    ),
+                    patch.object(
+                        store,
+                        "write_authz_denial_record",
+                        create=True,
+                        side_effect=AssertionError(
+                            "unauthorized preview must not persist denial evidence"
+                        ),
+                    ),
+                ):
+                    response = await client.post(
+                        "/v1/authz-diagnostics/candidate-policy/preview",
+                        headers={"Authorization": "Bearer admin-token"},
+                        json={"candidate_policy": {"schema_version": 2}},
+                    )
+
+        self.assertEqual(response.status_code, 403, response.text)
+        self.assertEqual(response.json()["error"]["code"], "authorization_denied")
+
+    async def test_non_administrator_cannot_use_granted_candidate_preview_action(self) -> None:
+        policy = LaunchplaneAuthzPolicy.model_validate(
+            {
+                "schema_version": 2,
+                "local_operators": [
+                    {
+                        "subjects": ["support-reader"],
+                        "token_labels": ["support-reader-label"],
+                        "products": ["launchplane"],
+                        "contexts": ["launchplane"],
+                        "actions": [AUTHZ_POLICY_CANDIDATE_PREVIEW_READ_ACTION],
+                    }
+                ],
+            }
+        )
+        with _database_app(policy) as (store, _record, app):
+            async with lifespan_client(app) as client:
+                with (
+                    patch.object(
+                        store,
+                        "list_authz_policy_records",
+                        create=True,
+                        side_effect=AssertionError(
+                            "non-administrator preview must not read DB policy"
+                        ),
+                    ),
+                    patch.object(
+                        store,
+                        "write_authz_denial_record",
+                        create=True,
+                        side_effect=AssertionError(
+                            "non-administrator preview must not persist denial evidence"
+                        ),
+                    ),
+                ):
+                    response = await client.post(
+                        "/v1/authz-diagnostics/candidate-policy/preview",
+                        headers={"Authorization": "Bearer support-token"},
+                        json={"candidate_policy": {"schema_version": 2}},
+                    )
+
+        self.assertEqual(response.status_code, 403, response.text)
+        self.assertEqual(response.json()["error"]["code"], "authorization_denied")
+
+    async def test_candidate_preview_rechecks_fresh_database_policy_without_denial_write(
+        self,
+    ) -> None:
+        runtime_policy = LaunchplaneAuthzPolicy.model_validate(
+            {
+                "schema_version": 2,
+                "local_admins": [
+                    {
+                        "subjects": ["authz-admin"],
+                        "token_labels": ["authz-admin-label"],
+                        "products": ["launchplane"],
+                        "contexts": ["launchplane"],
+                        "actions": [AUTHZ_POLICY_CANDIDATE_PREVIEW_READ_ACTION],
+                    }
+                ],
+            }
+        )
+        denied_policy = LaunchplaneAuthzPolicy.model_validate(
+            {
+                "schema_version": 2,
+                "local_admins": [
+                    {
+                        "subjects": ["independent-admin"],
+                        "token_labels": ["independent-label"],
+                        "products": ["launchplane"],
+                        "contexts": ["launchplane"],
+                        "actions": [AUTHZ_POLICY_CANDIDATE_PREVIEW_READ_ACTION],
+                    }
+                ],
+            }
+        )
+        denied_digest = authz_policy_sha256(denied_policy)
+        denied_record = LaunchplaneAuthzPolicyRecord(
+            record_id=build_authz_policy_record_id(
+                revision=2,
+                policy_sha256=denied_digest,
+            ),
+            revision=2,
+            status="active",
+            source="test:authz-candidate-preview-recheck",
+            updated_at="2026-08-20T19:45:00+00:00",
+            policy_sha256=denied_digest,
+            policy=denied_policy,
+        )
+        with _database_app(runtime_policy) as (store, _record, app):
+            async with lifespan_client(app) as client:
+                with (
+                    patch.object(
+                        store,
+                        "list_authz_policy_records",
+                        create=True,
+                        return_value=(denied_record,),
+                    ),
+                    patch.object(
+                        store,
+                        "write_authz_denial_record",
+                        create=True,
+                        side_effect=AssertionError(
+                            "fresh-record denial must not persist denial evidence"
+                        ),
+                    ),
+                ):
+                    response = await client.post(
+                        "/v1/authz-diagnostics/candidate-policy/preview",
+                        headers={"Authorization": "Bearer admin-token"},
+                        json={"candidate_policy": {"schema_version": 2}},
+                    )
+
+        self.assertEqual(response.status_code, 403, response.text)
+        self.assertEqual(response.json()["error"]["code"], "authorization_denied")
+
+    async def test_candidate_preview_rejects_invalid_complete_managed_contract(self) -> None:
+        policy = LaunchplaneAuthzPolicy.model_validate(
+            {
+                "schema_version": 2,
+                "local_admins": [
+                    {
+                        "subjects": ["authz-admin"],
+                        "token_labels": ["authz-admin-label"],
+                        "products": ["launchplane"],
+                        "contexts": ["launchplane"],
+                        "actions": [AUTHZ_POLICY_CANDIDATE_PREVIEW_READ_ACTION],
+                    }
+                ],
+            }
+        )
+        with _database_app(policy) as (store, _record, app):
+            async with lifespan_client(app) as client:
+                with patch.object(
+                    store,
+                    "write_authz_denial_record",
+                    create=True,
+                    side_effect=AssertionError("invalid previews must not persist"),
+                ):
+                    response = await client.post(
+                        "/v1/authz-diagnostics/candidate-policy/preview",
+                        headers={"Authorization": "Bearer admin-token"},
+                        json={
+                            "candidate_policy": {
+                                "schema_version": 2,
+                                "local_operators": [
+                                    {
+                                        "managed_set_id": "operator.invalid",
+                                        "managed_rule_id": "missing-actions",
+                                        "subjects": ["operator"],
+                                        "token_labels": ["operator-label"],
+                                        "products": ["launchplane"],
+                                        "contexts": ["launchplane"],
+                                    }
+                                ],
+                            }
+                        },
+                    )
+
+        self.assertEqual(response.status_code, 400, response.text)
+        self.assertEqual(response.json()["error"]["code"], "authz_candidate_policy_invalid")
 
     async def test_policy_health_reports_missing_reachable_policy_administrator(self) -> None:
         with TemporaryDirectory() as directory:
@@ -763,6 +1225,82 @@ class AuthzAccessReadHttpTests(unittest.IsolatedAsyncioTestCase):
 
 
 class AuthzDenialRecordStoreTests(unittest.TestCase):
+    def test_postgres_compatible_nonpersisting_session_read_keeps_expired_row(self) -> None:
+        with TemporaryDirectory() as directory:
+            now = datetime.now(timezone.utc).replace(microsecond=0)
+            store = PostgresRecordStore(
+                database_url=_database_url(Path(directory) / "launchplane.sqlite3")
+            )
+            store.ensure_schema()
+            session_manager = HumanSessionManager(
+                config=GitHubOAuthConfig(
+                    client_id="client-id",
+                    client_secret="client-secret",
+                    public_url="https://launchplane.example",
+                    session_secret="session-secret",
+                    cookie_secure=False,
+                ),
+                session_store=store,
+                now=lambda: now,
+            )
+            expired_session = LaunchplaneHumanSession(
+                session_id="expired-postgres-compatible-read",
+                identity=GitHubHumanIdentity(
+                    login="expired-admin",
+                    github_id=12345,
+                    name="Expired Admin",
+                    email="expired-admin@example.test",
+                    organizations=frozenset(),
+                    teams=frozenset(),
+                    role="admin",
+                ),
+                created_at=now - timedelta(days=15),
+                expires_at=now - timedelta(seconds=1),
+            )
+            store.write_session(expired_session)
+
+            resolved_session = session_manager.read_cookie_without_renewal(
+                session_manager.session_cookie_header(expired_session)
+            )
+            stored_session = store.read_session_without_cleanup(expired_session.session_id)
+            store.close()
+
+        self.assertIsNone(resolved_session)
+        self.assertEqual(stored_session, expired_session)
+
+    def test_candidate_policy_preview_requires_schema_v2_and_unique_probes(self) -> None:
+        with self.assertRaises(ValidationError):
+            AuthzPolicyCandidatePreviewRequest.model_validate(
+                {"candidate_policy": {"schema_version": 1}}
+            )
+
+        probe = {
+            "principal": {
+                "principal_type": "local_operator",
+                "subject": "operator",
+                "token_label": "operator-label",
+            },
+            "action": "example_access.read",
+            "product": "example-product",
+            "context": "example-context",
+            "target_scope": "context",
+        }
+        with self.assertRaises(ValidationError):
+            AuthzPolicyCandidatePreviewRequest.model_validate(
+                {
+                    "candidate_policy": {"schema_version": 2},
+                    "probes": [probe, probe],
+                }
+            )
+
+        with self.assertRaises(ValidationError):
+            AuthzPolicyCandidatePreviewRequest.model_validate(
+                {
+                    "candidate_policy": {"schema_version": 2},
+                    "unexpected": True,
+                }
+            )
+
     def test_effective_access_target_scope_requires_one_exact_instance(self) -> None:
         base_request = {
             "principal": {

--- a/tests/test_authz_grant_service.py
+++ b/tests/test_authz_grant_service.py
@@ -13,11 +13,14 @@ from control_plane.authz_grant_service import (
     AuthzPolicyConflictError,
     AuthzPolicyRequestError,
     AuthzPolicySafetyError,
+    build_authz_candidate_policy_structural_diff,
     execute_managed_authz_policy_reconcile,
     plan_managed_authz_policy_reconcile,
+    preview_authz_candidate_policy,
     summarize_active_authz_policy_record,
     summarize_active_authz_policy_health_record,
 )
+from control_plane.contracts.authz_access_read import AuthzPolicyCandidatePreviewRequest
 from control_plane.contracts.authz_policy_record import (
     LaunchplaneAuthzPolicyRecord,
     authz_policy_sha256,
@@ -2311,3 +2314,297 @@ class AuthzManagedPolicyServiceTests(unittest.TestCase):
         self.assertEqual(summary.health.unmanaged_rule_count, 1)
         self.assertTrue(summary.reachable_administrators.policy_reachable)
         self.assertTrue(summary.reachable_administrators.independent_from_caller_reachable)
+
+    def test_candidate_policy_structural_diff_is_bounded_and_deterministic(self) -> None:
+        active_policy = LaunchplaneAuthzPolicy.model_validate(
+            {
+                "schema_version": 2,
+                "local_admins": [
+                    {
+                        "managed_set_id": "operator.authz-preview",
+                        "managed_rule_id": "reader",
+                        "subjects": ["admin-secret"],
+                        "token_labels": ["admin-token-secret"],
+                        "products": ["launchplane"],
+                        "contexts": ["launchplane"],
+                        "actions": ["authz_policy_candidate_preview.read"],
+                    }
+                ],
+                "local_operators": [
+                    {
+                        "managed_set_id": "operator.authz-preview",
+                        "managed_rule_id": "removed-rule-secret",
+                        "subjects": ["removed-subject-secret"],
+                        "token_labels": ["removed-token-secret"],
+                        "products": ["example"],
+                        "contexts": ["testing"],
+                        "actions": ["artifact_protection.read"],
+                    }
+                ],
+            }
+        )
+        candidate_policy = LaunchplaneAuthzPolicy.model_validate(
+            {
+                "schema_version": 2,
+                "local_admins": [
+                    {
+                        "managed_set_id": "operator.authz-preview",
+                        "managed_rule_id": "reader",
+                        "subjects": ["admin-secret"],
+                        "token_labels": ["admin-token-secret"],
+                        "products": ["launchplane"],
+                        "contexts": ["launchplane"],
+                        "actions": [
+                            "authz_policy_candidate_preview.read",
+                            "authz_policy_grant.write",
+                        ],
+                    }
+                ],
+                "terminal_agents": [
+                    {
+                        "managed_set_id": "operator.new-set-secret",
+                        "managed_rule_id": "added-rule-secret",
+                        "subjects": ["added-subject-secret"],
+                        "token_labels": ["added-token-secret"],
+                        "products": ["example"],
+                        "contexts": ["testing"],
+                        "actions": ["artifact_protection.read"],
+                    }
+                ],
+            }
+        )
+
+        first = build_authz_candidate_policy_structural_diff(
+            active_policy=active_policy,
+            candidate_policy=candidate_policy,
+        )
+        second = build_authz_candidate_policy_structural_diff(
+            active_policy=active_policy,
+            candidate_policy=candidate_policy,
+        )
+
+        self.assertEqual(first, second)
+        self.assertTrue(first.changed)
+        self.assertEqual(first.added_rule_count, 1)
+        self.assertEqual(first.updated_rule_count, 1)
+        self.assertEqual(first.removed_rule_count, 1)
+        self.assertEqual(first.unchanged_rule_count, 0)
+        self.assertEqual(first.added_managed_set_count, 1)
+        self.assertEqual(first.removed_managed_set_count, 0)
+        self.assertEqual(
+            first.changed_principal_types,
+            ("terminal_agents", "local_operators", "local_admins"),
+        )
+        serialized = json.dumps(first.model_dump(mode="json"), sort_keys=True)
+        for private_value in (
+            "admin-secret",
+            "admin-token-secret",
+            "removed-rule-secret",
+            "removed-subject-secret",
+            "removed-token-secret",
+            "operator.new-set-secret",
+            "added-rule-secret",
+            "added-subject-secret",
+            "added-token-secret",
+        ):
+            self.assertNotIn(private_value, serialized)
+
+    def test_candidate_policy_preview_round_trips_exact_noop_policy(self) -> None:
+        active_policy = LaunchplaneAuthzPolicy.model_validate(
+            {
+                "schema_version": 2,
+                "local_admins": [
+                    {
+                        "managed_set_id": "operator.authz-preview",
+                        "managed_rule_id": "zzz-reader",
+                        "subjects": ["z-authz-admin", "authz-admin", "authz-admin"],
+                        "token_labels": ["z-label", "authz-admin-label"],
+                        "products": ["launchplane", "launchplane"],
+                        "contexts": ["launchplane", "launchplane"],
+                        "actions": [
+                            "authz_policy_grant.write",
+                            "authz_policy_candidate_preview.read",
+                            "authz_policy_grant.write",
+                        ],
+                    },
+                    {
+                        "subjects": ["independent-admin"],
+                        "token_labels": ["independent-admin-label"],
+                        "products": ["launchplane"],
+                        "contexts": ["launchplane"],
+                        "actions": ["authz_policy_grant.write", "authz_policy_grant.write"],
+                    },
+                ],
+            }
+        )
+        active_record = _active_record_for_policy(active_policy)
+        request = AuthzPolicyCandidatePreviewRequest.model_validate(
+            {"candidate_policy": active_policy.model_dump(mode="json")}
+        )
+
+        response = preview_authz_candidate_policy(
+            active_record=active_record,
+            caller_identity=LocalAdminIdentity(
+                subject="authz-admin",
+                token_label="authz-admin-label",
+            ),
+            request=request,
+            trace_id="launchplane_req_noop_preview",
+        )
+
+        self.assertFalse(response.diff.changed)
+        self.assertEqual(response.diff.added_rule_count, 0)
+        self.assertEqual(response.diff.updated_rule_count, 0)
+        self.assertEqual(response.diff.removed_rule_count, 0)
+        self.assertEqual(response.diff.unchanged_rule_count, 2)
+        self.assertEqual(response.diff.changed_principal_types, ())
+        self.assertEqual(
+            response.candidate_policy.submitted_policy_sha256,
+            active_record.policy_sha256,
+        )
+        self.assertNotEqual(
+            response.candidate_policy.evaluated_policy_sha256,
+            active_record.policy_sha256,
+        )
+        self.assertTrue(response.candidate_policy.normalized)
+
+    def test_candidate_policy_preview_reuses_effective_access_without_recording_context(
+        self,
+    ) -> None:
+        active_policy = LaunchplaneAuthzPolicy.model_validate(
+            {
+                "schema_version": 2,
+                "local_admins": [
+                    {
+                        "managed_set_id": "operator.authz-preview",
+                        "managed_rule_id": "reader",
+                        "subjects": ["authz-admin"],
+                        "token_labels": ["authz-admin-label"],
+                        "products": ["launchplane"],
+                        "contexts": ["launchplane"],
+                        "actions": [
+                            "authz_policy_candidate_preview.read",
+                            "authz_policy_grant.write",
+                        ],
+                    },
+                    {
+                        "managed_set_id": "operator.recovery",
+                        "managed_rule_id": "independent-admin",
+                        "subjects": ["independent-admin"],
+                        "token_labels": ["independent-admin-label"],
+                        "products": ["launchplane"],
+                        "contexts": ["launchplane"],
+                        "actions": ["authz_policy_grant.write"],
+                    },
+                ],
+            }
+        )
+        candidate_policy = active_policy.model_copy(
+            update={
+                "local_operators": (
+                    LocalOperatorPolicyRule(
+                        managed_set_id="operator.probe",
+                        managed_rule_id="probe-reader",
+                        subjects=("probe-subject",),
+                        token_labels=("probe-token",),
+                        products=("example",),
+                        contexts=("testing",),
+                        actions=("artifact_protection.read",),
+                    ),
+                )
+            }
+        )
+        request = AuthzPolicyCandidatePreviewRequest.model_validate(
+            {
+                "candidate_policy": candidate_policy.model_dump(mode="json"),
+                "probes": [
+                    {
+                        "principal": {
+                            "principal_type": "local_operator",
+                            "subject": "probe-subject",
+                            "token_label": "probe-token",
+                        },
+                        "action": "artifact_protection.read",
+                        "product": "example",
+                        "context": "testing",
+                        "target_scope": "context",
+                    }
+                ],
+            }
+        )
+
+        response = preview_authz_candidate_policy(
+            active_record=_active_record_for_policy(active_policy),
+            caller_identity=LocalAdminIdentity(
+                subject="authz-admin",
+                token_label="authz-admin-label",
+            ),
+            request=request,
+            trace_id="launchplane_req_preview",
+        )
+
+        self.assertEqual(response.trace_id, "launchplane_req_preview")
+        self.assertEqual(response.probes[0].active_evaluation.decision, "denied")
+        self.assertEqual(response.probes[0].candidate_evaluation.decision, "allowed")
+        self.assertEqual(response.probes[0].delta, "granted")
+        self.assertEqual(response.candidate_readiness.blocked_rule_count, 0)
+        self.assertTrue(response.candidate_reachable_administrators.policy_reachable)
+        self.assertTrue(
+            response.candidate_reachable_administrators.independent_from_caller_reachable
+        )
+
+    def test_candidate_policy_preview_reuses_managed_workflow_transition_validation(
+        self,
+    ) -> None:
+        active_policy = LaunchplaneAuthzPolicy.model_validate(
+            {
+                "schema_version": 2,
+                "local_admins": [
+                    {
+                        "managed_set_id": "operator.authz-preview",
+                        "managed_rule_id": "reader",
+                        "subjects": ["authz-admin"],
+                        "token_labels": ["authz-admin-label"],
+                        "products": ["launchplane"],
+                        "contexts": ["launchplane"],
+                        "actions": ["authz_policy_candidate_preview.read"],
+                    }
+                ],
+            }
+        )
+        candidate_payload = active_policy.model_dump(mode="json")
+        candidate_payload["github_actions"] = [
+            {
+                "managed_set_id": "operator.workflow",
+                "managed_rule_id": "mutable-worker",
+                "repository": "example/repository",
+                "repository_id": "1001",
+                "repository_owner_id": "2001",
+                "workflow_refs": [
+                    "example/repository/.github/workflows/caller.yml@refs/heads/main"
+                ],
+                "job_workflow_refs": [
+                    "example/repository/.github/workflows/worker.yml@refs/heads/main"
+                ],
+                "products": ["launchplane"],
+                "contexts": ["launchplane"],
+                "actions": ["authz_policy_grant.write"],
+            }
+        ]
+        request = AuthzPolicyCandidatePreviewRequest.model_validate(
+            {"candidate_policy": candidate_payload}
+        )
+
+        with self.assertRaisesRegex(
+            AuthzPolicyRequestError,
+            "pinned to a full commit SHA",
+        ):
+            preview_authz_candidate_policy(
+                active_record=_active_record_for_policy(active_policy),
+                caller_identity=LocalAdminIdentity(
+                    subject="authz-admin",
+                    token_label="authz-admin-label",
+                ),
+                request=request,
+                trace_id="launchplane_req_invalid_transition",
+            )

--- a/tests/test_service_auth.py
+++ b/tests/test_service_auth.py
@@ -340,6 +340,7 @@ class LaunchplaneAuthzPolicyBoundaryTests(unittest.TestCase):
             "odoo_prod_backup_restore_apply.execute": "destructive",
             "secret_binding.apply": "secret_backed",
             "authz_policy_health.read": "policy_admin",
+            "authz_policy_candidate_preview.read": "policy_admin",
             "authz_policy_grant.write": "policy_admin",
         }
 

--- a/tests/test_service_human_auth.py
+++ b/tests/test_service_human_auth.py
@@ -321,6 +321,59 @@ class HumanSessionManagerTests(unittest.TestCase):
         self.assertNotEqual(manager.csrf_token(rotated_session), csrf_token)
         self.assertIsNone(manager.consume_csrf_token(session, csrf_token))
 
+    def test_nonpersisting_csrf_validation_does_not_rotate_or_renew_session(self) -> None:
+        now = datetime.now(timezone.utc).replace(microsecond=0)
+        store = InMemoryHumanSessionStore()
+        manager = HumanSessionManager(
+            config=_config(),
+            session_store=store,
+            now=lambda: now,
+        )
+        session = LaunchplaneHumanSession(
+            session_id="nonpersisting-read",
+            identity=_identity(),
+            created_at=now - timedelta(days=13),
+            expires_at=now + timedelta(hours=1),
+        )
+        store.write_session(session)
+        token = manager.csrf_token(session)
+
+        read_session = manager.read_cookie_without_renewal(manager.session_cookie_header(session))
+
+        self.assertEqual(read_session, session)
+        assert read_session is not None
+        self.assertTrue(manager.csrf_token_is_valid(read_session, token))
+        self.assertEqual(store.read_session(session.session_id), session)
+        stored_session = store.read_session(session.session_id)
+        assert stored_session is not None
+        self.assertEqual(stored_session.csrf_generation, 0)
+
+    def test_nonpersisting_session_read_does_not_delete_expired_session(self) -> None:
+        now = datetime.now(timezone.utc).replace(microsecond=0)
+        store = InMemoryHumanSessionStore()
+        manager = HumanSessionManager(
+            config=_config(),
+            session_store=store,
+            now=lambda: now,
+        )
+        expired_session = LaunchplaneHumanSession(
+            session_id="expired-nonpersisting-read",
+            identity=_identity(),
+            created_at=now - timedelta(days=15),
+            expires_at=now - timedelta(seconds=1),
+        )
+        store.write_session(expired_session)
+
+        resolved_session = manager.read_cookie_without_renewal(
+            manager.session_cookie_header(expired_session)
+        )
+
+        self.assertIsNone(resolved_session)
+        self.assertEqual(
+            store.read_session_without_cleanup(expired_session.session_id),
+            expired_session,
+        )
+
     def test_csrf_token_rejects_other_session_and_stale_generation(self) -> None:
         store = InMemoryHumanSessionStore()
         manager = HumanSessionManager(config=_config(), session_store=store)


### PR DESCRIPTION
## Summary
- add administrator-only `POST /v1/authz-diagnostics/candidate-policy/preview`
- validate one exact schema-v2 candidate through existing managed reconciliation constraints
- return canonical bounded structural and explicit probe decision deltas through the existing evaluator
- preserve strict redaction and zero-write behavior, including non-renewing/non-cleanup session reads
- update OpenAPI and authorization/operator/service documentation

## Safety boundary
- no policy, session, denial, idempotency, outbox, provider, runtime, secret, or durable-operation write
- no draft, apply, revoke, rollback, recovery, import, export, migration, UI mutation, production grant, or workflow authority change
- `#2058` production authorization freeze remains intact
- final Opus and Gemini reviews are slice-level approvals, not final `#2062` sign-off

## Validation
- `uv run --extra dev launchplane ci unittest-shard local`
- `LAUNCHPLANE_TEST_POSTGRES_URL=... uv run --extra dev launchplane ci postgres-integration`
- `uv run --extra dev ruff check .`
- changed-file `ruff format --check`
- `uv run --extra dev mypy control_plane tests`
- `pnpm --dir frontend validate`
- JetBrains changed-files inspection: GREEN, 0 findings
- independent exact-head Opus review: approved
- independent exact-head Gemini review: approved

Closes #2198
Refs #2180
Refs #2058
Refs #2062