### PR TITLE
Classify protected Dokploy runtime log failures

### DIFF
--- a/control_plane/dokploy/runtime_evidence.py
+++ b/control_plane/dokploy/runtime_evidence.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 import re
-from typing import Literal
+from typing import Literal, TypedDict
 
 import click
 
@@ -23,6 +23,13 @@ _ALLOWED_STRUCTURED_EVENTS = frozenset(
     }
 )
 _ACTIVATION_PROOF_STRUCTURED_EVENTS = frozenset({"privileged_operation_worker_poll_succeeded"})
+_RUNTIME_LOG_PROVIDER_ERROR_MARKERS = (
+    ("configured logging driver does not support reading", "unsupported_logging_driver"),
+    ("no such container", "container_not_found"),
+    ("error response from daemon:", "docker_daemon_error"),
+    ("remote command failed", "provider_command_failed"),
+    ("command execution failed", "provider_command_failed"),
+)
 type DokployEvidenceProviderOperation = Literal[
     "provider-config",
     "target-inspect",
@@ -32,6 +39,14 @@ type DokployEvidenceProviderOperation = Literal[
     "image-identity",
     "runtime-log-read",
 ]
+
+
+class RuntimeLogClassification(TypedDict):
+    structured_event_line_count: int
+    json_line_count: int
+    non_json_line_count: int
+    provider_error_line_count: int
+    provider_error_kind: str
 
 
 class DokployEvidenceProviderError(RuntimeError):
@@ -219,6 +234,41 @@ def count_structured_log_events(lines: tuple[str, ...], *, event_name: str) -> i
         if isinstance(payload, dict) and payload.get("event") == normalized_event_name:
             matching_events += 1
     return matching_events
+
+
+def summarize_runtime_log_lines(lines: tuple[str, ...]) -> RuntimeLogClassification:
+    structured_event_line_count = 0
+    json_line_count = 0
+    non_json_line_count = 0
+    provider_error_line_count = 0
+    provider_error_kind = ""
+    for line in lines:
+        object_start = line.find("{")
+        if object_start >= 0:
+            try:
+                payload, _ = json.JSONDecoder().raw_decode(line[object_start:])
+            except json.JSONDecodeError:
+                pass
+            else:
+                json_line_count += 1
+                if isinstance(payload, dict) and isinstance(payload.get("event"), str):
+                    structured_event_line_count += 1
+                continue
+        non_json_line_count += 1
+        normalized_line = line.lower()
+        for marker, error_kind in _RUNTIME_LOG_PROVIDER_ERROR_MARKERS:
+            if marker in normalized_line:
+                provider_error_line_count += 1
+                if not provider_error_kind:
+                    provider_error_kind = error_kind
+                break
+    return {
+        "structured_event_line_count": structured_event_line_count,
+        "json_line_count": json_line_count,
+        "non_json_line_count": non_json_line_count,
+        "provider_error_line_count": provider_error_line_count,
+        "provider_error_kind": provider_error_kind,
+    }
 
 
 def _normalize_container_config(

--- a/control_plane/dokploy_target_inspect.py
+++ b/control_plane/dokploy_target_inspect.py
@@ -217,12 +217,14 @@ def inspect_dokploy_target(
         activation_proof_eligible = dokploy_runtime_evidence.structured_event_is_activation_proof(
             request.event
         )
+        log_classification = dokploy_runtime_evidence.summarize_runtime_log_lines(logs)
         event_evidence: dict[str, object] = {
             "name": request.event,
             "observed": event_observed,
             "activation_proof_eligible": activation_proof_eligible,
             "matching_line_count": matching_event_count,
             "candidate_line_count": len(logs),
+            "log_classification": log_classification,
         }
         running = runtime_payload.get("running") is True
         image_reference_immutable = runtime_payload.get("image_reference_immutable") is True
@@ -247,6 +249,7 @@ def inspect_dokploy_target(
                 and image_matches_expected
                 and event_observed
                 and activation_proof_eligible
+                and log_classification["provider_error_line_count"] == 0
             ),
         }
     if target_record is not None and target_id_record is not None:

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -3014,7 +3014,10 @@ image/state identity, exact image-match state, and a structured-event count, not
 raw logs or container config.
 The allow-listed `privileged_operation_worker_started` and
 `privileged_operation_worker_store_build_started` events may be queried for
-diagnostic localization, but they are not activation-proof eligible.
+diagnostic localization, but they are not activation-proof eligible. Runtime
+evidence includes bounded JSON/non-JSON counts and a fixed provider-error code
+for diagnosis, never line content. Provider errors are classified only from
+non-JSON provider text and always prevent activation proof.
 Activate only
 `privileged_secret_operation.plan`, `privileged_secret_operation.read`, and
 `privileged_secret_operation.cancel` first. Add

--- a/docs/privileged-operations.md
+++ b/docs/privileged-operations.md
@@ -85,7 +85,11 @@ deployment reference as `expected_image`, and proceed only when
 container configuration, or environment values as canary evidence. The
 allow-listed `privileged_operation_worker_started` and
 `privileged_operation_worker_store_build_started` events are diagnostic-only
-localization markers and can never make the response proof-ready.
+localization markers and can never make the response proof-ready. Failed proof
+responses also include only structural JSON/non-JSON counts and a fixed
+provider-error classification; they never include a runtime log line. Any
+recognized provider error keeps the response fail-closed even if retained logs
+also contain a matching activation event.
 
 ## Records And Lifecycle
 

--- a/docs/records.md
+++ b/docs/records.md
@@ -1620,7 +1620,11 @@ run` is the foreground loop intended for an external process supervisor, and
   `privileged_operation_worker_store_initialized`, and
   `privileged_operation_worker_first_poll_attempted` provide bounded lifecycle
   localization only; activation evidence still requires
-  `privileged_operation_worker_poll_succeeded`.
+  `privileged_operation_worker_poll_succeeded`. Runtime evidence may classify
+  candidate lines by JSON/non-JSON structure and fixed provider-error kind,
+  but it does not persist or return line content. A recognized provider error
+  invalidates activation proof even if another retained line contains the
+  successful-poll event.
   Production operation remains observable through the `launchplane service
   verireel-workers status` and `launchplane service verireel-workers reconcile`
   operator commands, and through

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -2225,13 +2225,18 @@ Callers may additionally provide an exact compose `service`, expected immutable
 runtime-evidence mode resolves exactly one service container for both image and
 log evidence, reads only its state and immutable image identity, and searches at
 most 1,000 redacted candidate log lines from the last day for the exact JSON
-event field. It returns image-match state, event counts, and a `proof_ready`
-decision only; it never returns container IDs, container config, environment
-values, configured mutable image text, or raw log lines. Missing or ambiguous
-containers, invalid image identity, and provider failures fail closed. The
-manual workflow treats a requested runtime proof as failed unless the service is
-running, its immutable configured image exactly matches the operator-supplied
-expected image, and the requested event was observed.
+event field. It returns image-match state, event counts, bounded JSON/non-JSON
+line counts, fixed provider-error classification, and a `proof_ready` decision;
+it never returns container IDs, container config, environment values,
+configured mutable image text, or raw log lines. Provider-error kinds are
+`unsupported_logging_driver`, `container_not_found`, `docker_daemon_error`, and
+`provider_command_failed`. The first recognized non-JSON provider error sets the
+reported kind while every recognized provider-error line is counted. Missing or
+ambiguous containers, invalid image identity, and provider failures fail closed.
+The manual workflow treats a requested runtime proof as failed unless the
+service is running, its immutable configured image exactly matches the
+operator-supplied expected image, the requested event was observed, and no
+provider error was classified.
 
 Provider failures expose only a bounded operation stage such as
 `provider-config`, `target-inspect`, `container-list`, `service-select`,

--- a/tests/test_dokploy_runtime_evidence.py
+++ b/tests/test_dokploy_runtime_evidence.py
@@ -270,6 +270,28 @@ class DokployRuntimeEvidenceTests(unittest.TestCase):
 
         self.assertEqual(matching_event_count, 1)
 
+    def test_runtime_log_summary_returns_only_structural_counts_and_fixed_error_kind(self) -> None:
+        summary = runtime_evidence.summarize_runtime_log_lines(
+            (
+                '2026-08-24T00:00:00Z {"event":"privileged_operation_worker_started"}',
+                '2026-08-24T00:00:01Z {"status":"remote command failed"}',
+                "Error response from daemon: configured logging driver does not support reading",
+                "not-json {broken secret-value",
+            )
+        )
+
+        self.assertEqual(
+            summary,
+            {
+                "structured_event_line_count": 1,
+                "json_line_count": 2,
+                "non_json_line_count": 2,
+                "provider_error_line_count": 1,
+                "provider_error_kind": "unsupported_logging_driver",
+            },
+        )
+        self.assertNotIn("secret-value", str(summary))
+
     def test_fetch_compose_container_logs_uses_selected_container_without_search(self) -> None:
         requests: list[dict[str, object]] = []
 

--- a/tests/test_dokploy_target_runtime_inspect.py
+++ b/tests/test_dokploy_target_runtime_inspect.py
@@ -139,6 +139,16 @@ class DokployTargetRuntimeInspectTests(unittest.TestCase):
         self.assertTrue(runtime_evidence["proof_ready"])
         self.assertEqual(structured_event["matching_line_count"], 1)
         self.assertEqual(structured_event["candidate_line_count"], 2)
+        self.assertEqual(
+            structured_event["log_classification"],
+            {
+                "structured_event_line_count": 1,
+                "json_line_count": 1,
+                "non_json_line_count": 1,
+                "provider_error_line_count": 0,
+                "provider_error_kind": "",
+            },
+        )
         self.assertTrue(structured_event["observed"])
         self.assertTrue(structured_event["activation_proof_eligible"])
         self.assertNotIn("LAUNCHPLANE_DATABASE_URL", str(runtime_evidence))
@@ -197,6 +207,37 @@ class DokployTargetRuntimeInspectTests(unittest.TestCase):
         runtime_evidence = result["runtime_evidence"]
         assert isinstance(runtime_evidence, dict)
         self.assertFalse(runtime_evidence["image_matches_expected"])
+        self.assertFalse(runtime_evidence["proof_ready"])
+
+    def test_provider_error_line_invalidates_matching_activation_event(self) -> None:
+        result = inspect_dokploy_target(
+            record_store=_UNUSED_STORE,
+            host="https://dokploy.example.invalid",
+            token="token",
+            request=DokployTargetInspectRequest(
+                target_type="compose",
+                target_id="compose-123",
+                service="launchplane-privileged-operation-workers",
+                event="privileged_operation_worker_poll_succeeded",
+                expected_image=f"ghcr.io/example/launchplane@sha256:{'a' * 64}",
+            ),
+            fetch_target_payload=_fetch_target_payload,
+            fetch_compose_service_runtime=_fetch_service_runtime,
+            fetch_compose_logs=lambda **_kwargs: (
+                "Error response from daemon: configured logging driver does not support reading",
+                '{"event":"privileged_operation_worker_poll_succeeded"}',
+            ),
+        )
+
+        runtime_evidence = result["runtime_evidence"]
+        assert isinstance(runtime_evidence, dict)
+        structured_event = runtime_evidence["structured_event"]
+        assert isinstance(structured_event, dict)
+        classification = structured_event["log_classification"]
+        assert isinstance(classification, dict)
+        self.assertTrue(structured_event["observed"])
+        self.assertEqual(classification["provider_error_line_count"], 1)
+        self.assertEqual(classification["provider_error_kind"], "unsupported_logging_driver")
         self.assertFalse(runtime_evidence["proof_ready"])
 
     def test_non_running_service_is_not_proof_ready(self) -> None:


### PR DESCRIPTION
## Summary
- classify runtime-log candidates by bounded JSON/non-JSON counts and fixed provider error kinds without returning line content
- inspect provider-error markers only on non-JSON provider text
- fail activation proof closed whenever any recognized provider error is present, even alongside a retained success event
- document the exact response and error-kind contract

## Why
The exact deployed worker image is running, but protected Dokploy inspection returns one candidate line that is not any allow-listed worker lifecycle event. The self-bootstrap target is not tracked, so the tracked-target log workflow cannot resolve it. This bounded classification identifies whether the provider is returning an unsupported logging-driver or command error without exposing raw logs, container config, or secrets.

## Validation
- focused runtime evidence, target inspection, and HTTP tests (28 tests)
- `uv run --extra dev launchplane ci unittest-shard local` (3,080 targets; 12/12 shards)
- `uv run --extra dev mypy control_plane tests` (759 files)
- changed-file Ruff and format checks
- production image build
- independent final exact-diff review approved
- JetBrains reported one pre-existing Markdown table warning at `docs/privileged-operations.md:47`, outside this diff

Refs #2219
