### PR TITLE
Add privileged worker stage telemetry

### DIFF
--- a/control_plane/cli_service.py
+++ b/control_plane/cli_service.py
@@ -547,6 +547,8 @@ def service_privileged_operation_workers_run(
             )
         )
         store: PrivilegedOperationExecutionStore | None = None
+        store_initialized = False
+        first_poll_attempted = False
         consecutive_errors = 0
         while not stop_event.is_set():
             try:
@@ -555,6 +557,22 @@ def service_privileged_operation_workers_run(
                         PrivilegedOperationExecutionStore,
                         build_privileged_operation_worker_store(database_url=database_url),
                     )
+                if not store_initialized:
+                    click.echo(
+                        json.dumps(
+                            {"event": "privileged_operation_worker_store_initialized"},
+                            sort_keys=True,
+                        )
+                    )
+                    store_initialized = True
+                if not first_poll_attempted:
+                    click.echo(
+                        json.dumps(
+                            {"event": "privileged_operation_worker_first_poll_attempted"},
+                            sort_keys=True,
+                        )
+                    )
+                    first_poll_attempted = True
                 records = execute_approved_privileged_operations_once(
                     record_store=store,
                     lease_owner=generated_lease_owner,

--- a/control_plane/dokploy/runtime_evidence.py
+++ b/control_plane/dokploy/runtime_evidence.py
@@ -12,7 +12,13 @@ _STRUCTURED_EVENT_PATTERN = re.compile(r"^$|^[a-z][a-z0-9_]{0,127}$")
 _IMAGE_ID_PATTERN = re.compile(r"^sha256:[a-f0-9]{64}$")
 _IMMUTABLE_IMAGE_REFERENCE_PATTERN = re.compile(r"^[^\s@]+@sha256:[a-f0-9]{64}$")
 _MAX_RUNTIME_TEXT_LENGTH = 500
-_ALLOWED_STRUCTURED_EVENTS = frozenset({"privileged_operation_worker_poll_succeeded"})
+_ALLOWED_STRUCTURED_EVENTS = frozenset(
+    {
+        "privileged_operation_worker_store_initialized",
+        "privileged_operation_worker_first_poll_attempted",
+        "privileged_operation_worker_poll_succeeded",
+    }
+)
 type DokployEvidenceProviderOperation = Literal[
     "provider-config",
     "target-inspect",

--- a/docs/records.md
+++ b/docs/records.md
@@ -1606,6 +1606,11 @@ run` is the foreground loop intended for an external process supervisor, and
   through the existing reservation, transaction, retry, and reconciliation
   boundaries. An unavailable or blocked poll therefore enters the redacted
   retry/threshold-exit path instead of hanging silently.
+  The one-time structured events
+  `privileged_operation_worker_store_initialized` and
+  `privileged_operation_worker_first_poll_attempted` provide bounded lifecycle
+  localization only; activation evidence still requires
+  `privileged_operation_worker_poll_succeeded`.
   Production operation remains observable through the `launchplane service
   verireel-workers status` and `launchplane service verireel-workers reconcile`
   operator commands, and through

--- a/tests/test_dokploy_runtime_evidence.py
+++ b/tests/test_dokploy_runtime_evidence.py
@@ -17,6 +17,18 @@ class DokployRuntimeEvidenceTests(unittest.TestCase):
         with self.assertRaisesRegex(click.ClickException, "allow-listed"):
             runtime_evidence.normalize_structured_event_name("arbitrary_event")
 
+    def test_structured_event_accepts_bounded_worker_lifecycle_markers(self) -> None:
+        for event_name in (
+            "privileged_operation_worker_store_initialized",
+            "privileged_operation_worker_first_poll_attempted",
+            "privileged_operation_worker_poll_succeeded",
+        ):
+            with self.subTest(event_name=event_name):
+                self.assertEqual(
+                    runtime_evidence.normalize_structured_event_name(event_name),
+                    event_name,
+                )
+
     def test_fetch_compose_service_runtime_returns_bounded_image_and_state(self) -> None:
         requests: list[dict[str, object]] = []
         image_digest = "a" * 64

--- a/tests/test_privileged_operation_worker.py
+++ b/tests/test_privileged_operation_worker.py
@@ -272,6 +272,8 @@ class PrivilegedOperationWorkerTests(unittest.TestCase):
             [
                 "privileged_operation_worker_started",
                 "privileged_operation_worker_retry",
+                "privileged_operation_worker_store_initialized",
+                "privileged_operation_worker_first_poll_attempted",
                 "privileged_operation_worker_poll_succeeded",
                 "privileged_operation_worker_retry",
                 "privileged_operation_worker_threshold_exit",
@@ -280,15 +282,15 @@ class PrivilegedOperationWorkerTests(unittest.TestCase):
         self.assertEqual(telemetry[1]["consecutive_errors"], 1)
         self.assertEqual(telemetry[1]["error_type"], "RuntimeError")
         self.assertEqual(
-            telemetry[2],
+            telemetry[4],
             {
                 "event": "privileged_operation_worker_poll_succeeded",
                 "processed": 1,
                 "statuses": ["executed"],
             },
         )
-        self.assertEqual(telemetry[3]["consecutive_errors"], 1)
-        self.assertEqual(telemetry[4]["consecutive_errors"], 2)
+        self.assertEqual(telemetry[5]["consecutive_errors"], 1)
+        self.assertEqual(telemetry[6]["consecutive_errors"], 2)
 
     def test_worker_loop_stops_cleanly_after_sigterm(self) -> None:
         signal_handlers: dict[int, object] = {}
@@ -355,6 +357,8 @@ class PrivilegedOperationWorkerTests(unittest.TestCase):
             [entry["event"] for entry in telemetry],
             [
                 "privileged_operation_worker_started",
+                "privileged_operation_worker_store_initialized",
+                "privileged_operation_worker_first_poll_attempted",
                 "privileged_operation_worker_poll_succeeded",
                 "privileged_operation_worker_stopped",
             ],
@@ -410,9 +414,72 @@ class PrivilegedOperationWorkerTests(unittest.TestCase):
         telemetry = [json.loads(call.args[0]) for call in echo.call_args_list]
         self.assertEqual(
             telemetry,
-            [{"event": "privileged_operation_worker_started", "limit": 20, "poll_seconds": 15}],
+            [
+                {
+                    "event": "privileged_operation_worker_started",
+                    "limit": 20,
+                    "poll_seconds": 15,
+                },
+                {"event": "privileged_operation_worker_store_initialized"},
+                {"event": "privileged_operation_worker_first_poll_attempted"},
+            ],
         )
         self.assertEqual(signal_calls[-2:], list(previous_handlers.items()))
+
+    def test_worker_lifecycle_markers_are_not_repeated_across_successful_polls(self) -> None:
+        class TestStopEvent:
+            stopped = False
+            waits = 0
+
+            def is_set(self) -> bool:
+                return self.stopped
+
+            def wait(self, _timeout: int) -> bool:
+                self.waits += 1
+                if self.waits == 2:
+                    self.stopped = True
+                return self.stopped
+
+        runner = CliRunner()
+        with (
+            patch("control_plane.cli_service.Event", return_value=TestStopEvent()),
+            patch(
+                "control_plane.cli_service.build_privileged_operation_worker_store",
+                return_value=object(),
+            ),
+            patch(
+                "control_plane.cli_service.execute_approved_privileged_operations_once",
+                return_value=[],
+            ) as execute_once,
+            patch("control_plane.cli_service.signal.signal", return_value=object()),
+        ):
+            result = runner.invoke(
+                main,
+                [
+                    "service",
+                    "privileged-operation-workers",
+                    "run",
+                    "--database-url",
+                    "sqlite+pysqlite:///:memory:",
+                ],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        telemetry = [
+            json.loads(line) for line in result.output.splitlines() if line.startswith("{")
+        ]
+        self.assertEqual(
+            [entry["event"] for entry in telemetry],
+            [
+                "privileged_operation_worker_started",
+                "privileged_operation_worker_store_initialized",
+                "privileged_operation_worker_first_poll_attempted",
+                "privileged_operation_worker_poll_succeeded",
+                "privileged_operation_worker_poll_succeeded",
+                "privileged_operation_worker_stopped",
+            ],
+        )
+        self.assertEqual(execute_once.call_count, 2)
 
     def test_worker_reauthorizes_by_github_id_and_executes_only_once(self) -> None:
         approval_policy = _policy_record(revision=3)


### PR DESCRIPTION
## Summary

- add one-time redacted worker lifecycle markers for store initialization and first poll attempt
- allow the protected runtime inspect workflow to count those two diagnostic events
- keep activation proof exclusively bound to `privileged_operation_worker_poll_succeeded`
- add retry, signal, allow-list, and two-successful-poll no-repeat coverage

## Live Failure Evidence

- #2228 deployed successfully as image `ghcr.io/cbusillo/launchplane@sha256:e6d64614617a986f55d6846119c7be547b693c7a6bdb9d3e5124dd01da3d1bc3`
- protected inspect runs `32697820031` and `32698018178` proved the exact-image worker retained only its startup event after four minutes
- startup and runtime PostgreSQL statements are bounded, so the remaining synchronous region needs explicit lifecycle localization

## Validation

- 32 focused tests passed
- full local unit gate passed 12/12 shards and 3,074 targets
- full mypy passed 758 files
- changed-file Ruff and format passed
- container build passed
- JetBrains changed-files closeout passed GREEN
- exact-head Claude review approved `eb5bb3ab`

Refs #2219
