### PR TITLE
Add worker runtime evidence diagnostic boundary

### DIFF
--- a/control_plane/cli_service.py
+++ b/control_plane/cli_service.py
@@ -574,6 +574,12 @@ def service_privileged_operation_workers_run(
                 sort_keys=True,
             )
         )
+        click.echo(
+            json.dumps(
+                {"event": "privileged_operation_worker_store_build_started"},
+                sort_keys=True,
+            )
+        )
         store: PrivilegedOperationExecutionStore | None = None
         schema_probe_succeeded = False
         store_initialized = False

--- a/control_plane/dokploy/runtime_evidence.py
+++ b/control_plane/dokploy/runtime_evidence.py
@@ -14,6 +14,8 @@ _IMMUTABLE_IMAGE_REFERENCE_PATTERN = re.compile(r"^[^\s@]+@sha256:[a-f0-9]{64}$"
 _MAX_RUNTIME_TEXT_LENGTH = 500
 _ALLOWED_STRUCTURED_EVENTS = frozenset(
     {
+        "privileged_operation_worker_started",
+        "privileged_operation_worker_store_build_started",
         "privileged_operation_worker_schema_probe_succeeded",
         "privileged_operation_worker_store_initialized",
         "privileged_operation_worker_first_poll_attempted",

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -3012,6 +3012,9 @@ artifact for both success and failure diagnosis, but treat it as activation
 evidence only when `runtime_evidence.proof_ready` is true. The artifact contains
 image/state identity, exact image-match state, and a structured-event count, not
 raw logs or container config.
+The allow-listed `privileged_operation_worker_started` and
+`privileged_operation_worker_store_build_started` events may be queried for
+diagnostic localization, but they are not activation-proof eligible.
 Activate only
 `privileged_secret_operation.plan`, `privileged_secret_operation.read`, and
 `privileged_secret_operation.cancel` first. Add

--- a/docs/privileged-operations.md
+++ b/docs/privileged-operations.md
@@ -82,7 +82,10 @@ request service `launchplane-privileged-operation-workers` and event
 `privileged_operation_worker_poll_succeeded`, supply the exact immutable
 deployment reference as `expected_image`, and proceed only when
 `runtime_evidence.proof_ready` is true. Do not retain or expose raw runtime logs,
-container configuration, or environment values as canary evidence.
+container configuration, or environment values as canary evidence. The
+allow-listed `privileged_operation_worker_started` and
+`privileged_operation_worker_store_build_started` events are diagnostic-only
+localization markers and can never make the response proof-ready.
 
 ## Records And Lifecycle
 

--- a/docs/records.md
+++ b/docs/records.md
@@ -1614,6 +1614,8 @@ run` is the foreground loop intended for an external process supervisor, and
   unavailable or blocked startup probe or poll therefore cannot hang the worker
   loop silently.
   The one-time structured events
+  `privileged_operation_worker_started`,
+  `privileged_operation_worker_store_build_started`,
   `privileged_operation_worker_schema_probe_succeeded`,
   `privileged_operation_worker_store_initialized`, and
   `privileged_operation_worker_first_poll_attempted` provide bounded lifecycle

--- a/tests/test_dokploy_runtime_evidence.py
+++ b/tests/test_dokploy_runtime_evidence.py
@@ -19,6 +19,8 @@ class DokployRuntimeEvidenceTests(unittest.TestCase):
 
     def test_structured_event_accepts_bounded_worker_lifecycle_markers(self) -> None:
         for event_name in (
+            "privileged_operation_worker_started",
+            "privileged_operation_worker_store_build_started",
             "privileged_operation_worker_schema_probe_succeeded",
             "privileged_operation_worker_store_initialized",
             "privileged_operation_worker_first_poll_attempted",
@@ -31,11 +33,15 @@ class DokployRuntimeEvidenceTests(unittest.TestCase):
                 )
 
     def test_only_successful_poll_is_activation_proof(self) -> None:
-        self.assertFalse(
-            runtime_evidence.structured_event_is_activation_proof(
-                "privileged_operation_worker_schema_probe_succeeded"
-            )
-        )
+        for event_name in (
+            "privileged_operation_worker_started",
+            "privileged_operation_worker_store_build_started",
+            "privileged_operation_worker_schema_probe_succeeded",
+            "privileged_operation_worker_store_initialized",
+            "privileged_operation_worker_first_poll_attempted",
+        ):
+            with self.subTest(event_name=event_name):
+                self.assertFalse(runtime_evidence.structured_event_is_activation_proof(event_name))
         self.assertTrue(
             runtime_evidence.structured_event_is_activation_proof(
                 "privileged_operation_worker_poll_succeeded"

--- a/tests/test_dokploy_target_runtime_inspect.py
+++ b/tests/test_dokploy_target_runtime_inspect.py
@@ -145,33 +145,37 @@ class DokployTargetRuntimeInspectTests(unittest.TestCase):
         self.assertNotIn("secret", str(runtime_evidence))
 
     def test_diagnostic_worker_event_is_observed_but_not_proof_ready(self) -> None:
-        def fetch_diagnostic_logs(**kwargs: object) -> tuple[str, ...]:
-            del kwargs
-            return ('{"event":"privileged_operation_worker_schema_probe_succeeded"}',)
+        for event_name in (
+            "privileged_operation_worker_started",
+            "privileged_operation_worker_store_build_started",
+            "privileged_operation_worker_schema_probe_succeeded",
+            "privileged_operation_worker_store_initialized",
+            "privileged_operation_worker_first_poll_attempted",
+        ):
+            with self.subTest(event_name=event_name):
+                result = inspect_dokploy_target(
+                    record_store=_UNUSED_STORE,
+                    host="https://dokploy.example.invalid",
+                    token="token",
+                    request=DokployTargetInspectRequest(
+                        target_type="compose",
+                        target_id="compose-123",
+                        service="launchplane-privileged-operation-workers",
+                        event=event_name,
+                        expected_image=f"ghcr.io/example/launchplane@sha256:{'a' * 64}",
+                    ),
+                    fetch_target_payload=_fetch_target_payload,
+                    fetch_compose_service_runtime=_fetch_service_runtime,
+                    fetch_compose_logs=lambda **_kwargs: (f'{{"event":"{event_name}"}}',),
+                )
 
-        result = inspect_dokploy_target(
-            record_store=_UNUSED_STORE,
-            host="https://dokploy.example.invalid",
-            token="token",
-            request=DokployTargetInspectRequest(
-                target_type="compose",
-                target_id="compose-123",
-                service="launchplane-privileged-operation-workers",
-                event="privileged_operation_worker_schema_probe_succeeded",
-                expected_image=f"ghcr.io/example/launchplane@sha256:{'a' * 64}",
-            ),
-            fetch_target_payload=_fetch_target_payload,
-            fetch_compose_service_runtime=_fetch_service_runtime,
-            fetch_compose_logs=fetch_diagnostic_logs,
-        )
-
-        runtime_evidence = result["runtime_evidence"]
-        assert isinstance(runtime_evidence, dict)
-        structured_event = runtime_evidence["structured_event"]
-        assert isinstance(structured_event, dict)
-        self.assertTrue(structured_event["observed"])
-        self.assertFalse(structured_event["activation_proof_eligible"])
-        self.assertFalse(runtime_evidence["proof_ready"])
+                runtime_evidence = result["runtime_evidence"]
+                assert isinstance(runtime_evidence, dict)
+                structured_event = runtime_evidence["structured_event"]
+                assert isinstance(structured_event, dict)
+                self.assertTrue(structured_event["observed"])
+                self.assertFalse(structured_event["activation_proof_eligible"])
+                self.assertFalse(runtime_evidence["proof_ready"])
 
     def test_expected_image_mismatch_is_not_proof_ready(self) -> None:
         result = inspect_dokploy_target(

--- a/tests/test_privileged_operation_worker.py
+++ b/tests/test_privileged_operation_worker.py
@@ -304,6 +304,7 @@ class PrivilegedOperationWorkerTests(unittest.TestCase):
             [entry["event"] for entry in telemetry],
             [
                 "privileged_operation_worker_started",
+                "privileged_operation_worker_store_build_started",
                 "privileged_operation_worker_retry",
                 "privileged_operation_worker_schema_probe_succeeded",
                 "privileged_operation_worker_store_initialized",
@@ -313,18 +314,18 @@ class PrivilegedOperationWorkerTests(unittest.TestCase):
                 "privileged_operation_worker_threshold_exit",
             ],
         )
-        self.assertEqual(telemetry[1]["consecutive_errors"], 1)
-        self.assertEqual(telemetry[1]["error_type"], "RuntimeError")
+        self.assertEqual(telemetry[2]["consecutive_errors"], 1)
+        self.assertEqual(telemetry[2]["error_type"], "RuntimeError")
         self.assertEqual(
-            telemetry[5],
+            telemetry[6],
             {
                 "event": "privileged_operation_worker_poll_succeeded",
                 "processed": 1,
                 "statuses": ["executed"],
             },
         )
-        self.assertEqual(telemetry[6]["consecutive_errors"], 1)
-        self.assertEqual(telemetry[7]["consecutive_errors"], 2)
+        self.assertEqual(telemetry[7]["consecutive_errors"], 1)
+        self.assertEqual(telemetry[8]["consecutive_errors"], 2)
 
     def test_worker_loop_stops_cleanly_after_sigterm(self) -> None:
         signal_handlers: dict[int, object] = {}
@@ -396,6 +397,7 @@ class PrivilegedOperationWorkerTests(unittest.TestCase):
             [entry["event"] for entry in telemetry],
             [
                 "privileged_operation_worker_started",
+                "privileged_operation_worker_store_build_started",
                 "privileged_operation_worker_schema_probe_succeeded",
                 "privileged_operation_worker_store_initialized",
                 "privileged_operation_worker_first_poll_attempted",
@@ -465,6 +467,7 @@ class PrivilegedOperationWorkerTests(unittest.TestCase):
                     "limit": 20,
                     "poll_seconds": 15,
                 },
+                {"event": "privileged_operation_worker_store_build_started"},
                 {"event": "privileged_operation_worker_schema_probe_succeeded"},
                 {"event": "privileged_operation_worker_store_initialized"},
                 {"event": "privileged_operation_worker_first_poll_attempted"},
@@ -523,6 +526,7 @@ class PrivilegedOperationWorkerTests(unittest.TestCase):
             [entry["event"] for entry in telemetry],
             [
                 "privileged_operation_worker_started",
+                "privileged_operation_worker_store_build_started",
                 "privileged_operation_worker_schema_probe_succeeded",
                 "privileged_operation_worker_store_initialized",
                 "privileged_operation_worker_first_poll_attempted",


### PR DESCRIPTION
## Summary
- allow the fixed worker startup and store-build lifecycle markers through protected runtime inspection as diagnostic-only evidence
- emit a one-time store-build boundary immediately after worker startup
- lock every non-poll lifecycle event out of activation proof and document the diagnostic boundary

## Why
Production inspection of the exact deployed worker image consistently returns one candidate log line while the same image emits the full lifecycle against disposable PostgreSQL locally. This change distinguishes a worker blocked before store construction from a bounded Dokploy log-read visibility problem without exposing raw logs, container configuration, or environment values.

## Validation
- `uv run --extra dev python -m unittest tests.test_dokploy_runtime_evidence tests.test_dokploy_target_runtime_inspect tests.test_privileged_operation_worker`
- `uv run --extra dev launchplane ci unittest-shard local` (3,080 targets; 12/12 shards)
- `uv run --extra dev mypy control_plane tests` (759 files)
- changed-file Ruff and format checks
- production image build
- real entrypoint + disposable PostgreSQL smoke through `privileged_operation_worker_poll_succeeded`
- direct continuous-worker startup without probe evidence refused
- independent exact-diff reviews; JetBrains inspection remained stale/UNKNOWN after its one maintained retry

Refs #2219
