### PR TITLE
Deploy privileged-operation worker and correct Phase 2 runbook

### DIFF
--- a/control_plane/cli_service.py
+++ b/control_plane/cli_service.py
@@ -535,10 +535,6 @@ def service_privileged_operation_workers_run(
     previous_sigint = signal.signal(signal.SIGINT, request_stop)
     stopped_cleanly = False
     try:
-        store = cast(
-            PrivilegedOperationExecutionStore,
-            _store(state_dir=state_dir, database_url=database_url),
-        )
         click.echo(
             json.dumps(
                 {
@@ -549,9 +545,15 @@ def service_privileged_operation_workers_run(
                 sort_keys=True,
             )
         )
+        store: PrivilegedOperationExecutionStore | None = None
         consecutive_errors = 0
         while not stop_event.is_set():
             try:
+                if store is None:
+                    store = cast(
+                        PrivilegedOperationExecutionStore,
+                        _store(state_dir=state_dir, database_url=database_url),
+                    )
                 records = execute_approved_privileged_operations_once(
                     record_store=store,
                     lease_owner=generated_lease_owner,

--- a/control_plane/cli_service.py
+++ b/control_plane/cli_service.py
@@ -479,7 +479,6 @@ def service_privileged_operation_workers_run_once(
         json.dumps(
             {
                 "processed": len(records),
-                "operation_ids": [record.operation_id for record in records],
                 "statuses": [record.status for record in records],
             },
             indent=2,
@@ -505,12 +504,20 @@ def service_privileged_operation_workers_run_once(
 )
 @click.option("--poll-seconds", type=click.IntRange(min=1, max=300), default=15, show_default=True)
 @click.option("--limit", type=click.IntRange(min=1, max=100), default=20, show_default=True)
+@click.option(
+    "--error-backoff-seconds", type=click.IntRange(min=1, max=300), default=15, show_default=True
+)
+@click.option(
+    "--max-consecutive-errors", type=click.IntRange(min=1, max=100), default=3, show_default=True
+)
 def service_privileged_operation_workers_run(
     state_dir: Path,
     database_url: str,
     lease_owner: str,
     poll_seconds: int,
     limit: int,
+    error_backoff_seconds: int,
+    max_consecutive_errors: int,
 ) -> None:
     if not database_url.strip():
         raise click.ClickException(
@@ -526,22 +533,76 @@ def service_privileged_operation_workers_run(
 
     previous_sigterm = signal.signal(signal.SIGTERM, request_stop)
     previous_sigint = signal.signal(signal.SIGINT, request_stop)
+    stopped_cleanly = False
     try:
         store = cast(
             PrivilegedOperationExecutionStore,
             _store(state_dir=state_dir, database_url=database_url),
         )
+        click.echo(
+            json.dumps(
+                {
+                    "event": "privileged_operation_worker_started",
+                    "limit": limit,
+                    "poll_seconds": poll_seconds,
+                },
+                sort_keys=True,
+            )
+        )
+        consecutive_errors = 0
         while not stop_event.is_set():
-            execute_approved_privileged_operations_once(
-                record_store=store,
-                lease_owner=generated_lease_owner,
-                limit=limit,
+            try:
+                records = execute_approved_privileged_operations_once(
+                    record_store=store,
+                    lease_owner=generated_lease_owner,
+                    limit=limit,
+                )
+            except Exception as error:  # noqa: BLE001 - bounded worker retry loop.
+                consecutive_errors += 1
+                telemetry = {
+                    "consecutive_errors": consecutive_errors,
+                    "error_type": type(error).__name__,
+                }
+                if consecutive_errors >= max_consecutive_errors:
+                    click.echo(
+                        json.dumps(
+                            {
+                                "event": "privileged_operation_worker_threshold_exit",
+                                **telemetry,
+                            },
+                            sort_keys=True,
+                        )
+                    )
+                    raise click.ClickException(
+                        "Privileged-operation workers exited after "
+                        f"{consecutive_errors} consecutive polling errors."
+                    ) from error
+                click.echo(
+                    json.dumps(
+                        {"event": "privileged_operation_worker_retry", **telemetry},
+                        sort_keys=True,
+                    )
+                )
+                stop_event.wait(error_backoff_seconds)
+                continue
+            consecutive_errors = 0
+            click.echo(
+                json.dumps(
+                    {
+                        "event": "privileged_operation_worker_poll_succeeded",
+                        "processed": len(records),
+                        "statuses": [record.status for record in records],
+                    },
+                    sort_keys=True,
+                )
             )
             stop_event.wait(poll_seconds)
+        stopped_cleanly = True
     finally:
         signal.signal(signal.SIGTERM, previous_sigterm)
         signal.signal(signal.SIGINT, previous_sigint)
-    click.echo(json.dumps({"status": "stopped"}, indent=2, sort_keys=True))
+    if stopped_cleanly:
+        click.echo(json.dumps({"event": "privileged_operation_worker_stopped"}, sort_keys=True))
 
 
 @service_odoo_workers.command("run-once")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,6 +77,26 @@ services:
       - default
       - launchplane-external-network
 
+  launchplane-privileged-operation-workers:
+    image: ${DOCKER_IMAGE_REFERENCE:-launchplane:local}
+    pull_policy: always
+    restart: unless-stopped
+    depends_on:
+      launchplane:
+        condition: service_healthy
+    env_file:
+      - .env
+    command:
+      - /app/scripts/start-launchplane-privileged-operation-workers.sh
+    environment:
+      DOCKER_IMAGE_REFERENCE: ${DOCKER_IMAGE_REFERENCE:-launchplane:local}
+      LAUNCHPLANE_STATE_DIR: /app/runtime
+    volumes:
+      - launchplane-runtime:/app/runtime
+    networks:
+      - default
+      - launchplane-external-network
+
 networks:
   launchplane-external-network:
     name: ${LAUNCHPLANE_COMPOSE_EXTERNAL_NETWORK:?Missing LAUNCHPLANE_COMPOSE_EXTERNAL_NETWORK}

--- a/docs/authorization-authority.md
+++ b/docs/authorization-authority.md
@@ -215,20 +215,37 @@ Immutable-image rollback is service-code recovery; it is not authorization-data
 recovery. Do not claim that rolling back the Launchplane image repairs an active
 DB policy.
 
-## Privileged-Operation Planning Actions
+## Privileged-Operation Canary Actions
 
-Phase 1 introduces explicit actions for privileged-operation planning, human
-reads, cancellation, and counts-only agent reads. It introduces no policy rule
-or grant. Authorization uses only schema-v2 managed rules and requires exactly
-one match with both managed IDs, so legacy unmanaged action-empty rules cannot
-inherit the new actions.
+The governed privileged-operation surface uses schema-v2 managed rules and
+requires exactly one match with both managed IDs. Legacy unmanaged action-empty
+rules cannot inherit any action. Code deployment introduces no policy rule or
+grant.
 
 The browser-human identity dependency is separate from the existing browser
 mutation dependency that permits bearer identities to pass through. Bearer,
 workflow, terminal-agent, local-operator, and local-admin identities are
 rejected before human-route policy evaluation. The agent summary route is a
-separate action and projection and never authorizes approval or execution.
+separate action and projection and never authorizes approval or execution; keep
+`privileged_operation_summary.read` ungranted during the canary.
 
-Before any later production activation, inspect active action-empty rules and
-record policy-schema evidence. Activation remains a separate owner-approved
-DB-native administration event; it is not authorized by landing Phase 1 code.
+Before activation, inspect active action-empty rules, record policy-schema
+evidence, prove the expected-image worker container is running, and retain one
+successful DB-backed worker poll. Use staged DB-native activation: first grant
+only `privileged_secret_operation.plan`,
+`privileged_secret_operation.read`, and
+`privileged_secret_operation.cancel`; after exact plan review, add only
+`privileged_secret_operation.approve` and
+`privileged_secret_operation.revoke`. Approval can be claimed immediately, so
+revocation is only possible before worker claim. Keep approval authority active
+until the worker's terminal reauthorization, then revoke every canary rule and
+read the active policy back after terminal verification or any post-activation
+worker stop.
+
+Activation remains a separately owner-approved DB-native administration event;
+it is not authorized by landing code. Keep #2204 open until actual migration,
+rollback, read-back, and soak evidence exists, and keep #2177 open until its
+handoff criteria are complete.
+
+**Preserved history:** Phase 1 introduced planning-only actions without grants.
+That history does not describe the deployed Phase 2 worker flow.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1939,19 +1939,18 @@ return a typed blocked result rather than guessing a domain.
   product-config apply as a record mutation only until that next action has
   been dry-run and applied through `/v1/live-target-runtime/apply`; redeploying
   the same app image does not sync the live Dokploy target environment.
-- `POST /v1/secrets/reencrypt` is the normal shared/production root-rotation
-  path. Run `mode: "dry-run"` with `secret.reencrypt.dry-run`, then submit
-  `mode: "apply"` with the returned plan digest, a reason, an
-  `Idempotency-Key`, and `secret.reencrypt.apply`. Launchplane atomically writes
-  the new versions, current-version pointers, audit events, and idempotency
-  completion evidence in one storage transaction. A failure before commit leaves
-  current pointers and replay evidence unchanged; a committed apply is replayable
-  by the same idempotency key. Direct `launchplane secrets reencrypt --apply`
-  remains bootstrap/recovery-only and requires explicit direct-DB
-  acknowledgement.
-- The operator UI uses the same service route. It requires a successful dry-run
-  result before enabling apply, clears rendered secret input values after each
-  submit, and shows only key/action/count metadata from Launchplane responses.
+- `POST /v1/secrets/reencrypt` is a legacy migration boundary, not a shared or
+  production root-rotation path. It always refuses `mode: "dry-run"` with
+  `privileged_operation_planning_required` and `mode: "apply"` with
+  `privileged_operation_approval_required`; the legacy
+  `secret.reencrypt.dry-run` and `secret.reencrypt.apply` actions no longer
+  grant an effect.
+- Use the governed privileged-operation flow for managed-secret re-encryption:
+  a GitHub-human creates and reviews a typed plan in
+  `/ui/engineering/privileged-operations`, then approval makes that plan
+  immediately claimable by the supervised service worker. The UI has no execute
+  control, and the worker is the only execution path. Revocation is possible
+  only before the worker claims the approved record.
 - `environments unset` removes named keys from a DB-backed runtime-environment
   record without reading or printing plaintext values. It requires
   `--allow-direct-db-mutation` and is intended only for explicit local/bootstrap
@@ -2967,19 +2966,41 @@ path, register the exact caller and worker there, then run the reviewed plan and
 apply sequence. Never substitute a mutable ref, a checked-in target value, or a
 local CLI live-target fallback.
 
-## Privileged-Operation Planning
+## Privileged-Operation Canary
 
-Use `/ui/engineering/privileged-operations` to inspect existing typed plans.
-The Phase 1 UI is read-only. Plan creation and cancellation are browser-human
-API writes protected by the same-origin/fetch-metadata/single-use-CSRF boundary;
-they write only the operation projection and append-only event ledger.
+Use `/ui/engineering/privileged-operations` for the governed browser-human
+plan, read, cancel, approve, and revoke flow. Planning and cancellation remain
+same-origin/fetch-metadata/single-use-CSRF browser writes; approval may execute
+immediately because the supervised worker can claim the record as soon as it is
+approved. Revocation works only before that claim. The UI never exposes execute;
+the DB-backed worker reauthorizes the immutable approver against the exact rule
+before terminal work.
 
-Do not add a policy rule merely to exercise the new routes. Code ships with no
-matching production managed rule. A later activation requires separate owner
-approval and the existing DB-native managed-rule-set reconciliation path used
-by a GitHub human who already holds `authz_policy_grant.write`. If that authority
-does not exist, remain blocked under the authorization redesign; do not use a
-local-admin bearer, workflow, GitHub secret, or borrowed identity.
+Compose runs that loop as `launchplane-privileged-operation-workers` using the
+same image as the API service. Its startup surface accepts only process settings
+for polling, batch limit, error backoff, and consecutive-error threshold; it
+does not accept operation IDs, plan digests, targets, or execution payloads.
 
-Phase 1 never approves or executes a privileged effect. See
+Before any canary-rule activation, prove the privileged-operation worker
+container is running the expected image and record one successful DB-backed poll
+from its structured redacted telemetry. Activate only
+`privileged_secret_operation.plan`, `privileged_secret_operation.read`, and
+`privileged_secret_operation.cancel` first. Add
+`privileged_secret_operation.approve` and `privileged_secret_operation.revoke`
+only after exact plan review. Keep `privileged_operation_summary.read`
+ungranted. Approval authority must remain active through the worker's terminal
+reauthorization. After terminal verification, or after any post-activation
+worker stop, revoke every canary rule and read the active policy back before
+continuing.
+
+Do not add a policy rule merely to exercise the routes. Any activation remains
+a separately owner-approved DB-native administration event by a GitHub human
+that already holds `authz_policy_grant.write`. If that authority does not exist,
+remain blocked under the authorization redesign; do not use a local-admin
+bearer, workflow, GitHub secret, or borrowed identity. Keep #2204 open until
+the actual migration, rollback, read-back, and soak are complete, and keep #2177
+open until its handoff criteria are complete.
+
+**Preserved history:** the Phase 1 read-only UI description applied before the
+Phase 2 worker deployment and is not current operating guidance. See
 `docs/privileged-operations.md`.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1949,8 +1949,11 @@ return a typed blocked result rather than guessing a domain.
   a GitHub-human creates and reviews a typed plan in
   `/ui/engineering/privileged-operations`, then approval makes that plan
   immediately claimable by the supervised service worker. The UI has no execute
-  control, and the worker is the only execution path. Revocation is possible
-  only before the worker claims the approved record.
+  control, and the worker is the only service execution path. Revocation is
+  possible only before the worker claims the approved record. Direct
+  `launchplane secrets reencrypt --apply --allow-direct-db-mutation` remains an
+  explicit bootstrap/recovery-only path, not routine shared or production
+  authority.
 - `environments unset` removes named keys from a DB-backed runtime-environment
   record without reading or printing plaintext values. It requires
   `--allow-direct-db-mutation` and is intended only for explicit local/bootstrap

--- a/docs/privileged-operations.md
+++ b/docs/privileged-operations.md
@@ -12,8 +12,8 @@ Intents, workflow authorization, and ordinary operator mutations.
 ## Approval And Execution Boundary
 
 Planning remains typed and dry-run-only. Phase 2 adds a separate finite human
-approval and a service-internal worker; it adds no HTTP execute route, execute
-action, static execution credential, or agent execution path.
+approval and a supervised service-internal worker; it adds no HTTP execute
+route, execute action, static execution credential, or agent execution path.
 
 - Descriptor IDs, versions, safety classes, request schemas, evidence schemas,
   and planners are compiled into the service registry.
@@ -61,6 +61,18 @@ policy rule or grant. The routes fail closed until a later, separately approved
 DB-native managed-rule activation. GitHub secrets,
 workflows, borrowed identities, and local-admin bearer credentials are not
 bootstrap paths.
+
+Canary activation is staged and DB-native: first activate exactly
+`privileged_secret_operation.plan`, `privileged_secret_operation.read`, and
+`privileged_secret_operation.cancel`. After exact plan review, activate exactly
+`privileged_secret_operation.approve` and
+`privileged_secret_operation.revoke`. Keep
+`privileged_operation_summary.read` ungranted. Before activation, prove the
+worker container is running the expected image and retain telemetry for one
+successful DB-backed poll. After terminal verification, or any
+post-activation worker stop, revoke every canary rule and read the active policy
+back. Approval rules must remain active through the worker's terminal
+reauthorization.
 
 ## Records And Lifecycle
 
@@ -124,6 +136,10 @@ The UI is at `/ui/engineering/privileged-operations`. It exposes bounded
 browser-human approve/revoke controls and clearly states that the service worker
 executes approved work internally; it has no execute control.
 
+Approval may make an operation immediately claimable by the worker. A browser
+human can revoke only before that claim; after claim, the worker owns terminal
+execution and performs its required fresh authorization check.
+
 `launchplane service privileged-operation-workers run` is the service-internal worker loop.
 It claims approved records, re-plans with `apply=False`, rejects plan/pre-state
 drift, reads the fresh active policy, reauthorizes only the immutable approver
@@ -141,5 +157,15 @@ reconciliation state.
 ## Legacy Re-encryption Route
 
 `POST /v1/secrets/reencrypt` is retained only as an explicit migration boundary:
-`mode="apply"` always refuses, and `mode="dry-run"` directs callers to the
-privileged-operation planner. It cannot approve or execute an operation.
+`mode="dry-run"` refuses with `privileged_operation_planning_required`, and
+`mode="apply"` refuses with `privileged_operation_approval_required`. The
+legacy `secret.reencrypt.dry-run` and `secret.reencrypt.apply` actions cannot
+approve or execute an operation.
+
+## Completion Holds
+
+Keep #2204 open until actual migration, rollback, policy read-back, and soak
+evidence are complete. Keep #2177 open until its handoff criteria are complete.
+
+**Preserved history:** Phase 1 planning-only descriptions remain historical
+context only; the supervised Phase 2 worker flow above is current guidance.

--- a/docs/records.md
+++ b/docs/records.md
@@ -2562,9 +2562,9 @@ historical facts independently visible. Owner events and admission/outcome
 records are marked current or historical relative to the resolved PR head/tree;
 historical records never grant current effect authority.
 
-## Privileged-Operation Planning Records
+## Privileged-Operation Records
 
-Phase 1 privileged-operation planning uses a distinct current projection and
+The governed privileged-operation flow uses a distinct current projection and
 append-only lifecycle ledger. PostgreSQL stores them in
 `launchplane_privileged_operations` and
 `launchplane_privileged_operation_events`; filesystem storage mirrors those
@@ -2572,11 +2572,15 @@ names for local/test/rehearsal use only.
 
 `PrivilegedOperationRecord` stores the typed descriptor/version, safety class,
 GitHub-human requester, normalized request and digests, bounded redacted human
-evidence, current `planned`/`expired`/`cancelled` status, and lifecycle
-timestamps. `PrivilegedOperationEventRecord` binds each transition to the exact
-resulting record digest. Creation is replay-safe; changed replay payloads and
-all transitions from terminal state fail closed.
+evidence, current lifecycle status, and timestamps.
+`PrivilegedOperationEventRecord` binds each transition to the exact resulting
+record digest. Creation is replay-safe; changed replay payloads and all
+transitions from terminal state fail closed. Approved records can be claimed by
+the supervised worker immediately; a revocation is possible only before claim.
 
 The payload excludes managed-secret IDs, secret-version IDs, ciphertext,
 plaintext, and raw planner errors. See `docs/privileged-operations.md` for the
 full evidence and authorization boundary.
+
+**Preserved history:** references to Phase 1 planning records describe the
+pre-worker lifecycle and do not constrain the current Phase 2 statuses.

--- a/docs/records.md
+++ b/docs/records.md
@@ -1582,6 +1582,11 @@ run` is the foreground loop intended for an external process supervisor, and
   VeriReel backup-gate operation execution follows the same deployment model via
   `launchplane-verireel-workers` and
   `/app/scripts/start-launchplane-verireel-workers.sh`.
+  Privileged-operation execution follows the same deployment model via
+  `launchplane-privileged-operation-workers` and
+  `/app/scripts/start-launchplane-privileged-operation-workers.sh`; it accepts
+  process timing settings only, while approved operation selection remains in
+  DB-backed Launchplane records.
   Production operation remains observable through the `launchplane service
   verireel-workers status` and `launchplane service verireel-workers reconcile`
   operator commands, and through

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -418,8 +418,8 @@ decryption key state denies the reveal or resolution.
 - `uv run launchplane secrets reencrypt --allow-direct-db-mutation` is a
   bootstrap/recovery-only dry-run. A direct apply additionally requires
   `--expected-plan-digest`, `--reason`, and `--apply`. Routine shared and
-  production root rotation must use the deployed service endpoint rather than
-  an arbitrary checkout.
+  production root rotation must use the governed privileged-operation UI and
+  supervised worker rather than an arbitrary checkout or legacy service route.
 - `uv run launchplane product-config apply --input-file bundle.json --dry-run`
   previews an approved product runtime/secret bundle without printing plaintext
   values or writing records. `--apply` writes non-secret runtime keys and
@@ -484,5 +484,16 @@ state, actor/source metadata, and lifecycle timestamps.
 
 Managed-secret IDs, secret-version IDs, ciphertext, plaintext, and raw error
 strings are neither persisted nor returned in the agent projection. The agent
-projection also excludes key IDs and request/actor details. Phase 1 does not
-change `/v1/secrets/reencrypt` apply authority and cannot mutate a secret.
+projection also excludes key IDs and request/actor details.
+
+`POST /v1/secrets/reencrypt` is legacy-only: its `mode: "dry-run"` response
+refuses with `privileged_operation_planning_required`, and its `mode: "apply"`
+response refuses with `privileged_operation_approval_required`. The legacy
+`secret.reencrypt.dry-run` and `secret.reencrypt.apply` actions are not a
+current authority path. Use the typed browser-human plan and approval flow, then
+the supervised privileged-operation worker; approval may execute immediately,
+and revocation is possible only before worker claim. See
+`docs/privileged-operations.md` for canary activation and worker proof rules.
+
+**Preserved history:** Phase 1 described planning evidence before a deployed
+worker existed; it is not current root-rotation operating guidance.

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -1970,15 +1970,16 @@ the active managed-secret root. Concurrent same-key applies that race after the
 initial replay lookup converge by re-reading the completed idempotency record
 after a transactional write conflict and returning the winner as a replay.
 
-`POST /v1/secrets/reencrypt` owns shared and production managed-secret root
-rotation. The route requires JSON with a bounded body, exact
-`secret.reencrypt.dry-run` or `secret.reencrypt.apply` authority, a reason, and
-DB-backed storage. Apply additionally requires the matching dry-run digest and
-an `Idempotency-Key`. Version, current-pointer, and audit writes commit in one
-transaction; the audit operation token provides retry recovery if idempotency
-evidence cannot be persisted after that transaction. Terminal-agent read
-credentials cannot call the route, and responses expose key IDs and counts but
-never plaintext or ciphertext.
+`POST /v1/secrets/reencrypt` is a legacy migration boundary. It refuses
+`mode: "dry-run"` with `privileged_operation_planning_required` and
+`mode: "apply"` with `privileged_operation_approval_required`; neither
+`secret.reencrypt.dry-run` nor `secret.reencrypt.apply` is current effect
+authority. Shared and production root rotation instead uses the typed
+browser-human privileged-operation plan/approval routes and the supervised
+DB-backed worker. The worker is the only execute path, reauthorizes the
+immutable approver before terminal work, and emits redacted counts/statuses
+only. Approval may be claimed immediately, so revocation is possible only
+before worker claim.
 
 #### Product-config secret source contract
 
@@ -3799,10 +3800,10 @@ control-plane context, never a product instance. Phase one adds the reusable
 adds no mutable dispatch wrapper, live managed rule/secret value, deployment,
 or provider mutation.
 
-## Privileged-Operation Planning API
+## Privileged-Operation API
 
-The Phase 1 privileged-operation API is a typed planning surface, not an
-execution proxy. Human create/read/cancel routes are under
+The privileged-operation API is a typed governed surface, not an execution
+proxy. Human create/read/cancel routes are under
 `/v1/privileged-operations/plans`; the counts-only agent read is under
 `/v1/agent/privileged-operations/plans/{operation_id}`.
 
@@ -3811,7 +3812,12 @@ and use the browser origin/fetch-metadata/CSRF boundary for writes. Every route
 requires schema-v2 policy and exactly one matching managed rule carrying both
 managed IDs. Bare policy evaluation and unmanaged action-empty rules cannot
 authorize the surface. The first planner invokes managed-secret re-encryption
-with `apply=False`; no approval, execute, or apply endpoint exists in Phase 1.
+with `apply=False`. Browser-human approval/revocation routes remain governed;
+there is no HTTP execute or apply endpoint. Approval can be claimed immediately
+by the supervised worker, so revocation is possible only before claim.
 
 Responses and stored records follow the redaction contract in
 `docs/privileged-operations.md`.
+
+**Preserved history:** the Phase 1 planning-only API description predates the
+supervised Phase 2 worker and is not current operating guidance.

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -1976,10 +1976,12 @@ after a transactional write conflict and returning the winner as a replay.
 `secret.reencrypt.dry-run` nor `secret.reencrypt.apply` is current effect
 authority. Shared and production root rotation instead uses the typed
 browser-human privileged-operation plan/approval routes and the supervised
-DB-backed worker. The worker is the only execute path, reauthorizes the
+DB-backed worker. The worker is the only service execute path, reauthorizes the
 immutable approver before terminal work, and emits redacted counts/statuses
 only. Approval may be claimed immediately, so revocation is possible only
-before worker claim.
+before worker claim. Direct CLI apply remains an explicit
+bootstrap/recovery-only path guarded by `--allow-direct-db-mutation`, not routine
+shared or production authority.
 
 #### Product-config secret source contract
 

--- a/scripts/start-launchplane-privileged-operation-workers.sh
+++ b/scripts/start-launchplane-privileged-operation-workers.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+
+set -eu
+
+launchplane_app_root="${LAUNCHPLANE_APP_ROOT:-/app}"
+state_dir="${LAUNCHPLANE_STATE_DIR:-$launchplane_app_root/runtime}"
+launchplane_database_url="${LAUNCHPLANE_DATABASE_URL:-}"
+
+if [ -z "$launchplane_database_url" ]; then
+	echo "Launchplane privileged-operation workers refuse startup without LAUNCHPLANE_DATABASE_URL." >&2
+	echo "Worker execution must use Postgres-backed Launchplane records and leases." >&2
+	exit 1
+fi
+
+mkdir -p "$state_dir"
+
+set -- uv run launchplane service privileged-operation-workers run \
+	--state-dir "$state_dir"
+
+if [ -n "${LAUNCHPLANE_PRIVILEGED_OPERATION_WORKER_POLL_SECONDS:-}" ]; then
+	set -- "$@" --poll-seconds "$LAUNCHPLANE_PRIVILEGED_OPERATION_WORKER_POLL_SECONDS"
+fi
+
+if [ -n "${LAUNCHPLANE_PRIVILEGED_OPERATION_WORKER_LIMIT:-}" ]; then
+	set -- "$@" --limit "$LAUNCHPLANE_PRIVILEGED_OPERATION_WORKER_LIMIT"
+fi
+
+if [ -n "${LAUNCHPLANE_PRIVILEGED_OPERATION_WORKER_ERROR_BACKOFF_SECONDS:-}" ]; then
+	set -- "$@" --error-backoff-seconds "$LAUNCHPLANE_PRIVILEGED_OPERATION_WORKER_ERROR_BACKOFF_SECONDS"
+fi
+
+if [ -n "${LAUNCHPLANE_PRIVILEGED_OPERATION_WORKER_MAX_CONSECUTIVE_ERRORS:-}" ]; then
+	set -- "$@" --max-consecutive-errors "$LAUNCHPLANE_PRIVILEGED_OPERATION_WORKER_MAX_CONSECUTIVE_ERRORS"
+fi
+
+exec "$@"

--- a/tests/test_privileged_operation_worker.py
+++ b/tests/test_privileged_operation_worker.py
@@ -5,7 +5,9 @@ from datetime import datetime, timezone
 import json
 import os
 from pathlib import Path
+import signal
 from tempfile import TemporaryDirectory
+from types import SimpleNamespace
 import unittest
 from unittest.mock import patch
 
@@ -195,12 +197,155 @@ class PrivilegedOperationWorkerTests(unittest.TestCase):
         runner = CliRunner()
 
         service_help = runner.invoke(main, ["service", "privileged-operation-workers", "--help"])
+        run_help = runner.invoke(main, ["service", "privileged-operation-workers", "run", "--help"])
         top_level = runner.invoke(main, ["privileged-operations", "--help"])
 
         self.assertEqual(service_help.exit_code, 0)
+        self.assertEqual(run_help.exit_code, 0)
         self.assertIn("run-once", service_help.output)
         self.assertIn("run", service_help.output)
+        self.assertIn("--error-backoff-seconds", run_help.output)
+        self.assertIn("--max-consecutive-errors", run_help.output)
+        self.assertNotIn("--operation-id", run_help.output)
+        self.assertNotIn("--plan-digest", run_help.output)
+        self.assertNotIn("--execute-payload", run_help.output)
         self.assertNotEqual(top_level.exit_code, 0)
+
+    def test_worker_loop_retries_redacts_and_exits_at_threshold(self) -> None:
+        class TestStopEvent:
+            def is_set(self) -> bool:
+                return False
+
+            def wait(self, timeout: int) -> bool:
+                wait_durations.append(timeout)
+                return False
+
+        wait_durations: list[int] = []
+        runner = CliRunner()
+        records = [SimpleNamespace(operation_id="operation-secret-id", status="executed")]
+        with (
+            patch("control_plane.cli_service.Event", return_value=TestStopEvent()),
+            patch("control_plane.cli_service._store", return_value=object()),
+            patch(
+                "control_plane.cli_service.execute_approved_privileged_operations_once",
+                side_effect=[
+                    RuntimeError("operation-secret-id must not be emitted"),
+                    records,
+                    RuntimeError("plan-digest must not be emitted"),
+                    RuntimeError("execute-payload must not be emitted"),
+                ],
+            ),
+            patch("control_plane.cli_service.signal.signal", return_value=object()),
+        ):
+            result = runner.invoke(
+                main,
+                [
+                    "service",
+                    "privileged-operation-workers",
+                    "run",
+                    "--database-url",
+                    "sqlite+pysqlite:///:memory:",
+                    "--poll-seconds",
+                    "7",
+                    "--limit",
+                    "4",
+                    "--error-backoff-seconds",
+                    "3",
+                    "--max-consecutive-errors",
+                    "2",
+                ],
+            )
+
+        self.assertEqual(result.exit_code, 1, result.output)
+        self.assertEqual(wait_durations, [3, 7, 3])
+        self.assertNotIn("operation-secret-id", result.output)
+        self.assertNotIn("plan-digest", result.output)
+        self.assertNotIn("execute-payload", result.output)
+        telemetry = [
+            json.loads(line) for line in result.output.splitlines() if line.startswith("{")
+        ]
+        self.assertEqual(
+            [entry["event"] for entry in telemetry],
+            [
+                "privileged_operation_worker_started",
+                "privileged_operation_worker_retry",
+                "privileged_operation_worker_poll_succeeded",
+                "privileged_operation_worker_retry",
+                "privileged_operation_worker_threshold_exit",
+            ],
+        )
+        self.assertEqual(telemetry[1]["consecutive_errors"], 1)
+        self.assertEqual(telemetry[1]["error_type"], "RuntimeError")
+        self.assertEqual(
+            telemetry[2],
+            {
+                "event": "privileged_operation_worker_poll_succeeded",
+                "processed": 1,
+                "statuses": ["executed"],
+            },
+        )
+        self.assertEqual(telemetry[3]["consecutive_errors"], 1)
+        self.assertEqual(telemetry[4]["consecutive_errors"], 2)
+
+    def test_worker_loop_stops_cleanly_after_sigterm(self) -> None:
+        signal_handlers: dict[int, object] = {}
+
+        class TestStopEvent:
+            stopped = False
+
+            def is_set(self) -> bool:
+                return self.stopped
+
+            def set(self) -> None:
+                self.stopped = True
+
+            def wait(self, _timeout: int) -> bool:
+                handler = signal_handlers[signal.SIGTERM]
+                assert callable(handler)
+                handler(signal.SIGTERM, None)
+                return True
+
+        def record_signal(signum: int, handler: object) -> object:
+            if callable(handler):
+                signal_handlers[signum] = handler
+            return object()
+
+        runner = CliRunner()
+        with (
+            patch("control_plane.cli_service.Event", return_value=TestStopEvent()),
+            patch("control_plane.cli_service._store", return_value=object()),
+            patch(
+                "control_plane.cli_service.execute_approved_privileged_operations_once",
+                return_value=[
+                    SimpleNamespace(operation_id="operation-secret-id", status="executed")
+                ],
+            ),
+            patch("control_plane.cli_service.signal.signal", side_effect=record_signal),
+        ):
+            result = runner.invoke(
+                main,
+                [
+                    "service",
+                    "privileged-operation-workers",
+                    "run",
+                    "--database-url",
+                    "sqlite+pysqlite:///:memory:",
+                ],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertNotIn("operation-secret-id", result.output)
+        telemetry = [
+            json.loads(line) for line in result.output.splitlines() if line.startswith("{")
+        ]
+        self.assertEqual(
+            [entry["event"] for entry in telemetry],
+            [
+                "privileged_operation_worker_started",
+                "privileged_operation_worker_poll_succeeded",
+                "privileged_operation_worker_stopped",
+            ],
+        )
 
     def test_worker_reauthorizes_by_github_id_and_executes_only_once(self) -> None:
         approval_policy = _policy_record(revision=3)

--- a/tests/test_privileged_operation_worker.py
+++ b/tests/test_privileged_operation_worker.py
@@ -225,11 +225,13 @@ class PrivilegedOperationWorkerTests(unittest.TestCase):
         records = [SimpleNamespace(operation_id="operation-secret-id", status="executed")]
         with (
             patch("control_plane.cli_service.Event", return_value=TestStopEvent()),
-            patch("control_plane.cli_service._store", return_value=object()),
+            patch(
+                "control_plane.cli_service._store",
+                side_effect=[RuntimeError("database-url-secret must not be emitted"), object()],
+            ),
             patch(
                 "control_plane.cli_service.execute_approved_privileged_operations_once",
                 side_effect=[
-                    RuntimeError("operation-secret-id must not be emitted"),
                     records,
                     RuntimeError("plan-digest must not be emitted"),
                     RuntimeError("execute-payload must not be emitted"),
@@ -258,6 +260,7 @@ class PrivilegedOperationWorkerTests(unittest.TestCase):
 
         self.assertEqual(result.exit_code, 1, result.output)
         self.assertEqual(wait_durations, [3, 7, 3])
+        self.assertNotIn("database-url-secret", result.output)
         self.assertNotIn("operation-secret-id", result.output)
         self.assertNotIn("plan-digest", result.output)
         self.assertNotIn("execute-payload", result.output)
@@ -289,6 +292,11 @@ class PrivilegedOperationWorkerTests(unittest.TestCase):
 
     def test_worker_loop_stops_cleanly_after_sigterm(self) -> None:
         signal_handlers: dict[int, object] = {}
+        signal_calls: list[tuple[int, object]] = []
+        previous_handlers: dict[int, object] = {
+            signal.SIGTERM: object(),
+            signal.SIGINT: object(),
+        }
 
         class TestStopEvent:
             stopped = False
@@ -306,8 +314,10 @@ class PrivilegedOperationWorkerTests(unittest.TestCase):
                 return True
 
         def record_signal(signum: int, handler: object) -> object:
+            signal_calls.append((signum, handler))
             if callable(handler):
                 signal_handlers[signum] = handler
+                return previous_handlers[signum]
             return object()
 
         runner = CliRunner()
@@ -346,6 +356,57 @@ class PrivilegedOperationWorkerTests(unittest.TestCase):
                 "privileged_operation_worker_stopped",
             ],
         )
+        self.assertEqual(signal_calls[-2:], list(previous_handlers.items()))
+
+    def test_worker_loop_preserves_base_exception_and_restores_signal_handlers(self) -> None:
+        class FatalWorkerError(BaseException):
+            pass
+
+        class TestStopEvent:
+            def is_set(self) -> bool:
+                return False
+
+        signal_calls: list[tuple[int, object]] = []
+        previous_handlers: dict[int, object] = {
+            signal.SIGTERM: object(),
+            signal.SIGINT: object(),
+        }
+
+        def record_signal(signum: int, handler: object) -> object:
+            signal_calls.append((signum, handler))
+            if callable(handler):
+                return previous_handlers[signum]
+            return object()
+
+        runner = CliRunner()
+        with (
+            patch("control_plane.cli_service.Event", return_value=TestStopEvent()),
+            patch("control_plane.cli_service._store", return_value=object()),
+            patch(
+                "control_plane.cli_service.execute_approved_privileged_operations_once",
+                side_effect=FatalWorkerError("operation-secret-id must not be emitted"),
+            ),
+            patch("control_plane.cli_service.signal.signal", side_effect=record_signal),
+            patch("control_plane.cli_service.click.echo") as echo,
+        ):
+            with self.assertRaises(FatalWorkerError):
+                runner.invoke(
+                    main,
+                    [
+                        "service",
+                        "privileged-operation-workers",
+                        "run",
+                        "--database-url",
+                        "sqlite+pysqlite:///:memory:",
+                    ],
+                )
+
+        telemetry = [json.loads(call.args[0]) for call in echo.call_args_list]
+        self.assertEqual(
+            telemetry,
+            [{"event": "privileged_operation_worker_started", "limit": 20, "poll_seconds": 15}],
+        )
+        self.assertEqual(signal_calls[-2:], list(previous_handlers.items()))
 
     def test_worker_reauthorizes_by_github_id_and_executes_only_once(self) -> None:
         approval_policy = _policy_record(revision=3)

--- a/tests/test_start_launchplane_service.py
+++ b/tests/test_start_launchplane_service.py
@@ -571,5 +571,110 @@ printf '%s\n' "$@" >>"$UV_CAPTURE_FILE"
         self.assertGreaterEqual(compose_text.count("- launchplane-external-network"), 3)
 
 
+class StartLaunchplanePrivilegedOperationWorkersScriptTests(unittest.TestCase):
+    def setUp(self) -> None:
+        repo_root = Path(__file__).resolve().parents[1]
+        self.script_path = (
+            repo_root / "scripts" / "start-launchplane-privileged-operation-workers.sh"
+        )
+        self.compose_path = repo_root / "docker-compose.yml"
+
+    def _write_fake_uv(self, bin_dir: Path) -> None:
+        uv_path = bin_dir / "uv"
+        uv_path.write_text(
+            """#!/bin/sh
+printf '%s\\n' \"$@\" >>\"$UV_CAPTURE_FILE\"
+""",
+            encoding="utf-8",
+        )
+        uv_path.chmod(uv_path.stat().st_mode | stat.S_IXUSR)
+
+    def test_requires_database_url_for_worker_startup(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            temporary_directory = Path(temporary_directory_name)
+            app_root = temporary_directory / "app"
+            app_root.mkdir()
+
+            result = subprocess.run(
+                [str(self.script_path)],
+                capture_output=True,
+                text=True,
+                env={
+                    **os.environ,
+                    "LAUNCHPLANE_APP_ROOT": str(app_root),
+                    "LAUNCHPLANE_STATE_DIR": str(temporary_directory / "runtime"),
+                    "LAUNCHPLANE_DATABASE_URL": "",
+                },
+                check=False,
+            )
+
+        self.assertEqual(result.returncode, 1, msg=result.stderr)
+        self.assertIn("refuse startup without LAUNCHPLANE_DATABASE_URL", result.stderr)
+
+    def test_worker_startup_wires_only_process_settings(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            temporary_directory = Path(temporary_directory_name)
+            app_root = temporary_directory / "app"
+            bin_dir = temporary_directory / "bin"
+            capture_file = temporary_directory / "uv-args.txt"
+            app_root.mkdir()
+            bin_dir.mkdir()
+            self._write_fake_uv(bin_dir)
+
+            result = subprocess.run(
+                [str(self.script_path)],
+                capture_output=True,
+                text=True,
+                env={
+                    **os.environ,
+                    "PATH": f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}",
+                    "UV_CAPTURE_FILE": str(capture_file),
+                    "LAUNCHPLANE_APP_ROOT": str(app_root),
+                    "LAUNCHPLANE_STATE_DIR": str(temporary_directory / "runtime"),
+                    "LAUNCHPLANE_DATABASE_URL": "postgresql+psycopg://launchplane:test@db/launchplane",
+                    "LAUNCHPLANE_PRIVILEGED_OPERATION_WORKER_POLL_SECONDS": "5",
+                    "LAUNCHPLANE_PRIVILEGED_OPERATION_WORKER_LIMIT": "4",
+                    "LAUNCHPLANE_PRIVILEGED_OPERATION_WORKER_ERROR_BACKOFF_SECONDS": "15",
+                    "LAUNCHPLANE_PRIVILEGED_OPERATION_WORKER_MAX_CONSECUTIVE_ERRORS": "3",
+                    "LAUNCHPLANE_PRIVILEGED_OPERATION_WORKER_OPERATION_ID": "must-not-forward",
+                    "LAUNCHPLANE_PRIVILEGED_OPERATION_WORKER_PLAN_DIGEST": "must-not-forward",
+                    "LAUNCHPLANE_PRIVILEGED_OPERATION_WORKER_EXECUTE_PAYLOAD": "must-not-forward",
+                },
+                check=False,
+            )
+
+            captured_args = capture_file.read_text(encoding="utf-8").splitlines()
+
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertEqual(
+            captured_args[:5],
+            ["run", "launchplane", "service", "privileged-operation-workers", "run"],
+        )
+        self.assertIn("--state-dir", captured_args)
+        self.assertNotIn("--database-url", captured_args)
+        self.assertIn("--poll-seconds", captured_args)
+        self.assertIn("5", captured_args)
+        self.assertIn("--limit", captured_args)
+        self.assertIn("4", captured_args)
+        self.assertIn("--error-backoff-seconds", captured_args)
+        self.assertIn("15", captured_args)
+        self.assertIn("--max-consecutive-errors", captured_args)
+        self.assertIn("3", captured_args)
+        self.assertNotIn("must-not-forward", captured_args)
+
+    def test_compose_includes_supervised_privileged_operation_worker_service(self) -> None:
+        compose_text = self.compose_path.read_text(encoding="utf-8")
+
+        self.assertIn("  launchplane-privileged-operation-workers:\n", compose_text)
+        self.assertIn("image: ${DOCKER_IMAGE_REFERENCE:-launchplane:local}", compose_text)
+        self.assertIn("restart: unless-stopped", compose_text)
+        self.assertIn("condition: service_healthy", compose_text)
+        self.assertIn(
+            "- /app/scripts/start-launchplane-privileged-operation-workers.sh", compose_text
+        )
+        self.assertIn("- launchplane-runtime:/app/runtime", compose_text)
+        self.assertGreaterEqual(compose_text.count("- launchplane-external-network"), 4)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- deploy a supervised `launchplane-privileged-operation-workers` Compose service
- add bounded retry/backoff, threshold exit, signal cleanup, and redacted worker telemetry
- remove operation IDs from worker output and keep operation selection DB-backed
- correct privileged-operation and root-rotation docs for the current Phase 2 path
- document staged canary authorization, immediate claim semantics, worker proof, and mandatory cleanup

## Safety Boundary

This PR performs no production authorization grant, policy reconciliation,
privileged-operation plan, approval, key generation, secret mutation, or deploy.
It enables the worker to be deployed but does not prove production readiness.

After merge and deployment, activation remains blocked until operators prove the
expected image digest is running and retain one successful DB-backed worker poll
from structured redacted telemetry. The owner must separately approve any
DB-native canary activation.

## Validation

- focused worker/startup tests: 29 passed
- docs/service contract tests: 29 passed
- full unit gate: 12/12 shards, 3058 targets passed
- Ruff check and format check: passed
- mypy: 750 source files passed
- shellcheck and shfmt: passed
- Compose config: passed
- Docker build: passed
- Opus final review: READY
- Gemini code/test final review: READY
- Gemini documentation final review: READY
- JetBrains inspection: initial clean zero-finding result; post-fix rerun inconclusive because the IDE returned stale results

Refs #2219
