### PR TITLE
Bound privileged worker runtime statements

### DIFF
--- a/control_plane/storage/factory.py
+++ b/control_plane/storage/factory.py
@@ -5,7 +5,7 @@ from control_plane.storage.postgres import PostgresRecordStore
 
 DATABASE_URL_ENV_VARS = ("LAUNCHPLANE_DATABASE_URL",)
 PRIVILEGED_OPERATION_WORKER_CONNECT_TIMEOUT_SECONDS = 10
-PRIVILEGED_OPERATION_WORKER_STARTUP_TIMEOUT_MILLISECONDS = 30_000
+PRIVILEGED_OPERATION_WORKER_STATEMENT_TIMEOUT_MILLISECONDS = 30_000
 PRIVILEGED_OPERATION_WORKER_REQUIRED_RELATIONS = (
     "launchplane_privileged_operations",
     "launchplane_privileged_operations_status_idx",
@@ -71,7 +71,7 @@ def build_privileged_operation_worker_store(
         database_url=resolved_database_url,
         postgres_connect_timeout_seconds=PRIVILEGED_OPERATION_WORKER_CONNECT_TIMEOUT_SECONDS,
         postgres_statement_timeout_milliseconds=(
-            PRIVILEGED_OPERATION_WORKER_STARTUP_TIMEOUT_MILLISECONDS
+            PRIVILEGED_OPERATION_WORKER_STATEMENT_TIMEOUT_MILLISECONDS
         ),
     )
     try:
@@ -87,6 +87,9 @@ def build_privileged_operation_worker_store(
     return PostgresRecordStore(
         database_url=resolved_database_url,
         postgres_connect_timeout_seconds=PRIVILEGED_OPERATION_WORKER_CONNECT_TIMEOUT_SECONDS,
+        postgres_statement_timeout_milliseconds=(
+            PRIVILEGED_OPERATION_WORKER_STATEMENT_TIMEOUT_MILLISECONDS
+        ),
     )
 
 

--- a/docs/records.md
+++ b/docs/records.md
@@ -1600,10 +1600,11 @@ run` is the foreground loop intended for an external process supervisor, and
   schema verification and health gate, this worker performs a bounded two-query
   compatibility probe: the exact runtime-compatible Alembic revision and the
   worker-domain tables and safety indexes required before claim or execution.
-  It does not repeat the API's catalog-wide schema audit. The short statement
-  timeout applies only to that startup probe; the runtime store retains normal
-  privileged-execution statement semantics and a bounded PostgreSQL connection
-  wait. An unavailable or blocked startup enters the existing redacted
+  It does not repeat the API's catalog-wide schema audit. Both the startup probe
+  and runtime store use bounded PostgreSQL connect and per-statement waits; the
+  timeout does not cap the total operation and any timed-out DB statement fails
+  through the existing reservation, transaction, retry, and reconciliation
+  boundaries. An unavailable or blocked poll therefore enters the redacted
   retry/threshold-exit path instead of hanging silently.
   Production operation remains observable through the `launchplane service
   verireel-workers status` and `launchplane service verireel-workers reconcile`

--- a/tests/test_postgres_integration.py
+++ b/tests/test_postgres_integration.py
@@ -999,6 +999,26 @@ class RealPostgresSchemaIntegrationTests(unittest.TestCase):
                     required_relations=("launchplane_missing_worker_relation",)
                 )
 
+    def test_privileged_operation_worker_runtime_store_times_out_blocked_statement(
+        self,
+    ) -> None:
+        with _isolated_postgres_database() as database_url:
+            _upgrade_empty_database_to_head(database_url)
+            with patch(
+                "control_plane.storage.factory."
+                "PRIVILEGED_OPERATION_WORKER_STATEMENT_TIMEOUT_MILLISECONDS",
+                100,
+            ):
+                store = build_privileged_operation_worker_store(database_url=database_url)
+            try:
+                with (
+                    self.assertRaises(OperationalError),
+                    store._engine.connect() as connection,
+                ):
+                    connection.execute(text("select pg_sleep(1)"))
+            finally:
+                store.close()
+
     def test_repository_human_admission_schema_has_postgres_types_and_partial_index(
         self,
     ) -> None:

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -221,7 +221,7 @@ from control_plane.tenant_repository_classification import (
 from control_plane.storage.factory import (
     PRIVILEGED_OPERATION_WORKER_CONNECT_TIMEOUT_SECONDS,
     PRIVILEGED_OPERATION_WORKER_REQUIRED_RELATIONS,
-    PRIVILEGED_OPERATION_WORKER_STARTUP_TIMEOUT_MILLISECONDS,
+    PRIVILEGED_OPERATION_WORKER_STATEMENT_TIMEOUT_MILLISECONDS,
     PrivilegedOperationWorkerSchemaError,
     build_privileged_operation_worker_store,
     build_shared_record_store,
@@ -3710,13 +3710,16 @@ class PostgresRecordStoreTests(unittest.TestCase):
                         PRIVILEGED_OPERATION_WORKER_CONNECT_TIMEOUT_SECONDS
                     ),
                     postgres_statement_timeout_milliseconds=(
-                        PRIVILEGED_OPERATION_WORKER_STARTUP_TIMEOUT_MILLISECONDS
+                        PRIVILEGED_OPERATION_WORKER_STATEMENT_TIMEOUT_MILLISECONDS
                     ),
                 ),
                 call(
                     database_url=database_url,
                     postgres_connect_timeout_seconds=(
                         PRIVILEGED_OPERATION_WORKER_CONNECT_TIMEOUT_SECONDS
+                    ),
+                    postgres_statement_timeout_milliseconds=(
+                        PRIVILEGED_OPERATION_WORKER_STATEMENT_TIMEOUT_MILLISECONDS
                     ),
                 ),
             ],


### PR DESCRIPTION
## Summary

- apply the worker's existing 30-second PostgreSQL statement timeout to the long-lived runtime store
- keep the timeout per statement rather than per operation, preserving multi-statement DB-only re-encryption
- route blocked runtime polls into the existing redacted retry, threshold, transaction, reservation, and reconciliation paths
- add a real PostgreSQL test proving the runtime store cancels `pg_sleep` and surfaces `OperationalError`

## Live Failure Evidence

- #2227 deployed successfully as image `ghcr.io/cbusillo/launchplane@sha256:4e4e6ac5f45f43c6b2d9c5c7db5306875c6f937b9ae26156336de57e7da76370`
- protected inspect run `32695723683` proved the exact-image worker still retained only its startup event after the schema probe was narrowed
- the remaining unbounded region is the first actual DB-backed poll on the long-lived runtime store

## Validation

- 18 focused unit tests passed
- real PostgreSQL blocked-statement timeout test passed
- full local unit gate passed 12/12 shards and 3,073 targets
- full mypy passed 758 files
- changed-file Ruff and format passed
- container build passed
- JetBrains changed-files closeout passed GREEN
- exact-head Claude review approved `103d12bd`

Refs #2219
