### PR TITLE
Read worker logs from the selected container

### DIFF
--- a/control_plane/dokploy/runtime_evidence.py
+++ b/control_plane/dokploy/runtime_evidence.py
@@ -146,6 +146,7 @@ def fetch_compose_service_runtime(
     )
     return {
         "compose_id": normalized_compose_id,
+        "container_id": container_id,
         "service": normalized_service_name,
         "state": state.strip()[:_MAX_RUNTIME_TEXT_LENGTH],
         "status": status.strip()[:_MAX_RUNTIME_TEXT_LENGTH],
@@ -155,6 +156,37 @@ def fetch_compose_service_runtime(
         "immutable_image_reference": immutable_image_reference,
         "image_reference_immutable": bool(immutable_image_reference),
     }
+
+
+def fetch_compose_container_logs(
+    *,
+    host: str,
+    token: str,
+    compose_id: str,
+    container_id: str,
+    line_count: int,
+) -> tuple[str, ...]:
+    normalized_compose_id = compose_id.strip()
+    normalized_container_id = container_id.strip()
+    if not normalized_compose_id or not normalized_container_id:
+        raise DokployEvidenceProviderError("runtime-log-read")
+    normalized_line_count = dokploy_api.normalize_dokploy_log_line_count(line_count)
+    try:
+        payload = dokploy_api.dokploy_request(
+            host=host,
+            token=token,
+            path="/api/compose.readLogs",
+            query={
+                "composeId": normalized_compose_id,
+                "containerId": normalized_container_id,
+                "tail": normalized_line_count,
+                "since": "1d",
+            },
+        )
+    except click.ClickException as error:
+        raise DokployEvidenceProviderError("runtime-log-read") from error
+    lines = dokploy_api.normalize_dokploy_log_payload(payload)
+    return lines[-normalized_line_count:]
 
 
 def count_structured_log_events(lines: tuple[str, ...], *, event_name: str) -> int:

--- a/control_plane/dokploy_target_inspect.py
+++ b/control_plane/dokploy_target_inspect.py
@@ -14,7 +14,6 @@ from control_plane.dokploy import runtime_evidence as dokploy_runtime_evidence
 
 DokployTargetType = Literal["application", "compose"]
 _RUNTIME_EVIDENCE_LOG_LINE_COUNT = dokploy_api.MAX_DOKPLOY_LOG_LINE_COUNT
-_RUNTIME_EVIDENCE_LOG_SINCE = "1d"
 
 
 class FetchDokployTargetPayload(Protocol):
@@ -43,12 +42,8 @@ class FetchDokployComposeLogs(Protocol):
         host: str,
         token: str,
         compose_id: str,
-        app_name: str,
-        server_id: str,
-        service_name: str,
+        container_id: str,
         line_count: int,
-        since: str,
-        search: str,
     ) -> tuple[str, ...]: ...
 
 
@@ -198,18 +193,17 @@ def inspect_dokploy_target(
             server_id=server_id,
             service_name=request.service,
         )
-        logs_fetcher = fetch_compose_logs or dokploy_api.fetch_dokploy_compose_logs
+        container_id = str(runtime_payload.get("container_id") or "").strip()
+        if not container_id:
+            raise dokploy_runtime_evidence.DokployEvidenceProviderError("service-select")
+        logs_fetcher = fetch_compose_logs or dokploy_runtime_evidence.fetch_compose_container_logs
         try:
             logs = logs_fetcher(
                 host=host,
                 token=token,
                 compose_id=target_id,
-                app_name=app_name,
-                server_id=server_id,
-                service_name=request.service,
+                container_id=container_id,
                 line_count=_RUNTIME_EVIDENCE_LOG_LINE_COUNT,
-                since=_RUNTIME_EVIDENCE_LOG_SINCE,
-                search=request.event,
             )
         except click.ClickException as error:
             raise dokploy_runtime_evidence.DokployEvidenceProviderError(
@@ -357,15 +351,7 @@ def _domain_summaries(payload: Mapping[str, object]) -> list[dict[str, object]]:
 
 
 def _present(value: object) -> bool:
-    if value is None:
-        return False
-    if value == "":
-        return False
-    if value == []:
-        return False
-    if value == {}:
-        return False
-    return True
+    return value not in (None, "", [], {})
 
 
 def _object_field(payload: Mapping[str, object], key: str) -> dict[str, object]:
@@ -378,7 +364,7 @@ def _object_field(payload: Mapping[str, object], key: str) -> dict[str, object]:
 def _string_field(payload: Mapping[str, object], *keys: str) -> str:
     for key in keys:
         value = payload.get(key)
-        if value is None:
+        if not isinstance(value, (str, int, float, bool)):
             continue
         normalized_value = str(value).strip()
         if normalized_value:

--- a/tests/test_dokploy_runtime_evidence.py
+++ b/tests/test_dokploy_runtime_evidence.py
@@ -239,6 +239,50 @@ class DokployRuntimeEvidenceTests(unittest.TestCase):
 
         self.assertEqual(matching_event_count, 1)
 
+    def test_fetch_compose_container_logs_uses_selected_container_without_search(self) -> None:
+        requests: list[dict[str, object]] = []
+
+        def capture_request(**kwargs: object) -> object:
+            requests.append(kwargs)
+            return {
+                "logs": (
+                    '{"event":"privileged_operation_worker_poll_succeeded"}\nSERVICE_TOKEN=secret'
+                )
+            }
+
+        with patch(
+            "control_plane.dokploy.runtime_evidence.dokploy_api.dokploy_request",
+            side_effect=capture_request,
+        ):
+            lines = runtime_evidence.fetch_compose_container_logs(
+                host="https://dokploy.example.com",
+                token="secret-token",
+                compose_id="compose-123",
+                container_id="worker-container",
+                line_count=200,
+            )
+
+        self.assertEqual(requests[0]["path"], "/api/compose.readLogs")
+        self.assertEqual(
+            requests[0]["query"],
+            {
+                "composeId": "compose-123",
+                "containerId": "worker-container",
+                "tail": 200,
+                "since": "1d",
+            },
+        )
+        query = requests[0]["query"]
+        assert isinstance(query, dict)
+        self.assertNotIn("search", query)
+        self.assertEqual(
+            lines,
+            (
+                '{"event":"privileged_operation_worker_poll_succeeded"}',
+                "SERVICE_TOKEN=[redacted]",
+            ),
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_dokploy_target_runtime_inspect.py
+++ b/tests/test_dokploy_target_runtime_inspect.py
@@ -39,6 +39,7 @@ def _fetch_service_runtime(
 ) -> dokploy_api.JsonObject:
     del host, token, compose_id, app_name, server_id, service_name
     return {
+        "container_id": "worker-container",
         "state": "running",
         "status": "Up 5 minutes",
         "running": True,
@@ -54,14 +55,10 @@ def _fetch_logs(
     host: str,
     token: str,
     compose_id: str,
-    app_name: str,
-    server_id: str,
-    service_name: str,
+    container_id: str,
     line_count: int,
-    since: str,
-    search: str,
 ) -> tuple[str, ...]:
-    del host, token, compose_id, app_name, server_id, service_name, line_count, since, search
+    del host, token, compose_id, container_id, line_count
     return (
         '{"event":"privileged_operation_worker_poll_succeeded","processed":0,"statuses":[]}',
         "LAUNCHPLANE_DATABASE_URL=secret",

--- a/tests/test_http_dokploy_runtime_evidence.py
+++ b/tests/test_http_dokploy_runtime_evidence.py
@@ -37,6 +37,7 @@ class FastApiDokployRuntimeEvidenceTests(unittest.IsolatedAsyncioTestCase):
                 patch(
                     "control_plane.dokploy_target_inspect.dokploy_runtime_evidence.fetch_compose_service_runtime",
                     return_value={
+                        "container_id": "worker-container",
                         "state": "running",
                         "status": "Up 5 minutes",
                         "running": True,
@@ -49,7 +50,7 @@ class FastApiDokployRuntimeEvidenceTests(unittest.IsolatedAsyncioTestCase):
                     },
                 ),
                 patch(
-                    "control_plane.dokploy_target_inspect.dokploy_api.fetch_dokploy_compose_logs",
+                    "control_plane.dokploy_target_inspect.dokploy_runtime_evidence.fetch_compose_container_logs",
                     return_value=(
                         '{"event":"privileged_operation_worker_poll_succeeded",'
                         '"processed":0,"statuses":[]}',


### PR DESCRIPTION
## Summary
- reuse the container already selected for image/state evidence when reading worker logs
- remove the second container lookup and provider-side `search` parameter
- keep the proof bounded to the selected container's last 1,000 lines from the last day, with allow-listed event matching performed locally after redaction
- keep the internal container ID out of the HTTP response and workflow artifact

## Validation
- `uv run --extra dev launchplane ci unittest-shard local` — 3,063 targets, 12/12 shards passed
- `uv run --extra dev mypy control_plane tests` — 758 files passed
- focused runtime evidence modules — 26 tests passed
- changed-file Ruff check/format passed
- JetBrains changed-files closeout passed
- exact-head Opus and Gemini reviews approved without blocking or important findings

## Live Context
The bounded-stage workflow run `32686925968` proved image/state resolution succeeds and isolated the only failure to `runtime-log-read`. This patch removes the redundant selection and provider search assumptions from that operation.

Refs #2219
