### PR TITLE
Support canonical secret roots in self-deploy

### DIFF
--- a/control_plane/cli.py
+++ b/control_plane/cli.py
@@ -154,6 +154,7 @@ _RUNTIME_CONTRACT_ENV_KEYS = (
     "OPENUPGRADE_ADDON_REPOSITORY",
 )
 _MASTER_ENCRYPTION_KEY_ENV_KEYS = ("LAUNCHPLANE_MASTER_ENCRYPTION_KEY",)
+_SECRET_KEYS_JSON_ENV_KEY = control_plane_secrets.LAUNCHPLANE_SECRET_KEYS_JSON_ENV_VAR
 _LAUNCHPLANE_SERVICE_POLICY_ENV_KEYS = (
     "LAUNCHPLANE_POLICY_TOML",
     "LAUNCHPLANE_POLICY_B64",
@@ -2056,6 +2057,10 @@ def _inspect_local_launchplane_config_boundary(*, control_plane_root: Path) -> d
         "control_plane_root": str(control_plane_root),
         "bootstrap": {
             "database_url_present": bool(database_url),
+            "secret_keys_json_present": _launchplane_service_env_key_present(
+                env_map=env_map,
+                env_key=_SECRET_KEYS_JSON_ENV_KEY,
+            ),
             "master_encryption_key_present": _launchplane_service_any_env_keys_present(
                 env_map=env_map,
                 env_keys=_MASTER_ENCRYPTION_KEY_ENV_KEYS,
@@ -2228,16 +2233,35 @@ def _build_launchplane_service_runtime_contract(
     runtime_environment_record_count = _int_from_json_value(
         managed_store_status.get("runtime_environment_record_count")
     )
+    secret_keys_json = env_map.get(_SECRET_KEYS_JSON_ENV_KEY, "")
+    master_encryption_key = _launchplane_service_env_alias_value(
+        env_map=env_map,
+        env_keys=_MASTER_ENCRYPTION_KEY_ENV_KEYS,
+    )
+    try:
+        control_plane_secrets.validate_secret_key_configuration_values(
+            keys_json=secret_keys_json,
+            legacy_master_key=master_encryption_key,
+        )
+    except click.ClickException as error:
+        secret_key_configuration_valid = False
+        secret_key_configuration_error = str(error)
+    else:
+        secret_key_configuration_valid = True
+        secret_key_configuration_error = ""
     return {
         "database_url_present": bool(database_url),
         "database_scheme": database_scheme,
         "database_host": database_host,
         "managed_store_inspectable": bool(managed_store_status.get("inspectable")),
         "managed_store_error": str(managed_store_status.get("error") or ""),
-        "master_encryption_key_present": _launchplane_service_env_alias_present(
+        "secret_keys_json_present": _launchplane_service_env_key_present(
             env_map=env_map,
-            env_keys=_MASTER_ENCRYPTION_KEY_ENV_KEYS,
+            env_key=_SECRET_KEYS_JSON_ENV_KEY,
         ),
+        "master_encryption_key_present": bool(master_encryption_key),
+        "secret_key_configuration_valid": secret_key_configuration_valid,
+        "secret_key_configuration_error": secret_key_configuration_error,
         "dokploy_host_present": _launchplane_service_env_key_present(
             env_map=env_map,
             env_key="DOKPLOY_HOST",
@@ -2296,8 +2320,11 @@ def _launchplane_service_preflight_blockers(
     elif not runtime_contract["database_host"]:
         blockers.append("Launchplane service target database URL is missing a database host.")
 
-    if not runtime_contract["master_encryption_key_present"]:
-        blockers.append("Launchplane service target is missing LAUNCHPLANE_MASTER_ENCRYPTION_KEY.")
+    if not runtime_contract["secret_key_configuration_valid"]:
+        blockers.append(
+            "Launchplane service target managed-secret root configuration is invalid: "
+            f"{runtime_contract['secret_key_configuration_error']}"
+        )
     if runtime_contract["managed_store_inspectable"]:
         if not runtime_contract["dokploy_managed_host_present"]:
             blockers.append(
@@ -2322,6 +2349,14 @@ def _launchplane_service_preflight_warnings(
     runtime_contract: Mapping[str, object],
 ) -> list[str]:
     warnings: list[str] = []
+    if (
+        runtime_contract["master_encryption_key_present"]
+        and not runtime_contract["secret_keys_json_present"]
+    ):
+        warnings.append(
+            "Launchplane service target still uses the migration-only legacy managed-secret root. "
+            "Add LAUNCHPLANE_SECRET_KEYS_JSON before retiring LAUNCHPLANE_MASTER_ENCRYPTION_KEY."
+        )
     if not runtime_contract["managed_store_inspectable"]:
         warnings.append(
             "Launchplane service managed-store inspection was unavailable. Confirm the shared store has configured Dokploy bindings for DOKPLOY_HOST and DOKPLOY_TOKEN."

--- a/control_plane/secrets.py
+++ b/control_plane/secrets.py
@@ -176,8 +176,9 @@ def _canonical_fernet_key(raw_key: object, *, key_id: str) -> bytes:
     return encoded
 
 
-def _get_key_ring() -> KeyRing:
-    keys_json = os.environ.get(LAUNCHPLANE_SECRET_KEYS_JSON_ENV_VAR, "").strip()
+def _key_ring_from_values(*, keys_json: str, legacy_master_key: str) -> KeyRing:
+    keys_json = keys_json.strip()
+    legacy_master_key = legacy_master_key.strip()
     if keys_json:
         try:
             parsed = json.loads(keys_json)
@@ -204,9 +205,8 @@ def _get_key_ring() -> KeyRing:
             raise click.ClickException(f"Active key id '{active_key_id}' not found in keys.")
 
         legacy_compatibility_key_loaded = False
-        legacy_value = os.environ.get(LAUNCHPLANE_SECRET_MASTER_KEY_ENV_VAR, "").strip()
-        if legacy_value:
-            legacy_key = _master_fernet_key(legacy_value)
+        if legacy_master_key:
+            legacy_key = _master_fernet_key(legacy_master_key)
             configured_legacy_key = encoded_keys.get(LEGACY_SECRET_KEY_ID)
             if configured_legacy_key is not None and configured_legacy_key != legacy_key:
                 raise click.ClickException(
@@ -224,22 +224,33 @@ def _get_key_ring() -> KeyRing:
             legacy_compatibility_key_loaded=legacy_compatibility_key_loaded,
         )
 
-    for environment_key in LAUNCHPLANE_SECRET_MASTER_KEY_ENV_VARS:
-        configured_value = os.environ.get(environment_key, "")
-        if configured_value.strip():
-            fernet = Fernet(_master_fernet_key(configured_value))
-            return KeyRing(
-                active_key_id=LEGACY_SECRET_KEY_ID,
-                keys={LEGACY_SECRET_KEY_ID: fernet},
-                active_hmac_key=_derived_hmac_key(_master_fernet_key(configured_value)),
-                legacy_compatibility_key_loaded=True,
-            )
+    if legacy_master_key:
+        encoded_legacy_key = _master_fernet_key(legacy_master_key)
+        return KeyRing(
+            active_key_id=LEGACY_SECRET_KEY_ID,
+            keys={LEGACY_SECRET_KEY_ID: Fernet(encoded_legacy_key)},
+            active_hmac_key=_derived_hmac_key(encoded_legacy_key),
+            legacy_compatibility_key_loaded=True,
+        )
 
     expected_keys = " or ".join(
         (LAUNCHPLANE_SECRET_KEYS_JSON_ENV_VAR, *LAUNCHPLANE_SECRET_MASTER_KEY_ENV_VARS)
     )
     raise click.ClickException(
         f"Launchplane managed secrets require {expected_keys} to read or write encrypted values."
+    )
+
+
+def _get_key_ring() -> KeyRing:
+    legacy_master_key = ""
+    for environment_key in LAUNCHPLANE_SECRET_MASTER_KEY_ENV_VARS:
+        configured_value = os.environ.get(environment_key, "")
+        if configured_value.strip():
+            legacy_master_key = configured_value
+            break
+    return _key_ring_from_values(
+        keys_json=os.environ.get(LAUNCHPLANE_SECRET_KEYS_JSON_ENV_VAR, ""),
+        legacy_master_key=legacy_master_key,
     )
 
 
@@ -285,6 +296,17 @@ def keyed_secret_payload_fingerprint(payload: str, *, purpose: str) -> str:
 
 def validate_secret_key_configuration() -> None:
     _get_key_ring()
+
+
+def validate_secret_key_configuration_values(
+    *,
+    keys_json: str,
+    legacy_master_key: str,
+) -> None:
+    _key_ring_from_values(
+        keys_json=keys_json,
+        legacy_master_key=legacy_master_key,
+    )
 
 
 def _encrypt_secret_value(plaintext_value: str) -> tuple[str, str]:

--- a/control_plane/workflows/launchplane_self_deploy.py
+++ b/control_plane/workflows/launchplane_self_deploy.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Literal
 from urllib.parse import urlparse
 
+import click
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from control_plane.service_auth import parse_authz_policy_toml
@@ -19,6 +20,7 @@ from control_plane.dokploy import source as dokploy_source
 
 LAUNCHPLANE_IMAGE_REFERENCE_ENV_KEY = "DOCKER_IMAGE_REFERENCE"
 _DATABASE_URL_ENV_KEY = "LAUNCHPLANE_DATABASE_URL"
+_SECRET_KEYS_JSON_ENV_KEY = "LAUNCHPLANE_SECRET_KEYS_JSON"
 _MASTER_ENCRYPTION_KEY_ENV_KEY = "LAUNCHPLANE_MASTER_ENCRYPTION_KEY"
 _MANAGER_PREVIEW_GITHUB_WEBHOOK_SECRET_ENV_KEY = "LAUNCHPLANE_MANAGER_PREVIEW_GITHUB_WEBHOOK_SECRET"
 _POLICY_ENV_KEYS = (
@@ -35,6 +37,8 @@ LAUNCHPLANE_SELF_DEPLOY_OAUTH_ENV_KEYS = frozenset(
         "LAUNCHPLANE_COOKIE_SECURE",
         "LAUNCHPLANE_BOOTSTRAP_ADMIN_EMAILS",
         "LAUNCHPLANE_COMPOSE_EXTERNAL_NETWORK",
+        _SECRET_KEYS_JSON_ENV_KEY,
+        _MASTER_ENCRYPTION_KEY_ENV_KEY,
         "LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET",
         _MANAGER_PREVIEW_GITHUB_WEBHOOK_SECRET_ENV_KEY,
         "LAUNCHPLANE_EVERY_CODE_GITHUB_TOKEN",
@@ -224,6 +228,8 @@ def execute_launchplane_self_deploy(
 
 
 def _validate_bootstrap_target_env(env_map: dict[str, str]) -> None:
+    from control_plane import secrets as control_plane_secrets
+
     blockers: list[str] = []
     database_url = env_map.get(_DATABASE_URL_ENV_KEY, "").strip()
     if not database_url:
@@ -236,10 +242,13 @@ def _validate_bootstrap_target_env(env_map: dict[str, str]) -> None:
             blockers.append("Launchplane self deploy target database URL is not PostgreSQL.")
         elif not parsed_url.hostname:
             blockers.append("Launchplane self deploy target database URL is missing a host.")
-    if not env_map.get(_MASTER_ENCRYPTION_KEY_ENV_KEY, "").strip():
-        blockers.append(
-            "Launchplane self deploy target is missing LAUNCHPLANE_MASTER_ENCRYPTION_KEY."
+    try:
+        control_plane_secrets.validate_secret_key_configuration_values(
+            keys_json=env_map.get(_SECRET_KEYS_JSON_ENV_KEY, ""),
+            legacy_master_key=env_map.get(_MASTER_ENCRYPTION_KEY_ENV_KEY, ""),
         )
+    except click.ClickException as error:
+        blockers.append(str(error))
     if not env_map.get(_MANAGER_PREVIEW_GITHUB_WEBHOOK_SECRET_ENV_KEY, "").strip():
         blockers.append(
             "Launchplane self deploy target is missing "

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -195,6 +195,12 @@ printing the old root:
 5. Remove `LAUNCHPLANE_MASTER_ENCRYPTION_KEY` and restart the service. A final
    dry-run must remain clean before the old bootstrap secret is destroyed.
 
+Launchplane self-deploy must carry `LAUNCHPLANE_SECRET_KEYS_JSON` through its
+reviewed bootstrap-secret path and validate the resulting target environment
+before provider mutation. It may remove the migration-only legacy root only
+when the remaining canonical configuration is valid; malformed, mismatched, or
+rootless target state fails closed before deployment.
+
 Old ciphertext versions and audit metadata retain the old/new key ids and
 version ids as rollback evidence. To roll back before destroying an old root,
 restore that root as an allowed active key and run the same audited dry-run/apply

--- a/tests/test_launchplane_self_deploy.py
+++ b/tests/test_launchplane_self_deploy.py
@@ -1,6 +1,9 @@
+import json
 import unittest
 from pathlib import Path
 from unittest.mock import patch
+
+from cryptography.fernet import Fernet
 
 from control_plane.workflows.launchplane_self_deploy import (
     LaunchplaneSelfDeployRequest,
@@ -16,6 +19,16 @@ class LaunchplaneSelfDeployWorkflowTests(unittest.TestCase):
         "LAUNCHPLANE_POLICY_B64=dGVzdA==\n"
         "LAUNCHPLANE_MANAGER_PREVIEW_GITHUB_WEBHOOK_SECRET=old-manager-secret\n"
     )
+
+    @staticmethod
+    def _canonical_key_ring() -> str:
+        return json.dumps(
+            {
+                "active_key_id": "root-2026-08",
+                "keys": {"root-2026-08": Fernet.generate_key().decode("ascii")},
+            },
+            separators=(",", ":"),
+        )
 
     def test_execute_updates_target_env_and_triggers_deployment(self) -> None:
         request = LaunchplaneSelfDeployRequest.model_validate(
@@ -158,6 +171,208 @@ class LaunchplaneSelfDeployWorkflowTests(unittest.TestCase):
                 ValueError,
                 "LAUNCHPLANE_MANAGER_PREVIEW_GITHUB_WEBHOOK_SECRET",
             ):
+                execute_launchplane_self_deploy(
+                    control_plane_root_path=Path("."),
+                    request=request,
+                )
+
+        update_env_mock.assert_not_called()
+        trigger_mock.assert_not_called()
+
+    def test_execute_accepts_canonical_only_bootstrap(self) -> None:
+        canonical_key_ring = self._canonical_key_ring()
+        request = LaunchplaneSelfDeployRequest.model_validate(
+            {
+                "target_type": "compose",
+                "target_id": "compose-123",
+                "image_reference": "ghcr.io/cbusillo/launchplane@sha256:new",
+                "oauth_env": {"LAUNCHPLANE_SECRET_KEYS_JSON": canonical_key_ring},
+                "oauth_env_removals": ("LAUNCHPLANE_MASTER_ENCRYPTION_KEY",),
+            }
+        )
+
+        with (
+            patch(
+                "control_plane.workflows.launchplane_self_deploy.dokploy_source.read_dokploy_config",
+                return_value=("https://dokploy.example.com", "token-123"),
+            ),
+            patch(
+                "control_plane.workflows.launchplane_self_deploy.dokploy_api.fetch_dokploy_target_payload",
+                return_value={"env": self._BOOTSTRAP_ENV},
+            ),
+            patch(
+                "control_plane.workflows.launchplane_self_deploy.dokploy_api.update_dokploy_target_env"
+            ) as update_env_mock,
+            patch(
+                "control_plane.workflows.launchplane_self_deploy.dokploy_api.trigger_deployment"
+            ) as trigger_mock,
+        ):
+            result = execute_launchplane_self_deploy(
+                control_plane_root_path=Path("."),
+                request=request,
+            )
+
+        updated_env_text = update_env_mock.call_args.kwargs["env_text"]
+        self.assertIn("LAUNCHPLANE_SECRET_KEYS_JSON=", updated_env_text)
+        self.assertNotIn("LAUNCHPLANE_MASTER_ENCRYPTION_KEY=", updated_env_text)
+        self.assertEqual(
+            result.oauth_env_keys_changed,
+            ("LAUNCHPLANE_SECRET_KEYS_JSON",),
+        )
+        self.assertEqual(
+            result.oauth_env_keys_removed,
+            ("LAUNCHPLANE_MASTER_ENCRYPTION_KEY",),
+        )
+        self.assertNotIn(canonical_key_ring, result.model_dump_json())
+        trigger_mock.assert_called_once()
+
+    def test_execute_accepts_dual_root_migration_bootstrap(self) -> None:
+        canonical_key_ring = self._canonical_key_ring()
+        request = LaunchplaneSelfDeployRequest.model_validate(
+            {
+                "target_type": "compose",
+                "target_id": "compose-123",
+                "image_reference": "ghcr.io/cbusillo/launchplane@sha256:new",
+                "oauth_env": {"LAUNCHPLANE_SECRET_KEYS_JSON": canonical_key_ring},
+            }
+        )
+
+        with (
+            patch(
+                "control_plane.workflows.launchplane_self_deploy.dokploy_source.read_dokploy_config",
+                return_value=("https://dokploy.example.com", "token-123"),
+            ),
+            patch(
+                "control_plane.workflows.launchplane_self_deploy.dokploy_api.fetch_dokploy_target_payload",
+                return_value={"env": self._BOOTSTRAP_ENV},
+            ),
+            patch(
+                "control_plane.workflows.launchplane_self_deploy.dokploy_api.update_dokploy_target_env"
+            ) as update_env_mock,
+            patch(
+                "control_plane.workflows.launchplane_self_deploy.dokploy_api.trigger_deployment"
+            ) as trigger_mock,
+        ):
+            execute_launchplane_self_deploy(
+                control_plane_root_path=Path("."),
+                request=request,
+            )
+
+        updated_env_text = update_env_mock.call_args.kwargs["env_text"]
+        self.assertIn("LAUNCHPLANE_SECRET_KEYS_JSON=", updated_env_text)
+        self.assertIn("LAUNCHPLANE_MASTER_ENCRYPTION_KEY=test-key", updated_env_text)
+        trigger_mock.assert_called_once()
+
+    def test_execute_rejects_invalid_canonical_bootstrap_before_mutation(self) -> None:
+        request = LaunchplaneSelfDeployRequest.model_validate(
+            {
+                "target_type": "compose",
+                "target_id": "compose-123",
+                "image_reference": "ghcr.io/cbusillo/launchplane@sha256:new",
+                "oauth_env": {"LAUNCHPLANE_SECRET_KEYS_JSON": "not-json"},
+            }
+        )
+
+        with (
+            patch(
+                "control_plane.workflows.launchplane_self_deploy.dokploy_source.read_dokploy_config",
+                return_value=("https://dokploy.example.com", "token-123"),
+            ),
+            patch(
+                "control_plane.workflows.launchplane_self_deploy.dokploy_api.fetch_dokploy_target_payload",
+                return_value={"env": self._BOOTSTRAP_ENV},
+            ),
+            patch(
+                "control_plane.workflows.launchplane_self_deploy.dokploy_api.update_dokploy_target_env"
+            ) as update_env_mock,
+            patch(
+                "control_plane.workflows.launchplane_self_deploy.dokploy_api.trigger_deployment"
+            ) as trigger_mock,
+        ):
+            with self.assertRaisesRegex(ValueError, "Invalid LAUNCHPLANE_SECRET_KEYS_JSON"):
+                execute_launchplane_self_deploy(
+                    control_plane_root_path=Path("."),
+                    request=request,
+                )
+
+        update_env_mock.assert_not_called()
+        trigger_mock.assert_not_called()
+
+    def test_execute_rejects_dual_root_mismatch_before_mutation(self) -> None:
+        canonical_key_ring = json.dumps(
+            {
+                "active_key_id": "root-2026-08",
+                "keys": {
+                    "root-2026-08": Fernet.generate_key().decode("ascii"),
+                    "launchplane-master-key": Fernet.generate_key().decode("ascii"),
+                },
+            },
+            separators=(",", ":"),
+        )
+        request = LaunchplaneSelfDeployRequest.model_validate(
+            {
+                "target_type": "compose",
+                "target_id": "compose-123",
+                "image_reference": "ghcr.io/cbusillo/launchplane@sha256:new",
+                "oauth_env": {"LAUNCHPLANE_SECRET_KEYS_JSON": canonical_key_ring},
+            }
+        )
+
+        with (
+            patch(
+                "control_plane.workflows.launchplane_self_deploy.dokploy_source.read_dokploy_config",
+                return_value=("https://dokploy.example.com", "token-123"),
+            ),
+            patch(
+                "control_plane.workflows.launchplane_self_deploy.dokploy_api.fetch_dokploy_target_payload",
+                return_value={"env": self._BOOTSTRAP_ENV},
+            ),
+            patch(
+                "control_plane.workflows.launchplane_self_deploy.dokploy_api.update_dokploy_target_env"
+            ) as update_env_mock,
+            patch(
+                "control_plane.workflows.launchplane_self_deploy.dokploy_api.trigger_deployment"
+            ) as trigger_mock,
+        ):
+            with self.assertRaisesRegex(
+                ValueError,
+                "does not match LAUNCHPLANE_MASTER_ENCRYPTION_KEY",
+            ):
+                execute_launchplane_self_deploy(
+                    control_plane_root_path=Path("."),
+                    request=request,
+                )
+
+        update_env_mock.assert_not_called()
+        trigger_mock.assert_not_called()
+
+    def test_execute_rejects_removing_last_secret_root_before_mutation(self) -> None:
+        request = LaunchplaneSelfDeployRequest.model_validate(
+            {
+                "target_type": "compose",
+                "target_id": "compose-123",
+                "image_reference": "ghcr.io/cbusillo/launchplane@sha256:new",
+                "oauth_env_removals": ("LAUNCHPLANE_MASTER_ENCRYPTION_KEY",),
+            }
+        )
+
+        with (
+            patch(
+                "control_plane.workflows.launchplane_self_deploy.dokploy_source.read_dokploy_config",
+                return_value=("https://dokploy.example.com", "token-123"),
+            ),
+            patch(
+                "control_plane.workflows.launchplane_self_deploy.dokploy_api.fetch_dokploy_target_payload",
+                return_value={"env": self._BOOTSTRAP_ENV},
+            ),
+            patch(
+                "control_plane.workflows.launchplane_self_deploy.dokploy_api.update_dokploy_target_env"
+            ) as update_env_mock,
+            patch(
+                "control_plane.workflows.launchplane_self_deploy.dokploy_api.trigger_deployment"
+            ) as trigger_mock,
+        ):
+            with self.assertRaisesRegex(ValueError, "Launchplane managed secrets require"):
                 execute_launchplane_self_deploy(
                     control_plane_root_path=Path("."),
                     request=request,

--- a/tests/test_launchplane_service_preflight.py
+++ b/tests/test_launchplane_service_preflight.py
@@ -1,0 +1,144 @@
+import json
+import unittest
+
+from cryptography.fernet import Fernet
+
+from control_plane.cli import _build_launchplane_service_runtime_contract
+from control_plane.cli import _launchplane_service_preflight_blockers
+from control_plane.cli import _launchplane_service_preflight_warnings
+
+
+class LaunchplaneServicePreflightTests(unittest.TestCase):
+    _DATABASE_URL = "postgresql+psycopg://launchplane:test@db.internal:5432/launchplane"
+    _MANAGED_STORE_STATUS = {
+        "inspectable": True,
+        "error": "",
+        "dokploy_secret_bindings": {"DOKPLOY_HOST": True, "DOKPLOY_TOKEN": True},
+        "authz_policy_record_count": 1,
+        "dokploy_target_id_record_count": 1,
+        "runtime_environment_record_count": 1,
+    }
+
+    @staticmethod
+    def _canonical_key_ring() -> str:
+        return json.dumps(
+            {
+                "active_key_id": "root-2026-08",
+                "keys": {"root-2026-08": Fernet.generate_key().decode("ascii")},
+            },
+            separators=(",", ":"),
+        )
+
+    def _runtime_contract(self, env_map: dict[str, str]) -> dict[str, object]:
+        return _build_launchplane_service_runtime_contract(
+            env_map=env_map,
+            database_url=self._DATABASE_URL,
+            database_scheme="postgresql+psycopg",
+            database_host="db.internal",
+            managed_store_status=self._MANAGED_STORE_STATUS,
+        )
+
+    @staticmethod
+    def _blockers(runtime_contract: dict[str, object]) -> list[str]:
+        return _launchplane_service_preflight_blockers(
+            target_type="application",
+            source_type="docker",
+            custom_git_url="",
+            custom_git_branch="",
+            custom_git_ssh_key_id="",
+            compose_path="",
+            git_access_mode="",
+            runtime_contract=runtime_contract,
+        )
+
+    def test_canonical_only_configuration_passes_preflight(self) -> None:
+        canonical_key_ring = self._canonical_key_ring()
+        runtime_contract = self._runtime_contract(
+            {
+                "DOCKER_IMAGE_REFERENCE": "ghcr.io/cbusillo/launchplane@sha256:test",
+                "LAUNCHPLANE_SECRET_KEYS_JSON": canonical_key_ring,
+                "LAUNCHPLANE_POLICY_B64": "dGVzdA==",
+            }
+        )
+
+        self.assertTrue(runtime_contract["secret_key_configuration_valid"])
+        self.assertFalse(runtime_contract["master_encryption_key_present"])
+        self.assertEqual(self._blockers(runtime_contract), [])
+        self.assertEqual(
+            _launchplane_service_preflight_warnings(
+                compose_status="success",
+                runtime_contract=runtime_contract,
+            ),
+            [],
+        )
+        self.assertNotIn(canonical_key_ring, json.dumps(runtime_contract))
+
+    def test_legacy_only_configuration_passes_with_migration_warning(self) -> None:
+        runtime_contract = self._runtime_contract(
+            {
+                "LAUNCHPLANE_MASTER_ENCRYPTION_KEY": "test-key",
+                "LAUNCHPLANE_POLICY_B64": "dGVzdA==",
+            }
+        )
+
+        self.assertTrue(runtime_contract["secret_key_configuration_valid"])
+        self.assertEqual(self._blockers(runtime_contract), [])
+        self.assertIn(
+            "migration-only legacy managed-secret root",
+            " ".join(
+                _launchplane_service_preflight_warnings(
+                    compose_status="running",
+                    runtime_contract=runtime_contract,
+                )
+            ),
+        )
+
+    def test_malformed_canonical_configuration_fails_preflight(self) -> None:
+        runtime_contract = self._runtime_contract(
+            {
+                "LAUNCHPLANE_SECRET_KEYS_JSON": "not-json",
+                "LAUNCHPLANE_POLICY_B64": "dGVzdA==",
+            }
+        )
+
+        self.assertFalse(runtime_contract["secret_key_configuration_valid"])
+        blockers = " ".join(self._blockers(runtime_contract))
+        self.assertIn("Invalid LAUNCHPLANE_SECRET_KEYS_JSON", blockers)
+        self.assertNotIn("not-json", blockers)
+
+    def test_dual_root_mismatch_fails_preflight_without_exposing_values(self) -> None:
+        legacy_key = Fernet.generate_key().decode("ascii")
+        mismatched_key = Fernet.generate_key().decode("ascii")
+        runtime_contract = self._runtime_contract(
+            {
+                "LAUNCHPLANE_SECRET_KEYS_JSON": json.dumps(
+                    {
+                        "active_key_id": "root-2026-08",
+                        "keys": {
+                            "root-2026-08": Fernet.generate_key().decode("ascii"),
+                            "launchplane-master-key": mismatched_key,
+                        },
+                    },
+                    separators=(",", ":"),
+                ),
+                "LAUNCHPLANE_MASTER_ENCRYPTION_KEY": legacy_key,
+                "LAUNCHPLANE_POLICY_B64": "dGVzdA==",
+            }
+        )
+
+        self.assertFalse(runtime_contract["secret_key_configuration_valid"])
+        blockers = " ".join(self._blockers(runtime_contract))
+        self.assertIn("does not match LAUNCHPLANE_MASTER_ENCRYPTION_KEY", blockers)
+        self.assertNotIn(legacy_key, blockers)
+        self.assertNotIn(mismatched_key, blockers)
+
+    def test_missing_secret_root_fails_preflight(self) -> None:
+        runtime_contract = self._runtime_contract({"LAUNCHPLANE_POLICY_B64": "dGVzdA=="})
+
+        self.assertFalse(runtime_contract["secret_key_configuration_valid"])
+        blockers = " ".join(self._blockers(runtime_contract))
+        self.assertIn("Launchplane managed secrets require", blockers)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -409,6 +409,22 @@ class LaunchplaneSecretsTests(unittest.TestCase):
                     with self.assertRaises(click.ClickException):
                         control_plane_secrets.validate_secret_key_configuration()
 
+    def test_value_validation_accepts_explicit_matching_legacy_key(self) -> None:
+        legacy_key = _test_fernet_key(0)
+
+        control_plane_secrets.validate_secret_key_configuration_values(
+            keys_json=json.dumps(
+                {
+                    "active_key_id": "key-2",
+                    "keys": {
+                        "key-2": _test_fernet_key(32),
+                        control_plane_secrets.LEGACY_SECRET_KEY_ID: legacy_key,
+                    },
+                }
+            ),
+            legacy_master_key=legacy_key,
+        )
+
     def test_reencrypt_secrets_migrates_legacy_key_and_proves_retirement(self) -> None:
         key2 = _test_fernet_key(32)
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary
- reuse canonical managed-secret key-ring validation for proposed self-deploy target environments
- support legacy-only migration, dual-root migration, and canonical-only steady state
- fail before Dokploy mutation for malformed, mismatched, or rootless configurations
- report redacted root presence/validation state in service preflight and document the migration contract

## Validation
- `uv run --extra dev launchplane ci unittest-shard local` (3,055 targets; all 12 shards passed)
- `uv run --extra dev python -m unittest tests.test_launchplane_self_deploy tests.test_launchplane_service_preflight tests.test_secrets tests.test_http_app_secret_rotation` (24 passed)
- changed-file Ruff check and format check
- changed-file mypy
- Markdownlint and Prettier for `docs/secrets.md`
- `uv run launchplane service audit-config-authority --control-plane-root .` (`status: ok`)
- secret-pattern scan and `git diff --check`
- two independent code reviews found no blocking defects

JetBrains changed-file inspection was attempted twice after required preparation, but PyCharm returned stale results and withheld cached findings; executable repository gates remain green.

## Safety Boundary
This PR changes deploy capability only. It does not stage or generate production keys, run production dry-run/apply, restart or deploy production, change authorization, modify provider state, or advance #2177. Production apply remains blocked on verified backup/restore evidence and an already-authorized owner dry-run path.

Refs #2204