### PR TITLE
Expose bounded Dokploy evidence failure stages

### DIFF
--- a/control_plane/dokploy/runtime_evidence.py
+++ b/control_plane/dokploy/runtime_evidence.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import re
+from typing import Literal
 
 import click
 
@@ -12,6 +13,21 @@ _IMAGE_ID_PATTERN = re.compile(r"^sha256:[a-f0-9]{64}$")
 _IMMUTABLE_IMAGE_REFERENCE_PATTERN = re.compile(r"^[^\s@]+@sha256:[a-f0-9]{64}$")
 _MAX_RUNTIME_TEXT_LENGTH = 500
 _ALLOWED_STRUCTURED_EVENTS = frozenset({"privileged_operation_worker_poll_succeeded"})
+type DokployEvidenceProviderOperation = Literal[
+    "provider-config",
+    "target-inspect",
+    "container-list",
+    "service-select",
+    "container-config",
+    "image-identity",
+    "runtime-log-read",
+]
+
+
+class DokployEvidenceProviderError(RuntimeError):
+    def __init__(self, operation: DokployEvidenceProviderOperation) -> None:
+        self.operation = operation
+        super().__init__(operation)
 
 
 def normalize_structured_event_name(raw_event_name: str) -> str:
@@ -51,16 +67,17 @@ def fetch_compose_service_runtime(
 ) -> dokploy_api.JsonObject:
     normalized_compose_id = compose_id.strip()
     if not normalized_compose_id:
-        raise click.ClickException("Dokploy compose runtime evidence requires a compose id.")
+        raise DokployEvidenceProviderError("target-inspect")
     normalized_app_name = app_name.strip()
     if not normalized_app_name:
-        raise click.ClickException(
-            "Dokploy compose runtime evidence requires tracked application metadata."
-        )
+        raise DokployEvidenceProviderError("target-inspect")
     normalized_server_id = server_id.strip()
-    normalized_service_name = dokploy_api.normalize_dokploy_compose_service_name(service_name)
+    try:
+        normalized_service_name = dokploy_api.normalize_dokploy_compose_service_name(service_name)
+    except click.ClickException as error:
+        raise DokployEvidenceProviderError("service-select") from error
     if not normalized_service_name:
-        raise click.ClickException("Dokploy compose runtime evidence requires a service name.")
+        raise DokployEvidenceProviderError("service-select")
 
     container_query: dict[str, str | int] = {
         "appName": normalized_app_name,
@@ -68,50 +85,53 @@ def fetch_compose_service_runtime(
     }
     if normalized_server_id:
         container_query["serverId"] = normalized_server_id
-    containers_payload = dokploy_api.dokploy_request(
-        host=host,
-        token=token,
-        path="/api/docker.getContainersByAppNameMatch",
-        query=container_query,
-    )
+    try:
+        containers_payload = dokploy_api.dokploy_request(
+            host=host,
+            token=token,
+            path="/api/docker.getContainersByAppNameMatch",
+            query=container_query,
+        )
+    except click.ClickException as error:
+        raise DokployEvidenceProviderError("container-list") from error
     if not isinstance(containers_payload, list):
-        raise click.ClickException("Dokploy returned an invalid compose container list.")
-    selected_container = dokploy_api.select_dokploy_compose_container(
-        dokploy_api.collect_dokploy_object_items(containers_payload),
-        app_name=normalized_app_name,
-        service_name=normalized_service_name,
-    )
+        raise DokployEvidenceProviderError("container-list")
+    try:
+        selected_container = dokploy_api.select_dokploy_compose_container(
+            dokploy_api.collect_dokploy_object_items(containers_payload),
+            app_name=normalized_app_name,
+            service_name=normalized_service_name,
+        )
+    except click.ClickException as error:
+        raise DokployEvidenceProviderError("service-select") from error
     container_id = str(selected_container.get("containerId") or "").strip()
     if not container_id:
-        raise click.ClickException(
-            f"Dokploy compose service {normalized_service_name!r} has no container id."
-        )
+        raise DokployEvidenceProviderError("service-select")
 
     config_query: dict[str, str | int] = {"containerId": container_id}
     if normalized_server_id:
         config_query["serverId"] = normalized_server_id
-    config_payload = dokploy_api.dokploy_request(
-        host=host,
-        token=token,
-        path="/api/docker.getConfig",
-        query=config_query,
-    )
+    try:
+        config_payload = dokploy_api.dokploy_request(
+            host=host,
+            token=token,
+            path="/api/docker.getConfig",
+            query=config_query,
+        )
+    except click.ClickException as error:
+        raise DokployEvidenceProviderError("container-config") from error
     container_config = _normalize_container_config(config_payload)
     if container_config is None:
-        raise click.ClickException("Dokploy returned invalid compose container configuration.")
+        raise DokployEvidenceProviderError("container-config")
     raw_config = container_config.get("Config")
     configured_image = (
         str(raw_config.get("Image") or "").strip() if isinstance(raw_config, dict) else ""
     )
     if not configured_image:
-        raise click.ClickException(
-            f"Dokploy compose service {normalized_service_name!r} has no configured image."
-        )
+        raise DokployEvidenceProviderError("image-identity")
     image_id = str(container_config.get("Image") or "").strip().lower()
     if not _IMAGE_ID_PATTERN.fullmatch(image_id):
-        raise click.ClickException(
-            f"Dokploy compose service {normalized_service_name!r} has no immutable image id."
-        )
+        raise DokployEvidenceProviderError("image-identity")
     state = dokploy_api.redact_dokploy_log_line(
         str(selected_container.get("state") or selected_container.get("State") or "")
     )

--- a/control_plane/dokploy_target_inspect.py
+++ b/control_plane/dokploy_target_inspect.py
@@ -161,12 +161,15 @@ def inspect_dokploy_target(
         target_id = target_id_record.target_id
 
     payload_fetcher = fetch_target_payload or dokploy_api.fetch_dokploy_target_payload
-    provider_payload = payload_fetcher(
-        host=host,
-        token=token,
-        target_type=target_type,
-        target_id=target_id,
-    )
+    try:
+        provider_payload = payload_fetcher(
+            host=host,
+            token=token,
+            target_type=target_type,
+            target_id=target_id,
+        )
+    except click.ClickException as error:
+        raise dokploy_runtime_evidence.DokployEvidenceProviderError("target-inspect") from error
     provider_summary = summarize_dokploy_target_payload(
         target_type=target_type,
         target_id=target_id,
@@ -196,17 +199,22 @@ def inspect_dokploy_target(
             service_name=request.service,
         )
         logs_fetcher = fetch_compose_logs or dokploy_api.fetch_dokploy_compose_logs
-        logs = logs_fetcher(
-            host=host,
-            token=token,
-            compose_id=target_id,
-            app_name=app_name,
-            server_id=server_id,
-            service_name=request.service,
-            line_count=_RUNTIME_EVIDENCE_LOG_LINE_COUNT,
-            since=_RUNTIME_EVIDENCE_LOG_SINCE,
-            search=request.event,
-        )
+        try:
+            logs = logs_fetcher(
+                host=host,
+                token=token,
+                compose_id=target_id,
+                app_name=app_name,
+                server_id=server_id,
+                service_name=request.service,
+                line_count=_RUNTIME_EVIDENCE_LOG_LINE_COUNT,
+                since=_RUNTIME_EVIDENCE_LOG_SINCE,
+                search=request.event,
+            )
+        except click.ClickException as error:
+            raise dokploy_runtime_evidence.DokployEvidenceProviderError(
+                "runtime-log-read"
+            ) from error
         matching_event_count = dokploy_runtime_evidence.count_structured_log_events(
             logs,
             event_name=request.event,

--- a/control_plane/http_routes/drivers.py
+++ b/control_plane/http_routes/drivers.py
@@ -22,6 +22,7 @@ from control_plane.contracts.odoo_stable_target_replacement_operation import (
     OdooStableTargetReplacementOperationRecord,
 )
 from control_plane.dokploy import api as dokploy_api
+from control_plane.dokploy import runtime_evidence as dokploy_runtime_evidence
 from control_plane.dokploy import source as dokploy_source
 from control_plane.dokploy_target_inspect import (
     DokployTargetInspectRequest,
@@ -845,10 +846,15 @@ def register_dokploy_target_inspect_read_routes(
                     "expected_image": expected_image,
                 }
             )
-            host, token = dokploy_source.read_dokploy_config(
-                control_plane_root=dependencies.control_plane_root,
-                database_url=dependencies.database_url,
-            )
+            try:
+                host, token = dokploy_source.read_dokploy_config(
+                    control_plane_root=dependencies.control_plane_root,
+                    database_url=dependencies.database_url,
+                )
+            except click.ClickException as error:
+                raise dokploy_runtime_evidence.DokployEvidenceProviderError(
+                    "provider-config"
+                ) from error
             inspect_result = inspect_dokploy_target(
                 record_store=inspect_store,
                 host=host,
@@ -869,12 +875,14 @@ def register_dokploy_target_inspect_read_routes(
                 code="not_found",
                 message=str(error),
             ) from error
-        except click.ClickException as error:
+        except dokploy_runtime_evidence.DokployEvidenceProviderError as error:
             raise common.http_error(
                 status_code=503,
                 trace_id=trace_id,
                 code="dokploy_target_inspect_unavailable",
-                message="Dokploy target inspect evidence is unavailable from the provider.",
+                message=(
+                    f"Dokploy target inspect evidence is unavailable during {error.operation}."
+                ),
             ) from error
         return DokployTargetInspectResponse(trace_id=trace_id, inspect=inspect_result)
 

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -2233,6 +2233,11 @@ manual workflow treats a requested runtime proof as failed unless the service is
 running, its immutable configured image exactly matches the operator-supplied
 expected image, and the requested event was observed.
 
+Provider failures expose only a bounded operation stage such as
+`provider-config`, `target-inspect`, `container-list`, `service-select`,
+`container-config`, `image-identity`, or `runtime-log-read`; raw provider
+messages remain excluded.
+
 Runtime-event evidence remains under `dokploy_target.inspect` because the
 service accepts only code-owned allow-listed event names and returns counts, not
 log content. It is not an alternate arbitrary log-read surface; caller-selected

--- a/tests/test_dokploy_runtime_evidence.py
+++ b/tests/test_dokploy_runtime_evidence.py
@@ -135,13 +135,92 @@ class DokployRuntimeEvidenceTests(unittest.TestCase):
                     {"containerId": "worker-2", "name": "launchplane_worker_2"},
                 ],
             ),
-            self.assertRaisesRegex(click.ClickException, "ambiguous"),
+            self.assertRaisesRegex(
+                runtime_evidence.DokployEvidenceProviderError,
+                "service-select",
+            ),
         ):
             runtime_evidence.fetch_compose_service_runtime(
                 host="https://dokploy.example.com",
                 token="secret-token",
                 compose_id="compose-123",
                 app_name="launchplane",
+                service_name="worker",
+            )
+
+    def test_fetch_compose_service_runtime_identifies_config_stage(self) -> None:
+        with (
+            patch(
+                "control_plane.dokploy.runtime_evidence.dokploy_api.dokploy_request",
+                side_effect=[
+                    [{"containerId": "worker", "serviceName": "worker"}],
+                    click.ClickException("provider secret detail"),
+                ],
+            ),
+            self.assertRaisesRegex(
+                runtime_evidence.DokployEvidenceProviderError,
+                "container-config",
+            ),
+        ):
+            runtime_evidence.fetch_compose_service_runtime(
+                host="https://dokploy.example.com",
+                token="secret-token",
+                compose_id="compose-123",
+                app_name="launchplane",
+                service_name="worker",
+            )
+
+    def test_fetch_compose_service_runtime_identifies_container_list_stage(self) -> None:
+        with (
+            patch(
+                "control_plane.dokploy.runtime_evidence.dokploy_api.dokploy_request",
+                return_value={"unexpected": "shape"},
+            ),
+            self.assertRaisesRegex(
+                runtime_evidence.DokployEvidenceProviderError,
+                "container-list",
+            ),
+        ):
+            runtime_evidence.fetch_compose_service_runtime(
+                host="https://dokploy.example.com",
+                token="secret-token",
+                compose_id="compose-123",
+                app_name="launchplane",
+                service_name="worker",
+            )
+
+    def test_fetch_compose_service_runtime_identifies_image_stage(self) -> None:
+        with (
+            patch(
+                "control_plane.dokploy.runtime_evidence.dokploy_api.dokploy_request",
+                side_effect=[
+                    [{"containerId": "worker", "serviceName": "worker"}],
+                    {"Image": "", "Config": {"Image": "example:latest"}},
+                ],
+            ),
+            self.assertRaisesRegex(
+                runtime_evidence.DokployEvidenceProviderError,
+                "image-identity",
+            ),
+        ):
+            runtime_evidence.fetch_compose_service_runtime(
+                host="https://dokploy.example.com",
+                token="secret-token",
+                compose_id="compose-123",
+                app_name="launchplane",
+                service_name="worker",
+            )
+
+    def test_fetch_compose_service_runtime_identifies_target_stage(self) -> None:
+        with self.assertRaisesRegex(
+            runtime_evidence.DokployEvidenceProviderError,
+            "target-inspect",
+        ):
+            runtime_evidence.fetch_compose_service_runtime(
+                host="https://dokploy.example.com",
+                token="secret-token",
+                compose_id="compose-123",
+                app_name="",
                 service_name="worker",
             )
 

--- a/tests/test_dokploy_target_runtime_inspect.py
+++ b/tests/test_dokploy_target_runtime_inspect.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 import unittest
 from typing import cast
 
+import click
+
 from control_plane.dokploy import api as dokploy_api
+from control_plane.dokploy import runtime_evidence as dokploy_runtime_evidence
 from control_plane.dokploy_target_inspect import (
     DokployTargetInspectRequest,
     DokployTargetInspectStore,
@@ -66,6 +69,26 @@ def _fetch_logs(
 
 
 class DokployTargetRuntimeInspectTests(unittest.TestCase):
+    def test_target_fetch_failure_identifies_target_stage(self) -> None:
+        def fetch_target_failure(**kwargs: str) -> dokploy_api.JsonObject:
+            del kwargs
+            raise click.ClickException("provider TOKEN=secret")
+
+        with self.assertRaisesRegex(
+            dokploy_runtime_evidence.DokployEvidenceProviderError,
+            "target-inspect",
+        ):
+            inspect_dokploy_target(
+                record_store=_UNUSED_STORE,
+                host="https://dokploy.example.invalid",
+                token="token",
+                request=DokployTargetInspectRequest(
+                    target_type="compose",
+                    target_id="compose-123",
+                ),
+                fetch_target_payload=fetch_target_failure,
+            )
+
     def test_request_requires_service_for_runtime_event_evidence(self) -> None:
         with self.assertRaisesRegex(ValueError, "requires a compose service"):
             DokployTargetInspectRequest(
@@ -195,6 +218,31 @@ class DokployTargetRuntimeInspectTests(unittest.TestCase):
                     expected_image=f"example@sha256:{'a' * 64}",
                 ),
                 fetch_target_payload=_fetch_target_payload,
+            )
+
+    def test_log_fetch_failure_identifies_runtime_log_stage(self) -> None:
+        def fetch_log_failure(**kwargs: str | int) -> tuple[str, ...]:
+            del kwargs
+            raise click.ClickException("provider TOKEN=secret")
+
+        with self.assertRaisesRegex(
+            dokploy_runtime_evidence.DokployEvidenceProviderError,
+            "runtime-log-read",
+        ):
+            inspect_dokploy_target(
+                record_store=_UNUSED_STORE,
+                host="https://dokploy.example.invalid",
+                token="token",
+                request=DokployTargetInspectRequest(
+                    target_type="compose",
+                    target_id="compose-123",
+                    service="launchplane-privileged-operation-workers",
+                    event="privileged_operation_worker_poll_succeeded",
+                    expected_image=f"ghcr.io/example/launchplane@sha256:{'a' * 64}",
+                ),
+                fetch_target_payload=_fetch_target_payload,
+                fetch_compose_service_runtime=_fetch_service_runtime,
+                fetch_compose_logs=fetch_log_failure,
             )
 
 

--- a/tests/test_http_dokploy_runtime_evidence.py
+++ b/tests/test_http_dokploy_runtime_evidence.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest.mock import patch
 
-from click import ClickException
+import click
 
 from control_plane.http_app import create_launchplane_fastapi_app
 from control_plane.storage.postgres import PostgresRecordStore
@@ -79,9 +79,9 @@ class FastApiDokployRuntimeEvidenceTests(unittest.IsolatedAsyncioTestCase):
             store.close()
 
         self.assertEqual(response.status_code, 200)
-        runtime_evidence = response.json()["inspect"]["runtime_evidence"]
-        self.assertTrue(runtime_evidence["proof_ready"])
-        self.assertTrue(runtime_evidence["structured_event"]["observed"])
+        runtime_payload = response.json()["inspect"]["runtime_evidence"]
+        self.assertTrue(runtime_payload["proof_ready"])
+        self.assertTrue(runtime_payload["structured_event"]["observed"])
 
     async def test_dokploy_target_inspect_redacts_provider_runtime_failure(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
@@ -99,8 +99,8 @@ class FastApiDokployRuntimeEvidenceTests(unittest.IsolatedAsyncioTestCase):
                     return_value={"id": "compose-123", "appName": "launchplane"},
                 ),
                 patch(
-                    "control_plane.dokploy_target_inspect.dokploy_runtime_evidence.fetch_compose_service_runtime",
-                    side_effect=ClickException("provider TOKEN=secret"),
+                    "control_plane.dokploy.runtime_evidence.dokploy_api.dokploy_request",
+                    side_effect=click.ClickException("provider TOKEN=secret"),
                 ),
             ):
                 app = create_launchplane_fastapi_app(
@@ -126,6 +126,40 @@ class FastApiDokployRuntimeEvidenceTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(response.status_code, 503)
         payload = response.json()
         self.assertEqual(payload["error"]["code"], "dokploy_target_inspect_unavailable")
+        self.assertIn("container-list", payload["error"]["message"])
+        self.assertNotIn("secret", str(payload))
+        self.assertNotIn("TOKEN", str(payload))
+
+    async def test_dokploy_target_inspect_identifies_provider_config_stage(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = sqlite_database_url(root / "launchplane.sqlite3")
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            with patch(
+                "control_plane.http_routes.drivers.dokploy_source.read_dokploy_config",
+                side_effect=click.ClickException("provider TOKEN=secret"),
+            ):
+                app = create_launchplane_fastapi_app(
+                    verifier=StubVerifier(identity()),
+                    authz_policy=_record_read_policy(
+                        action="dokploy_target.inspect",
+                        context="launchplane",
+                    ),
+                    database_url=database_url,
+                    record_store_factory=lambda: store,
+                    control_plane_root_path=root,
+                )
+                response = await _asgi_get(
+                    app,
+                    "/v1/dokploy-targets/inspect?target_type=compose&target_id=compose-123",
+                    headers={"Authorization": "Bearer valid-token"},
+                )
+            store.close()
+
+        self.assertEqual(response.status_code, 503)
+        payload = response.json()
+        self.assertIn("provider-config", payload["error"]["message"])
         self.assertNotIn("secret", str(payload))
         self.assertNotIn("TOKEN", str(payload))
 


### PR DESCRIPTION
## Summary
- replace the generic runtime-evidence provider 503 with a bounded seven-stage operation code
- preserve raw provider exception details only in the chained cause, never in the HTTP payload
- cover provider config, target inspect, container list/select/config, image identity, and runtime log failures

## Validation
- `uv run --extra dev launchplane ci unittest-shard local` — 3,063 targets, 12/12 shards passed
- `uv run --extra dev mypy control_plane tests` — 758 files passed
- focused runtime evidence tests — 24 tests passed
- changed-file Ruff check/format passed
- JetBrains changed-files closeout passed
- exact-head Opus and Gemini reviews approved without blocking or important findings

## Live Context
The first deployed runtime proof call on run `32684885828` failed closed with the intentionally generic 503. This patch adds only a redacted operation stage so the next read can identify the provider operation without exposing provider messages or secret-like content.

Refs #2219
