### PR TITLE
Narrow privileged worker schema probe

### DIFF
--- a/control_plane/storage/factory.py
+++ b/control_plane/storage/factory.py
@@ -6,6 +6,30 @@ from control_plane.storage.postgres import PostgresRecordStore
 DATABASE_URL_ENV_VARS = ("LAUNCHPLANE_DATABASE_URL",)
 PRIVILEGED_OPERATION_WORKER_CONNECT_TIMEOUT_SECONDS = 10
 PRIVILEGED_OPERATION_WORKER_STARTUP_TIMEOUT_MILLISECONDS = 30_000
+PRIVILEGED_OPERATION_WORKER_REQUIRED_RELATIONS = (
+    "launchplane_privileged_operations",
+    "launchplane_privileged_operations_status_idx",
+    "launchplane_privileged_operations_descriptor_idx",
+    "launchplane_privileged_operation_events",
+    "launchplane_privileged_operation_events_operation_sequence_uidx",
+    "launchplane_privileged_operation_events_occurred_idx",
+    "launchplane_idempotency_records",
+    "launchplane_idempotency_scope_route_key_idx",
+    "launchplane_idempotency_state_lease_idx",
+    "launchplane_idempotency_active_reconciliation_idx",
+    "launchplane_authz_policies",
+    "launchplane_authz_policies_revision_uidx",
+    "launchplane_authz_policies_active_uidx",
+    "launchplane_secrets",
+    "launchplane_secrets_scope_name_idx",
+    "launchplane_secrets_lookup_idx",
+    "launchplane_secret_versions",
+    "launchplane_secret_versions_secret_idx",
+    "launchplane_secret_bindings",
+    "launchplane_secret_bindings_lookup_idx",
+    "launchplane_secret_audit_events",
+    "launchplane_secret_audit_events_secret_idx",
+)
 
 
 class PrivilegedOperationWorkerSchemaError(RuntimeError):
@@ -51,7 +75,9 @@ def build_privileged_operation_worker_store(
         ),
     )
     try:
-        startup_probe.verify_runtime_schema_invariants()
+        startup_probe.verify_runtime_schema_compatibility(
+            required_relations=PRIVILEGED_OPERATION_WORKER_REQUIRED_RELATIONS
+        )
     except RuntimeError as error:
         raise PrivilegedOperationWorkerSchemaError(
             "Launchplane privileged-operation worker schema is not runtime-compatible."

--- a/control_plane/storage/postgres.py
+++ b/control_plane/storage/postgres.py
@@ -330,7 +330,10 @@ from control_plane.storage.product_authority_bundle import (
     ProductAuthorityBundle,
     ProviderTargetWrite,
 )
-from control_plane.storage.schema_invariants import verify_postgres_schema_invariants
+from control_plane.storage.schema_invariants import (
+    RUNTIME_COMPATIBLE_ALEMBIC_REVISIONS,
+    verify_postgres_schema_invariants,
+)
 
 RecordModel = TypeVar("RecordModel", bound=BaseModel)
 
@@ -3664,10 +3667,38 @@ class PostgresRecordStore(HumanSessionStore):
         if backend_name == "postgresql":
             verify_postgres_schema_invariants(self._engine)
 
-    def verify_runtime_schema_invariants(self) -> None:
+    def verify_runtime_schema_compatibility(
+        self,
+        *,
+        required_relations: Sequence[str],
+    ) -> None:
         if self._engine.url.get_backend_name() != "postgresql":
             raise RuntimeError("Launchplane runtime schema verification requires PostgreSQL.")
-        verify_postgres_schema_invariants(self._engine)
+        revision = self.schema_revision()
+        if revision not in RUNTIME_COMPATIBLE_ALEMBIC_REVISIONS:
+            raise RuntimeError("Launchplane database revision is not runtime-compatible.")
+        normalized_relations = tuple(
+            dict.fromkeys(relation.strip() for relation in required_relations if relation.strip())
+        )
+        if not normalized_relations:
+            raise ValueError("Launchplane runtime schema verification requires relations.")
+        values_sql = ", ".join(f"(:relation_{index})" for index in range(len(normalized_relations)))
+        parameters = {
+            f"relation_{index}": relation for index, relation in enumerate(normalized_relations)
+        }
+        statement = text(
+            "SELECT required.relation_name "
+            f"FROM (VALUES {values_sql}) AS required(relation_name) "
+            "WHERE to_regclass(required.relation_name) IS NULL "
+            "ORDER BY required.relation_name"
+        )
+        with self._engine.connect() as connection:
+            missing_relations = tuple(connection.execute(statement, parameters).scalars().all())
+        if missing_relations:
+            raise RuntimeError(
+                "Launchplane runtime schema is missing required relation(s): "
+                + ", ".join(str(relation) for relation in missing_relations)
+            )
 
     def schema_revision(self) -> str:
         if self._engine.url.get_backend_name() != "postgresql":

--- a/docs/records.md
+++ b/docs/records.md
@@ -1597,13 +1597,14 @@ run` is the foreground loop intended for an external process supervisor, and
   `/app/scripts/start-launchplane-privileged-operation-workers.sh`; it accepts
   process timing settings only, while approved operation selection remains in
   DB-backed Launchplane records. After the API service has passed its full
-  schema verification and health gate, this worker performs bounded runtime
-  invariant verification without repeating the API's all-mapped-table and
-  all-mapped-column checks. The short statement timeout applies only to that
-  startup check; the runtime store retains normal privileged-execution
-  statement semantics and a bounded PostgreSQL connection wait. An unavailable
-  or blocked startup enters the existing redacted retry/threshold-exit path
-  instead of hanging silently.
+  schema verification and health gate, this worker performs a bounded two-query
+  compatibility probe: the exact runtime-compatible Alembic revision and the
+  worker-domain tables and safety indexes required before claim or execution.
+  It does not repeat the API's catalog-wide schema audit. The short statement
+  timeout applies only to that startup probe; the runtime store retains normal
+  privileged-execution statement semantics and a bounded PostgreSQL connection
+  wait. An unavailable or blocked startup enters the existing redacted
+  retry/threshold-exit path instead of hanging silently.
   Production operation remains observable through the `launchplane service
   verireel-workers status` and `launchplane service verireel-workers reconcile`
   operator commands, and through

--- a/tests/test_postgres_integration.py
+++ b/tests/test_postgres_integration.py
@@ -117,6 +117,9 @@ from control_plane.provider_operations import (
     ProviderTargetSupersession,
     run_durable_provider_operation,
 )
+from control_plane.privileged_operation_worker import (
+    execute_approved_privileged_operations_once,
+)
 from control_plane.workflows.public_ingress_monitor import (
     HttpObservation,
     run_public_ingress_monitor_once,
@@ -138,6 +141,7 @@ from control_plane.storage.postgres import (
     OutboxWithIdempotencyRequest,
     PostgresRecordStore,
 )
+from control_plane.storage.factory import build_privileged_operation_worker_store
 from tests.support.durable_operations import durable_operation_cancellation_payload
 from tests.test_product_retirement import _Store as _RetirementStore
 from tests.test_product_retirement import _observation as _retirement_observation
@@ -971,6 +975,30 @@ def _owner_acceptance_system_event(
 
 
 class RealPostgresSchemaIntegrationTests(unittest.TestCase):
+    def test_privileged_operation_worker_store_probes_schema_and_empty_poll(self) -> None:
+        with _isolated_postgres_database() as database_url:
+            _upgrade_empty_database_to_head(database_url)
+            store = build_privileged_operation_worker_store(database_url=database_url)
+            try:
+                records = execute_approved_privileged_operations_once(
+                    record_store=store,
+                    lease_owner="postgres-integration-worker",
+                )
+            finally:
+                store.close()
+
+        self.assertEqual(records, ())
+
+    def test_runtime_schema_compatibility_reports_missing_relation(self) -> None:
+        with _store_for_fresh_head_database() as store:
+            with self.assertRaisesRegex(
+                RuntimeError,
+                "launchplane_missing_worker_relation",
+            ):
+                store.verify_runtime_schema_compatibility(
+                    required_relations=("launchplane_missing_worker_relation",)
+                )
+
     def test_repository_human_admission_schema_has_postgres_types_and_partial_index(
         self,
     ) -> None:

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -220,6 +220,7 @@ from control_plane.tenant_repository_classification import (
 )
 from control_plane.storage.factory import (
     PRIVILEGED_OPERATION_WORKER_CONNECT_TIMEOUT_SECONDS,
+    PRIVILEGED_OPERATION_WORKER_REQUIRED_RELATIONS,
     PRIVILEGED_OPERATION_WORKER_STARTUP_TIMEOUT_MILLISECONDS,
     PrivilegedOperationWorkerSchemaError,
     build_privileged_operation_worker_store,
@@ -3720,13 +3721,15 @@ class PostgresRecordStoreTests(unittest.TestCase):
                 ),
             ],
         )
-        startup_probe.verify_runtime_schema_invariants.assert_called_once_with()
+        startup_probe.verify_runtime_schema_compatibility.assert_called_once_with(
+            required_relations=PRIVILEGED_OPERATION_WORKER_REQUIRED_RELATIONS
+        )
         startup_probe.verify_schema.assert_not_called()
         startup_probe.close.assert_called_once_with()
 
     def test_privileged_operation_worker_store_closes_incompatible_schema(self) -> None:
         startup_probe = Mock()
-        startup_probe.verify_runtime_schema_invariants.side_effect = RuntimeError(
+        startup_probe.verify_runtime_schema_compatibility.side_effect = RuntimeError(
             "schema detail must remain internal"
         )
 
@@ -3789,25 +3792,46 @@ class PostgresRecordStoreTests(unittest.TestCase):
         )
         store.close()
 
-    def test_runtime_schema_invariants_require_postgres(self) -> None:
+    def test_runtime_schema_compatibility_requires_postgres(self) -> None:
         store = object.__new__(PostgresRecordStore)
         store._engine = Mock()
         store._engine.url.get_backend_name.return_value = "sqlite"
 
         with self.assertRaisesRegex(RuntimeError, "requires PostgreSQL"):
-            store.verify_runtime_schema_invariants()
+            store.verify_runtime_schema_compatibility(required_relations=("required_table",))
 
-    def test_runtime_schema_invariants_delegate_to_bounded_invariant_set(self) -> None:
+    def test_runtime_schema_compatibility_checks_revision_and_relations(self) -> None:
         store = object.__new__(PostgresRecordStore)
-        store._engine = Mock()
+        store._engine = MagicMock()
         store._engine.url.get_backend_name.return_value = "postgresql"
+        connection = store._engine.connect.return_value.__enter__.return_value
+        connection.execute.return_value.scalars.return_value.all.return_value = []
 
-        with patch(
-            "control_plane.storage.postgres.verify_postgres_schema_invariants"
-        ) as verify_invariants:
-            store.verify_runtime_schema_invariants()
+        with patch.object(store, "schema_revision", return_value="c2221a0b1c2d"):
+            store.verify_runtime_schema_compatibility(
+                required_relations=("required_table", "required_index")
+            )
 
-        verify_invariants.assert_called_once_with(store._engine)
+        connection.execute.assert_called_once()
+        self.assertEqual(
+            connection.execute.call_args.args[1],
+            {"relation_0": "required_table", "relation_1": "required_index"},
+        )
+
+    def test_runtime_schema_compatibility_rejects_missing_relations(self) -> None:
+        store = object.__new__(PostgresRecordStore)
+        store._engine = MagicMock()
+        store._engine.url.get_backend_name.return_value = "postgresql"
+        connection = store._engine.connect.return_value.__enter__.return_value
+        connection.execute.return_value.scalars.return_value.all.return_value = ["missing_index"]
+
+        with (
+            patch.object(store, "schema_revision", return_value="c2221a0b1c2d"),
+            self.assertRaisesRegex(RuntimeError, "missing_index"),
+        ):
+            store.verify_runtime_schema_compatibility(
+                required_relations=("required_table", "missing_index")
+            )
 
     def test_postgres_engine_rejects_nonpositive_timeouts(self) -> None:
         database_url = "postgresql+psycopg://launchplane.invalid/launchplane"


### PR DESCRIPTION
## Summary

- replace the still-slow global worker startup invariant sweep with a bounded two-query compatibility probe
- require the exact runtime Alembic revision plus every worker-domain table and safety index needed before claim or execution
- retain the startup-only timeout, DSN option preservation, typed failure, and normal runtime statement semantics from #2226
- add real PostgreSQL success, empty-poll, and missing-relation coverage

## Live Failure Evidence

- #2226 deployed successfully as image `ghcr.io/cbusillo/launchplane@sha256:7c6f8a8fb764d9975fc4174dee156751b8b7011d95e5266acd2b8740f6f00f7f`
- protected inspect runs `32692460534` and `32692676872` proved the exact-image worker remained running for up to four minutes with only its startup event
- the startup timeout was per statement, while the global invariant sweep still issued many catalog statements before the first poll

## Validation

- 18 focused unit tests passed
- real PostgreSQL builder/empty-poll and missing-relation tests passed
- PostgreSQL integration gate passed 88 tests
- full local unit gate passed 12/12 shards and 3,072 targets
- full mypy passed 758 files
- changed-file Ruff and format passed
- container build passed
- JetBrains changed-files closeout passed GREEN
- exact-head Claude review approved `8bdf03cd`

Refs #2219
