### PR TITLE
Add bounded worker runtime evidence

### DIFF
--- a/.github/workflows/dokploy-target-inspect.yml
+++ b/.github/workflows/dokploy-target-inspect.yml
@@ -24,13 +24,28 @@ name: Dokploy Target Inspect
         required: false
         default: ""
         type: string
+      service:
+        description: Optional exact compose service for bounded runtime evidence.
+        required: false
+        default: ""
+        type: string
+      event:
+        description: Optional structured event name that must be observed for runtime proof.
+        required: false
+        default: ""
+        type: string
+      expected_image:
+        description: Expected immutable image reference for runtime proof.
+        required: false
+        default: ""
+        type: string
 
 permissions:
   contents: read
   id-token: write
 
 concurrency:
-  group: dokploy-target-inspect-${{ inputs.context }}-${{ inputs.instance }}-${{ inputs.target_type }}-${{ inputs.target_id }}
+  group: dokploy-target-inspect-${{ inputs.context }}-${{ inputs.instance }}-${{ inputs.target_type }}-${{ inputs.target_id }}-${{ inputs.service }}
   cancel-in-progress: false
 
 jobs:
@@ -41,6 +56,9 @@ jobs:
       INSTANCE: ${{ inputs.instance }}
       TARGET_TYPE: ${{ inputs.target_type }}
       TARGET_ID: ${{ inputs.target_id }}
+      SERVICE: ${{ inputs.service }}
+      EVENT: ${{ inputs.event }}
+      EXPECTED_IMAGE: ${{ inputs.expected_image }}
     steps:
       - name: Validate inspect inputs
         shell: bash
@@ -74,6 +92,21 @@ jobs:
             echo "context/instance or target_type/target_id is required." >&2
             exit 1
           fi
+          if [ -n "$(printf '%s' "$EVENT" | xargs)" ] \
+            && [ -z "$(printf '%s' "$SERVICE" | xargs)" ]; then
+            echo "event requires an exact compose service." >&2
+            exit 1
+          fi
+          if [ -n "$(printf '%s' "$SERVICE" | xargs)" ] \
+            && [ -z "$(printf '%s' "$EXPECTED_IMAGE" | xargs)" ]; then
+            echo "runtime proof requires the expected immutable image." >&2
+            exit 1
+          fi
+          if [ -n "$(printf '%s' "$SERVICE" | xargs)" ] \
+            && [ -z "$(printf '%s' "$EVENT" | xargs)" ]; then
+            echo "runtime proof requires the structured event name." >&2
+            exit 1
+          fi
 
       - name: Build inspect request
         id: request
@@ -85,13 +118,19 @@ jobs:
             --arg instance "$INSTANCE" \
             --arg target_type "$TARGET_TYPE" \
             --arg target_id "$TARGET_ID" \
+            --arg service "$SERVICE" \
+            --arg event "$EVENT" \
+            --arg expected_image "$EXPECTED_IMAGE" \
             'def encpair($key; $value):
               select(($value | length) > 0) | "\($key)=\($value | @uri)";
             [
               encpair("context"; $context),
               encpair("instance"; $instance),
               encpair("target_type"; $target_type),
-              encpair("target_id"; $target_id)
+              encpair("target_id"; $target_id),
+              encpair("service"; $service),
+              encpair("event"; $event),
+              encpair("expected_image"; $expected_image)
             ] | join("&")')"
           echo "route_path=/v1/dokploy-targets/inspect?${query}" >> "$GITHUB_OUTPUT"
 
@@ -118,6 +157,11 @@ jobs:
             echo "Dokploy target inspect failed with HTTP ${STATUS_CODE}." >&2
             exit 1
           fi
+          if [ -n "$(printf '%s' "$SERVICE" | xargs)" ] \
+            && [ "$(jq -r '.inspect.runtime_evidence.proof_ready // false' "$response_file")" != "true" ]; then
+            echo "Dokploy target runtime evidence is not proof-ready." >&2
+            exit 1
+          fi
 
       - name: Upload inspect evidence
         if: always()
@@ -141,7 +185,8 @@ jobs:
                 trace_id,
                 target: .inspect.tracked_target,
                 provider_target_record: .inspect.provider_target_record,
-                provider: .inspect.provider
+                provider: .inspect.provider,
+                runtime_evidence: .inspect.runtime_evidence
               }' dokploy-target-inspect-response.json
             fi
           } >> "$GITHUB_STEP_SUMMARY"

--- a/control_plane/dokploy/api.py
+++ b/control_plane/dokploy/api.py
@@ -624,6 +624,19 @@ def _select_compose_log_container(
     return {}
 
 
+def select_dokploy_compose_container(
+    containers: list[JsonObject],
+    *,
+    app_name: str = "",
+    service_name: str = "",
+) -> JsonObject:
+    return _select_compose_log_container(
+        containers,
+        app_name=app_name,
+        service_name=service_name,
+    )
+
+
 def _compose_log_container_matches_service(
     container: JsonObject,
     *,
@@ -1315,6 +1328,10 @@ def _collect_object_items(raw_items: list[JsonValue]) -> list[JsonObject]:
         if item_as_object is not None:
             object_items.append(item_as_object)
     return object_items
+
+
+def collect_dokploy_object_items(raw_items: list[JsonValue]) -> list[JsonObject]:
+    return _collect_object_items(raw_items)
 
 
 def _wait_for_deployment_status(

--- a/control_plane/dokploy/runtime_evidence.py
+++ b/control_plane/dokploy/runtime_evidence.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import json
+import re
+
+import click
+
+from control_plane.dokploy import api as dokploy_api
+
+_STRUCTURED_EVENT_PATTERN = re.compile(r"^$|^[a-z][a-z0-9_]{0,127}$")
+_IMAGE_ID_PATTERN = re.compile(r"^sha256:[a-f0-9]{64}$")
+_IMMUTABLE_IMAGE_REFERENCE_PATTERN = re.compile(r"^[^\s@]+@sha256:[a-f0-9]{64}$")
+_MAX_RUNTIME_TEXT_LENGTH = 500
+_ALLOWED_STRUCTURED_EVENTS = frozenset({"privileged_operation_worker_poll_succeeded"})
+
+
+def normalize_structured_event_name(raw_event_name: str) -> str:
+    event_name = raw_event_name.strip().lower()
+    if not _STRUCTURED_EVENT_PATTERN.fullmatch(event_name):
+        raise click.ClickException(
+            "Dokploy structured event names may contain only lowercase letters, numbers, and underscores."
+        )
+    if event_name and event_name not in _ALLOWED_STRUCTURED_EVENTS:
+        raise click.ClickException(
+            "Dokploy runtime evidence supports only allow-listed structured events."
+        )
+    return event_name
+
+
+def normalize_expected_image_reference(raw_image_reference: str) -> str:
+    image_reference = raw_image_reference.strip()
+    if not image_reference:
+        return ""
+    if len(image_reference) > _MAX_RUNTIME_TEXT_LENGTH or not (
+        _IMMUTABLE_IMAGE_REFERENCE_PATTERN.fullmatch(image_reference)
+    ):
+        raise click.ClickException(
+            "Expected Dokploy runtime image must be an immutable repository@sha256 reference."
+        )
+    return image_reference
+
+
+def fetch_compose_service_runtime(
+    *,
+    host: str,
+    token: str,
+    compose_id: str,
+    app_name: str,
+    server_id: str = "",
+    service_name: str,
+) -> dokploy_api.JsonObject:
+    normalized_compose_id = compose_id.strip()
+    if not normalized_compose_id:
+        raise click.ClickException("Dokploy compose runtime evidence requires a compose id.")
+    normalized_app_name = app_name.strip()
+    if not normalized_app_name:
+        raise click.ClickException(
+            "Dokploy compose runtime evidence requires tracked application metadata."
+        )
+    normalized_server_id = server_id.strip()
+    normalized_service_name = dokploy_api.normalize_dokploy_compose_service_name(service_name)
+    if not normalized_service_name:
+        raise click.ClickException("Dokploy compose runtime evidence requires a service name.")
+
+    container_query: dict[str, str | int] = {
+        "appName": normalized_app_name,
+        "appType": "docker-compose",
+    }
+    if normalized_server_id:
+        container_query["serverId"] = normalized_server_id
+    containers_payload = dokploy_api.dokploy_request(
+        host=host,
+        token=token,
+        path="/api/docker.getContainersByAppNameMatch",
+        query=container_query,
+    )
+    if not isinstance(containers_payload, list):
+        raise click.ClickException("Dokploy returned an invalid compose container list.")
+    selected_container = dokploy_api.select_dokploy_compose_container(
+        dokploy_api.collect_dokploy_object_items(containers_payload),
+        app_name=normalized_app_name,
+        service_name=normalized_service_name,
+    )
+    container_id = str(selected_container.get("containerId") or "").strip()
+    if not container_id:
+        raise click.ClickException(
+            f"Dokploy compose service {normalized_service_name!r} has no container id."
+        )
+
+    config_query: dict[str, str | int] = {"containerId": container_id}
+    if normalized_server_id:
+        config_query["serverId"] = normalized_server_id
+    config_payload = dokploy_api.dokploy_request(
+        host=host,
+        token=token,
+        path="/api/docker.getConfig",
+        query=config_query,
+    )
+    container_config = _normalize_container_config(config_payload)
+    if container_config is None:
+        raise click.ClickException("Dokploy returned invalid compose container configuration.")
+    raw_config = container_config.get("Config")
+    configured_image = (
+        str(raw_config.get("Image") or "").strip() if isinstance(raw_config, dict) else ""
+    )
+    if not configured_image:
+        raise click.ClickException(
+            f"Dokploy compose service {normalized_service_name!r} has no configured image."
+        )
+    image_id = str(container_config.get("Image") or "").strip().lower()
+    if not _IMAGE_ID_PATTERN.fullmatch(image_id):
+        raise click.ClickException(
+            f"Dokploy compose service {normalized_service_name!r} has no immutable image id."
+        )
+    state = dokploy_api.redact_dokploy_log_line(
+        str(selected_container.get("state") or selected_container.get("State") or "")
+    )
+    status = dokploy_api.redact_dokploy_log_line(
+        str(selected_container.get("status") or selected_container.get("Status") or "")
+    )
+    immutable_image_reference = (
+        configured_image
+        if len(configured_image) <= _MAX_RUNTIME_TEXT_LENGTH
+        and _IMMUTABLE_IMAGE_REFERENCE_PATTERN.fullmatch(configured_image)
+        else ""
+    )
+    return {
+        "compose_id": normalized_compose_id,
+        "service": normalized_service_name,
+        "state": state.strip()[:_MAX_RUNTIME_TEXT_LENGTH],
+        "status": status.strip()[:_MAX_RUNTIME_TEXT_LENGTH],
+        "running": state.strip().lower() == "running",
+        "configured_image": configured_image[:_MAX_RUNTIME_TEXT_LENGTH],
+        "image_id": image_id,
+        "immutable_image_reference": immutable_image_reference,
+        "image_reference_immutable": bool(immutable_image_reference),
+    }
+
+
+def count_structured_log_events(lines: tuple[str, ...], *, event_name: str) -> int:
+    normalized_event_name = normalize_structured_event_name(event_name)
+    if not normalized_event_name:
+        return 0
+    matching_events = 0
+    for line in lines:
+        object_start = line.find("{")
+        if object_start < 0:
+            continue
+        try:
+            payload, _ = json.JSONDecoder().raw_decode(line[object_start:])
+        except json.JSONDecodeError:
+            continue
+        if isinstance(payload, dict) and payload.get("event") == normalized_event_name:
+            matching_events += 1
+    return matching_events
+
+
+def _normalize_container_config(
+    raw_config: dokploy_api.JsonValue,
+) -> dokploy_api.JsonObject | None:
+    container_config = dokploy_api.as_json_object(raw_config)
+    if container_config is not None:
+        return container_config
+    if isinstance(raw_config, list) and len(raw_config) == 1:
+        return dokploy_api.as_json_object(raw_config[0])
+    return None

--- a/control_plane/dokploy_target_inspect.py
+++ b/control_plane/dokploy_target_inspect.py
@@ -3,20 +3,53 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import Literal, Protocol
 
+import click
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from control_plane.contracts.deploy_target import ProviderTargetRecord
 from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
 from control_plane.contracts.dokploy_target_record import DokployTargetRecord
 from control_plane.dokploy import api as dokploy_api
+from control_plane.dokploy import runtime_evidence as dokploy_runtime_evidence
 
 DokployTargetType = Literal["application", "compose"]
+_RUNTIME_EVIDENCE_LOG_LINE_COUNT = dokploy_api.MAX_DOKPLOY_LOG_LINE_COUNT
+_RUNTIME_EVIDENCE_LOG_SINCE = "1d"
 
 
 class FetchDokployTargetPayload(Protocol):
     def __call__(
         self, *, host: str, token: str, target_type: str, target_id: str
     ) -> dokploy_api.JsonObject: ...
+
+
+class FetchDokployComposeServiceRuntime(Protocol):
+    def __call__(
+        self,
+        *,
+        host: str,
+        token: str,
+        compose_id: str,
+        app_name: str,
+        server_id: str,
+        service_name: str,
+    ) -> dokploy_api.JsonObject: ...
+
+
+class FetchDokployComposeLogs(Protocol):
+    def __call__(
+        self,
+        *,
+        host: str,
+        token: str,
+        compose_id: str,
+        app_name: str,
+        server_id: str,
+        service_name: str,
+        line_count: int,
+        since: str,
+        search: str,
+    ) -> tuple[str, ...]: ...
 
 
 class DokployTargetInspectRequest(BaseModel):
@@ -28,6 +61,9 @@ class DokployTargetInspectRequest(BaseModel):
     instance: str = ""
     target_type: DokployTargetType | str = ""
     target_id: str = ""
+    service: str = ""
+    event: str = ""
+    expected_image: str = ""
 
     @model_validator(mode="after")
     def _validate_request(self) -> "DokployTargetInspectRequest":
@@ -36,8 +72,24 @@ class DokployTargetInspectRequest(BaseModel):
         self.instance = self.instance.strip()
         self.target_type = self.target_type.strip().lower()
         self.target_id = self.target_id.strip()
+        try:
+            self.service = dokploy_api.normalize_dokploy_compose_service_name(self.service)
+            self.event = dokploy_runtime_evidence.normalize_structured_event_name(self.event)
+            self.expected_image = dokploy_runtime_evidence.normalize_expected_image_reference(
+                self.expected_image
+            )
+        except click.ClickException as error:
+            raise ValueError(str(error)) from error
         if self.product != "launchplane":
             raise ValueError("Dokploy target inspect requires product 'launchplane'.")
+        if self.event and not self.service:
+            raise ValueError("Dokploy runtime event evidence requires a compose service.")
+        if self.expected_image and not self.service:
+            raise ValueError("Dokploy expected image evidence requires a compose service.")
+        if self.service and not self.event:
+            raise ValueError("Dokploy runtime service evidence requires a structured event.")
+        if self.service and not self.expected_image:
+            raise ValueError("Dokploy runtime service evidence requires an expected image.")
         has_route = bool(self.context or self.instance)
         has_explicit_target = bool(self.target_type or self.target_id)
         if has_route and has_explicit_target:
@@ -76,6 +128,8 @@ def inspect_dokploy_target(
     token: str,
     request: DokployTargetInspectRequest,
     fetch_target_payload: FetchDokployTargetPayload | None = None,
+    fetch_compose_service_runtime: FetchDokployComposeServiceRuntime | None = None,
+    fetch_compose_logs: FetchDokployComposeLogs | None = None,
 ) -> dict[str, object]:
     target_record: DokployTargetRecord | None = None
     target_id_record: DokployTargetIdRecord | None = None
@@ -125,6 +179,66 @@ def inspect_dokploy_target(
         "provider_payload_redacted": True,
         "provider": provider_summary,
     }
+    if request.service:
+        if target_type != "compose":
+            raise ValueError("Dokploy runtime service evidence supports compose targets only.")
+        app_name = str(provider_payload.get("appName") or "").strip()
+        server_id = str(provider_payload.get("serverId") or "").strip()
+        runtime_fetcher = (
+            fetch_compose_service_runtime or dokploy_runtime_evidence.fetch_compose_service_runtime
+        )
+        runtime_payload = runtime_fetcher(
+            host=host,
+            token=token,
+            compose_id=target_id,
+            app_name=app_name,
+            server_id=server_id,
+            service_name=request.service,
+        )
+        logs_fetcher = fetch_compose_logs or dokploy_api.fetch_dokploy_compose_logs
+        logs = logs_fetcher(
+            host=host,
+            token=token,
+            compose_id=target_id,
+            app_name=app_name,
+            server_id=server_id,
+            service_name=request.service,
+            line_count=_RUNTIME_EVIDENCE_LOG_LINE_COUNT,
+            since=_RUNTIME_EVIDENCE_LOG_SINCE,
+            search=request.event,
+        )
+        matching_event_count = dokploy_runtime_evidence.count_structured_log_events(
+            logs,
+            event_name=request.event,
+        )
+        event_observed = matching_event_count > 0
+        event_evidence: dict[str, object] = {
+            "name": request.event,
+            "observed": event_observed,
+            "matching_line_count": matching_event_count,
+            "candidate_line_count": len(logs),
+        }
+        running = runtime_payload.get("running") is True
+        image_reference_immutable = runtime_payload.get("image_reference_immutable") is True
+        immutable_image_reference = str(runtime_payload.get("immutable_image_reference") or "")
+        image_matches_expected = (
+            not request.expected_image or immutable_image_reference == request.expected_image
+        )
+        result["runtime_evidence"] = {
+            "service": request.service,
+            "state": str(runtime_payload.get("state") or ""),
+            "status": str(runtime_payload.get("status") or ""),
+            "running": running,
+            "image_id": str(runtime_payload.get("image_id") or ""),
+            "immutable_image_reference": immutable_image_reference,
+            "image_reference_immutable": image_reference_immutable,
+            "expected_image": request.expected_image,
+            "image_matches_expected": image_matches_expected,
+            "structured_event": event_evidence,
+            "proof_ready": (
+                running and image_reference_immutable and image_matches_expected and event_observed
+            ),
+        }
     if target_record is not None and target_id_record is not None:
         result["tracked_target"] = {
             "context": target_record.context,

--- a/control_plane/http_routes/drivers.py
+++ b/control_plane/http_routes/drivers.py
@@ -805,6 +805,9 @@ def register_dokploy_target_inspect_read_routes(
         instance: Annotated[str, Query()] = "",
         target_type: Annotated[str, Query()] = "",
         target_id: Annotated[str, Query()] = "",
+        service: Annotated[str, Query()] = "",
+        event: Annotated[str, Query()] = "",
+        expected_image: Annotated[str, Query()] = "",
     ) -> DokployTargetInspectResponse:
         trace_id = common.next_trace_id()
         if not common.authorization_allows(
@@ -837,6 +840,9 @@ def register_dokploy_target_inspect_read_routes(
                     "instance": instance,
                     "target_type": target_type,
                     "target_id": target_id,
+                    "service": service,
+                    "event": event,
+                    "expected_image": expected_image,
                 }
             )
             host, token = dokploy_source.read_dokploy_config(
@@ -862,6 +868,13 @@ def register_dokploy_target_inspect_read_routes(
                 trace_id=trace_id,
                 code="not_found",
                 message=str(error),
+            ) from error
+        except click.ClickException as error:
+            raise common.http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="dokploy_target_inspect_unavailable",
+                message="Dokploy target inspect evidence is unavailable from the provider.",
             ) from error
         return DokployTargetInspectResponse(trace_id=trace_id, inspect=inspect_result)
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -3003,7 +3003,16 @@ does not accept operation IDs, plan digests, targets, or execution payloads.
 
 Before any canary-rule activation, prove the privileged-operation worker
 container is running the expected image and record one successful DB-backed poll
-from its structured redacted telemetry. Activate only
+from its structured redacted telemetry. Dispatch the protected `Dokploy Target
+Inspect` workflow with the deployed target identity, exact service
+`launchplane-privileged-operation-workers`, and event
+`privileged_operation_worker_poll_succeeded`, plus the exact immutable image
+reference retained from the deployment as `expected_image`. Retain its redacted
+artifact for both success and failure diagnosis, but treat it as activation
+evidence only when `runtime_evidence.proof_ready` is true. The artifact contains
+image/state identity, exact image-match state, and a structured-event count, not
+raw logs or container config.
+Activate only
 `privileged_secret_operation.plan`, `privileged_secret_operation.read`, and
 `privileged_secret_operation.cancel` first. Add
 `privileged_secret_operation.approve` and `privileged_secret_operation.revoke`

--- a/docs/privileged-operations.md
+++ b/docs/privileged-operations.md
@@ -74,6 +74,16 @@ post-activation worker stop, revoke every canary rule and read the active policy
 back. Approval rules must remain active through the worker's terminal
 reauthorization.
 
+Use the protected `Dokploy Target Inspect` workflow for that pre-activation
+proof. Its optional runtime-evidence mode requires an exact compose service,
+expected immutable image, and allow-listed structured event, and returns only
+bounded image/state identity and a structured-event match count. For the worker,
+request service `launchplane-privileged-operation-workers` and event
+`privileged_operation_worker_poll_succeeded`, supply the exact immutable
+deployment reference as `expected_image`, and proceed only when
+`runtime_evidence.proof_ready` is true. Do not retain or expose raw runtime logs,
+container configuration, or environment values as canary evidence.
+
 ## Records And Lifecycle
 
 `PrivilegedOperationRecord` is the current operation projection and

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -2220,6 +2220,25 @@ raw provider payloads or environment values. The manual `Dokploy Target Inspect`
 workflow is the supported shared and production caller when operators need
 provider evidence without mutating Dokploy or Launchplane records.
 
+Callers may additionally provide an exact compose `service`, expected immutable
+`expected_image`, and the allow-listed structured `event` name. That bounded
+runtime-evidence mode resolves exactly one service container for both image and
+log evidence, reads only its state and immutable image identity, and searches at
+most 1,000 redacted candidate log lines from the last day for the exact JSON
+event field. It returns image-match state, event counts, and a `proof_ready`
+decision only; it never returns container IDs, container config, environment
+values, configured mutable image text, or raw log lines. Missing or ambiguous
+containers, invalid image identity, and provider failures fail closed. The
+manual workflow treats a requested runtime proof as failed unless the service is
+running, its immutable configured image exactly matches the operator-supplied
+expected image, and the requested event was observed.
+
+Runtime-event evidence remains under `dokploy_target.inspect` because the
+service accepts only code-owned allow-listed event names and returns counts, not
+log content. It is not an alternate arbitrary log-read surface; caller-selected
+log text and raw lines remain exclusively behind `target_logs.read` and exact
+context/instance authorization.
+
 The manual `Product Environment Evidence` workflow is the supported read-only
 caller for product environment read-model evidence. It uses GitHub OIDC and
 `product_environment.read` to call `GET

--- a/frontend/generated/openapi-canonical.json
+++ b/frontend/generated/openapi-canonical.json
@@ -40583,6 +40583,36 @@
             }
           },
           {
+            "in": "query",
+            "name": "service",
+            "required": false,
+            "schema": {
+              "default": "",
+              "title": "Service",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "event",
+            "required": false,
+            "schema": {
+              "default": "",
+              "title": "Event",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "expected_image",
+            "required": false,
+            "schema": {
+              "default": "",
+              "title": "Expected Image",
+              "type": "string"
+            }
+          },
+          {
             "in": "header",
             "name": "Authorization",
             "required": false,

--- a/tests/test_dokploy_runtime_evidence.py
+++ b/tests/test_dokploy_runtime_evidence.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import unittest
+from unittest.mock import patch
+
+import click
+
+from control_plane.dokploy import runtime_evidence
+
+
+class DokployRuntimeEvidenceTests(unittest.TestCase):
+    def test_expected_image_requires_immutable_digest_reference(self) -> None:
+        with self.assertRaisesRegex(click.ClickException, "immutable repository@sha256"):
+            runtime_evidence.normalize_expected_image_reference("example:latest")
+
+    def test_structured_event_requires_allow_list_membership(self) -> None:
+        with self.assertRaisesRegex(click.ClickException, "allow-listed"):
+            runtime_evidence.normalize_structured_event_name("arbitrary_event")
+
+    def test_fetch_compose_service_runtime_returns_bounded_image_and_state(self) -> None:
+        requests: list[dict[str, object]] = []
+        image_digest = "a" * 64
+        image_id = "b" * 64
+
+        def capture_request(**kwargs: object) -> object:
+            requests.append(kwargs)
+            if kwargs["path"] == "/api/docker.getContainersByAppNameMatch":
+                return [
+                    {
+                        "containerId": "worker-container",
+                        "serviceName": "launchplane-privileged-operation-workers",
+                        "state": "running",
+                        "status": "Up 5 minutes",
+                    }
+                ]
+            return {
+                "Image": f"sha256:{image_id}",
+                "Config": {
+                    "Image": f"ghcr.io/example/launchplane@sha256:{image_digest}",
+                    "Env": ["LAUNCHPLANE_DATABASE_URL=secret"],
+                },
+            }
+
+        with patch(
+            "control_plane.dokploy.api.dokploy_request",
+            side_effect=capture_request,
+        ):
+            runtime = runtime_evidence.fetch_compose_service_runtime(
+                host="https://dokploy.example.com",
+                token="secret-token",
+                compose_id="compose-123",
+                app_name="launchplane",
+                server_id="server-1",
+                service_name="launchplane-privileged-operation-workers",
+            )
+
+        self.assertEqual(
+            [request["path"] for request in requests],
+            [
+                "/api/docker.getContainersByAppNameMatch",
+                "/api/docker.getConfig",
+            ],
+        )
+        self.assertEqual(
+            requests[1]["query"],
+            {"containerId": "worker-container", "serverId": "server-1"},
+        )
+        self.assertTrue(runtime["running"])
+        self.assertTrue(runtime["image_reference_immutable"])
+        self.assertEqual(
+            runtime["immutable_image_reference"],
+            f"ghcr.io/example/launchplane@sha256:{image_digest}",
+        )
+        self.assertEqual(runtime["image_id"], f"sha256:{image_id}")
+        self.assertNotIn("Env", runtime)
+        self.assertNotIn("secret", str(runtime))
+
+    def test_fetch_compose_service_runtime_marks_mutable_reference_unverified(self) -> None:
+        with patch(
+            "control_plane.dokploy.api.dokploy_request",
+            side_effect=[
+                [
+                    {
+                        "containerId": "worker-container",
+                        "serviceName": "worker",
+                        "state": "running",
+                    }
+                ],
+                {"Image": f"sha256:{'b' * 64}", "Config": {"Image": "example:latest"}},
+            ],
+        ):
+            runtime = runtime_evidence.fetch_compose_service_runtime(
+                host="https://dokploy.example.com",
+                token="secret-token",
+                compose_id="compose-123",
+                app_name="launchplane",
+                service_name="worker",
+            )
+
+        self.assertFalse(runtime["image_reference_immutable"])
+        self.assertEqual(runtime["immutable_image_reference"], "")
+
+    def test_fetch_compose_service_runtime_selects_exact_container_name(self) -> None:
+        with patch(
+            "control_plane.dokploy.runtime_evidence.dokploy_api.dokploy_request",
+            side_effect=[
+                [
+                    {"containerId": "database", "name": "launchplane_database_1"},
+                    {"containerId": "worker", "name": "launchplane_worker_1"},
+                ],
+                [
+                    {
+                        "Image": f"sha256:{'b' * 64}",
+                        "Config": {"Image": f"example@sha256:{'a' * 64}"},
+                    }
+                ],
+            ],
+        ):
+            runtime = runtime_evidence.fetch_compose_service_runtime(
+                host="https://dokploy.example.com",
+                token="secret-token",
+                compose_id="compose-123",
+                app_name="launchplane",
+                service_name="worker",
+            )
+
+        self.assertEqual(runtime["service"], "worker")
+
+    def test_fetch_compose_service_runtime_rejects_ambiguous_service(self) -> None:
+        with (
+            patch(
+                "control_plane.dokploy.runtime_evidence.dokploy_api.dokploy_request",
+                return_value=[
+                    {"containerId": "worker-1", "name": "launchplane_worker_1"},
+                    {"containerId": "worker-2", "name": "launchplane_worker_2"},
+                ],
+            ),
+            self.assertRaisesRegex(click.ClickException, "ambiguous"),
+        ):
+            runtime_evidence.fetch_compose_service_runtime(
+                host="https://dokploy.example.com",
+                token="secret-token",
+                compose_id="compose-123",
+                app_name="launchplane",
+                service_name="worker",
+            )
+
+    def test_count_structured_log_events_requires_exact_json_event(self) -> None:
+        event_name = "privileged_operation_worker_poll_succeeded"
+
+        matching_event_count = runtime_evidence.count_structured_log_events(
+            (
+                f'2026-08-24T00:00:00Z {{"event":"{event_name}","processed":0}} trailing',
+                '{"event":"privileged_operation_worker_retry"}',
+                f"plain text mentioning {event_name}",
+                "not-json {broken",
+            ),
+            event_name=event_name,
+        )
+
+        self.assertEqual(matching_event_count, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_dokploy_runtime_evidence_workflow.py
+++ b/tests/test_dokploy_runtime_evidence_workflow.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import unittest
+from collections.abc import Mapping
+
+from tests.support.workflows import YamlValue, load_workflow
+
+
+def _mapping(value: YamlValue) -> Mapping[str, YamlValue]:
+    assert isinstance(value, dict)
+    return value
+
+
+class DokployRuntimeEvidenceWorkflowTests(unittest.TestCase):
+    def test_manual_inspect_supports_bounded_runtime_proof(self) -> None:
+        workflow = load_workflow(".github/workflows/dokploy-target-inspect.yml")
+        dispatch = _mapping(_mapping(workflow.data["on"])["workflow_dispatch"])
+        inputs = _mapping(dispatch["inputs"])
+
+        self.assertIn("service", inputs)
+        self.assertIn("event", inputs)
+        self.assertIn("expected_image", inputs)
+        self.assertEqual(workflow.permissions, {"contents": "read", "id-token": "write"})
+
+        build_request = workflow.step_named("inspect", "Build inspect request")
+        check_response = workflow.step_named("inspect", "Check inspect response")
+        upload_evidence = workflow.step_named("inspect", "Upload inspect evidence")
+        self.assertIsNotNone(build_request)
+        self.assertIsNotNone(check_response)
+        self.assertIsNotNone(upload_evidence)
+        assert build_request is not None
+        assert check_response is not None
+        assert upload_evidence is not None
+        self.assertIn('encpair("service"; $service)', build_request.run)
+        self.assertIn('encpair("event"; $event)', build_request.run)
+        self.assertIn('encpair("expected_image"; $expected_image)', build_request.run)
+        self.assertIn("runtime_evidence.proof_ready", check_response.run)
+        validate_inputs = workflow.step_named("inspect", "Validate inspect inputs")
+        self.assertIsNotNone(validate_inputs)
+        assert validate_inputs is not None
+        self.assertIn("runtime proof requires the expected immutable image", validate_inputs.run)
+        self.assertIn("runtime proof requires the structured event name", validate_inputs.run)
+        self.assertEqual(upload_evidence.data.get("if"), "always()")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_dokploy_target_runtime_inspect.py
+++ b/tests/test_dokploy_target_runtime_inspect.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+import unittest
+from typing import cast
+
+from control_plane.dokploy import api as dokploy_api
+from control_plane.dokploy_target_inspect import (
+    DokployTargetInspectRequest,
+    DokployTargetInspectStore,
+    inspect_dokploy_target,
+)
+
+_UNUSED_STORE = cast(DokployTargetInspectStore, object())
+
+
+def _fetch_target_payload(
+    *, host: str, token: str, target_type: str, target_id: str
+) -> dokploy_api.JsonObject:
+    del host, token, target_type, target_id
+    return {
+        "id": "compose-123",
+        "appName": "launchplane",
+        "serverId": "server-123",
+        "env": {"LAUNCHPLANE_DATABASE_URL": "secret"},
+    }
+
+
+def _fetch_service_runtime(
+    *,
+    host: str,
+    token: str,
+    compose_id: str,
+    app_name: str,
+    server_id: str,
+    service_name: str,
+) -> dokploy_api.JsonObject:
+    del host, token, compose_id, app_name, server_id, service_name
+    return {
+        "state": "running",
+        "status": "Up 5 minutes",
+        "running": True,
+        "configured_image": f"ghcr.io/example/launchplane@sha256:{'a' * 64}",
+        "image_id": f"sha256:{'b' * 64}",
+        "immutable_image_reference": f"ghcr.io/example/launchplane@sha256:{'a' * 64}",
+        "image_reference_immutable": True,
+    }
+
+
+def _fetch_logs(
+    *,
+    host: str,
+    token: str,
+    compose_id: str,
+    app_name: str,
+    server_id: str,
+    service_name: str,
+    line_count: int,
+    since: str,
+    search: str,
+) -> tuple[str, ...]:
+    del host, token, compose_id, app_name, server_id, service_name, line_count, since, search
+    return (
+        '{"event":"privileged_operation_worker_poll_succeeded","processed":0,"statuses":[]}',
+        "LAUNCHPLANE_DATABASE_URL=secret",
+    )
+
+
+class DokployTargetRuntimeInspectTests(unittest.TestCase):
+    def test_request_requires_service_for_runtime_event_evidence(self) -> None:
+        with self.assertRaisesRegex(ValueError, "requires a compose service"):
+            DokployTargetInspectRequest(
+                target_type="compose",
+                target_id="compose-123",
+                event="privileged_operation_worker_poll_succeeded",
+            )
+
+    def test_request_requires_complete_runtime_proof_selectors(self) -> None:
+        with self.assertRaisesRegex(ValueError, "requires a structured event"):
+            DokployTargetInspectRequest(
+                target_type="compose",
+                target_id="compose-123",
+                service="worker",
+                expected_image=f"example@sha256:{'a' * 64}",
+            )
+        with self.assertRaisesRegex(ValueError, "requires an expected image"):
+            DokployTargetInspectRequest(
+                target_type="compose",
+                target_id="compose-123",
+                service="worker",
+                event="privileged_operation_worker_poll_succeeded",
+            )
+
+    def test_explicit_compose_target_returns_bounded_runtime_evidence(self) -> None:
+        result = inspect_dokploy_target(
+            record_store=_UNUSED_STORE,
+            host="https://dokploy.example.invalid",
+            token="token",
+            request=DokployTargetInspectRequest(
+                target_type="compose",
+                target_id="compose-123",
+                service="launchplane-privileged-operation-workers",
+                event="privileged_operation_worker_poll_succeeded",
+                expected_image=f"ghcr.io/example/launchplane@sha256:{'a' * 64}",
+            ),
+            fetch_target_payload=_fetch_target_payload,
+            fetch_compose_service_runtime=_fetch_service_runtime,
+            fetch_compose_logs=_fetch_logs,
+        )
+
+        runtime_evidence = result["runtime_evidence"]
+        self.assertIsInstance(runtime_evidence, dict)
+        assert isinstance(runtime_evidence, dict)
+        structured_event = runtime_evidence["structured_event"]
+        self.assertIsInstance(structured_event, dict)
+        assert isinstance(structured_event, dict)
+        self.assertTrue(runtime_evidence["running"])
+        self.assertTrue(runtime_evidence["image_reference_immutable"])
+        self.assertTrue(runtime_evidence["image_matches_expected"])
+        self.assertTrue(runtime_evidence["proof_ready"])
+        self.assertEqual(structured_event["matching_line_count"], 1)
+        self.assertEqual(structured_event["candidate_line_count"], 2)
+        self.assertTrue(structured_event["observed"])
+        self.assertNotIn("LAUNCHPLANE_DATABASE_URL", str(runtime_evidence))
+        self.assertNotIn("secret", str(runtime_evidence))
+
+    def test_expected_image_mismatch_is_not_proof_ready(self) -> None:
+        result = inspect_dokploy_target(
+            record_store=_UNUSED_STORE,
+            host="https://dokploy.example.invalid",
+            token="token",
+            request=DokployTargetInspectRequest(
+                target_type="compose",
+                target_id="compose-123",
+                service="launchplane-privileged-operation-workers",
+                event="privileged_operation_worker_poll_succeeded",
+                expected_image=f"ghcr.io/example/launchplane@sha256:{'c' * 64}",
+            ),
+            fetch_target_payload=_fetch_target_payload,
+            fetch_compose_service_runtime=_fetch_service_runtime,
+            fetch_compose_logs=_fetch_logs,
+        )
+
+        runtime_evidence = result["runtime_evidence"]
+        assert isinstance(runtime_evidence, dict)
+        self.assertFalse(runtime_evidence["image_matches_expected"])
+        self.assertFalse(runtime_evidence["proof_ready"])
+
+    def test_non_running_service_is_not_proof_ready(self) -> None:
+        def fetch_stopped_runtime(**kwargs: str) -> dokploy_api.JsonObject:
+            del kwargs
+            runtime = _fetch_service_runtime(
+                host="",
+                token="",
+                compose_id="",
+                app_name="",
+                server_id="",
+                service_name="",
+            )
+            runtime["state"] = "exited"
+            runtime["running"] = False
+            return runtime
+
+        result = inspect_dokploy_target(
+            record_store=_UNUSED_STORE,
+            host="https://dokploy.example.invalid",
+            token="token",
+            request=DokployTargetInspectRequest(
+                target_type="compose",
+                target_id="compose-123",
+                service="launchplane-privileged-operation-workers",
+                event="privileged_operation_worker_poll_succeeded",
+                expected_image=f"ghcr.io/example/launchplane@sha256:{'a' * 64}",
+            ),
+            fetch_target_payload=_fetch_target_payload,
+            fetch_compose_service_runtime=fetch_stopped_runtime,
+            fetch_compose_logs=_fetch_logs,
+        )
+
+        runtime_evidence = result["runtime_evidence"]
+        assert isinstance(runtime_evidence, dict)
+        self.assertFalse(runtime_evidence["running"])
+        self.assertFalse(runtime_evidence["proof_ready"])
+
+    def test_application_target_rejects_runtime_service_evidence(self) -> None:
+        with self.assertRaisesRegex(ValueError, "supports compose targets only"):
+            inspect_dokploy_target(
+                record_store=_UNUSED_STORE,
+                host="https://dokploy.example.invalid",
+                token="token",
+                request=DokployTargetInspectRequest(
+                    target_type="application",
+                    target_id="application-123",
+                    service="worker",
+                    event="privileged_operation_worker_poll_succeeded",
+                    expected_image=f"example@sha256:{'a' * 64}",
+                ),
+                fetch_target_payload=_fetch_target_payload,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_http_dokploy_runtime_evidence.py
+++ b/tests/test_http_dokploy_runtime_evidence.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+from click import ClickException
+
+from control_plane.http_app import create_launchplane_fastapi_app
+from control_plane.storage.postgres import PostgresRecordStore
+from tests.http_app_test_support import _asgi_get, _record_read_policy
+from tests.support.auth import identity, StubVerifier
+from tests.support.stores import sqlite_database_url
+
+
+class FastApiDokployRuntimeEvidenceTests(unittest.IsolatedAsyncioTestCase):
+    async def test_dokploy_target_inspect_returns_runtime_proof(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = sqlite_database_url(root / "launchplane.sqlite3")
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            with (
+                patch(
+                    "control_plane.http_routes.drivers.dokploy_source.read_dokploy_config",
+                    return_value=("https://dokploy.example.invalid", "token"),
+                ),
+                patch(
+                    "control_plane.dokploy_target_inspect.dokploy_api.fetch_dokploy_target_payload",
+                    return_value={
+                        "id": "compose-123",
+                        "appName": "launchplane",
+                        "serverId": "server-123",
+                    },
+                ),
+                patch(
+                    "control_plane.dokploy_target_inspect.dokploy_runtime_evidence.fetch_compose_service_runtime",
+                    return_value={
+                        "state": "running",
+                        "status": "Up 5 minutes",
+                        "running": True,
+                        "configured_image": f"ghcr.io/example/launchplane@sha256:{'a' * 64}",
+                        "image_id": f"sha256:{'b' * 64}",
+                        "immutable_image_reference": (
+                            f"ghcr.io/example/launchplane@sha256:{'a' * 64}"
+                        ),
+                        "image_reference_immutable": True,
+                    },
+                ),
+                patch(
+                    "control_plane.dokploy_target_inspect.dokploy_api.fetch_dokploy_compose_logs",
+                    return_value=(
+                        '{"event":"privileged_operation_worker_poll_succeeded",'
+                        '"processed":0,"statuses":[]}',
+                    ),
+                ),
+            ):
+                app = create_launchplane_fastapi_app(
+                    verifier=StubVerifier(identity()),
+                    authz_policy=_record_read_policy(
+                        action="dokploy_target.inspect",
+                        context="launchplane",
+                    ),
+                    database_url=database_url,
+                    record_store_factory=lambda: store,
+                    control_plane_root_path=root,
+                )
+                response = await _asgi_get(
+                    app,
+                    "/v1/dokploy-targets/inspect"
+                    "?target_type=compose"
+                    "&target_id=compose-123"
+                    "&service=launchplane-privileged-operation-workers"
+                    "&event=privileged_operation_worker_poll_succeeded"
+                    f"&expected_image=ghcr.io/example/launchplane@sha256:{'a' * 64}",
+                    headers={"Authorization": "Bearer valid-token"},
+                )
+            store.close()
+
+        self.assertEqual(response.status_code, 200)
+        runtime_evidence = response.json()["inspect"]["runtime_evidence"]
+        self.assertTrue(runtime_evidence["proof_ready"])
+        self.assertTrue(runtime_evidence["structured_event"]["observed"])
+
+    async def test_dokploy_target_inspect_redacts_provider_runtime_failure(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = sqlite_database_url(root / "launchplane.sqlite3")
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            with (
+                patch(
+                    "control_plane.http_routes.drivers.dokploy_source.read_dokploy_config",
+                    return_value=("https://dokploy.example.invalid", "token"),
+                ),
+                patch(
+                    "control_plane.dokploy_target_inspect.dokploy_api.fetch_dokploy_target_payload",
+                    return_value={"id": "compose-123", "appName": "launchplane"},
+                ),
+                patch(
+                    "control_plane.dokploy_target_inspect.dokploy_runtime_evidence.fetch_compose_service_runtime",
+                    side_effect=ClickException("provider TOKEN=secret"),
+                ),
+            ):
+                app = create_launchplane_fastapi_app(
+                    verifier=StubVerifier(identity()),
+                    authz_policy=_record_read_policy(
+                        action="dokploy_target.inspect",
+                        context="launchplane",
+                    ),
+                    database_url=database_url,
+                    record_store_factory=lambda: store,
+                    control_plane_root_path=root,
+                )
+                response = await _asgi_get(
+                    app,
+                    "/v1/dokploy-targets/inspect"
+                    "?target_type=compose&target_id=compose-123&service=worker"
+                    "&event=privileged_operation_worker_poll_succeeded"
+                    f"&expected_image=example@sha256:{'a' * 64}",
+                    headers={"Authorization": "Bearer valid-token"},
+                )
+            store.close()
+
+        self.assertEqual(response.status_code, 503)
+        payload = response.json()
+        self.assertEqual(payload["error"]["code"], "dokploy_target_inspect_unavailable")
+        self.assertNotIn("secret", str(payload))
+        self.assertNotIn("TOKEN", str(payload))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- extend the existing read-only Dokploy target inspect surface with bounded compose-service runtime evidence
- require an exact immutable expected image and the allow-listed privileged-worker successful-poll event before `proof_ready`
- return only redacted/bounded state, image identity, match booleans, and event counts; never raw logs, container IDs, config, or env values
- update the protected operator workflow, OpenAPI artifact, tests, and Phase 2 runbooks

## Validation
- `uv run --extra dev launchplane ci unittest-shard local` — 3,063 targets, 12/12 shards passed
- `uv run --extra dev mypy control_plane tests` — 758 files passed
- `pnpm --dir frontend validate` — 64 tests, typecheck, OpenAPI drift, production build passed
- changed-file Ruff check/format passed
- config-authority audit status `ok`
- JetBrains changed-files closeout passed with zero actionable findings
- exact-head Opus and Gemini reviews approved without blocking or important findings

## Safety
- read-only provider calls only; no Dokploy or Launchplane mutation
- no new authorization grant or policy change
- no raw logs, browser credentials, direct DB access, host access, or secret values

Refs #2219
