### PR TITLE
Bound privileged worker startup probe

### DIFF
--- a/control_plane/storage/factory.py
+++ b/control_plane/storage/factory.py
@@ -1,11 +1,34 @@
 from __future__ import annotations
 
 import os
+import subprocess
+import sys
+
 from control_plane.storage.postgres import PostgresRecordStore
 
 DATABASE_URL_ENV_VARS = ("LAUNCHPLANE_DATABASE_URL",)
 PRIVILEGED_OPERATION_WORKER_CONNECT_TIMEOUT_SECONDS = 10
 PRIVILEGED_OPERATION_WORKER_STATEMENT_TIMEOUT_MILLISECONDS = 30_000
+PRIVILEGED_OPERATION_WORKER_STARTUP_TIMEOUT_SECONDS = 90
+PRIVILEGED_OPERATION_WORKER_PROBE_SUCCESS_EXIT_CODE = 0
+PRIVILEGED_OPERATION_WORKER_PROBE_SCHEMA_INCOMPATIBLE_EXIT_CODE = 2
+PRIVILEGED_OPERATION_WORKER_PROBE_FAILED_EXIT_CODE = 3
+PRIVILEGED_OPERATION_WORKER_PROBE_ENVIRONMENT_KEYS = frozenset(
+    {
+        "DYLD_LIBRARY_PATH",
+        "HOME",
+        "LANG",
+        "LC_ALL",
+        "LC_CTYPE",
+        "LD_LIBRARY_PATH",
+        "PYTHONHOME",
+        "PYTHONPATH",
+        "SSL_CERT_DIR",
+        "SSL_CERT_FILE",
+        "TMPDIR",
+        "TZ",
+    }
+)
 PRIVILEGED_OPERATION_WORKER_REQUIRED_RELATIONS = (
     "launchplane_privileged_operations",
     "launchplane_privileged_operations_status_idx",
@@ -36,6 +59,14 @@ class PrivilegedOperationWorkerSchemaError(RuntimeError):
     pass
 
 
+class PrivilegedOperationWorkerStartupTimeoutError(RuntimeError):
+    pass
+
+
+class PrivilegedOperationWorkerProbeError(RuntimeError):
+    pass
+
+
 def resolve_database_url(database_url: str | None = None) -> str | None:
     if database_url is not None and database_url.strip():
         return database_url.strip()
@@ -44,6 +75,16 @@ def resolve_database_url(database_url: str | None = None) -> str | None:
         if environment_value:
             return environment_value
     return None
+
+
+def _privileged_operation_worker_probe_environment(*, database_url: str) -> dict[str, str]:
+    environment = {
+        key: value
+        for key, value in os.environ.items()
+        if key in PRIVILEGED_OPERATION_WORKER_PROBE_ENVIRONMENT_KEYS or key.startswith("PG")
+    }
+    environment[DATABASE_URL_ENV_VARS[0]] = database_url
+    return environment
 
 
 def build_shared_record_store(*, database_url: str | None = None) -> PostgresRecordStore:
@@ -67,23 +108,36 @@ def build_privileged_operation_worker_store(
             "Launchplane privileged-operation workers require --database-url or "
             "LAUNCHPLANE_DATABASE_URL."
         )
-    startup_probe = PostgresRecordStore(
-        database_url=resolved_database_url,
-        postgres_connect_timeout_seconds=PRIVILEGED_OPERATION_WORKER_CONNECT_TIMEOUT_SECONDS,
-        postgres_statement_timeout_milliseconds=(
-            PRIVILEGED_OPERATION_WORKER_STATEMENT_TIMEOUT_MILLISECONDS
-        ),
+    probe_environment = _privileged_operation_worker_probe_environment(
+        database_url=resolved_database_url
     )
     try:
-        startup_probe.verify_runtime_schema_compatibility(
-            required_relations=PRIVILEGED_OPERATION_WORKER_REQUIRED_RELATIONS
+        completed_probe = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "control_plane.storage.privileged_operation_worker_probe",
+            ],
+            env=probe_environment,
+            stderr=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            timeout=PRIVILEGED_OPERATION_WORKER_STARTUP_TIMEOUT_SECONDS,
         )
-    except RuntimeError as error:
+    except subprocess.TimeoutExpired as error:
+        raise PrivilegedOperationWorkerStartupTimeoutError(
+            "Launchplane privileged-operation worker store initialization timed out."
+        ) from error
+    if (
+        completed_probe.returncode
+        == PRIVILEGED_OPERATION_WORKER_PROBE_SCHEMA_INCOMPATIBLE_EXIT_CODE
+    ):
         raise PrivilegedOperationWorkerSchemaError(
             "Launchplane privileged-operation worker schema is not runtime-compatible."
-        ) from error
-    finally:
-        startup_probe.close()
+        )
+    if completed_probe.returncode != PRIVILEGED_OPERATION_WORKER_PROBE_SUCCESS_EXIT_CODE:
+        raise PrivilegedOperationWorkerProbeError(
+            "Launchplane privileged-operation worker schema probe failed."
+        )
     return PostgresRecordStore(
         database_url=resolved_database_url,
         postgres_connect_timeout_seconds=PRIVILEGED_OPERATION_WORKER_CONNECT_TIMEOUT_SECONDS,

--- a/control_plane/storage/privileged_operation_worker_probe.py
+++ b/control_plane/storage/privileged_operation_worker_probe.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from contextlib import suppress
+
+from sqlalchemy.exc import SQLAlchemyError
+
+from control_plane.storage.factory import (
+    PRIVILEGED_OPERATION_WORKER_CONNECT_TIMEOUT_SECONDS,
+    PRIVILEGED_OPERATION_WORKER_PROBE_FAILED_EXIT_CODE,
+    PRIVILEGED_OPERATION_WORKER_PROBE_SCHEMA_INCOMPATIBLE_EXIT_CODE,
+    PRIVILEGED_OPERATION_WORKER_PROBE_SUCCESS_EXIT_CODE,
+    PRIVILEGED_OPERATION_WORKER_REQUIRED_RELATIONS,
+    PRIVILEGED_OPERATION_WORKER_STATEMENT_TIMEOUT_MILLISECONDS,
+    resolve_database_url,
+)
+from control_plane.storage.postgres import PostgresRecordStore
+
+
+def run_privileged_operation_worker_schema_probe() -> int:
+    database_url = resolve_database_url()
+    if database_url is None:
+        return PRIVILEGED_OPERATION_WORKER_PROBE_FAILED_EXIT_CODE
+    store: PostgresRecordStore | None = None
+    try:
+        store = PostgresRecordStore(
+            database_url=database_url,
+            postgres_connect_timeout_seconds=PRIVILEGED_OPERATION_WORKER_CONNECT_TIMEOUT_SECONDS,
+            postgres_statement_timeout_milliseconds=(
+                PRIVILEGED_OPERATION_WORKER_STATEMENT_TIMEOUT_MILLISECONDS
+            ),
+        )
+        try:
+            store.verify_runtime_schema_compatibility(
+                required_relations=PRIVILEGED_OPERATION_WORKER_REQUIRED_RELATIONS
+            )
+        except RuntimeError:
+            return PRIVILEGED_OPERATION_WORKER_PROBE_SCHEMA_INCOMPATIBLE_EXIT_CODE
+        except (OSError, SQLAlchemyError, ValueError):
+            return PRIVILEGED_OPERATION_WORKER_PROBE_FAILED_EXIT_CODE
+    except (ImportError, OSError, SQLAlchemyError, ValueError):
+        return PRIVILEGED_OPERATION_WORKER_PROBE_FAILED_EXIT_CODE
+    finally:
+        if store is not None:
+            with suppress(OSError, RuntimeError, SQLAlchemyError):
+                store.close()
+    return PRIVILEGED_OPERATION_WORKER_PROBE_SUCCESS_EXIT_CODE
+
+
+if __name__ == "__main__":
+    raise SystemExit(run_privileged_operation_worker_schema_probe())

--- a/docs/records.md
+++ b/docs/records.md
@@ -1600,12 +1600,14 @@ run` is the foreground loop intended for an external process supervisor, and
   schema verification and health gate, this worker performs a bounded two-query
   compatibility probe: the exact runtime-compatible Alembic revision and the
   worker-domain tables and safety indexes required before claim or execution.
-  It does not repeat the API's catalog-wide schema audit. Both the startup probe
-  and runtime store use bounded PostgreSQL connect and per-statement waits; the
-  timeout does not cap the total operation and any timed-out DB statement fails
-  through the existing reservation, transaction, retry, and reconciliation
-  boundaries. An unavailable or blocked poll therefore enters the redacted
-  retry/threshold-exit path instead of hanging silently.
+  It does not repeat the API's catalog-wide schema audit. The startup probe runs
+  in an isolated child process with a hard wall-clock deadline, and both the
+  probe and runtime store use bounded PostgreSQL connect and per-statement
+  waits. A timed-out startup probe returns control to the supervised worker
+  retry/threshold-exit path; a timed-out runtime DB statement fails through the
+  existing reservation, transaction, retry, and reconciliation boundaries.
+  An unavailable or blocked startup probe or poll therefore cannot hang the
+  worker loop silently.
   The one-time structured events
   `privileged_operation_worker_store_initialized` and
   `privileged_operation_worker_first_poll_attempted` provide bounded lifecycle

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -3,9 +3,11 @@ from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta, timezone
 import json
 from pathlib import Path
+import subprocess
+import sys
 from tempfile import TemporaryDirectory
 from typing import Literal
-from unittest.mock import MagicMock, Mock, call, patch
+from unittest.mock import MagicMock, Mock, patch
 
 from alembic import command as alembic_command
 from alembic.config import Config as AlembicConfig
@@ -220,11 +222,20 @@ from control_plane.tenant_repository_classification import (
 )
 from control_plane.storage.factory import (
     PRIVILEGED_OPERATION_WORKER_CONNECT_TIMEOUT_SECONDS,
+    PRIVILEGED_OPERATION_WORKER_PROBE_FAILED_EXIT_CODE,
+    PRIVILEGED_OPERATION_WORKER_PROBE_SCHEMA_INCOMPATIBLE_EXIT_CODE,
+    PRIVILEGED_OPERATION_WORKER_PROBE_SUCCESS_EXIT_CODE,
     PRIVILEGED_OPERATION_WORKER_REQUIRED_RELATIONS,
+    PRIVILEGED_OPERATION_WORKER_STARTUP_TIMEOUT_SECONDS,
     PRIVILEGED_OPERATION_WORKER_STATEMENT_TIMEOUT_MILLISECONDS,
     PrivilegedOperationWorkerSchemaError,
+    PrivilegedOperationWorkerProbeError,
+    PrivilegedOperationWorkerStartupTimeoutError,
     build_privileged_operation_worker_store,
     build_shared_record_store,
+)
+from control_plane.storage.privileged_operation_worker_probe import (
+    run_privileged_operation_worker_schema_probe,
 )
 from control_plane.storage.postgres import (
     Base,
@@ -3690,56 +3701,100 @@ class PostgresRecordStoreTests(unittest.TestCase):
         self.assertEqual(loaded.artifact_id, manifest.artifact_id)
 
     def test_privileged_operation_worker_store_uses_bounded_runtime_check(self) -> None:
-        startup_probe = Mock()
         runtime_store = Mock()
         database_url = "postgresql+psycopg://launchplane.invalid/launchplane"
 
-        with patch(
-            "control_plane.storage.factory.PostgresRecordStore",
-            side_effect=[startup_probe, runtime_store],
-        ) as store_type:
+        with (
+            patch.dict(
+                "os.environ",
+                {
+                    "HOME": "/tmp/launchplane-home",
+                    "PGSSLROOTCERT": "/tmp/root.crt",
+                    "UNRELATED_SECRET": "must-not-be-inherited",
+                },
+                clear=True,
+            ),
+            patch(
+                "control_plane.storage.factory.subprocess.run",
+                return_value=subprocess.CompletedProcess(
+                    args=(), returncode=PRIVILEGED_OPERATION_WORKER_PROBE_SUCCESS_EXIT_CODE
+                ),
+            ) as run_probe,
+            patch(
+                "control_plane.storage.factory.PostgresRecordStore",
+                return_value=runtime_store,
+            ) as store_type,
+        ):
             result = build_privileged_operation_worker_store(database_url=database_url)
 
         self.assertIs(result, runtime_store)
+        store_type.assert_called_once_with(
+            database_url=database_url,
+            postgres_connect_timeout_seconds=(PRIVILEGED_OPERATION_WORKER_CONNECT_TIMEOUT_SECONDS),
+            postgres_statement_timeout_milliseconds=(
+                PRIVILEGED_OPERATION_WORKER_STATEMENT_TIMEOUT_MILLISECONDS
+            ),
+        )
+        probe_args, probe_kwargs = run_probe.call_args
         self.assertEqual(
-            store_type.call_args_list,
+            probe_args[0],
             [
-                call(
-                    database_url=database_url,
-                    postgres_connect_timeout_seconds=(
-                        PRIVILEGED_OPERATION_WORKER_CONNECT_TIMEOUT_SECONDS
-                    ),
-                    postgres_statement_timeout_milliseconds=(
-                        PRIVILEGED_OPERATION_WORKER_STATEMENT_TIMEOUT_MILLISECONDS
-                    ),
-                ),
-                call(
-                    database_url=database_url,
-                    postgres_connect_timeout_seconds=(
-                        PRIVILEGED_OPERATION_WORKER_CONNECT_TIMEOUT_SECONDS
-                    ),
-                    postgres_statement_timeout_milliseconds=(
-                        PRIVILEGED_OPERATION_WORKER_STATEMENT_TIMEOUT_MILLISECONDS
-                    ),
-                ),
+                sys.executable,
+                "-m",
+                "control_plane.storage.privileged_operation_worker_probe",
             ],
         )
-        startup_probe.verify_runtime_schema_compatibility.assert_called_once_with(
-            required_relations=PRIVILEGED_OPERATION_WORKER_REQUIRED_RELATIONS
+        self.assertEqual(
+            probe_kwargs["timeout"], PRIVILEGED_OPERATION_WORKER_STARTUP_TIMEOUT_SECONDS
         )
-        startup_probe.verify_schema.assert_not_called()
-        startup_probe.close.assert_called_once_with()
+        self.assertEqual(probe_kwargs["env"]["LAUNCHPLANE_DATABASE_URL"], database_url)
+        self.assertEqual(probe_kwargs["env"]["HOME"], "/tmp/launchplane-home")
+        self.assertEqual(probe_kwargs["env"]["PGSSLROOTCERT"], "/tmp/root.crt")
+        self.assertNotIn("UNRELATED_SECRET", probe_kwargs["env"])
+        self.assertEqual(probe_kwargs["stdout"], subprocess.DEVNULL)
+        self.assertEqual(probe_kwargs["stderr"], subprocess.DEVNULL)
 
     def test_privileged_operation_worker_store_closes_incompatible_schema(self) -> None:
         startup_probe = Mock()
         startup_probe.verify_runtime_schema_compatibility.side_effect = RuntimeError(
             "schema detail must remain internal"
         )
+        database_url = "postgresql+psycopg://launchplane.invalid/launchplane"
 
         with (
             patch(
-                "control_plane.storage.factory.PostgresRecordStore",
+                "control_plane.storage.privileged_operation_worker_probe.PostgresRecordStore",
                 return_value=startup_probe,
+            ) as store_type,
+            patch.dict(
+                "os.environ",
+                {"LAUNCHPLANE_DATABASE_URL": database_url},
+                clear=True,
+            ),
+        ):
+            result = run_privileged_operation_worker_schema_probe()
+
+        self.assertEqual(result, PRIVILEGED_OPERATION_WORKER_PROBE_SCHEMA_INCOMPATIBLE_EXIT_CODE)
+        store_type.assert_called_once_with(
+            database_url=database_url,
+            postgres_connect_timeout_seconds=(PRIVILEGED_OPERATION_WORKER_CONNECT_TIMEOUT_SECONDS),
+            postgres_statement_timeout_milliseconds=(
+                PRIVILEGED_OPERATION_WORKER_STATEMENT_TIMEOUT_MILLISECONDS
+            ),
+        )
+        startup_probe.verify_runtime_schema_compatibility.assert_called_once_with(
+            required_relations=PRIVILEGED_OPERATION_WORKER_REQUIRED_RELATIONS
+        )
+        startup_probe.close.assert_called_once_with()
+
+    def test_privileged_operation_worker_store_rejects_failed_schema_probe(self) -> None:
+        with (
+            patch(
+                "control_plane.storage.factory.subprocess.run",
+                return_value=subprocess.CompletedProcess(
+                    args=(),
+                    returncode=PRIVILEGED_OPERATION_WORKER_PROBE_SCHEMA_INCOMPATIBLE_EXIT_CODE,
+                ),
             ),
             self.assertRaisesRegex(PrivilegedOperationWorkerSchemaError, "not runtime-compatible"),
         ):
@@ -3747,7 +3802,54 @@ class PostgresRecordStoreTests(unittest.TestCase):
                 database_url="postgresql+psycopg://launchplane.invalid/launchplane"
             )
 
-        startup_probe.close.assert_called_once_with()
+    def test_privileged_operation_worker_store_rejects_failed_probe_process(self) -> None:
+        with (
+            patch(
+                "control_plane.storage.factory.subprocess.run",
+                return_value=subprocess.CompletedProcess(
+                    args=(), returncode=PRIVILEGED_OPERATION_WORKER_PROBE_FAILED_EXIT_CODE
+                ),
+            ),
+            self.assertRaisesRegex(PrivilegedOperationWorkerProbeError, "schema probe failed"),
+        ):
+            build_privileged_operation_worker_store(
+                database_url="postgresql+psycopg://launchplane.invalid/launchplane"
+            )
+
+    def test_privileged_operation_worker_store_times_out_blocked_schema_probe(self) -> None:
+        with (
+            patch(
+                "control_plane.storage.factory.subprocess.run",
+                side_effect=subprocess.TimeoutExpired(
+                    cmd=(sys.executable, "-m", "worker-probe"),
+                    timeout=PRIVILEGED_OPERATION_WORKER_STARTUP_TIMEOUT_SECONDS,
+                ),
+            ),
+            self.assertRaisesRegex(
+                PrivilegedOperationWorkerStartupTimeoutError,
+                "store initialization timed out",
+            ),
+        ):
+            build_privileged_operation_worker_store(
+                database_url="postgresql+psycopg://launchplane.invalid/launchplane"
+            )
+
+    def test_privileged_operation_worker_probe_module_is_silent_without_database_url(self) -> None:
+        completed = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "control_plane.storage.privileged_operation_worker_probe",
+            ],
+            capture_output=True,
+            check=False,
+            env={},
+            text=True,
+        )
+
+        self.assertEqual(completed.returncode, PRIVILEGED_OPERATION_WORKER_PROBE_FAILED_EXIT_CODE)
+        self.assertEqual(completed.stdout, "")
+        self.assertEqual(completed.stderr, "")
 
     def test_postgres_engine_applies_bounded_connection_options(self) -> None:
         database_url = (


### PR DESCRIPTION
## Summary

- isolate the privileged-operation worker schema compatibility probe in a redacted child process
- enforce a 90-second wall-clock startup deadline so blocked client or network calls return to worker retry telemetry
- distinguish schema incompatibility, probe failure, and hard timeout without exposing database details
- limit the child environment to PostgreSQL, certificate, locale, and Python runtime inputs
- document the fail-closed startup boundary

## Validation

- `uv run --extra dev launchplane ci unittest-shard local` (3,078 targets)
- `uv run --extra dev mypy control_plane tests`
- focused Ruff and format checks
- real PostgreSQL schema-probe/empty-poll and runtime statement-timeout integration tests
- production container build
- JetBrains production-file inspection: GREEN
- independent exact-head review: approved

Refs #2219
