### PR TITLE
Add bounded DB-backed authorization repository scope

### DIFF
--- a/control_plane/authz_repository_scope.py
+++ b/control_plane/authz_repository_scope.py
@@ -1,0 +1,624 @@
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from datetime import datetime
+import os
+from typing import Protocol, TypeVar
+
+import click
+
+from control_plane import secrets as control_plane_secrets
+from control_plane.contracts.authz_access_read import (
+    AUTHZ_REPOSITORY_SCOPE_MAX_SOURCE_RECORDS,
+    AuthzRepositoryScopeCandidateResult,
+    AuthzRepositoryScopeGap,
+    AuthzRepositoryScopeGapReason,
+    AuthzRepositoryScopeGapSource,
+    AuthzRepositoryScopeMembership,
+    AuthzRepositoryScopePolicyProvenance,
+    AuthzRepositoryScopeProvenance,
+    AuthzRepositoryScopeReadRequest,
+    AuthzRepositoryScopeRecordProvenance,
+    AuthzRepositoryScopeResponse,
+    AuthzRepositoryScopeSourceCounts,
+    AuthzRepositoryScopeCoverage,
+)
+from control_plane.contracts.authz_policy_record import LaunchplaneAuthzPolicyRecord
+from control_plane.contracts.every_code_work_request import EveryCodeWorkRequestRecord
+from control_plane.contracts.product_profile_record import LaunchplaneProductProfileRecord
+from control_plane.contracts.repository_human_admission import RepositoryHumanRolePolicyRecord
+from control_plane.contracts.tenant_merge_eligibility import (
+    TenantRepositoryClassificationRecord,
+)
+
+
+_HANDLE_PURPOSE = "authz-repository-scope-handle-v1"
+_HANDLE_GENERATION_PURPOSE = "authz-repository-scope-handle-generation-v1"
+_MEMBERSHIP_ORDER: tuple[AuthzRepositoryScopeMembership, ...] = (
+    "product",
+    "repository_record",
+    "work_graph",
+    "authorization_chain",
+)
+_GAP_SOURCE_ORDER: tuple[AuthzRepositoryScopeGapSource, ...] = (
+    "product",
+    "repository_record",
+    "work_graph",
+    "authorization_chain",
+    "candidate",
+)
+_CURRENT_WORK_REQUEST_STATES = frozenset({"queued", "claimed", "running"})
+_RecordT = TypeVar("_RecordT")
+
+
+class AuthzRepositoryScopeStore(Protocol):
+    def list_product_profile_records(
+        self,
+        *,
+        driver_id: str = "",
+    ) -> tuple[LaunchplaneProductProfileRecord, ...]: ...
+
+    def list_repository_human_role_policy_records(
+        self,
+        *,
+        repository_id: str = "",
+        repository_owner_id: str = "",
+        repository: str = "",
+        product: str = "",
+        context: str = "",
+        status: str = "",
+        limit: int | None = None,
+    ) -> tuple[RepositoryHumanRolePolicyRecord, ...]: ...
+
+    def list_tenant_repository_classification_records(
+        self,
+        *,
+        repository_id: str = "",
+        limit: int | None = None,
+    ) -> tuple[TenantRepositoryClassificationRecord, ...]: ...
+
+    def list_every_code_work_request_records(
+        self,
+        *,
+        state: str = "",
+        repository: str = "",
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> tuple[EveryCodeWorkRequestRecord, ...]: ...
+
+
+@dataclass(frozen=True)
+class _Evidence:
+    repository: str
+    repository_id: str
+    repository_owner_id: str
+    membership: AuthzRepositoryScopeMembership
+    current: bool
+    preserves_repository_case: bool
+
+
+@dataclass
+class _RepositoryNode:
+    normalized_repository: str
+    exact_repositories: set[str] = field(default_factory=set)
+    immutable_identities: set[tuple[str, str]] = field(default_factory=set)
+    memberships: set[AuthzRepositoryScopeMembership] = field(default_factory=set)
+    stale_memberships: set[AuthzRepositoryScopeMembership] = field(default_factory=set)
+    ambiguous: bool = False
+
+    @property
+    def immutable_identity(self) -> tuple[str, str]:
+        if len(self.immutable_identities) != 1:
+            return "", ""
+        return next(iter(self.immutable_identities))
+
+    @property
+    def ordered_memberships(self) -> tuple[AuthzRepositoryScopeMembership, ...]:
+        return tuple(
+            membership for membership in _MEMBERSHIP_ORDER if membership in self.memberships
+        )
+
+
+def build_authz_repository_scope_response(
+    *,
+    trace_id: str,
+    generated_at: str,
+    request: AuthzRepositoryScopeReadRequest,
+    active_policy_record: LaunchplaneAuthzPolicyRecord,
+    store: AuthzRepositoryScopeStore,
+) -> AuthzRepositoryScopeResponse:
+    generated_time = _parse_timestamp(generated_at)
+    if generated_time is None:
+        raise ValueError("Repository scope generation time must be timezone-aware.")
+    truncated_sources: Counter[AuthzRepositoryScopeGapSource] = Counter()
+    product_profiles = _bounded_records(
+        store.list_product_profile_records(),
+        source="product",
+        truncated_sources=truncated_sources,
+    )
+    role_policy_records = _bounded_records(
+        store.list_repository_human_role_policy_records(
+            limit=AUTHZ_REPOSITORY_SCOPE_MAX_SOURCE_RECORDS + 1
+        ),
+        source="repository_record",
+        truncated_sources=truncated_sources,
+    )
+    classification_records = _bounded_records(
+        store.list_tenant_repository_classification_records(
+            limit=AUTHZ_REPOSITORY_SCOPE_MAX_SOURCE_RECORDS + 1
+        ),
+        source="repository_record",
+        truncated_sources=truncated_sources,
+    )
+    work_requests = _bounded_interleaved_records(
+        tuple(
+            store.list_every_code_work_request_records(
+                state=state,
+                limit=AUTHZ_REPOSITORY_SCOPE_MAX_SOURCE_RECORDS + 1,
+            )
+            for state in ("queued", "claimed", "running")
+        ),
+        source="work_graph",
+        truncated_sources=truncated_sources,
+    )
+    authorization_rules = _bounded_records(
+        active_policy_record.policy.github_actions,
+        source="authorization_chain",
+        truncated_sources=truncated_sources,
+    )
+
+    current_role_policy_records, role_policy_ambiguity_count = _current_role_policy_records(
+        role_policy_records
+    )
+    current_classification_records, classification_ambiguity_count = (
+        _current_classification_records(classification_records)
+    )
+    current_work_requests = tuple(
+        record for record in work_requests if record.state in _CURRENT_WORK_REQUEST_STATES
+    )
+
+    evidence = (
+        tuple(_product_evidence(record) for record in product_profiles)
+        + tuple(
+            _role_policy_evidence(record, current_role_policy_records)
+            for record in role_policy_records
+        )
+        + tuple(
+            _classification_evidence(record, current_classification_records)
+            for record in classification_records
+        )
+        + tuple(_work_request_evidence(record) for record in work_requests)
+        + tuple(_authorization_evidence(rule) for rule in authorization_rules)
+    )
+
+    nodes, malformed_identity_counts = _build_nodes(evidence)
+    gap_counts: Counter[tuple[AuthzRepositoryScopeGapSource, AuthzRepositoryScopeGapReason]] = (
+        Counter()
+    )
+    if role_policy_ambiguity_count:
+        gap_counts[("repository_record", "active_record_ambiguous")] += role_policy_ambiguity_count
+    if classification_ambiguity_count:
+        gap_counts[("repository_record", "active_record_ambiguous")] += (
+            classification_ambiguity_count
+        )
+    for source in _GAP_SOURCE_ORDER:
+        if count := truncated_sources[source]:
+            gap_counts[(source, "source_truncated")] += count
+    stale_work_request_count = sum(
+        record.state in {"claimed", "running"}
+        and (
+            (lease_expires_at := _parse_timestamp(record.lease_expires_at)) is None
+            or lease_expires_at <= generated_time
+        )
+        for record in current_work_requests
+    )
+    if stale_work_request_count:
+        gap_counts[("work_graph", "stale_work_graph_record")] += stale_work_request_count
+    for source in _GAP_SOURCE_ORDER:
+        if count := malformed_identity_counts[source]:
+            gap_counts[(source, "repository_identity_conflict")] += count
+
+    id_to_names: dict[tuple[str, str], set[str]] = defaultdict(set)
+    for node in nodes.values():
+        for immutable_identity in node.immutable_identities:
+            id_to_names[immutable_identity].add(node.normalized_repository)
+    conflicting_names = {
+        repository
+        for repositories in id_to_names.values()
+        if len(repositories) > 1
+        for repository in repositories
+    }
+
+    for node in nodes.values():
+        if len(node.immutable_identities) > 1:
+            node.ambiguous = True
+            gap_counts[("repository_record", "immutable_identity_conflict")] += 1
+        if node.normalized_repository in conflicting_names:
+            node.ambiguous = True
+            gap_counts[("repository_record", "repository_identity_conflict")] += 1
+        if len(node.exact_repositories) > 1:
+            gap_counts[("authorization_chain", "repository_case_variant")] += 1
+        if not node.immutable_identities and node.memberships != {"work_graph"}:
+            gap_counts[("repository_record", "immutable_identity_missing")] += 1
+        if node.memberships == {"authorization_chain"} and node.stale_memberships:
+            gap_counts[("authorization_chain", "stale_authorization_membership")] += 1
+
+    timestamp_gaps = _timestamp_gap_counts(
+        product_profiles=tuple(record for record in product_profiles if record.is_active),
+        repository_records=(*current_role_policy_records, *current_classification_records),
+        work_requests=current_work_requests,
+    )
+    gap_counts.update(timestamp_gaps)
+
+    candidate_results: list[AuthzRepositoryScopeCandidateResult] = []
+    matched_repositories: set[str] = set()
+    handle_key_id, handle_generation = _keyed_digest(
+        "",
+        purpose=_HANDLE_GENERATION_PURPOSE,
+    )
+    for index, candidate in enumerate(request.candidates):
+        normalized_repository = candidate.repository.casefold()
+        candidate_node = nodes.get(normalized_repository)
+        if candidate_node is None:
+            gap_counts[("candidate", "candidate_repository_missing")] += 1
+            candidate_results.append(
+                AuthzRepositoryScopeCandidateResult(index=index, state="not_found")
+            )
+            continue
+        candidate_identity = (candidate.repository_id, candidate.repository_owner_id)
+        resolved_identity = candidate_node.immutable_identity
+        immutable_identity_mismatch = bool(
+            candidate.repository_id
+            and (not resolved_identity[0] or candidate_identity != resolved_identity)
+        )
+        if (
+            candidate_node.ambiguous
+            or immutable_identity_mismatch
+            or not candidate_node.ordered_memberships
+        ):
+            gap_counts[("candidate", "candidate_repository_ambiguous")] += 1
+            candidate_results.append(
+                AuthzRepositoryScopeCandidateResult(index=index, state="ambiguous")
+            )
+            continue
+        key_id, digest = _keyed_digest(
+            _handle_payload(candidate_node),
+            purpose=_HANDLE_PURPOSE,
+        )
+        if key_id != handle_key_id:
+            raise RuntimeError("Repository scope handle generation changed during one response.")
+        matched_repositories.add(normalized_repository)
+        candidate_results.append(
+            AuthzRepositoryScopeCandidateResult(
+                index=index,
+                state="matched",
+                handle=f"repo_{digest}",
+                memberships=candidate_node.ordered_memberships,
+            )
+        )
+
+    unmatched_nodes = tuple(
+        node
+        for normalized_repository, node in nodes.items()
+        if normalized_repository not in matched_repositories
+    )
+    if unmatched_nodes:
+        gap_counts[("candidate", "candidate_coverage_incomplete")] += len(unmatched_nodes)
+
+    gaps = tuple(
+        AuthzRepositoryScopeGap(source=source, reason_code=reason_code, count=count)
+        for (source, reason_code), count in sorted(gap_counts.items())
+        if count
+    )
+    repository_count = len(nodes)
+    matched_repository_count = len(matched_repositories)
+    return AuthzRepositoryScopeResponse(
+        trace_id=trace_id,
+        generated_at=generated_at,
+        handle_generation=f"generation_{handle_generation[:16]}",
+        coverage=AuthzRepositoryScopeCoverage(
+            state="complete" if not gaps else "partial",
+            source_counts=AuthzRepositoryScopeSourceCounts(
+                product=sum(record.is_active for record in product_profiles),
+                repository_record=len(current_role_policy_records)
+                + len(current_classification_records),
+                work_graph=len(current_work_requests),
+                authorization_chain=sum(
+                    "authorization_chain" in node.memberships for node in nodes.values()
+                ),
+            ),
+            repository_count=repository_count,
+            matched_repository_count=matched_repository_count,
+            unmatched_repository_count=repository_count - matched_repository_count,
+            gaps=gaps,
+        ),
+        provenance=AuthzRepositoryScopeProvenance(
+            authorization_chain=AuthzRepositoryScopePolicyProvenance(
+                record_id=active_policy_record.record_id,
+                revision=active_policy_record.revision,
+                updated_at=active_policy_record.updated_at,
+            ),
+            product=_record_provenance(
+                tuple(record.updated_at for record in product_profiles if record.is_active)
+            ),
+            repository_record=_record_provenance(
+                tuple(record.effective_at for record in current_role_policy_records)
+                + tuple(record.classified_at for record in current_classification_records)
+            ),
+            work_graph=_record_provenance(
+                tuple(record.updated_at for record in current_work_requests)
+            ),
+        ),
+        candidates=tuple(candidate_results),
+    )
+
+
+def _build_nodes(
+    evidence: tuple[_Evidence, ...],
+) -> tuple[
+    dict[str, _RepositoryNode],
+    Counter[AuthzRepositoryScopeGapSource],
+]:
+    nodes: dict[str, _RepositoryNode] = {}
+    malformed_counts: Counter[AuthzRepositoryScopeGapSource] = Counter()
+    for item in evidence:
+        repository = item.repository.strip()
+        owner, separator, name = repository.partition("/")
+        if not separator or not owner or not name or "/" in name:
+            malformed_counts[_gap_source(item.membership)] += 1
+            continue
+        normalized_repository = repository.casefold()
+        node = nodes.setdefault(
+            normalized_repository,
+            _RepositoryNode(normalized_repository=normalized_repository),
+        )
+        if item.preserves_repository_case:
+            node.exact_repositories.add(repository)
+        if item.repository_id and item.repository_owner_id:
+            node.immutable_identities.add((item.repository_id, item.repository_owner_id))
+        if item.current:
+            node.memberships.add(item.membership)
+        else:
+            node.stale_memberships.add(item.membership)
+    return (
+        {
+            normalized_repository: node
+            for normalized_repository, node in nodes.items()
+            if node.memberships
+        },
+        malformed_counts,
+    )
+
+
+def _bounded_records(
+    records: tuple[_RecordT, ...],
+    *,
+    source: AuthzRepositoryScopeGapSource,
+    truncated_sources: Counter[AuthzRepositoryScopeGapSource],
+) -> tuple[_RecordT, ...]:
+    if len(records) <= AUTHZ_REPOSITORY_SCOPE_MAX_SOURCE_RECORDS:
+        return records
+    truncated_sources[source] += 1
+    return records[:AUTHZ_REPOSITORY_SCOPE_MAX_SOURCE_RECORDS]
+
+
+def _bounded_interleaved_records(
+    record_groups: tuple[tuple[_RecordT, ...], ...],
+    *,
+    source: AuthzRepositoryScopeGapSource,
+    truncated_sources: Counter[AuthzRepositoryScopeGapSource],
+) -> tuple[_RecordT, ...]:
+    retained: list[_RecordT] = []
+    for index in range(max((len(records) for records in record_groups), default=0)):
+        for records in record_groups:
+            if index >= len(records):
+                continue
+            if len(retained) == AUTHZ_REPOSITORY_SCOPE_MAX_SOURCE_RECORDS:
+                truncated_sources[source] += 1
+                return tuple(retained)
+            retained.append(records[index])
+    return tuple(retained)
+
+
+def _current_role_policy_records(
+    records: tuple[RepositoryHumanRolePolicyRecord, ...],
+) -> tuple[tuple[RepositoryHumanRolePolicyRecord, ...], int]:
+    return _latest_unique_records(
+        tuple(record for record in records if record.status == "active"),
+        key=lambda record: (record.repository_id, record.product, record.context),
+        revision=lambda record: record.role_policy_revision,
+    )
+
+
+def _current_classification_records(
+    records: tuple[TenantRepositoryClassificationRecord, ...],
+) -> tuple[tuple[TenantRepositoryClassificationRecord, ...], int]:
+    return _latest_unique_records(
+        records,
+        key=lambda record: record.repository_id,
+        revision=lambda record: record.classification_revision,
+    )
+
+
+def _latest_unique_records(
+    records: tuple[_RecordT, ...],
+    *,
+    key: Callable[[_RecordT], object],
+    revision: Callable[[_RecordT], int],
+) -> tuple[tuple[_RecordT, ...], int]:
+    grouped: dict[object, list[_RecordT]] = defaultdict(list)
+    for record in records:
+        grouped[key(record)].append(record)
+    current: list[_RecordT] = []
+    ambiguity_count = 0
+    for matching_records in grouped.values():
+        highest_revision = max(revision(record) for record in matching_records)
+        latest = [record for record in matching_records if revision(record) == highest_revision]
+        if len(latest) != 1:
+            ambiguity_count += 1
+            continue
+        current.append(latest[0])
+    return tuple(current), ambiguity_count
+
+
+def _product_evidence(record: LaunchplaneProductProfileRecord) -> _Evidence:
+    return _Evidence(
+        repository=record.repository,
+        repository_id=record.repository_id,
+        repository_owner_id=record.repository_owner_id,
+        membership="product",
+        current=record.is_active,
+        preserves_repository_case=True,
+    )
+
+
+def _role_policy_evidence(
+    record: RepositoryHumanRolePolicyRecord,
+    current_records: tuple[RepositoryHumanRolePolicyRecord, ...],
+) -> _Evidence:
+    return _Evidence(
+        repository=record.repository,
+        repository_id=record.repository_id,
+        repository_owner_id=record.repository_owner_id,
+        membership="repository_record",
+        current=record in current_records,
+        preserves_repository_case=False,
+    )
+
+
+def _classification_evidence(
+    record: TenantRepositoryClassificationRecord,
+    current_records: tuple[TenantRepositoryClassificationRecord, ...],
+) -> _Evidence:
+    return _Evidence(
+        repository=record.repository,
+        repository_id=record.repository_id,
+        repository_owner_id=record.repository_owner_id,
+        membership="repository_record",
+        current=record in current_records,
+        preserves_repository_case=False,
+    )
+
+
+def _work_request_evidence(record: EveryCodeWorkRequestRecord) -> _Evidence:
+    return _Evidence(
+        repository=record.repository,
+        repository_id="",
+        repository_owner_id="",
+        membership="work_graph",
+        current=record.state in _CURRENT_WORK_REQUEST_STATES,
+        preserves_repository_case=True,
+    )
+
+
+def _authorization_evidence(rule: object) -> _Evidence:
+    repository = str(getattr(rule, "repository", ""))
+    repository_id = str(getattr(rule, "repository_id", ""))
+    repository_owner_id = str(getattr(rule, "repository_owner_id", ""))
+    return _Evidence(
+        repository=repository,
+        repository_id=repository_id,
+        repository_owner_id=repository_owner_id,
+        membership="authorization_chain",
+        current=True,
+        preserves_repository_case=True,
+    )
+
+
+def _handle_payload(node: _RepositoryNode) -> str:
+    repository_id, repository_owner_id = node.immutable_identity
+    if repository_id:
+        return f"id:{repository_owner_id}:{repository_id}"
+    return f"name:{node.normalized_repository}"
+
+
+def _keyed_digest(payload: str, *, purpose: str) -> tuple[str, str]:
+    if not os.environ.get(control_plane_secrets.LAUNCHPLANE_SECRET_KEYS_JSON_ENV_VAR, "").strip():
+        raise click.ClickException(
+            "Public stable identifiers require the canonical managed-secret key ring."
+        )
+    fingerprint = control_plane_secrets.keyed_secret_payload_fingerprint(
+        payload,
+        purpose=purpose,
+    )
+    algorithm, separator, remainder = fingerprint.partition(":")
+    key_id, digest_separator, digest = remainder.partition(":")
+    if (
+        algorithm != "hmac-sha256"
+        or not separator
+        or not key_id
+        or not digest_separator
+        or len(digest) != 64
+        or any(character not in "0123456789abcdef" for character in digest)
+    ):
+        raise RuntimeError("Managed-secret fingerprint returned an unsupported format.")
+    return key_id, digest
+
+
+def _timestamp_gap_counts(
+    *,
+    product_profiles: tuple[LaunchplaneProductProfileRecord, ...],
+    repository_records: tuple[
+        RepositoryHumanRolePolicyRecord | TenantRepositoryClassificationRecord,
+        ...,
+    ],
+    work_requests: tuple[EveryCodeWorkRequestRecord, ...],
+) -> Counter[tuple[AuthzRepositoryScopeGapSource, AuthzRepositoryScopeGapReason]]:
+    gaps: Counter[tuple[AuthzRepositoryScopeGapSource, AuthzRepositoryScopeGapReason]] = Counter()
+    timestamp_groups: tuple[tuple[AuthzRepositoryScopeGapSource, tuple[str, ...]], ...] = (
+        ("product", tuple(record.updated_at for record in product_profiles)),
+        (
+            "repository_record",
+            tuple(
+                record.effective_at
+                if isinstance(record, RepositoryHumanRolePolicyRecord)
+                else record.classified_at
+                for record in repository_records
+            ),
+        ),
+        ("work_graph", tuple(record.updated_at for record in work_requests)),
+    )
+    for source, values in timestamp_groups:
+        malformed_count = sum(not _is_timestamp(value) for value in values)
+        if malformed_count:
+            gaps[(source, "record_timestamp_malformed")] += malformed_count
+    return gaps
+
+
+def _record_provenance(values: tuple[str, ...]) -> AuthzRepositoryScopeRecordProvenance:
+    parsed = tuple(
+        (parsed_value, value)
+        for value in values
+        if (parsed_value := _parse_timestamp(value)) is not None
+    )
+    latest = max(parsed, default=None)
+    return AuthzRepositoryScopeRecordProvenance(
+        active_record_count=len(values),
+        latest_recorded_at=latest[1] if latest is not None else "",
+    )
+
+
+def _is_timestamp(value: str) -> bool:
+    return _parse_timestamp(value) is not None
+
+
+def _parse_timestamp(value: str) -> datetime | None:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.utcoffset() is None:
+        return None
+    return parsed
+
+
+def _gap_source(membership: AuthzRepositoryScopeMembership) -> AuthzRepositoryScopeGapSource:
+    if membership == "product":
+        return "product"
+    if membership == "work_graph":
+        return "work_graph"
+    if membership == "authorization_chain":
+        return "authorization_chain"
+    return "repository_record"

--- a/control_plane/contracts/authz_access_read.py
+++ b/control_plane/contracts/authz_access_read.py
@@ -20,8 +20,11 @@ EFFECTIVE_ACCESS_READ_ACTION = "authz_policy_effective_access.read"
 AUTHZ_DENIAL_EXPLANATION_READ_ACTION = "authz_denial_explanation.read"
 AUTHZ_POLICY_HEALTH_READ_ACTION = "authz_policy_health.read"
 AUTHZ_POLICY_CANDIDATE_PREVIEW_READ_ACTION = "authz_policy_candidate_preview.read"
+AUTHZ_REPOSITORY_SCOPE_READ_ACTION = "authz_repository_scope.read"
 AUTHZ_POLICY_CANDIDATE_PREVIEW_MAX_PROBES = 25
 AUTHZ_POLICY_CANDIDATE_PREVIEW_MAX_RULES = 500
+AUTHZ_REPOSITORY_SCOPE_MAX_CANDIDATES = 100
+AUTHZ_REPOSITORY_SCOPE_MAX_SOURCE_RECORDS = 1000
 AuthzPolicyPrincipalType: TypeAlias = Literal[
     "github_actions",
     "github_humans",
@@ -491,3 +494,175 @@ class AuthzPolicyCandidatePreviewSnapshot(BaseModel):
 class AuthzPolicyCandidatePreviewResponse(AuthzPolicyCandidatePreviewSnapshot):
     status: Literal["ok"] = "ok"
     trace_id: str
+
+
+AuthzRepositoryScopeMembership: TypeAlias = Literal[
+    "product",
+    "repository_record",
+    "work_graph",
+    "authorization_chain",
+]
+AuthzRepositoryScopeCoverageState: TypeAlias = Literal["complete", "partial"]
+AuthzRepositoryScopeGapSource: TypeAlias = Literal[
+    "product",
+    "repository_record",
+    "work_graph",
+    "authorization_chain",
+    "candidate",
+]
+AuthzRepositoryScopeGapReason: TypeAlias = Literal[
+    "active_record_ambiguous",
+    "candidate_coverage_incomplete",
+    "candidate_repository_ambiguous",
+    "candidate_repository_missing",
+    "immutable_identity_conflict",
+    "immutable_identity_missing",
+    "record_timestamp_malformed",
+    "repository_case_variant",
+    "repository_identity_conflict",
+    "source_truncated",
+    "stale_authorization_membership",
+    "stale_work_graph_record",
+]
+
+
+class AuthzRepositoryScopeCandidate(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    repository: str
+    repository_id: str = ""
+    repository_owner_id: str = ""
+
+    @model_validator(mode="after")
+    def _validate_candidate(self) -> "AuthzRepositoryScopeCandidate":
+        repository = self.repository.strip()
+        owner, separator, name = repository.partition("/")
+        if (
+            not separator
+            or not owner
+            or not name
+            or "/" in name
+            or len(repository) > 512
+            or any(character in repository for character in "*?[]")
+        ):
+            raise ValueError("Repository scope candidates require one exact owner/repository name.")
+        object.__setattr__(self, "repository", repository)
+        repository_id = self.repository_id.strip()
+        repository_owner_id = self.repository_owner_id.strip()
+        if bool(repository_id) != bool(repository_owner_id):
+            raise ValueError(
+                "Repository scope candidate immutable identity requires both numeric IDs."
+            )
+        if repository_id and (not repository_id.isdecimal() or not repository_owner_id.isdecimal()):
+            raise ValueError("Repository scope candidate immutable IDs must be numeric.")
+        object.__setattr__(self, "repository_id", repository_id)
+        object.__setattr__(self, "repository_owner_id", repository_owner_id)
+        return self
+
+
+class AuthzRepositoryScopeReadRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    candidates: tuple[AuthzRepositoryScopeCandidate, ...] = Field(
+        default=(),
+        max_length=AUTHZ_REPOSITORY_SCOPE_MAX_CANDIDATES,
+    )
+
+    @model_validator(mode="after")
+    def _validate_candidates(self) -> "AuthzRepositoryScopeReadRequest":
+        identities = tuple(candidate.repository.casefold() for candidate in self.candidates)
+        if len(identities) != len(set(identities)):
+            raise ValueError("Repository scope candidates must be unique.")
+        return self
+
+
+class AuthzRepositoryScopeGap(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    source: AuthzRepositoryScopeGapSource
+    reason_code: AuthzRepositoryScopeGapReason
+    count: int = Field(ge=1)
+
+
+class AuthzRepositoryScopeSourceCounts(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    product: int = Field(ge=0)
+    repository_record: int = Field(ge=0)
+    work_graph: int = Field(ge=0)
+    authorization_chain: int = Field(ge=0)
+
+
+class AuthzRepositoryScopeCoverage(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    state: AuthzRepositoryScopeCoverageState
+    source_counts: AuthzRepositoryScopeSourceCounts
+    repository_count: int = Field(ge=0)
+    matched_repository_count: int = Field(ge=0)
+    unmatched_repository_count: int = Field(ge=0)
+    gaps: tuple[AuthzRepositoryScopeGap, ...]
+
+    @model_validator(mode="after")
+    def _validate_coverage(self) -> "AuthzRepositoryScopeCoverage":
+        if self.matched_repository_count + self.unmatched_repository_count != self.repository_count:
+            raise ValueError("Repository scope coverage counts must reconcile.")
+        if (self.state == "complete") != (not self.gaps):
+            raise ValueError("Complete repository scope coverage cannot include gaps.")
+        return self
+
+
+class AuthzRepositoryScopePolicyProvenance(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    record_id: str
+    revision: int = Field(ge=1)
+    updated_at: str
+
+
+class AuthzRepositoryScopeRecordProvenance(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    active_record_count: int = Field(ge=0)
+    latest_recorded_at: str = ""
+
+
+class AuthzRepositoryScopeProvenance(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    authorization_chain: AuthzRepositoryScopePolicyProvenance
+    product: AuthzRepositoryScopeRecordProvenance
+    repository_record: AuthzRepositoryScopeRecordProvenance
+    work_graph: AuthzRepositoryScopeRecordProvenance
+
+
+AuthzRepositoryScopeCandidateState: TypeAlias = Literal["matched", "not_found", "ambiguous"]
+
+
+class AuthzRepositoryScopeCandidateResult(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    index: int = Field(ge=0)
+    state: AuthzRepositoryScopeCandidateState
+    handle: str = ""
+    memberships: tuple[AuthzRepositoryScopeMembership, ...] = ()
+
+    @model_validator(mode="after")
+    def _validate_result(self) -> "AuthzRepositoryScopeCandidateResult":
+        if self.state == "matched" and (not self.handle or not self.memberships):
+            raise ValueError("Matched repository scope candidates require bounded evidence.")
+        if self.state != "matched" and (self.handle or self.memberships):
+            raise ValueError("Unmatched repository scope candidates cannot expose evidence.")
+        return self
+
+
+class AuthzRepositoryScopeResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    status: Literal["ok"] = "ok"
+    trace_id: str
+    generated_at: str
+    handle_generation: str
+    coverage: AuthzRepositoryScopeCoverage
+    provenance: AuthzRepositoryScopeProvenance
+    candidates: tuple[AuthzRepositoryScopeCandidateResult, ...]

--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -29,6 +29,7 @@ from requests.exceptions import RequestException
 from sqlalchemy.exc import SQLAlchemyError
 from control_plane import authz_grant_service as control_plane_authz_grant_service
 from control_plane import authz_diagnostics as control_plane_authz_diagnostics
+from control_plane import authz_repository_scope as control_plane_authz_repository_scope
 from control_plane import ingress_route_scope as control_plane_ingress_route_scope
 from control_plane.dokploy_target_setup_http import (
     DokployTargetSetupEnvelope,
@@ -78,11 +79,14 @@ from control_plane.contracts.authz_access_read import (
     AUTHZ_DENIAL_EXPLANATION_READ_ACTION,
     AUTHZ_POLICY_CANDIDATE_PREVIEW_READ_ACTION,
     AUTHZ_POLICY_HEALTH_READ_ACTION,
+    AUTHZ_REPOSITORY_SCOPE_READ_ACTION,
     EFFECTIVE_ACCESS_READ_ACTION,
     AuthzDenialExplanationResponse,
     AuthzPolicyCandidatePreviewRequest,
     AuthzPolicyCandidatePreviewResponse,
     AuthzPolicyHealthResponse,
+    AuthzRepositoryScopeReadRequest,
+    AuthzRepositoryScopeResponse,
     EffectiveAccessDecision,
     EffectiveAccessEvaluateRequest,
     EffectiveAccessEvaluateResponse,
@@ -1028,6 +1032,7 @@ _AUTHZ_DIAGNOSTIC_EVALUATE_ROUTE = "/v1/authz-diagnostics/github-actions/evaluat
 _AUTHZ_EFFECTIVE_ACCESS_EVALUATE_ROUTE = "/v1/authz-diagnostics/effective-access/evaluate"
 _AUTHZ_POLICY_HEALTH_ROUTE = "/v1/authz-diagnostics/active-policy/health"
 _AUTHZ_POLICY_CANDIDATE_PREVIEW_ROUTE = "/v1/authz-diagnostics/candidate-policy/preview"
+_AUTHZ_REPOSITORY_SCOPE_READ_ROUTE = "/v1/authz-diagnostics/repository-scope/read"
 _AUTHZ_DENIAL_EXPLANATION_ROUTE = "/v1/authz-diagnostics/denials/{trace_id}"
 _AUTHZ_POLICY_MANAGED_RECONCILE_ROUTE = "/v1/authz-policies/managed-rule-sets/reconcile"
 _GENERIC_WEB_PREVIEW_AUTHZ_PLAN_ROUTE = (
@@ -14619,6 +14624,115 @@ def create_launchplane_fastapi_app(
             **snapshot.model_dump(),
         )
 
+    async def read_authz_repository_scope(
+        scope_request: AuthzRepositoryScopeReadRequest,
+        response: Response,
+        identity: Annotated[
+            LaunchplaneIdentity,
+            Depends(read_nonpersisting_sensitive_identity),
+        ],
+        record_store: Annotated[object, Depends(get_record_store)],
+    ) -> AuthzRepositoryScopeResponse:
+        trace_id = next_trace_id()
+        eligible_reader = isinstance(
+            identity,
+            GitHubHumanIdentity | LocalOperatorIdentity | LocalAdminIdentity,
+        )
+        preflight = resolved_authz_policy_runtime.policy.evaluate(
+            identity=identity,
+            action=AUTHZ_REPOSITORY_SCOPE_READ_ACTION,
+            product="launchplane",
+            context=_LAUNCHPLANE_SERVICE_CONTEXT,
+        )
+        if not eligible_reader or preflight.decision != "allowed":
+            raise _launchplane_http_error(
+                status_code=403,
+                trace_id=trace_id,
+                code="authorization_denied",
+                message="Identity cannot read Launchplane authorization repository scope.",
+                headers={"Cache-Control": "no-store"},
+            )
+        try:
+            database_store = require_authz_policy_database_store(
+                record_store=record_store,
+                trace_id=trace_id,
+                message=(
+                    "Authorization repository scope reads require Launchplane database storage."
+                ),
+            )
+            active_record = read_single_active_authz_policy_record(
+                database_store=database_store,
+                trace_id=trace_id,
+            )
+        except LaunchplaneHTTPException as error:
+            error.headers = {**(error.headers or {}), "Cache-Control": "no-store"}
+            raise
+        except (TypeError, ValueError) as error:
+            raise _launchplane_http_error(
+                status_code=409,
+                trace_id=trace_id,
+                code="authz_repository_scope_invalid",
+                message="Authorization repository scope evidence is invalid.",
+                headers={"Cache-Control": "no-store"},
+            ) from error
+        except (OSError, SQLAlchemyError) as error:
+            raise _launchplane_http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="authz_repository_scope_unavailable",
+                message="Authorization repository scope evidence is unavailable.",
+                headers={"Cache-Control": "no-store"},
+            ) from error
+        active_policy_evaluation = active_record.policy.evaluate(
+            identity=identity,
+            action=AUTHZ_REPOSITORY_SCOPE_READ_ACTION,
+            product="launchplane",
+            context=_LAUNCHPLANE_SERVICE_CONTEXT,
+        )
+        if active_policy_evaluation.decision != "allowed":
+            raise _launchplane_http_error(
+                status_code=403,
+                trace_id=trace_id,
+                code="authorization_denied",
+                message="Identity cannot read Launchplane authorization repository scope.",
+                authz_policy_provenance=AuthzPolicyProvenance.from_record(active_record),
+                headers={"Cache-Control": "no-store"},
+            )
+        try:
+            result = control_plane_authz_repository_scope.build_authz_repository_scope_response(
+                trace_id=trace_id,
+                generated_at=datetime.now(timezone.utc).isoformat(),
+                request=scope_request,
+                active_policy_record=active_record,
+                store=database_store,
+            )
+        except click.ClickException as error:
+            raise _launchplane_http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="authz_repository_scope_handle_unavailable",
+                message="Authorization repository scope handles are unavailable.",
+                headers={"Cache-Control": "no-store"},
+            ) from error
+        except (TypeError, ValueError) as error:
+            raise _launchplane_http_error(
+                status_code=409,
+                trace_id=trace_id,
+                code="authz_repository_scope_invalid",
+                message="Authorization repository scope evidence is invalid.",
+                headers={"Cache-Control": "no-store"},
+            ) from error
+        except (OSError, RuntimeError, SQLAlchemyError) as error:
+            raise _launchplane_http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="authz_repository_scope_unavailable",
+                message="Authorization repository scope evidence is unavailable.",
+                headers={"Cache-Control": "no-store"},
+            ) from error
+        response.headers["Cache-Control"] = "no-store"
+        return result
+
     async def preview_authz_candidate_policy(
         preview_request: AuthzPolicyCandidatePreviewRequest,
         identity: Annotated[
@@ -22518,6 +22632,20 @@ def create_launchplane_fastapi_app(
     )
 
     app.add_api_route(
+        _AUTHZ_REPOSITORY_SCOPE_READ_ROUTE,
+        read_authz_repository_scope,
+        methods=["POST"],
+        response_model=AuthzRepositoryScopeResponse,
+        response_model_exclude_none=True,
+        operation_id="read_authz_repository_scope",
+        summary="Read bounded authorization repository scope",
+        responses={
+            **authz_diagnostic_route_responses,
+            409: {"model": LaunchplaneErrorResponse},
+        },
+    )
+
+    app.add_api_route(
         _AUTHZ_POLICY_CANDIDATE_PREVIEW_ROUTE,
         preview_authz_candidate_policy,
         methods=["POST"],
@@ -22929,6 +23057,11 @@ def create_launchplane_fastapi_app(
         response = JSONResponse(
             status_code=400,
             content=payload.model_dump(mode="json", exclude_none=True),
+            headers=(
+                {"Cache-Control": "no-store"}
+                if request.url.path == _AUTHZ_REPOSITORY_SCOPE_READ_ROUTE
+                else None
+            ),
         )
         preserve_renewed_session_cookie(request, response)
         return response
@@ -22988,6 +23121,7 @@ def _launchplane_http_error(
     message: str,
     authz: dict[str, object] | None = None,
     authz_policy_provenance: AuthzPolicyProvenance | None = None,
+    headers: dict[str, str] | None = None,
 ) -> LaunchplaneHTTPException:
     detail: dict[str, object] = {"trace_id": trace_id, "code": code, "message": message}
     if authz is not None:
@@ -23000,6 +23134,7 @@ def _launchplane_http_error(
     return LaunchplaneHTTPException(
         status_code=status_code,
         detail=detail,
+        headers=headers,
         authz_evaluation=authz_evaluation,
         authz_policy_provenance=authz_policy_provenance,
     )

--- a/docs/authorization-authority.md
+++ b/docs/authorization-authority.md
@@ -137,6 +137,44 @@ provider, runtime, secret, durable-operation, or other persistence write. The
 preview does not produce an apply digest, does not prove future applying-
 administrator continuity, and does not authorize any production grant.
 
+The bounded repository-scope slice adds `authz_repository_scope.read` as a
+separate human-reader permission. `POST
+/v1/authz-diagnostics/repository-scope/read` accepts at most 100 exact
+caller-known repository candidates so an authorization audit can reconcile its
+GitHub/planning evidence with DB-backed Launchplane scope without granting the
+broad active-policy or work-graph reads. The permission is available only to
+authenticated GitHub humans, local operators, and local administrators;
+GitHub Actions and terminal-agent identities remain ineligible even when a rule
+mentions the action.
+
+The route derives current membership from active product profiles, current
+repository role/classification records, nonterminal Every Code work-request
+records, and exact GitHub Actions repository membership in the single active DB
+authorization policy. It does not evaluate or return actions, principals,
+selectors, rule identities, workflow identities, or policy payloads. Every
+repository identity is redacted. Candidate results are referenced only by input
+position and return a purpose-separated opaque handle plus source-membership
+categories when matched. Handles remain stable within one opaque handle
+generation; canonical managed-secret key-ring rotation changes both the handles
+and the non-secret opaque generation marker so evidence cannot silently compare
+across generations. Legacy passphrase-only managed-secret configuration is not
+accepted for this public identifier derivation and fails closed.
+
+This permission is a bounded repository-existence oracle and must not be granted
+broadly. Unmatched DB entries appear only as counts, never as handles or names.
+Each source query retains at most 1,000 records; any truncation is an explicit
+partial-coverage gap rather than silent omission.
+Any unmatched DB entry, submitted candidate missing from DB scope, conflicting
+identity evidence, case variant that would not match the exact authorization
+evaluator, malformed timestamp, missing immutable identity evidence, or
+expired active work-request lease, or stale-only authorization membership produces
+`coverage.state=partial` with bounded count/reason gaps. Partial coverage is a
+fail-closed audit result and cannot satisfy #2177 or final #2062 review. Storage
+or active-policy absence still fails hard; multiple active policies fail as
+ambiguous. Landing this route grants no production access and authorizes no
+policy, workflow, secret, provider, runtime, deployment, or durable-operation
+change.
+
 Landing these read contracts does not authorize their production grants and
 does not relax the active freeze. Production policy changes still require the
 separate reviewed administration and recovery gates owned by `#2058`/`#2061`.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -298,7 +298,7 @@ former replaces the previous process-local apply lock. Both require an
 `503 database_storage_required` on non-database stores.
 
 - A concurrent request with the same key while the effect runs returns `409
-  mutation_in_progress`; a completed effect replays; a different request
+mutation_in_progress`; a completed effect replays; a different request
   fingerprint returns `409 idempotency_key_reused`.
 - GitHub workflow retries must preserve the original operation key. The generic
   web stable-deploy workflow keeps the first-attempt `:<run_id>:1` suffix on
@@ -687,6 +687,43 @@ tokens, secrets, or topology. Browser calls retain same-origin and CSRF checks
 without session renewal or rotation, and no policy, session, denial, audit,
 idempotency, outbox, provider, runtime, secret, or durable-operation record is
 written.
+
+`POST /v1/authz-diagnostics/repository-scope/read` provides one bounded
+DB-backed comparison for authorization portfolio audits. Supply at most 100
+exact repositories already known from the pinned GitHub/planning evidence. The
+service does not echo those identities. Candidate results use only their input
+index, a matched/not-found/ambiguous state, an opaque handle for exact matches,
+and bounded membership categories. Do not place repository identities in URLs,
+logs, issue comments, or published evidence merely to use this route.
+
+The caller needs the separate `authz_repository_scope.read` action and must be
+an authenticated GitHub human, local operator, or local administrator. The
+route performs runtime-policy preflight, reloads the single active DB policy,
+and reauthorizes before reading product, repository, and work-graph records.
+GitHub Actions and terminal agents cannot use the route; do not borrow a
+workflow identity or dispatch a protected workflow as a workaround.
+
+Treat `coverage.state=partial` as blocked. The bounded gaps report only source,
+reason code, and count. Reconcile both directions: every DB entry must match a
+candidate and every candidate must exist in DB scope. Expand or correct the
+caller-known candidate set through the sanctioned #2177 evidence process, but
+do not inspect the database directly or widen another grant. Opaque handles are
+stable only within the returned `handle_generation`; if that marker changes after
+canonical managed-secret key-ring rotation, regenerate the comparison instead of
+correlating old and new handles. Legacy passphrase-only secret configuration
+cannot derive public handles and returns a fail-closed unavailable response. The
+response is `Cache-Control: no-store` and remains a narrow repository-existence
+oracle even though it exposes no repository names.
+Each source query retains at most 1,000 records; `source_truncated` keeps the
+result partial until the authoritative source can be reconciled within bounds.
+An expired or malformed lease on a claimed/running work request likewise keeps
+coverage partial until the normal recovery path refreshes that record.
+
+Successful and partial reads perform no policy, session, idempotency, outbox,
+provider, runtime, workflow, secret, deployment, or durable-operation mutation.
+A denied request may append the ordinary redacted denial record, which contains
+no candidate or repository identity. Landing the route does not grant
+production access and does not relax #2058.
 
 Standard `authorization_denied` HTTP failures with a captured policy evaluation
 write a redacted `launchplane_authz_denials` audit record on a best-effort basis.
@@ -2049,7 +2086,7 @@ context only, and `context_instance` has both context and instance.
   labels, and timestamps only. They do not echo literal values or managed secret
   binding ids.
 - `odoo-overrides migrate-secret-transport --apply` and `odoo-overrides
-  mark-apply` require `--allow-direct-db-mutation` before they persist local DB
+mark-apply` require `--allow-direct-db-mutation` before they persist local DB
   changes. `migrate-secret-transport` dry-run, `odoo-overrides list`, and
   `odoo-overrides show` stay read-only inspection paths.
 - Compose post-deploy updates consume deploy-phase overrides from these records

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -397,6 +397,7 @@ apply requires the same `Idempotency-Key` as its matching dry-run, an exact
 confirmation phrase, a non-empty reason and related issue, and an unchanged
 managed-comment observation. If the managed comment is already absent, apply
 records `already_absent` without claiming a GitHub mutation.
+
 - work graph chooser route:
   - `GET /v1/agent/context`
   - `GET /v1/repo-product-mapping`
@@ -746,6 +747,42 @@ principal identifiers, tokens, secrets, or topology. Same-origin browser calls
 verify CSRF without renewing the session or rotating its token, and the route
 performs no policy, session, denial-evidence, idempotency, outbox, provider,
 runtime, secret, durable-operation, or other persistence write.
+
+`POST /v1/authz-diagnostics/repository-scope/read` is the independently
+grantable DB-backed repository-scope audit read. It requires
+`authz_repository_scope.read` and accepts at most 100 exact caller-known
+repository candidates. GitHub humans, local operators, and local administrators
+may use the permission; GitHub Actions and terminal-agent identities are
+ineligible. The route authorizes against runtime policy before reading route
+state, reloads exactly one active DB policy, and authorizes again against that
+record.
+
+The response reconciles active product profiles, current repository human-role
+and tenant-classification records, nonterminal Every Code work requests, and
+exact GitHub Actions repository membership from the active policy. It never
+returns a repository name or numeric identifier. Matched candidates are
+referenced by request ordinal and receive only an opaque purpose-separated
+handle plus `product`, `repository_record`, `work_graph`, and/or
+`authorization_chain` membership categories. Unmatched DB repositories produce
+aggregate counts only. The response also includes generation time, bounded
+source counts/timestamps, active-policy record/revision/time provenance, an
+opaque handle-generation marker, and count/reason coverage gaps.
+Each source query is capped at 1,000 retained records. A source that exceeds its
+cap reports `source_truncated` and cannot produce complete coverage.
+Public handle derivation requires the canonical high-entropy managed-secret key
+ring; legacy passphrase-only compatibility configuration fails closed rather
+than exposing a known-plaintext verifier for the managed-secret root.
+
+`coverage.state=complete` requires exact set equality: every DB repository must
+match one submitted candidate, every candidate must exist in DB scope, and no
+conflicting, malformed, stale-only, case-variant, or missing-identity evidence
+may remain, and claimed/running work requests must retain a current lease.
+Otherwise the route returns `partial`; consumers must treat that as fail-closed
+and cannot use it as #2177 or #2062 completion evidence.
+The endpoint is a bounded repository-existence oracle, sets `Cache-Control:
+no-store`, and must remain narrowly granted. Successful and partial reads write
+nothing. A standard redacted denial record remains the only permitted
+best-effort write on HTTP 403 and contains no repository identity.
 
 New managed GitHub Actions rules require immutable GitHub `repository_id` and
 `repository_owner_id` selectors. Production-capable, destructive,
@@ -3672,6 +3709,7 @@ revision/digest and repository/PR/head/tree binding. See
    workflows still write through repo-local CLI adapters.
 3. Define the first explicit Odoo and VeriReel driver interfaces after the
    service ingress exists.
+
 ## Product retirement
 
 `POST /v1/product-retirement` is the only supported provider-mutation path for

--- a/frontend/generated/openapi-canonical.json
+++ b/frontend/generated/openapi-canonical.json
@@ -1974,6 +1974,333 @@
         "title": "AuthzReachableAdministratorSummary",
         "type": "object"
       },
+      "AuthzRepositoryScopeCandidate": {
+        "additionalProperties": false,
+        "properties": {
+          "repository": {
+            "title": "Repository",
+            "type": "string"
+          },
+          "repository_id": {
+            "default": "",
+            "title": "Repository Id",
+            "type": "string"
+          },
+          "repository_owner_id": {
+            "default": "",
+            "title": "Repository Owner Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "repository"
+        ],
+        "title": "AuthzRepositoryScopeCandidate",
+        "type": "object"
+      },
+      "AuthzRepositoryScopeCandidateResult": {
+        "additionalProperties": false,
+        "properties": {
+          "handle": {
+            "default": "",
+            "title": "Handle",
+            "type": "string"
+          },
+          "index": {
+            "minimum": 0.0,
+            "title": "Index",
+            "type": "integer"
+          },
+          "memberships": {
+            "default": [],
+            "items": {
+              "enum": [
+                "product",
+                "repository_record",
+                "work_graph",
+                "authorization_chain"
+              ],
+              "type": "string"
+            },
+            "title": "Memberships",
+            "type": "array"
+          },
+          "state": {
+            "enum": [
+              "matched",
+              "not_found",
+              "ambiguous"
+            ],
+            "title": "State",
+            "type": "string"
+          }
+        },
+        "required": [
+          "index",
+          "state"
+        ],
+        "title": "AuthzRepositoryScopeCandidateResult",
+        "type": "object"
+      },
+      "AuthzRepositoryScopeCoverage": {
+        "additionalProperties": false,
+        "properties": {
+          "gaps": {
+            "items": {
+              "$ref": "#/components/schemas/AuthzRepositoryScopeGap"
+            },
+            "title": "Gaps",
+            "type": "array"
+          },
+          "matched_repository_count": {
+            "minimum": 0.0,
+            "title": "Matched Repository Count",
+            "type": "integer"
+          },
+          "repository_count": {
+            "minimum": 0.0,
+            "title": "Repository Count",
+            "type": "integer"
+          },
+          "source_counts": {
+            "$ref": "#/components/schemas/AuthzRepositoryScopeSourceCounts"
+          },
+          "state": {
+            "enum": [
+              "complete",
+              "partial"
+            ],
+            "title": "State",
+            "type": "string"
+          },
+          "unmatched_repository_count": {
+            "minimum": 0.0,
+            "title": "Unmatched Repository Count",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "state",
+          "source_counts",
+          "repository_count",
+          "matched_repository_count",
+          "unmatched_repository_count",
+          "gaps"
+        ],
+        "title": "AuthzRepositoryScopeCoverage",
+        "type": "object"
+      },
+      "AuthzRepositoryScopeGap": {
+        "additionalProperties": false,
+        "properties": {
+          "count": {
+            "minimum": 1.0,
+            "title": "Count",
+            "type": "integer"
+          },
+          "reason_code": {
+            "enum": [
+              "active_record_ambiguous",
+              "candidate_coverage_incomplete",
+              "candidate_repository_ambiguous",
+              "candidate_repository_missing",
+              "immutable_identity_conflict",
+              "immutable_identity_missing",
+              "record_timestamp_malformed",
+              "repository_case_variant",
+              "repository_identity_conflict",
+              "source_truncated",
+              "stale_authorization_membership",
+              "stale_work_graph_record"
+            ],
+            "title": "Reason Code",
+            "type": "string"
+          },
+          "source": {
+            "enum": [
+              "product",
+              "repository_record",
+              "work_graph",
+              "authorization_chain",
+              "candidate"
+            ],
+            "title": "Source",
+            "type": "string"
+          }
+        },
+        "required": [
+          "source",
+          "reason_code",
+          "count"
+        ],
+        "title": "AuthzRepositoryScopeGap",
+        "type": "object"
+      },
+      "AuthzRepositoryScopePolicyProvenance": {
+        "additionalProperties": false,
+        "properties": {
+          "record_id": {
+            "title": "Record Id",
+            "type": "string"
+          },
+          "revision": {
+            "minimum": 1.0,
+            "title": "Revision",
+            "type": "integer"
+          },
+          "updated_at": {
+            "title": "Updated At",
+            "type": "string"
+          }
+        },
+        "required": [
+          "record_id",
+          "revision",
+          "updated_at"
+        ],
+        "title": "AuthzRepositoryScopePolicyProvenance",
+        "type": "object"
+      },
+      "AuthzRepositoryScopeProvenance": {
+        "additionalProperties": false,
+        "properties": {
+          "authorization_chain": {
+            "$ref": "#/components/schemas/AuthzRepositoryScopePolicyProvenance"
+          },
+          "product": {
+            "$ref": "#/components/schemas/AuthzRepositoryScopeRecordProvenance"
+          },
+          "repository_record": {
+            "$ref": "#/components/schemas/AuthzRepositoryScopeRecordProvenance"
+          },
+          "work_graph": {
+            "$ref": "#/components/schemas/AuthzRepositoryScopeRecordProvenance"
+          }
+        },
+        "required": [
+          "authorization_chain",
+          "product",
+          "repository_record",
+          "work_graph"
+        ],
+        "title": "AuthzRepositoryScopeProvenance",
+        "type": "object"
+      },
+      "AuthzRepositoryScopeReadRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "candidates": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/AuthzRepositoryScopeCandidate"
+            },
+            "maxItems": 100,
+            "title": "Candidates",
+            "type": "array"
+          }
+        },
+        "title": "AuthzRepositoryScopeReadRequest",
+        "type": "object"
+      },
+      "AuthzRepositoryScopeRecordProvenance": {
+        "additionalProperties": false,
+        "properties": {
+          "active_record_count": {
+            "minimum": 0.0,
+            "title": "Active Record Count",
+            "type": "integer"
+          },
+          "latest_recorded_at": {
+            "default": "",
+            "title": "Latest Recorded At",
+            "type": "string"
+          }
+        },
+        "required": [
+          "active_record_count"
+        ],
+        "title": "AuthzRepositoryScopeRecordProvenance",
+        "type": "object"
+      },
+      "AuthzRepositoryScopeResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "candidates": {
+            "items": {
+              "$ref": "#/components/schemas/AuthzRepositoryScopeCandidateResult"
+            },
+            "title": "Candidates",
+            "type": "array"
+          },
+          "coverage": {
+            "$ref": "#/components/schemas/AuthzRepositoryScopeCoverage"
+          },
+          "generated_at": {
+            "title": "Generated At",
+            "type": "string"
+          },
+          "handle_generation": {
+            "title": "Handle Generation",
+            "type": "string"
+          },
+          "provenance": {
+            "$ref": "#/components/schemas/AuthzRepositoryScopeProvenance"
+          },
+          "status": {
+            "const": "ok",
+            "default": "ok",
+            "title": "Status",
+            "type": "string"
+          },
+          "trace_id": {
+            "title": "Trace Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "trace_id",
+          "generated_at",
+          "handle_generation",
+          "coverage",
+          "provenance",
+          "candidates"
+        ],
+        "title": "AuthzRepositoryScopeResponse",
+        "type": "object"
+      },
+      "AuthzRepositoryScopeSourceCounts": {
+        "additionalProperties": false,
+        "properties": {
+          "authorization_chain": {
+            "minimum": 0.0,
+            "title": "Authorization Chain",
+            "type": "integer"
+          },
+          "product": {
+            "minimum": 0.0,
+            "title": "Product",
+            "type": "integer"
+          },
+          "repository_record": {
+            "minimum": 0.0,
+            "title": "Repository Record",
+            "type": "integer"
+          },
+          "work_graph": {
+            "minimum": 0.0,
+            "title": "Work Graph",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "product",
+          "repository_record",
+          "work_graph",
+          "authorization_chain"
+        ],
+        "title": "AuthzRepositoryScopeSourceCounts",
+        "type": "object"
+      },
       "BackupGateEvidence": {
         "additionalProperties": false,
         "properties": {
@@ -36845,6 +37172,106 @@
           }
         },
         "summary": "Evaluate the calling GitHub Actions identity against active authorization"
+      }
+    },
+    "/v1/authz-diagnostics/repository-scope/read": {
+      "post": {
+        "operationId": "read_authz_repository_scope",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Authorization",
+            "required": false,
+            "schema": {
+              "default": "",
+              "title": "Authorization",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "Cookie",
+            "required": false,
+            "schema": {
+              "default": "",
+              "title": "Cookie",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AuthzRepositoryScopeReadRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthzRepositoryScopeResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "summary": "Read bounded authorization repository scope"
       }
     },
     "/v1/authz-policies/active": {

--- a/tests/test_authz_access_read.py
+++ b/tests/test_authz_access_read.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import base64
 from collections.abc import Iterator
 from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
+import hashlib
 import json
+import os
 from pathlib import Path
 from tempfile import TemporaryDirectory
 import unittest
@@ -16,6 +19,7 @@ from control_plane.contracts.authz_access_read import (
     AUTHZ_DENIAL_EXPLANATION_READ_ACTION,
     AUTHZ_POLICY_CANDIDATE_PREVIEW_READ_ACTION,
     AUTHZ_POLICY_HEALTH_READ_ACTION,
+    AUTHZ_REPOSITORY_SCOPE_READ_ACTION,
     EFFECTIVE_ACCESS_READ_ACTION,
     AuthzPolicyCandidatePreviewRequest,
     EffectiveAccessEvaluateRequest,
@@ -26,6 +30,11 @@ from control_plane.contracts.authz_policy_record import (
     authz_policy_sha256,
     build_authz_policy_record_id,
 )
+from control_plane.contracts.product_profile_record import (
+    LaunchplaneProductProfileRecord,
+    ProductImageProfile,
+)
+from control_plane import secrets as control_plane_secrets
 from control_plane.http_app import LaunchplaneAuthzPolicyRuntime, create_launchplane_fastapi_app
 from control_plane.service_auth import (
     AuthzEvaluation,
@@ -106,6 +115,31 @@ def _support_reader_policy() -> LaunchplaneAuthzPolicy:
     )
 
 
+def _repository_scope_reader_policy() -> LaunchplaneAuthzPolicy:
+    return LaunchplaneAuthzPolicy.model_validate(
+        {
+            "schema_version": 2,
+            "github_actions": [
+                {
+                    "repository": "example/private-product",
+                    "repository_id": "123456",
+                    "repository_owner_id": "654321",
+                    "actions": ["deploy.write"],
+                }
+            ],
+            "local_operators": [
+                {
+                    "subjects": ["support-reader"],
+                    "token_labels": ["support-reader-label"],
+                    "products": ["launchplane"],
+                    "contexts": ["launchplane"],
+                    "actions": [AUTHZ_REPOSITORY_SCOPE_READ_ACTION],
+                }
+            ],
+        }
+    )
+
+
 def _app(
     *,
     root: Path,
@@ -161,7 +195,267 @@ def _database_app(
             store.close()
 
 
+def _repository_scope_product_profile() -> LaunchplaneProductProfileRecord:
+    return LaunchplaneProductProfileRecord(
+        product="example-product",
+        display_name="Example Product",
+        repository="example/private-product",
+        repository_id="123456",
+        repository_owner_id="654321",
+        driver_id="generic-web",
+        image=ProductImageProfile(),
+        updated_at="2026-08-20T21:00:00+00:00",
+        source="test:authz-access-read",
+    )
+
+
+def _repository_scope_key_ring(value: str) -> str:
+    encoded_key = base64.urlsafe_b64encode(hashlib.sha256(value.encode()).digest())
+    return json.dumps(
+        {
+            "active_key_id": "repository-scope-key",
+            "keys": {"repository-scope-key": encoded_key.decode()},
+        }
+    )
+
+
 class AuthzAccessReadHttpTests(unittest.IsolatedAsyncioTestCase):
+    async def test_operator_reads_complete_redacted_repository_scope_without_mutation(
+        self,
+    ) -> None:
+        with _database_app(_repository_scope_reader_policy()) as (store, record, app):
+            store.write_product_profile_record(_repository_scope_product_profile())
+            policy_records_before = store.list_authz_policy_records()
+            repository_scope_operation = app.openapi()["paths"][
+                "/v1/authz-diagnostics/repository-scope/read"
+            ]["post"]
+            self.assertEqual(
+                repository_scope_operation["operationId"],
+                "read_authz_repository_scope",
+            )
+            with patch.dict(
+                os.environ,
+                {
+                    control_plane_secrets.LAUNCHPLANE_SECRET_KEYS_JSON_ENV_VAR: (
+                        _repository_scope_key_ring("authz-repository-scope-test-key")
+                    )
+                },
+                clear=True,
+            ):
+                with (
+                    patch(
+                        "control_plane.storage.postgres.PostgresRecordStore.write_authz_denial_record",
+                        side_effect=AssertionError(
+                            "successful repository scope reads must not write"
+                        ),
+                    ),
+                    patch(
+                        "control_plane.storage.postgres.PostgresRecordStore.write_product_profile_record",
+                        side_effect=AssertionError(
+                            "repository scope reads must not mutate products"
+                        ),
+                    ),
+                    patch(
+                        "control_plane.storage.postgres.PostgresRecordStore.write_repository_human_role_policy_record",
+                        side_effect=AssertionError(
+                            "repository scope reads must not mutate repository records"
+                        ),
+                    ),
+                    patch(
+                        "control_plane.storage.postgres.PostgresRecordStore.write_every_code_work_request_record",
+                        side_effect=AssertionError(
+                            "repository scope reads must not mutate work graph"
+                        ),
+                    ),
+                ):
+                    async with lifespan_client(app) as client:
+                        response = await client.post(
+                            "/v1/authz-diagnostics/repository-scope/read",
+                            headers={"Authorization": "Bearer support-token"},
+                            json={
+                                "candidates": [
+                                    {
+                                        "repository": "example/private-product",
+                                        "repository_id": "123456",
+                                        "repository_owner_id": "654321",
+                                    }
+                                ]
+                            },
+                        )
+            policy_records_after = store.list_authz_policy_records()
+
+        self.assertEqual(response.status_code, 200, response.text)
+        self.assertEqual(response.headers["cache-control"], "no-store")
+        self.assertEqual(policy_records_after, policy_records_before)
+        payload = response.json()
+        self.assertEqual(payload["coverage"]["state"], "complete")
+        self.assertEqual(payload["coverage"]["repository_count"], 1)
+        self.assertEqual(payload["coverage"]["matched_repository_count"], 1)
+        self.assertEqual(payload["candidates"][0]["state"], "matched")
+        self.assertEqual(
+            payload["candidates"][0]["memberships"],
+            ["product", "authorization_chain"],
+        )
+        self.assertEqual(
+            payload["provenance"]["authorization_chain"]["record_id"], record.record_id
+        )
+        serialized = json.dumps(payload, sort_keys=True)
+        for private_value in (
+            "example/private-product",
+            "123456",
+            "654321",
+            "support-reader",
+            "support-reader-label",
+            "deploy.write",
+        ):
+            self.assertNotIn(private_value, serialized)
+
+    async def test_repository_scope_authorization_precedes_route_database_reads(self) -> None:
+        policy = LaunchplaneAuthzPolicy.model_validate(
+            {
+                "schema_version": 2,
+                "local_operators": [
+                    {
+                        "subjects": ["support-reader"],
+                        "token_labels": ["support-reader-label"],
+                        "products": ["launchplane"],
+                        "contexts": ["launchplane"],
+                        "actions": [AUTHZ_DENIAL_EXPLANATION_READ_ACTION],
+                    }
+                ],
+            }
+        )
+        with _database_app(policy) as (store, _record, app):
+            with (
+                patch(
+                    "control_plane.storage.postgres.PostgresRecordStore.list_authz_policy_records",
+                    side_effect=AssertionError("authorization must precede active policy reads"),
+                ),
+                patch(
+                    "control_plane.storage.postgres.PostgresRecordStore.list_product_profile_records",
+                    side_effect=AssertionError("authorization must precede product reads"),
+                ),
+                patch(
+                    "control_plane.storage.postgres.PostgresRecordStore.list_repository_human_role_policy_records",
+                    side_effect=AssertionError("authorization must precede repository reads"),
+                ),
+                patch(
+                    "control_plane.storage.postgres.PostgresRecordStore.list_every_code_work_request_records",
+                    side_effect=AssertionError("authorization must precede work graph reads"),
+                ),
+            ):
+                async with lifespan_client(app) as client:
+                    response = await client.post(
+                        "/v1/authz-diagnostics/repository-scope/read",
+                        headers={"Authorization": "Bearer support-token"},
+                        json={"candidates": []},
+                    )
+
+        self.assertEqual(response.status_code, 403, response.text)
+        self.assertEqual(response.json()["error"]["code"], "authorization_denied")
+
+    async def test_repository_scope_rechecks_fresh_policy_and_only_records_denial(self) -> None:
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            store = PostgresRecordStore(database_url=_database_url(root / "launchplane.sqlite3"))
+            store.ensure_schema()
+            active_record = _seed_policy(store, _support_reader_policy())
+            runtime_policy = _repository_scope_reader_policy()
+            runtime_digest = authz_policy_sha256(runtime_policy)
+            runtime_record = LaunchplaneAuthzPolicyRecord(
+                record_id=build_authz_policy_record_id(
+                    revision=2,
+                    policy_sha256=runtime_digest,
+                ),
+                revision=2,
+                status="active",
+                source="test:runtime-only",
+                updated_at="2026-08-20T22:00:00+00:00",
+                policy_sha256=runtime_digest,
+                policy=runtime_policy,
+            )
+            app = _app(root=root, store=store, record=runtime_record)
+            try:
+                async with lifespan_client(app) as client:
+                    response = await client.post(
+                        "/v1/authz-diagnostics/repository-scope/read",
+                        headers={"Authorization": "Bearer support-token"},
+                        json={"candidates": []},
+                    )
+                denial_record = store.read_authz_denial_record(
+                    trace_id=response.json()["trace_id"],
+                    observed_at="2026-08-20T23:00:00+00:00",
+                )
+                policy_records = store.list_authz_policy_records()
+            finally:
+                store.close()
+
+        self.assertEqual(response.status_code, 403, response.text)
+        self.assertEqual(policy_records, (active_record,))
+        self.assertIsNotNone(denial_record)
+        assert denial_record is not None
+        self.assertEqual(
+            denial_record.route_path,
+            "/v1/authz-diagnostics/repository-scope/read",
+        )
+        serialized = json.dumps(denial_record.model_dump(mode="json"), sort_keys=True)
+        self.assertNotIn("example/private-product", serialized)
+        self.assertNotIn("123456", serialized)
+
+    async def test_repository_scope_fails_closed_without_handle_root_or_valid_request(
+        self,
+    ) -> None:
+        with _database_app(_repository_scope_reader_policy()) as (store, _record, app):
+            store.write_product_profile_record(_repository_scope_product_profile())
+            async with lifespan_client(app) as client:
+                with patch.dict(os.environ, {}, clear=True):
+                    unavailable_response = await client.post(
+                        "/v1/authz-diagnostics/repository-scope/read",
+                        headers={"Authorization": "Bearer support-token"},
+                        json={"candidates": []},
+                    )
+                with patch.dict(
+                    os.environ,
+                    {
+                        control_plane_secrets.LAUNCHPLANE_SECRET_MASTER_KEY_ENV_VAR: (
+                            "legacy-low-entropy-key"
+                        )
+                    },
+                    clear=True,
+                ):
+                    legacy_key_response = await client.post(
+                        "/v1/authz-diagnostics/repository-scope/read",
+                        headers={"Authorization": "Bearer support-token"},
+                        json={"candidates": []},
+                    )
+                invalid_response = await client.post(
+                    "/v1/authz-diagnostics/repository-scope/read",
+                    headers={"Authorization": "Bearer support-token"},
+                    json={
+                        "candidates": [
+                            {
+                                "repository": "example/private-product",
+                                "repository_id": "private-id-must-not-echo",
+                            }
+                        ]
+                    },
+                )
+
+        self.assertEqual(unavailable_response.status_code, 503, unavailable_response.text)
+        self.assertEqual(
+            unavailable_response.json()["error"]["code"],
+            "authz_repository_scope_handle_unavailable",
+        )
+        self.assertEqual(legacy_key_response.status_code, 503, legacy_key_response.text)
+        self.assertEqual(
+            legacy_key_response.json()["error"]["code"],
+            "authz_repository_scope_handle_unavailable",
+        )
+        self.assertEqual(invalid_response.status_code, 400, invalid_response.text)
+        self.assertEqual(invalid_response.headers["cache-control"], "no-store")
+        self.assertEqual(invalid_response.json()["error"]["code"], "invalid_request")
+        self.assertNotIn("private-id-must-not-echo", invalid_response.text)
+
     async def test_administrator_reads_bounded_policy_health_without_selector_leakage(
         self,
     ) -> None:

--- a/tests/test_authz_repository_scope.py
+++ b/tests/test_authz_repository_scope.py
@@ -1,0 +1,552 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import os
+import unittest
+from unittest.mock import patch
+
+from pydantic import ValidationError
+
+from control_plane.authz_repository_scope import build_authz_repository_scope_response
+from control_plane.contracts.authz_access_read import AuthzRepositoryScopeReadRequest
+from control_plane.contracts.authz_policy_record import (
+    LaunchplaneAuthzPolicyRecord,
+    authz_policy_sha256,
+    build_authz_policy_record_id,
+)
+from control_plane.contracts.every_code_work_request import EveryCodeWorkRequestRecord
+from control_plane.contracts.product_profile_record import (
+    LaunchplaneProductProfileRecord,
+    ProductImageProfile,
+)
+from control_plane.contracts.repository_human_admission import RepositoryHumanRolePolicyRecord
+from control_plane.contracts.tenant_merge_eligibility import (
+    TenantRepositoryClassificationRecord,
+)
+from control_plane.service_auth import LaunchplaneAuthzPolicy
+from control_plane import secrets as control_plane_secrets
+
+
+REPOSITORY = "example/private-product"
+REPOSITORY_ID = "123456"
+REPOSITORY_OWNER_ID = "654321"
+
+
+class _Store:
+    def __init__(
+        self,
+        *,
+        product_profiles: tuple[LaunchplaneProductProfileRecord, ...] = (),
+        role_policies: tuple[RepositoryHumanRolePolicyRecord, ...] = (),
+        classifications: tuple[TenantRepositoryClassificationRecord, ...] = (),
+        work_requests: tuple[EveryCodeWorkRequestRecord, ...] = (),
+    ) -> None:
+        self.product_profiles = product_profiles
+        self.role_policies = role_policies
+        self.classifications = classifications
+        self.work_requests = work_requests
+
+    def list_product_profile_records(
+        self,
+        *,
+        driver_id: str = "",
+    ) -> tuple[LaunchplaneProductProfileRecord, ...]:
+        del driver_id
+        return self.product_profiles
+
+    def list_repository_human_role_policy_records(
+        self,
+        *,
+        repository_id: str = "",
+        repository_owner_id: str = "",
+        repository: str = "",
+        product: str = "",
+        context: str = "",
+        status: str = "",
+        limit: int | None = None,
+    ) -> tuple[RepositoryHumanRolePolicyRecord, ...]:
+        del repository_id, repository_owner_id, repository, product, context, status
+        return self.role_policies if limit is None else self.role_policies[:limit]
+
+    def list_tenant_repository_classification_records(
+        self,
+        *,
+        repository_id: str = "",
+        limit: int | None = None,
+    ) -> tuple[TenantRepositoryClassificationRecord, ...]:
+        del repository_id
+        return self.classifications if limit is None else self.classifications[:limit]
+
+    def list_every_code_work_request_records(
+        self,
+        *,
+        state: str = "",
+        repository: str = "",
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> tuple[EveryCodeWorkRequestRecord, ...]:
+        records = tuple(
+            record
+            for record in self.work_requests
+            if (not state or record.state == state)
+            and (not repository or record.repository == repository)
+        )
+        if limit is None:
+            return records[offset:]
+        return records[offset : offset + limit]
+
+
+class AuthzRepositoryScopeTests(unittest.TestCase):
+    def test_complete_scope_matches_candidates_without_identity_leakage(self) -> None:
+        policy_record = _policy_record(repository=REPOSITORY)
+        store = _Store(
+            product_profiles=(_product_profile(),),
+            role_policies=(_role_policy(),),
+            classifications=(_classification(),),
+            work_requests=(_work_request(),),
+        )
+        request = AuthzRepositoryScopeReadRequest.model_validate(
+            {
+                "candidates": [
+                    {
+                        "repository": REPOSITORY,
+                        "repository_id": REPOSITORY_ID,
+                        "repository_owner_id": REPOSITORY_OWNER_ID,
+                    }
+                ]
+            }
+        )
+
+        with _handle_key("repository-scope-key-one"):
+            first = build_authz_repository_scope_response(
+                trace_id="trace-one",
+                generated_at="2026-08-20T22:30:00+00:00",
+                request=request,
+                active_policy_record=policy_record,
+                store=store,
+            )
+            repeated = build_authz_repository_scope_response(
+                trace_id="trace-two",
+                generated_at="2026-08-20T22:31:00+00:00",
+                request=request,
+                active_policy_record=policy_record,
+                store=store,
+            )
+
+        self.assertEqual(first.coverage.state, "complete")
+        self.assertEqual(first.coverage.repository_count, 1)
+        self.assertEqual(first.coverage.matched_repository_count, 1)
+        self.assertEqual(first.coverage.gaps, ())
+        self.assertEqual(first.candidates[0].state, "matched")
+        self.assertEqual(
+            first.candidates[0].memberships,
+            ("product", "repository_record", "work_graph", "authorization_chain"),
+        )
+        self.assertEqual(first.candidates[0].handle, repeated.candidates[0].handle)
+        self.assertEqual(first.handle_generation, repeated.handle_generation)
+        serialized = json.dumps(first.model_dump(mode="json"), sort_keys=True)
+        for secret_value in (
+            REPOSITORY,
+            REPOSITORY_ID,
+            REPOSITORY_OWNER_ID,
+            "example-product",
+            "deploy.write",
+        ):
+            self.assertNotIn(secret_value, serialized)
+
+    def test_unmatched_scope_is_partial_without_disclosing_unknown_identity(self) -> None:
+        request = AuthzRepositoryScopeReadRequest.model_validate(
+            {"candidates": [{"repository": "example/known-public"}]}
+        )
+        with _handle_key("repository-scope-key-one"):
+            response = build_authz_repository_scope_response(
+                trace_id="trace-one",
+                generated_at="2026-08-20T22:30:00+00:00",
+                request=request,
+                active_policy_record=_policy_record(repository=REPOSITORY),
+                store=_Store(product_profiles=(_product_profile(),)),
+            )
+
+        self.assertEqual(response.coverage.state, "partial")
+        self.assertEqual(response.coverage.unmatched_repository_count, 1)
+        self.assertEqual(response.candidates[0].state, "not_found")
+        self.assertEqual(response.candidates[0].handle, "")
+        self.assertEqual(
+            {(gap.source, gap.reason_code, gap.count) for gap in response.coverage.gaps},
+            {
+                ("candidate", "candidate_coverage_incomplete", 1),
+                ("candidate", "candidate_repository_missing", 1),
+            },
+        )
+        self.assertNotIn(REPOSITORY, json.dumps(response.model_dump(mode="json")))
+
+    def test_case_variant_reports_gap_without_hiding_authorization_membership(self) -> None:
+        request = AuthzRepositoryScopeReadRequest.model_validate(
+            {"candidates": [{"repository": REPOSITORY}]}
+        )
+        with _handle_key("repository-scope-key-one"):
+            response = build_authz_repository_scope_response(
+                trace_id="trace-one",
+                generated_at="2026-08-20T22:30:00+00:00",
+                request=request,
+                active_policy_record=_policy_record(repository="Example/Private-Product"),
+                store=_Store(product_profiles=(_product_profile(),)),
+            )
+
+        self.assertEqual(response.coverage.state, "partial")
+        self.assertEqual(response.candidates[0].state, "matched")
+        self.assertEqual(
+            response.candidates[0].memberships,
+            ("product", "authorization_chain"),
+        )
+        self.assertIn(
+            ("authorization_chain", "repository_case_variant", 1),
+            {(gap.source, gap.reason_code, gap.count) for gap in response.coverage.gaps},
+        )
+
+    def test_lowercased_repository_records_do_not_create_false_case_variant(self) -> None:
+        canonical_repository = "ExampleOrg/Private-Product"
+        request = AuthzRepositoryScopeReadRequest.model_validate(
+            {"candidates": [{"repository": canonical_repository}]}
+        )
+        with _handle_key("repository-scope-key-one"):
+            response = build_authz_repository_scope_response(
+                trace_id="trace-one",
+                generated_at="2026-08-20T22:30:00+00:00",
+                request=request,
+                active_policy_record=_policy_record(repository=canonical_repository),
+                store=_Store(
+                    product_profiles=(
+                        _product_profile().model_copy(update={"repository": canonical_repository}),
+                    ),
+                    role_policies=(
+                        _role_policy().model_copy(
+                            update={"repository": canonical_repository.casefold()}
+                        ),
+                    ),
+                    classifications=(
+                        _classification().model_copy(
+                            update={"repository": canonical_repository.casefold()}
+                        ),
+                    ),
+                ),
+            )
+
+        self.assertEqual(response.coverage.state, "complete")
+        self.assertEqual(
+            response.candidates[0].memberships,
+            ("product", "repository_record", "authorization_chain"),
+        )
+
+    def test_stale_records_cannot_make_authorization_membership_complete(self) -> None:
+        request = AuthzRepositoryScopeReadRequest.model_validate(
+            {"candidates": [{"repository": REPOSITORY}]}
+        )
+        with _handle_key("repository-scope-key-one"):
+            response = build_authz_repository_scope_response(
+                trace_id="trace-one",
+                generated_at="2026-08-20T22:30:00+00:00",
+                request=request,
+                active_policy_record=_policy_record(repository=REPOSITORY),
+                store=_Store(
+                    product_profiles=(_product_profile(lifecycle_state="retired"),),
+                    work_requests=(_work_request(state="done"),),
+                ),
+            )
+
+        self.assertEqual(response.coverage.state, "partial")
+        self.assertEqual(response.candidates[0].memberships, ("authorization_chain",))
+        self.assertIn(
+            ("authorization_chain", "stale_authorization_membership", 1),
+            {(gap.source, gap.reason_code, gap.count) for gap in response.coverage.gaps},
+        )
+
+    def test_handle_generation_changes_with_managed_secret_root(self) -> None:
+        request = AuthzRepositoryScopeReadRequest.model_validate(
+            {"candidates": [{"repository": REPOSITORY}]}
+        )
+        with _handle_key("repository-scope-key-one"):
+            first = build_authz_repository_scope_response(
+                trace_id="trace-one",
+                generated_at="2026-08-20T22:30:00+00:00",
+                request=request,
+                active_policy_record=_policy_record(repository=REPOSITORY),
+                store=_Store(product_profiles=(_product_profile(),)),
+            )
+        with _handle_key("repository-scope-key-two"):
+            rotated = build_authz_repository_scope_response(
+                trace_id="trace-two",
+                generated_at="2026-08-20T22:31:00+00:00",
+                request=request,
+                active_policy_record=_policy_record(repository=REPOSITORY),
+                store=_Store(product_profiles=(_product_profile(),)),
+            )
+
+        self.assertNotEqual(first.handle_generation, rotated.handle_generation)
+        self.assertNotEqual(first.candidates[0].handle, rotated.candidates[0].handle)
+
+    def test_schema_v1_active_policy_repository_membership_remains_readable(self) -> None:
+        request = AuthzRepositoryScopeReadRequest.model_validate(
+            {"candidates": [{"repository": REPOSITORY}]}
+        )
+        with _handle_key("repository-scope-key-one"):
+            response = build_authz_repository_scope_response(
+                trace_id="trace-one",
+                generated_at="2026-08-20T22:30:00+00:00",
+                request=request,
+                active_policy_record=_policy_record(
+                    repository=REPOSITORY,
+                    schema_version=1,
+                ),
+                store=_Store(product_profiles=(_product_profile(),)),
+            )
+
+        self.assertEqual(response.coverage.state, "complete")
+        self.assertEqual(
+            response.candidates[0].memberships,
+            ("product", "authorization_chain"),
+        )
+
+    def test_source_truncation_is_bounded_and_partial(self) -> None:
+        request = AuthzRepositoryScopeReadRequest.model_validate(
+            {"candidates": [{"repository": REPOSITORY}]}
+        )
+        repeated_work_request = _work_request()
+        with _handle_key("repository-scope-key-one"):
+            response = build_authz_repository_scope_response(
+                trace_id="trace-one",
+                generated_at="2026-08-20T22:30:00+00:00",
+                request=request,
+                active_policy_record=_policy_record(repository=REPOSITORY),
+                store=_Store(
+                    product_profiles=(_product_profile(),),
+                    work_requests=(repeated_work_request,) * 1001,
+                ),
+            )
+
+        self.assertEqual(response.coverage.state, "partial")
+        self.assertEqual(response.coverage.source_counts.work_graph, 1000)
+        self.assertIn(
+            ("work_graph", "source_truncated", 1),
+            {(gap.source, gap.reason_code, gap.count) for gap in response.coverage.gaps},
+        )
+
+    def test_work_graph_source_cap_applies_across_states(self) -> None:
+        request = AuthzRepositoryScopeReadRequest.model_validate(
+            {"candidates": [{"repository": REPOSITORY}]}
+        )
+        with _handle_key("repository-scope-key-one"):
+            response = build_authz_repository_scope_response(
+                trace_id="trace-one",
+                generated_at="2026-08-20T22:30:00+00:00",
+                request=request,
+                active_policy_record=_policy_record(repository=REPOSITORY),
+                store=_Store(
+                    product_profiles=(_product_profile(),),
+                    work_requests=(_work_request(),) * 600
+                    + (
+                        _work_request(
+                            state="running",
+                            lease_expires_at="2026-08-20T23:00:00Z",
+                        ),
+                    )
+                    * 600,
+                ),
+            )
+
+        self.assertEqual(response.coverage.state, "partial")
+        self.assertEqual(response.coverage.source_counts.work_graph, 1000)
+        self.assertIn(
+            ("work_graph", "source_truncated", 1),
+            {(gap.source, gap.reason_code, gap.count) for gap in response.coverage.gaps},
+        )
+
+    def test_expired_active_work_request_lease_is_partial(self) -> None:
+        request = AuthzRepositoryScopeReadRequest.model_validate(
+            {"candidates": [{"repository": REPOSITORY}]}
+        )
+        with _handle_key("repository-scope-key-one"):
+            response = build_authz_repository_scope_response(
+                trace_id="trace-one",
+                generated_at="2026-08-20T22:30:00+00:00",
+                request=request,
+                active_policy_record=_policy_record(repository=REPOSITORY),
+                store=_Store(
+                    product_profiles=(_product_profile(),),
+                    work_requests=(
+                        _work_request(
+                            state="running",
+                            lease_expires_at="2026-08-20T22:00:00Z",
+                        ),
+                    ),
+                ),
+            )
+
+        self.assertEqual(response.coverage.state, "partial")
+        self.assertIn(
+            ("work_graph", "stale_work_graph_record", 1),
+            {(gap.source, gap.reason_code, gap.count) for gap in response.coverage.gaps},
+        )
+
+    def test_candidate_contract_is_exact_bounded_and_unique(self) -> None:
+        invalid_payloads = (
+            {"candidates": [{"repository": "not-a-repository"}]},
+            {"candidates": [{"repository": "example/*"}]},
+            {
+                "candidates": [
+                    {"repository": REPOSITORY},
+                    {"repository": REPOSITORY.upper()},
+                ]
+            },
+            {
+                "candidates": [
+                    {
+                        "repository": REPOSITORY,
+                        "repository_id": REPOSITORY_ID,
+                    }
+                ]
+            },
+            {"candidates": [{"repository": f"example/repository-{index}"} for index in range(101)]},
+        )
+        for payload in invalid_payloads:
+            with self.subTest(payload_size=len(payload["candidates"])):
+                with self.assertRaises(ValidationError):
+                    AuthzRepositoryScopeReadRequest.model_validate(payload)
+
+
+def _policy_record(
+    *,
+    repository: str,
+    schema_version: int = 2,
+) -> LaunchplaneAuthzPolicyRecord:
+    policy = LaunchplaneAuthzPolicy.model_validate(
+        {
+            "schema_version": schema_version,
+            "github_actions": [
+                {
+                    "repository": repository,
+                    "repository_id": REPOSITORY_ID,
+                    "repository_owner_id": REPOSITORY_OWNER_ID,
+                    "actions": ["deploy.write"],
+                }
+            ],
+        }
+    )
+    digest = authz_policy_sha256(policy)
+    return LaunchplaneAuthzPolicyRecord(
+        record_id=build_authz_policy_record_id(revision=1, policy_sha256=digest),
+        revision=1,
+        status="active",
+        source="test:authz-repository-scope",
+        updated_at="2026-08-20T22:00:00+00:00",
+        policy_sha256=digest,
+        policy=policy,
+    )
+
+
+def _product_profile(
+    *,
+    lifecycle_state: str = "active",
+) -> LaunchplaneProductProfileRecord:
+    return LaunchplaneProductProfileRecord.model_validate(
+        {
+            "lifecycle_state": lifecycle_state,
+            "product": "example-product",
+            "display_name": "Example Product",
+            "repository": REPOSITORY,
+            "repository_id": REPOSITORY_ID,
+            "repository_owner_id": REPOSITORY_OWNER_ID,
+            "driver_id": "generic-web",
+            "image": ProductImageProfile().model_dump(mode="json"),
+            "updated_at": "2026-08-20T21:00:00+00:00",
+            "source": "test:authz-repository-scope",
+        }
+    )
+
+
+def _role_policy() -> RepositoryHumanRolePolicyRecord:
+    return RepositoryHumanRolePolicyRecord(
+        repository_id=REPOSITORY_ID,
+        repository_owner_id=REPOSITORY_OWNER_ID,
+        repository=REPOSITORY,
+        product="example-product",
+        context="prod",
+        role_policy_revision=1,
+        repository_owner_github_ids=(1001,),
+        manager_primary_github_ids=(1002,),
+        effective_at="2026-08-20T20:00:00Z",
+        source="test:authz-repository-scope",
+        reason="repository scope test",
+    )
+
+
+def _classification() -> TenantRepositoryClassificationRecord:
+    return TenantRepositoryClassificationRecord(
+        repository_id=REPOSITORY_ID,
+        repository_owner_id=REPOSITORY_OWNER_ID,
+        repository=REPOSITORY,
+        product="example-product",
+        context="prod",
+        classification_kind="engineering",
+        classification_revision=1,
+        classified_at="2026-08-20T20:30:00Z",
+        source="test:authz-repository-scope",
+        reason="repository scope test",
+    )
+
+
+def _work_request(
+    *,
+    state: str = "queued",
+    lease_expires_at: str = "",
+) -> EveryCodeWorkRequestRecord:
+    payload: dict[str, object] = {
+        "request_id": "repository-scope-work-request",
+        "source": "manual",
+        "state": state,
+        "repository": REPOSITORY,
+        "issue_number": 2199,
+        "issue_url": "https://example.invalid/issues/2199",
+        "trigger_label": "every-code",
+        "queued_at": "2026-08-20T19:00:00Z",
+        "updated_at": "2026-08-20T19:00:00Z",
+    }
+    if state == "done":
+        payload.update(
+            {
+                "claimed_at": "2026-08-20T19:01:00Z",
+                "claimed_by_host": "test-host",
+                "started_at": "2026-08-20T19:02:00Z",
+                "finished_at": "2026-08-20T19:03:00Z",
+            }
+        )
+    elif state == "running":
+        payload.update(
+            {
+                "claimed_at": "2026-08-20T19:01:00Z",
+                "claimed_by_host": "test-host",
+                "lease_expires_at": lease_expires_at,
+                "fencing_token": 1,
+                "attempt": 1,
+                "started_at": "2026-08-20T19:02:00Z",
+            }
+        )
+    return EveryCodeWorkRequestRecord.model_validate(payload)
+
+
+def _handle_key(value: str):  # type: ignore[no-untyped-def]
+    encoded_key = base64.urlsafe_b64encode(hashlib.sha256(value.encode()).digest())
+    return patch.dict(
+        os.environ,
+        {
+            control_plane_secrets.LAUNCHPLANE_SECRET_KEYS_JSON_ENV_VAR: json.dumps(
+                {
+                    "active_key_id": "repository-scope-key",
+                    "keys": {"repository-scope-key": encoded_key.decode()},
+                }
+            )
+        },
+        clear=True,
+    )

--- a/tests/test_service_auth.py
+++ b/tests/test_service_auth.py
@@ -341,6 +341,7 @@ class LaunchplaneAuthzPolicyBoundaryTests(unittest.TestCase):
             "secret_binding.apply": "secret_backed",
             "authz_policy_health.read": "policy_admin",
             "authz_policy_candidate_preview.read": "policy_admin",
+            "authz_repository_scope.read": "read",
             "authz_policy_grant.write": "policy_admin",
         }
 


### PR DESCRIPTION
## Summary

- add independently grantable `authz_repository_scope.read`
- add `POST /v1/authz-diagnostics/repository-scope/read` with fresh DB policy reauthorization
- derive bounded repository scope from DB-backed product, repository, work-graph, and authorization-chain evidence
- return candidate-indexed redacted results with opaque generation-scoped handles, provenance, coverage, and explicit gaps
- fail closed for unsupported, ambiguous, stale, malformed, truncated, unauthorized, or legacy-key state
- preserve zero-mutation success/partial reads and the #2058 authorization freeze

## Validation

- `uv run --extra dev python -m unittest tests.test_authz_repository_scope tests.test_authz_access_read tests.test_service_auth tests.test_docs_contracts tests.test_service`
- `uv run --extra dev launchplane ci unittest-shard local`
- `uv run --extra dev mypy control_plane tests`
- changed-file Ruff lint and format checks
- `pnpm --dir frontend validate`
- `uv run launchplane service audit-config-authority --control-plane-root .`
- JetBrains changed-files inspection: clean
- exact-head Opus review: APPROVE
- exact-head Gemini review: APPROVE

## Scope

This is the minimum #2199 repository-scope read needed by #2177. It is slice-level work only and is not #2062 authorization sign-off. Landing this code does not create a production grant or relax #2058.

Closes #2199
Refs #2180
Refs #2177
Refs #2058
Refs #2062
