### PR TITLE
Add privileged worker post-probe evidence

### DIFF
--- a/control_plane/cli_service.py
+++ b/control_plane/cli_service.py
@@ -547,15 +547,32 @@ def service_privileged_operation_workers_run(
             )
         )
         store: PrivilegedOperationExecutionStore | None = None
+        schema_probe_succeeded = False
         store_initialized = False
         first_poll_attempted = False
         consecutive_errors = 0
+
+        def report_schema_probe_succeeded() -> None:
+            nonlocal schema_probe_succeeded
+            if schema_probe_succeeded:
+                return
+            click.echo(
+                json.dumps(
+                    {"event": "privileged_operation_worker_schema_probe_succeeded"},
+                    sort_keys=True,
+                )
+            )
+            schema_probe_succeeded = True
+
         while not stop_event.is_set():
             try:
                 if store is None:
                     store = cast(
                         PrivilegedOperationExecutionStore,
-                        build_privileged_operation_worker_store(database_url=database_url),
+                        build_privileged_operation_worker_store(
+                            database_url=database_url,
+                            on_schema_probe_succeeded=report_schema_probe_succeeded,
+                        ),
                     )
                 if not store_initialized:
                     click.echo(

--- a/control_plane/dokploy/runtime_evidence.py
+++ b/control_plane/dokploy/runtime_evidence.py
@@ -14,11 +14,13 @@ _IMMUTABLE_IMAGE_REFERENCE_PATTERN = re.compile(r"^[^\s@]+@sha256:[a-f0-9]{64}$"
 _MAX_RUNTIME_TEXT_LENGTH = 500
 _ALLOWED_STRUCTURED_EVENTS = frozenset(
     {
+        "privileged_operation_worker_schema_probe_succeeded",
         "privileged_operation_worker_store_initialized",
         "privileged_operation_worker_first_poll_attempted",
         "privileged_operation_worker_poll_succeeded",
     }
 )
+_ACTIVATION_PROOF_STRUCTURED_EVENTS = frozenset({"privileged_operation_worker_poll_succeeded"})
 type DokployEvidenceProviderOperation = Literal[
     "provider-config",
     "target-inspect",
@@ -47,6 +49,10 @@ def normalize_structured_event_name(raw_event_name: str) -> str:
             "Dokploy runtime evidence supports only allow-listed structured events."
         )
     return event_name
+
+
+def structured_event_is_activation_proof(event_name: str) -> bool:
+    return event_name in _ACTIVATION_PROOF_STRUCTURED_EVENTS
 
 
 def normalize_expected_image_reference(raw_image_reference: str) -> str:

--- a/control_plane/dokploy_target_inspect.py
+++ b/control_plane/dokploy_target_inspect.py
@@ -214,9 +214,13 @@ def inspect_dokploy_target(
             event_name=request.event,
         )
         event_observed = matching_event_count > 0
+        activation_proof_eligible = dokploy_runtime_evidence.structured_event_is_activation_proof(
+            request.event
+        )
         event_evidence: dict[str, object] = {
             "name": request.event,
             "observed": event_observed,
+            "activation_proof_eligible": activation_proof_eligible,
             "matching_line_count": matching_event_count,
             "candidate_line_count": len(logs),
         }
@@ -238,7 +242,11 @@ def inspect_dokploy_target(
             "image_matches_expected": image_matches_expected,
             "structured_event": event_evidence,
             "proof_ready": (
-                running and image_reference_immutable and image_matches_expected and event_observed
+                running
+                and image_reference_immutable
+                and image_matches_expected
+                and event_observed
+                and activation_proof_eligible
             ),
         }
     if target_record is not None and target_id_record is not None:

--- a/control_plane/storage/factory.py
+++ b/control_plane/storage/factory.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import subprocess
 import sys
+from collections.abc import Callable
 
 from control_plane.storage.postgres import PostgresRecordStore
 
@@ -100,7 +101,9 @@ def build_shared_record_store(*, database_url: str | None = None) -> PostgresRec
 
 
 def build_privileged_operation_worker_store(
-    *, database_url: str | None = None
+    *,
+    database_url: str | None = None,
+    on_schema_probe_succeeded: Callable[[], None] | None = None,
 ) -> PostgresRecordStore:
     resolved_database_url = resolve_database_url(database_url)
     if resolved_database_url is None:
@@ -138,6 +141,8 @@ def build_privileged_operation_worker_store(
         raise PrivilegedOperationWorkerProbeError(
             "Launchplane privileged-operation worker schema probe failed."
         )
+    if on_schema_probe_succeeded is not None:
+        on_schema_probe_succeeded()
     return PostgresRecordStore(
         database_url=resolved_database_url,
         postgres_connect_timeout_seconds=PRIVILEGED_OPERATION_WORKER_CONNECT_TIMEOUT_SECONDS,

--- a/docs/records.md
+++ b/docs/records.md
@@ -1609,7 +1609,8 @@ run` is the foreground loop intended for an external process supervisor, and
   An unavailable or blocked startup probe or poll therefore cannot hang the
   worker loop silently.
   The one-time structured events
-  `privileged_operation_worker_store_initialized` and
+  `privileged_operation_worker_schema_probe_succeeded`,
+  `privileged_operation_worker_store_initialized`, and
   `privileged_operation_worker_first_poll_attempted` provide bounded lifecycle
   localization only; activation evidence still requires
   `privileged_operation_worker_poll_succeeded`.

--- a/tests/test_dokploy_runtime_evidence.py
+++ b/tests/test_dokploy_runtime_evidence.py
@@ -19,6 +19,7 @@ class DokployRuntimeEvidenceTests(unittest.TestCase):
 
     def test_structured_event_accepts_bounded_worker_lifecycle_markers(self) -> None:
         for event_name in (
+            "privileged_operation_worker_schema_probe_succeeded",
             "privileged_operation_worker_store_initialized",
             "privileged_operation_worker_first_poll_attempted",
             "privileged_operation_worker_poll_succeeded",
@@ -28,6 +29,18 @@ class DokployRuntimeEvidenceTests(unittest.TestCase):
                     runtime_evidence.normalize_structured_event_name(event_name),
                     event_name,
                 )
+
+    def test_only_successful_poll_is_activation_proof(self) -> None:
+        self.assertFalse(
+            runtime_evidence.structured_event_is_activation_proof(
+                "privileged_operation_worker_schema_probe_succeeded"
+            )
+        )
+        self.assertTrue(
+            runtime_evidence.structured_event_is_activation_proof(
+                "privileged_operation_worker_poll_succeeded"
+            )
+        )
 
     def test_fetch_compose_service_runtime_returns_bounded_image_and_state(self) -> None:
         requests: list[dict[str, object]] = []

--- a/tests/test_dokploy_target_runtime_inspect.py
+++ b/tests/test_dokploy_target_runtime_inspect.py
@@ -140,8 +140,38 @@ class DokployTargetRuntimeInspectTests(unittest.TestCase):
         self.assertEqual(structured_event["matching_line_count"], 1)
         self.assertEqual(structured_event["candidate_line_count"], 2)
         self.assertTrue(structured_event["observed"])
+        self.assertTrue(structured_event["activation_proof_eligible"])
         self.assertNotIn("LAUNCHPLANE_DATABASE_URL", str(runtime_evidence))
         self.assertNotIn("secret", str(runtime_evidence))
+
+    def test_diagnostic_worker_event_is_observed_but_not_proof_ready(self) -> None:
+        def fetch_diagnostic_logs(**kwargs: object) -> tuple[str, ...]:
+            del kwargs
+            return ('{"event":"privileged_operation_worker_schema_probe_succeeded"}',)
+
+        result = inspect_dokploy_target(
+            record_store=_UNUSED_STORE,
+            host="https://dokploy.example.invalid",
+            token="token",
+            request=DokployTargetInspectRequest(
+                target_type="compose",
+                target_id="compose-123",
+                service="launchplane-privileged-operation-workers",
+                event="privileged_operation_worker_schema_probe_succeeded",
+                expected_image=f"ghcr.io/example/launchplane@sha256:{'a' * 64}",
+            ),
+            fetch_target_payload=_fetch_target_payload,
+            fetch_compose_service_runtime=_fetch_service_runtime,
+            fetch_compose_logs=fetch_diagnostic_logs,
+        )
+
+        runtime_evidence = result["runtime_evidence"]
+        assert isinstance(runtime_evidence, dict)
+        structured_event = runtime_evidence["structured_event"]
+        assert isinstance(structured_event, dict)
+        self.assertTrue(structured_event["observed"])
+        self.assertFalse(structured_event["activation_proof_eligible"])
+        self.assertFalse(runtime_evidence["proof_ready"])
 
     def test_expected_image_mismatch_is_not_proof_ready(self) -> None:
         result = inspect_dokploy_target(

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -3702,6 +3702,7 @@ class PostgresRecordStoreTests(unittest.TestCase):
 
     def test_privileged_operation_worker_store_uses_bounded_runtime_check(self) -> None:
         runtime_store = Mock()
+        schema_probe_succeeded = Mock()
         database_url = "postgresql+psycopg://launchplane.invalid/launchplane"
 
         with (
@@ -3725,7 +3726,10 @@ class PostgresRecordStoreTests(unittest.TestCase):
                 return_value=runtime_store,
             ) as store_type,
         ):
-            result = build_privileged_operation_worker_store(database_url=database_url)
+            result = build_privileged_operation_worker_store(
+                database_url=database_url,
+                on_schema_probe_succeeded=schema_probe_succeeded,
+            )
 
         self.assertIs(result, runtime_store)
         store_type.assert_called_once_with(
@@ -3753,6 +3757,7 @@ class PostgresRecordStoreTests(unittest.TestCase):
         self.assertNotIn("UNRELATED_SECRET", probe_kwargs["env"])
         self.assertEqual(probe_kwargs["stdout"], subprocess.DEVNULL)
         self.assertEqual(probe_kwargs["stderr"], subprocess.DEVNULL)
+        schema_probe_succeeded.assert_called_once_with()
 
     def test_privileged_operation_worker_store_closes_incompatible_schema(self) -> None:
         startup_probe = Mock()

--- a/tests/test_privileged_operation_worker.py
+++ b/tests/test_privileged_operation_worker.py
@@ -52,6 +52,13 @@ from tests.support.stores import _sqlite_database_url
 FIXED_NOW = datetime(2026, 8, 22, 20, 10, tzinfo=timezone.utc)
 
 
+def _build_worker_store_with_successful_probe(**kwargs: object) -> object:
+    report_probe_succeeded = kwargs["on_schema_probe_succeeded"]
+    assert callable(report_probe_succeeded)
+    report_probe_succeeded()
+    return object()
+
+
 def _fernet_key(offset: int) -> str:
     return base64.urlsafe_b64encode(bytes((offset + index) % 256 for index in range(32))).decode()
 
@@ -221,13 +228,22 @@ class PrivilegedOperationWorkerTests(unittest.TestCase):
                 return False
 
         wait_durations: list[int] = []
+        store_attempts = 0
+
+        def build_store(**kwargs: object) -> object:
+            nonlocal store_attempts
+            store_attempts += 1
+            if store_attempts == 1:
+                raise RuntimeError("database-url-secret must not be emitted")
+            return _build_worker_store_with_successful_probe(**kwargs)
+
         runner = CliRunner()
         records = [SimpleNamespace(operation_id="operation-secret-id", status="executed")]
         with (
             patch("control_plane.cli_service.Event", return_value=TestStopEvent()),
             patch(
                 "control_plane.cli_service.build_privileged_operation_worker_store",
-                side_effect=[RuntimeError("database-url-secret must not be emitted"), object()],
+                side_effect=build_store,
             ),
             patch(
                 "control_plane.cli_service.execute_approved_privileged_operations_once",
@@ -272,6 +288,7 @@ class PrivilegedOperationWorkerTests(unittest.TestCase):
             [
                 "privileged_operation_worker_started",
                 "privileged_operation_worker_retry",
+                "privileged_operation_worker_schema_probe_succeeded",
                 "privileged_operation_worker_store_initialized",
                 "privileged_operation_worker_first_poll_attempted",
                 "privileged_operation_worker_poll_succeeded",
@@ -282,15 +299,15 @@ class PrivilegedOperationWorkerTests(unittest.TestCase):
         self.assertEqual(telemetry[1]["consecutive_errors"], 1)
         self.assertEqual(telemetry[1]["error_type"], "RuntimeError")
         self.assertEqual(
-            telemetry[4],
+            telemetry[5],
             {
                 "event": "privileged_operation_worker_poll_succeeded",
                 "processed": 1,
                 "statuses": ["executed"],
             },
         )
-        self.assertEqual(telemetry[5]["consecutive_errors"], 1)
-        self.assertEqual(telemetry[6]["consecutive_errors"], 2)
+        self.assertEqual(telemetry[6]["consecutive_errors"], 1)
+        self.assertEqual(telemetry[7]["consecutive_errors"], 2)
 
     def test_worker_loop_stops_cleanly_after_sigterm(self) -> None:
         signal_handlers: dict[int, object] = {}
@@ -327,7 +344,7 @@ class PrivilegedOperationWorkerTests(unittest.TestCase):
             patch("control_plane.cli_service.Event", return_value=TestStopEvent()),
             patch(
                 "control_plane.cli_service.build_privileged_operation_worker_store",
-                return_value=object(),
+                side_effect=_build_worker_store_with_successful_probe,
             ),
             patch(
                 "control_plane.cli_service.execute_approved_privileged_operations_once",
@@ -357,6 +374,7 @@ class PrivilegedOperationWorkerTests(unittest.TestCase):
             [entry["event"] for entry in telemetry],
             [
                 "privileged_operation_worker_started",
+                "privileged_operation_worker_schema_probe_succeeded",
                 "privileged_operation_worker_store_initialized",
                 "privileged_operation_worker_first_poll_attempted",
                 "privileged_operation_worker_poll_succeeded",
@@ -390,7 +408,7 @@ class PrivilegedOperationWorkerTests(unittest.TestCase):
             patch("control_plane.cli_service.Event", return_value=TestStopEvent()),
             patch(
                 "control_plane.cli_service.build_privileged_operation_worker_store",
-                return_value=object(),
+                side_effect=_build_worker_store_with_successful_probe,
             ),
             patch(
                 "control_plane.cli_service.execute_approved_privileged_operations_once",
@@ -420,6 +438,7 @@ class PrivilegedOperationWorkerTests(unittest.TestCase):
                     "limit": 20,
                     "poll_seconds": 15,
                 },
+                {"event": "privileged_operation_worker_schema_probe_succeeded"},
                 {"event": "privileged_operation_worker_store_initialized"},
                 {"event": "privileged_operation_worker_first_poll_attempted"},
             ],
@@ -445,7 +464,7 @@ class PrivilegedOperationWorkerTests(unittest.TestCase):
             patch("control_plane.cli_service.Event", return_value=TestStopEvent()),
             patch(
                 "control_plane.cli_service.build_privileged_operation_worker_store",
-                return_value=object(),
+                side_effect=_build_worker_store_with_successful_probe,
             ),
             patch(
                 "control_plane.cli_service.execute_approved_privileged_operations_once",
@@ -472,6 +491,7 @@ class PrivilegedOperationWorkerTests(unittest.TestCase):
             [entry["event"] for entry in telemetry],
             [
                 "privileged_operation_worker_started",
+                "privileged_operation_worker_schema_probe_succeeded",
                 "privileged_operation_worker_store_initialized",
                 "privileged_operation_worker_first_poll_attempted",
                 "privileged_operation_worker_poll_succeeded",


### PR DESCRIPTION
## Summary

- emit a one-time structured event after the isolated schema probe succeeds and before runtime-store construction
- keep diagnostic lifecycle events observable without allowing them to satisfy activation proof
- preserve `privileged_operation_worker_poll_succeeded` as the only proof-ready worker event
- add focused factory, worker lifecycle, evidence normalization, and target inspection tests

## Validation

- `uv run --extra dev launchplane ci unittest-shard local` (3,078 targets)
- `uv run --extra dev mypy control_plane tests`
- focused Ruff and format checks
- real PostgreSQL schema-probe/empty-poll and statement-timeout tests
- production container build
- JetBrains production-file inspection: GREEN
- independent review: approved

Refs #2219
