### PR TITLE
Add local authorization scope evidence

### DIFF
--- a/control_plane/cli_policy_profiles.py
+++ b/control_plane/cli_policy_profiles.py
@@ -2,18 +2,23 @@ import json
 import os
 from collections.abc import Callable
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from json import JSONDecodeError
 from pathlib import Path
 from typing import Protocol
+from uuid import uuid4
 
 import click
 from pydantic import ValidationError
+from sqlalchemy.exc import SQLAlchemyError
 
+from control_plane.authz_repository_scope import build_authz_repository_scope_response
 from control_plane.cli_shared import (
     DATABASE_URL_ENV_KEYS as _DATABASE_URL_ENV_KEYS,
     direct_db_mutation_acknowledgement_option as _direct_db_mutation_acknowledgement_option,
     require_direct_db_mutation_acknowledgement as _require_direct_db_mutation_acknowledgement,
 )
+from control_plane.contracts.authz_access_read import AuthzRepositoryScopeReadRequest
 from control_plane.contracts.merge_train_policy import (
     MergeTrainPolicyRecord,
     MergeTrainPolicyRecordStatus,
@@ -237,6 +242,16 @@ def _product_profile_store(database_url: str) -> PostgresRecordStore:
     return store
 
 
+def _load_authz_repository_scope_request(request_file: Path) -> AuthzRepositoryScopeReadRequest:
+    try:
+        payload = _load_json_file(request_file)
+        return AuthzRepositoryScopeReadRequest.model_validate(payload)
+    except (click.ClickException, JSONDecodeError, OSError, UnicodeError, ValidationError) as error:
+        raise click.ClickException(
+            "Authorization repository-scope request JSON is invalid."
+        ) from error
+
+
 @click.group("authz-policies")
 def authz_policies() -> None:
     """DB-backed Launchplane authorization policy commands."""
@@ -310,6 +325,54 @@ def authz_policies_reconcile_managed(
         idempotency_key=idempotency_key,
     )
     click.echo(json.dumps(response_payload, indent=2, sort_keys=True))
+
+
+@authz_policies.command("repository-scope-evidence")
+@click.option(
+    "--database-url",
+    envvar=_DATABASE_URL_ENV_KEYS,
+    required=True,
+    help="Postgres connection string for Launchplane authorization evidence records.",
+)
+@click.option(
+    "--request-file",
+    required=True,
+    help="Exact-candidate repository-scope request JSON.",
+)
+def authz_policies_repository_scope_evidence(database_url: str, request_file: str) -> None:
+    """Read redacted repository-scope evidence with configured DB credentials."""
+    scope_request = _load_authz_repository_scope_request(Path(request_file))
+    click.echo(
+        "Evidence source: configured PostgreSQL credentials; this does not prove that the "
+        "operator is authorized by the active policy.",
+        err=True,
+    )
+    try:
+        postgres_store = PostgresRecordStore(database_url=database_url)
+        try:
+            active_records = postgres_store.list_authz_policy_records(status="active", limit=2)
+            if not active_records:
+                raise click.ClickException("Launchplane active authz policy is unavailable.")
+            if len(active_records) > 1:
+                raise click.ClickException(
+                    "Multiple active Launchplane authz policy records were found."
+                )
+            response = build_authz_repository_scope_response(
+                trace_id=f"launchplane_req_{uuid4().hex}",
+                generated_at=datetime.now(UTC).isoformat(),
+                request=scope_request,
+                active_policy_record=active_records[0],
+                store=postgres_store,
+            )
+        finally:
+            postgres_store.close()
+    except click.ClickException:
+        raise
+    except (OSError, RuntimeError, SQLAlchemyError, TypeError, ValueError) as error:
+        raise click.ClickException(
+            "Authorization repository-scope evidence is unavailable."
+        ) from error
+    click.echo(json.dumps(response.model_dump(mode="json"), indent=2, sort_keys=True))
 
 
 @runtime_key_safety.command("list-policies")

--- a/control_plane/cli_policy_profiles.py
+++ b/control_plane/cli_policy_profiles.py
@@ -246,7 +246,14 @@ def _load_authz_repository_scope_request(request_file: Path) -> AuthzRepositoryS
     try:
         payload = _load_json_file(request_file)
         return AuthzRepositoryScopeReadRequest.model_validate(payload)
-    except (click.ClickException, JSONDecodeError, OSError, UnicodeError, ValidationError) as error:
+    except (
+        click.ClickException,
+        JSONDecodeError,
+        OSError,
+        RecursionError,
+        UnicodeError,
+        ValidationError,
+    ) as error:
         raise click.ClickException(
             "Authorization repository-scope request JSON is invalid."
         ) from error

--- a/docs/authorization-authority.md
+++ b/docs/authorization-authority.md
@@ -175,6 +175,16 @@ ambiguous. Landing this route grants no production access and authorizes no
 policy, workflow, secret, provider, runtime, deployment, or durable-operation
 change.
 
+For host-local audit recovery when the operator does not hold the HTTP action,
+`launchplane authz-policies repository-scope-evidence` accepts the same bounded
+exact-candidate request JSON and reads the same redacted response directly from
+the configured PostgreSQL record store. This command derives evidence from the
+operator's DB credentials; it does not evaluate the operator against the active
+policy and is not proof that the operator is policy-authorized. It requires
+exactly one active policy record, fails closed on missing or ambiguous active
+state, and performs no policy, secret, workflow, provider, runtime, deployment,
+session, denial, idempotency, outbox, or durable-operation write.
+
 Landing these read contracts does not authorize their production grants and
 does not relax the active freeze. Production policy changes still require the
 separate reviewed administration and recovery gates owned by `#2058`/`#2061`.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1126,6 +1126,23 @@ rehearsal use. Direct authz policy list/import DB commands are not supported.
 Launchplane self-deploy authority remains separate and does not authorize authz
 policy administration.
 
+The narrow exception is the host-local, read-only authorization audit command:
+
+```bash
+uv run launchplane authz-policies repository-scope-evidence \
+  --database-url "$LAUNCHPLANE_DATABASE_URL" \
+  --request-file ./repository-scope-request.json
+```
+
+The request file uses the same bounded exact-candidate JSON contract as `POST
+/v1/authz-diagnostics/repository-scope/read`. Standard output is the same
+redacted response shape; standard error states that provenance is derived from
+the configured PostgreSQL credentials. This command does not evaluate whether
+the operator is authorized by the active policy and must not be represented as
+proof of policy-authorized HTTP access. It requires exactly one active policy
+record and performs no policy, secret, workflow, provider, runtime, deployment,
+session, denial, idempotency, outbox, or durable-operation write.
+
 Authz policy schema v1 remains the compatibility contract for an active v1
 policy and retains its existing product/context breadth. Managed desired sets
 must use schema v2; reconciling an active v1 policy requires the explicit

--- a/tests/test_authz_repository_scope.py
+++ b/tests/test_authz_repository_scope.py
@@ -4,12 +4,18 @@ import base64
 import hashlib
 import json
 import os
+from pathlib import Path
+import tempfile
+from typing import cast
 import unittest
 from unittest.mock import patch
 
+from click import Command
+from click.testing import CliRunner, Result
 from pydantic import ValidationError
 
 from control_plane.authz_repository_scope import build_authz_repository_scope_response
+from control_plane.cli import main
 from control_plane.contracts.authz_access_read import AuthzRepositoryScopeReadRequest
 from control_plane.contracts.authz_policy_record import (
     LaunchplaneAuthzPolicyRecord,
@@ -32,6 +38,7 @@ from control_plane import secrets as control_plane_secrets
 REPOSITORY = "example/private-product"
 REPOSITORY_ID = "123456"
 REPOSITORY_OWNER_ID = "654321"
+CLI_MAIN = cast(Command, main)
 
 
 class _Store:
@@ -98,7 +105,175 @@ class _Store:
         return records[offset : offset + limit]
 
 
+class _CliStore(_Store):
+    def __init__(
+        self,
+        *,
+        active_policy_records: tuple[LaunchplaneAuthzPolicyRecord, ...],
+        product_profiles: tuple[LaunchplaneProductProfileRecord, ...] = (),
+        role_policies: tuple[RepositoryHumanRolePolicyRecord, ...] = (),
+        classifications: tuple[TenantRepositoryClassificationRecord, ...] = (),
+        work_requests: tuple[EveryCodeWorkRequestRecord, ...] = (),
+    ) -> None:
+        super().__init__(
+            product_profiles=product_profiles,
+            role_policies=role_policies,
+            classifications=classifications,
+            work_requests=work_requests,
+        )
+        self.active_policy_records = active_policy_records
+        self.closed = False
+        self.mutation_attempts = 0
+
+    def list_authz_policy_records(
+        self,
+        *,
+        status: str = "",
+        limit: int | None = None,
+    ) -> tuple[LaunchplaneAuthzPolicyRecord, ...]:
+        records = tuple(
+            record for record in self.active_policy_records if not status or record.status == status
+        )
+        return records if limit is None else records[:limit]
+
+    def close(self) -> None:
+        self.closed = True
+
+    def __getattr__(self, name: str):  # type: ignore[no-untyped-def]
+        if name.startswith(("write_", "compare_and_write_", "reserve_", "append_", "delete_")):
+            self.mutation_attempts += 1
+            raise AssertionError(f"Unexpected mutation method lookup: {name}")
+        raise AttributeError(name)
+
+
 class AuthzRepositoryScopeTests(unittest.TestCase):
+    def test_cli_reads_redacted_scope_without_mutation_or_authorization_claim(self) -> None:
+        store = _CliStore(
+            active_policy_records=(_policy_record(repository=REPOSITORY),),
+            product_profiles=(_product_profile(),),
+            role_policies=(_role_policy(),),
+            classifications=(_classification(),),
+            work_requests=(_work_request(),),
+        )
+
+        result = self._invoke_cli(store=store)
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        response = json.loads(result.stdout)
+        self.assertEqual(response["status"], "ok")
+        self.assertEqual(response["coverage"]["state"], "complete")
+        self.assertEqual(response["candidates"][0]["state"], "matched")
+        self.assertNotIn(REPOSITORY, result.output)
+        self.assertNotIn(REPOSITORY_ID, result.output)
+        self.assertNotIn(REPOSITORY_OWNER_ID, result.output)
+        self.assertIn("configured PostgreSQL credentials", result.stderr)
+        self.assertIn("does not prove", result.stderr)
+        self.assertEqual(store.mutation_attempts, 0)
+        self.assertTrue(store.closed)
+
+    def test_cli_fails_closed_when_active_policy_is_missing(self) -> None:
+        store = _CliStore(active_policy_records=())
+
+        result = self._invoke_cli(store=store)
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("active authz policy is unavailable", result.output)
+        self.assertTrue(store.closed)
+
+    def test_cli_fails_closed_when_active_policy_is_ambiguous(self) -> None:
+        policy_record = _policy_record(repository=REPOSITORY)
+        store = _CliStore(active_policy_records=(policy_record, policy_record))
+
+        result = self._invoke_cli(store=store)
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("Multiple active Launchplane authz policy records", result.output)
+        self.assertTrue(store.closed)
+
+    def test_cli_rejects_malformed_request_before_opening_store(self) -> None:
+        result = self._invoke_cli(
+            store=None,
+            request_payload={"candidates": [{"repository": "not-exact"}]},
+        )
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("request JSON is invalid", result.output)
+
+    def test_cli_rejects_non_object_request_without_exposing_local_path(self) -> None:
+        result = self._invoke_cli(store=None, request_payload=[])
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("request JSON is invalid", result.output)
+        self.assertNotIn("repository-scope.json", result.output)
+
+    def test_cli_rejects_non_utf8_request_before_opening_store(self) -> None:
+        result = self._invoke_cli(store=None, request_bytes=b"\xff")
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("request JSON is invalid", result.output)
+
+    def test_cli_reports_unavailable_store_without_leaking_connection_details(self) -> None:
+        result = self._invoke_cli(store=OSError("postgresql://secret@example.invalid/private"))
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("repository-scope evidence is unavailable", result.output)
+        self.assertNotIn("secret", result.output)
+        self.assertNotIn("example.invalid", result.output)
+
+    @staticmethod
+    def _invoke_cli(
+        *,
+        store: _CliStore | OSError | None,
+        request_payload: object | None = None,
+        request_bytes: bytes | None = None,
+    ) -> Result:
+        payload = (
+            {
+                "candidates": [
+                    {
+                        "repository": REPOSITORY,
+                        "repository_id": REPOSITORY_ID,
+                        "repository_owner_id": REPOSITORY_OWNER_ID,
+                    }
+                ]
+            }
+            if request_payload is None
+            else request_payload
+        )
+        with tempfile.TemporaryDirectory() as temporary_directory_name:
+            request_file = Path(temporary_directory_name) / "repository-scope.json"
+            if request_bytes is None:
+                request_file.write_text(json.dumps(payload), encoding="utf-8")
+            else:
+                request_file.write_bytes(request_bytes)
+            constructor_patch = (
+                patch(
+                    "control_plane.cli_policy_profiles.PostgresRecordStore",
+                    side_effect=store,
+                )
+                if isinstance(store, OSError)
+                else patch(
+                    "control_plane.cli_policy_profiles.PostgresRecordStore",
+                    return_value=store,
+                )
+            )
+            with constructor_patch as postgres_store:
+                with _handle_key("repository-scope-cli-key"):
+                    result = CliRunner().invoke(
+                        CLI_MAIN,
+                        [
+                            "authz-policies",
+                            "repository-scope-evidence",
+                            "--database-url",
+                            "postgresql+psycopg://localhost/launchplane",
+                            "--request-file",
+                            str(request_file),
+                        ],
+                    )
+        if store is None:
+            postgres_store.assert_not_called()
+        return result
+
     def test_complete_scope_matches_candidates_without_identity_leakage(self) -> None:
         policy_record = _policy_record(repository=REPOSITORY)
         store = _Store(

--- a/tests/test_authz_repository_scope.py
+++ b/tests/test_authz_repository_scope.py
@@ -212,6 +212,16 @@ class AuthzRepositoryScopeTests(unittest.TestCase):
         self.assertNotEqual(result.exit_code, 0)
         self.assertIn("request JSON is invalid", result.output)
 
+    def test_cli_rejects_deeply_nested_request_before_opening_store(self) -> None:
+        result = self._invoke_cli(
+            store=None,
+            request_bytes=(b'{"candidates":' + b'{"a":' * 100_000 + b"0" + b"}" * 100_000 + b"}"),
+        )
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("request JSON is invalid", result.output)
+        self.assertNotIn("Traceback", result.output)
+
     def test_cli_reports_unavailable_store_without_leaking_connection_details(self) -> None:
         result = self._invoke_cli(store=OSError("postgresql://secret@example.invalid/private"))
 


### PR DESCRIPTION
## Summary

- add a host-local, read-only `authz-policies repository-scope-evidence` command backed by configured PostgreSQL credentials
- reuse `AuthzRepositoryScopeReadRequest` and `build_authz_repository_scope_response` without duplicating repository-scope logic
- fail closed on malformed, non-UTF-8, pathologically nested, unavailable-storage, missing-policy, and ambiguous-policy input states
- document that the result is DB-credential-derived evidence, not proof of policy-authorized HTTP access

## Authorization Boundary

- no policy, secret, workflow, provider, runtime, deployment, session, denial, idempotency, outbox, or durable-operation writes
- no GitHub-managed grant, borrowed workflow identity, protected workflow dispatch, or relaxation of the #2058 freeze
- no work from #2181 or #2182

## Validation

- `uv run --extra dev launchplane ci unittest-shard local` (3,054 targets, 12/12 shards passed)
- `uv run --extra dev python -m unittest tests.test_authz_repository_scope` (19 passed)
- `uv run --extra dev mypy control_plane tests`
- `uv run --extra dev ruff check .`
- changed-file `ruff format --check`
- config-authority audit status `ok`
- exact-head JetBrains changed-file error-severity closeout green
- exact-head independent Opus and Gemini reviews approved `395d2f98d1b2fb7d5e326ed9e72a92c4c4589d9c`

Closes #2202

Refs #2177
Refs #2180
Refs #2058
Refs #2061
Refs #2062
