### PR TITLE
Fix privileged worker startup verification

### DIFF
--- a/control_plane/cli_service.py
+++ b/control_plane/cli_service.py
@@ -29,6 +29,7 @@ from control_plane.privileged_operation_worker import (
 from control_plane.contracts.driver_descriptor import DriverContextView
 from control_plane.drivers.registry import build_driver_context_view
 from control_plane.service import serve_launchplane_service
+from control_plane.storage.factory import build_privileged_operation_worker_store
 from control_plane.workflows.odoo_stable_operation_worker import (
     DEFAULT_ODOO_STABLE_WORKER_ERROR_BACKOFF_SECONDS,
     DEFAULT_ODOO_STABLE_WORKER_HEARTBEAT_SECONDS,
@@ -552,7 +553,7 @@ def service_privileged_operation_workers_run(
                 if store is None:
                     store = cast(
                         PrivilegedOperationExecutionStore,
-                        _store(state_dir=state_dir, database_url=database_url),
+                        build_privileged_operation_worker_store(database_url=database_url),
                     )
                 records = execute_approved_privileged_operations_once(
                     record_store=store,

--- a/control_plane/storage/factory.py
+++ b/control_plane/storage/factory.py
@@ -4,6 +4,12 @@ import os
 from control_plane.storage.postgres import PostgresRecordStore
 
 DATABASE_URL_ENV_VARS = ("LAUNCHPLANE_DATABASE_URL",)
+PRIVILEGED_OPERATION_WORKER_CONNECT_TIMEOUT_SECONDS = 10
+PRIVILEGED_OPERATION_WORKER_STARTUP_TIMEOUT_MILLISECONDS = 30_000
+
+
+class PrivilegedOperationWorkerSchemaError(RuntimeError):
+    pass
 
 
 def resolve_database_url(database_url: str | None = None) -> str | None:
@@ -26,6 +32,36 @@ def build_shared_record_store(*, database_url: str | None = None) -> PostgresRec
     store = PostgresRecordStore(database_url=resolved_database_url)
     store.verify_schema()
     return store
+
+
+def build_privileged_operation_worker_store(
+    *, database_url: str | None = None
+) -> PostgresRecordStore:
+    resolved_database_url = resolve_database_url(database_url)
+    if resolved_database_url is None:
+        raise ValueError(
+            "Launchplane privileged-operation workers require --database-url or "
+            "LAUNCHPLANE_DATABASE_URL."
+        )
+    startup_probe = PostgresRecordStore(
+        database_url=resolved_database_url,
+        postgres_connect_timeout_seconds=PRIVILEGED_OPERATION_WORKER_CONNECT_TIMEOUT_SECONDS,
+        postgres_statement_timeout_milliseconds=(
+            PRIVILEGED_OPERATION_WORKER_STARTUP_TIMEOUT_MILLISECONDS
+        ),
+    )
+    try:
+        startup_probe.verify_runtime_schema_invariants()
+    except RuntimeError as error:
+        raise PrivilegedOperationWorkerSchemaError(
+            "Launchplane privileged-operation worker schema is not runtime-compatible."
+        ) from error
+    finally:
+        startup_probe.close()
+    return PostgresRecordStore(
+        database_url=resolved_database_url,
+        postgres_connect_timeout_seconds=PRIVILEGED_OPERATION_WORKER_CONNECT_TIMEOUT_SECONDS,
+    )
 
 
 def storage_backend_name(record_store: object) -> str:

--- a/control_plane/storage/postgres.py
+++ b/control_plane/storage/postgres.py
@@ -34,7 +34,7 @@ from sqlalchemy import (
 )
 from sqlalchemy.dialects.postgresql import JSONB, insert as postgresql_insert
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
-from sqlalchemy.engine import Engine
+from sqlalchemy.engine import Engine, make_url
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, sessionmaker
 from sqlalchemy.pool import NullPool
@@ -3530,14 +3530,56 @@ def _human_session_from_payload(payload: PayloadDict) -> LaunchplaneHumanSession
 
 
 def _build_engine(
-    database_url: str, *, connection_factory: ConnectionFactory | None = None
+    database_url: str,
+    *,
+    connection_factory: ConnectionFactory | None = None,
+    postgres_connect_timeout_seconds: int | None = None,
+    postgres_statement_timeout_milliseconds: int | None = None,
 ) -> Engine:
     engine_kwargs: dict[str, Any] = {}
     if connection_factory is not None:
         engine_kwargs["creator"] = connection_factory
-    if database_url.startswith("sqlite"):
-        engine_kwargs["connect_args"] = {"check_same_thread": False}
+    connect_args = _engine_connect_args(
+        database_url,
+        postgres_connect_timeout_seconds=postgres_connect_timeout_seconds,
+        postgres_statement_timeout_milliseconds=postgres_statement_timeout_milliseconds,
+    )
+    if connect_args:
+        engine_kwargs["connect_args"] = connect_args
     return create_engine(database_url, **engine_kwargs)
+
+
+def _engine_connect_args(
+    database_url: str,
+    *,
+    postgres_connect_timeout_seconds: int | None = None,
+    postgres_statement_timeout_milliseconds: int | None = None,
+) -> dict[str, object]:
+    database_url_value = make_url(database_url)
+    backend_name = database_url_value.get_backend_name()
+    connect_args: dict[str, object] = {}
+    if backend_name == "sqlite":
+        connect_args["check_same_thread"] = False
+    elif backend_name == "postgresql":
+        if postgres_connect_timeout_seconds is not None:
+            if postgres_connect_timeout_seconds < 1:
+                raise ValueError("PostgreSQL connect timeout must be positive.")
+            connect_args["connect_timeout"] = postgres_connect_timeout_seconds
+        if postgres_statement_timeout_milliseconds is not None:
+            if postgres_statement_timeout_milliseconds < 1:
+                raise ValueError("PostgreSQL statement timeout must be positive.")
+            existing_options = database_url_value.query.get("options", "")
+            if isinstance(existing_options, tuple):
+                existing_options = " ".join(existing_options)
+            statement_timeout_option = (
+                f"-c statement_timeout={postgres_statement_timeout_milliseconds}"
+            )
+            connect_args["options"] = " ".join(
+                value
+                for value in (str(existing_options).strip(), statement_timeout_option)
+                if value
+            )
+    return connect_args
 
 
 class PostgresRecordStore(HumanSessionStore):
@@ -3546,13 +3588,28 @@ class PostgresRecordStore(HumanSessionStore):
         *,
         database_url: str,
         connection_factory: ConnectionFactory | None = None,
+        postgres_connect_timeout_seconds: int | None = None,
+        postgres_statement_timeout_milliseconds: int | None = None,
     ) -> None:
         self.database_url = database_url
-        self._engine = _build_engine(database_url, connection_factory=connection_factory)
+        self._engine = _build_engine(
+            database_url,
+            connection_factory=connection_factory,
+            postgres_connect_timeout_seconds=postgres_connect_timeout_seconds,
+            postgres_statement_timeout_milliseconds=postgres_statement_timeout_milliseconds,
+        )
         self._session_factory = sessionmaker(self._engine, expire_on_commit=False)
         lock_engine_kwargs: dict[str, Any] = {"poolclass": NullPool}
         if connection_factory is not None:
             lock_engine_kwargs["creator"] = connection_factory
+        elif self._engine.url.get_backend_name() == "postgresql":
+            connect_args = _engine_connect_args(
+                database_url,
+                postgres_connect_timeout_seconds=postgres_connect_timeout_seconds,
+                postgres_statement_timeout_milliseconds=(postgres_statement_timeout_milliseconds),
+            )
+            if connect_args:
+                lock_engine_kwargs["connect_args"] = connect_args
         self._owner_acceptance_projection_lock_engine = (
             create_engine(database_url, **lock_engine_kwargs)
             if self._engine.url.get_backend_name() == "postgresql"
@@ -3606,6 +3663,11 @@ class PostgresRecordStore(HumanSessionStore):
             )
         if backend_name == "postgresql":
             verify_postgres_schema_invariants(self._engine)
+
+    def verify_runtime_schema_invariants(self) -> None:
+        if self._engine.url.get_backend_name() != "postgresql":
+            raise RuntimeError("Launchplane runtime schema verification requires PostgreSQL.")
+        verify_postgres_schema_invariants(self._engine)
 
     def schema_revision(self) -> str:
         if self._engine.url.get_backend_name() != "postgresql":

--- a/docs/records.md
+++ b/docs/records.md
@@ -1596,7 +1596,14 @@ run` is the foreground loop intended for an external process supervisor, and
   `launchplane-privileged-operation-workers` and
   `/app/scripts/start-launchplane-privileged-operation-workers.sh`; it accepts
   process timing settings only, while approved operation selection remains in
-  DB-backed Launchplane records.
+  DB-backed Launchplane records. After the API service has passed its full
+  schema verification and health gate, this worker performs bounded runtime
+  invariant verification without repeating the API's all-mapped-table and
+  all-mapped-column checks. The short statement timeout applies only to that
+  startup check; the runtime store retains normal privileged-execution
+  statement semantics and a bounded PostgreSQL connection wait. An unavailable
+  or blocked startup enters the existing redacted retry/threshold-exit path
+  instead of hanging silently.
   Production operation remains observable through the `launchplane service
   verireel-workers status` and `launchplane service verireel-workers reconcile`
   operator commands, and through

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -5,7 +5,7 @@ import json
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Literal
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import MagicMock, Mock, call, patch
 
 from alembic import command as alembic_command
 from alembic.config import Config as AlembicConfig
@@ -218,7 +218,13 @@ from control_plane.tenant_repository_classification import (
     TenantRepositoryClassificationConflictError,
     TenantRepositoryClassificationSequenceError,
 )
-from control_plane.storage.factory import build_shared_record_store
+from control_plane.storage.factory import (
+    PRIVILEGED_OPERATION_WORKER_CONNECT_TIMEOUT_SECONDS,
+    PRIVILEGED_OPERATION_WORKER_STARTUP_TIMEOUT_MILLISECONDS,
+    PrivilegedOperationWorkerSchemaError,
+    build_privileged_operation_worker_store,
+    build_shared_record_store,
+)
 from control_plane.storage.postgres import (
     Base,
     DbOnlyMutationRequest,
@@ -230,6 +236,7 @@ from control_plane.storage.postgres import (
     MutationReservationResult,
     OutboxWithIdempotencyRequest,
     PostgresRecordStore,
+    _build_engine,
 )
 from control_plane.storage.product_authority_bundle import (
     ProductAuthorityBundle,
@@ -3680,6 +3687,135 @@ class PostgresRecordStoreTests(unittest.TestCase):
             store.close()
 
         self.assertEqual(loaded.artifact_id, manifest.artifact_id)
+
+    def test_privileged_operation_worker_store_uses_bounded_runtime_check(self) -> None:
+        startup_probe = Mock()
+        runtime_store = Mock()
+        database_url = "postgresql+psycopg://launchplane.invalid/launchplane"
+
+        with patch(
+            "control_plane.storage.factory.PostgresRecordStore",
+            side_effect=[startup_probe, runtime_store],
+        ) as store_type:
+            result = build_privileged_operation_worker_store(database_url=database_url)
+
+        self.assertIs(result, runtime_store)
+        self.assertEqual(
+            store_type.call_args_list,
+            [
+                call(
+                    database_url=database_url,
+                    postgres_connect_timeout_seconds=(
+                        PRIVILEGED_OPERATION_WORKER_CONNECT_TIMEOUT_SECONDS
+                    ),
+                    postgres_statement_timeout_milliseconds=(
+                        PRIVILEGED_OPERATION_WORKER_STARTUP_TIMEOUT_MILLISECONDS
+                    ),
+                ),
+                call(
+                    database_url=database_url,
+                    postgres_connect_timeout_seconds=(
+                        PRIVILEGED_OPERATION_WORKER_CONNECT_TIMEOUT_SECONDS
+                    ),
+                ),
+            ],
+        )
+        startup_probe.verify_runtime_schema_invariants.assert_called_once_with()
+        startup_probe.verify_schema.assert_not_called()
+        startup_probe.close.assert_called_once_with()
+
+    def test_privileged_operation_worker_store_closes_incompatible_schema(self) -> None:
+        startup_probe = Mock()
+        startup_probe.verify_runtime_schema_invariants.side_effect = RuntimeError(
+            "schema detail must remain internal"
+        )
+
+        with (
+            patch(
+                "control_plane.storage.factory.PostgresRecordStore",
+                return_value=startup_probe,
+            ),
+            self.assertRaisesRegex(PrivilegedOperationWorkerSchemaError, "not runtime-compatible"),
+        ):
+            build_privileged_operation_worker_store(
+                database_url="postgresql+psycopg://launchplane.invalid/launchplane"
+            )
+
+        startup_probe.close.assert_called_once_with()
+
+    def test_postgres_engine_applies_bounded_connection_options(self) -> None:
+        database_url = (
+            "postgresql+psycopg://launchplane.invalid/launchplane"
+            "?options=-c%20search_path%3Dlaunchplane"
+        )
+
+        with patch("control_plane.storage.postgres.create_engine") as create_engine_mock:
+            _build_engine(
+                database_url,
+                postgres_connect_timeout_seconds=10,
+                postgres_statement_timeout_milliseconds=30_000,
+            )
+
+        create_engine_mock.assert_called_once_with(
+            database_url,
+            connect_args={
+                "connect_timeout": 10,
+                "options": "-c search_path=launchplane -c statement_timeout=30000",
+            },
+        )
+
+    def test_postgres_store_applies_bounded_options_to_lock_engine(self) -> None:
+        database_url = "postgresql+psycopg://launchplane.invalid/launchplane"
+        primary_engine = Mock()
+        primary_engine.url.get_backend_name.return_value = "postgresql"
+
+        with (
+            patch("control_plane.storage.postgres._build_engine", return_value=primary_engine),
+            patch("control_plane.storage.postgres.create_engine") as create_engine_mock,
+        ):
+            store = PostgresRecordStore(
+                database_url=database_url,
+                postgres_connect_timeout_seconds=10,
+                postgres_statement_timeout_milliseconds=30_000,
+            )
+
+        create_engine_mock.assert_called_once_with(
+            database_url,
+            poolclass=NullPool,
+            connect_args={
+                "connect_timeout": 10,
+                "options": "-c statement_timeout=30000",
+            },
+        )
+        store.close()
+
+    def test_runtime_schema_invariants_require_postgres(self) -> None:
+        store = object.__new__(PostgresRecordStore)
+        store._engine = Mock()
+        store._engine.url.get_backend_name.return_value = "sqlite"
+
+        with self.assertRaisesRegex(RuntimeError, "requires PostgreSQL"):
+            store.verify_runtime_schema_invariants()
+
+    def test_runtime_schema_invariants_delegate_to_bounded_invariant_set(self) -> None:
+        store = object.__new__(PostgresRecordStore)
+        store._engine = Mock()
+        store._engine.url.get_backend_name.return_value = "postgresql"
+
+        with patch(
+            "control_plane.storage.postgres.verify_postgres_schema_invariants"
+        ) as verify_invariants:
+            store.verify_runtime_schema_invariants()
+
+        verify_invariants.assert_called_once_with(store._engine)
+
+    def test_postgres_engine_rejects_nonpositive_timeouts(self) -> None:
+        database_url = "postgresql+psycopg://launchplane.invalid/launchplane"
+
+        with self.assertRaisesRegex(ValueError, "connect timeout must be positive"):
+            _build_engine(database_url, postgres_connect_timeout_seconds=0)
+        with self.assertRaisesRegex(ValueError, "statement timeout must be positive"):
+            _build_engine(database_url, postgres_statement_timeout_milliseconds=0)
 
     def test_alembic_head_repairs_stamped_schema_missing_odoo_replacement_scope(
         self,

--- a/tests/test_privileged_operation_worker.py
+++ b/tests/test_privileged_operation_worker.py
@@ -226,7 +226,7 @@ class PrivilegedOperationWorkerTests(unittest.TestCase):
         with (
             patch("control_plane.cli_service.Event", return_value=TestStopEvent()),
             patch(
-                "control_plane.cli_service._store",
+                "control_plane.cli_service.build_privileged_operation_worker_store",
                 side_effect=[RuntimeError("database-url-secret must not be emitted"), object()],
             ),
             patch(
@@ -323,7 +323,10 @@ class PrivilegedOperationWorkerTests(unittest.TestCase):
         runner = CliRunner()
         with (
             patch("control_plane.cli_service.Event", return_value=TestStopEvent()),
-            patch("control_plane.cli_service._store", return_value=object()),
+            patch(
+                "control_plane.cli_service.build_privileged_operation_worker_store",
+                return_value=object(),
+            ),
             patch(
                 "control_plane.cli_service.execute_approved_privileged_operations_once",
                 return_value=[
@@ -381,7 +384,10 @@ class PrivilegedOperationWorkerTests(unittest.TestCase):
         runner = CliRunner()
         with (
             patch("control_plane.cli_service.Event", return_value=TestStopEvent()),
-            patch("control_plane.cli_service._store", return_value=object()),
+            patch(
+                "control_plane.cli_service.build_privileged_operation_worker_store",
+                return_value=object(),
+            ),
             patch(
                 "control_plane.cli_service.execute_approved_privileged_operations_once",
                 side_effect=FatalWorkerError("operation-secret-id must not be emitted"),


### PR DESCRIPTION
## Summary

- replace the privileged-operation worker's catalog-wide startup verification with a bounded runtime-invariant probe
- preserve existing PostgreSQL DSN options while applying startup connect and statement timeouts
- keep privileged execution on normal statement semantics with a bounded connection wait
- add fail-closed schema typing, cleanup coverage, timeout propagation tests, and operator documentation

## Live Failure Evidence

- deploy run `32688535074` produced immutable image `ghcr.io/cbusillo/launchplane@sha256:ccfb8068496799820a55c33040f003c3812fb1b1f2f245fc48307a2f0b05aaf5`
- protected inspect runs `32688653946`, `32688831184`, and `32689597179` proved the worker stayed running on that exact image for up to 16 minutes
- each retained only the startup event: zero successful-poll, retry, or threshold-exit events
- the blocking region was the synchronous generic store initialization before the first poll

## Validation

- `uv run --extra dev python -m unittest ...` — 17 focused tests passed
- `uv run --extra dev launchplane ci unittest-shard local` — 12/12 shards, 3,070 targets passed
- `uv run --extra dev mypy control_plane tests` — 758 files passed
- changed-file Ruff check and format passed
- container build passed
- JetBrains changed-files closeout passed GREEN
- exact-head Opus and Gemini reviews approved `fa6e03df`

Refs #2219
