### PR TITLE
Filter protected Dokploy proof logs by event

### DIFF
--- a/control_plane/dokploy/runtime_evidence.py
+++ b/control_plane/dokploy/runtime_evidence.py
@@ -194,23 +194,28 @@ def fetch_compose_container_logs(
     compose_id: str,
     container_id: str,
     line_count: int,
+    search_text: str = "",
 ) -> tuple[str, ...]:
     normalized_compose_id = compose_id.strip()
     normalized_container_id = container_id.strip()
     if not normalized_compose_id or not normalized_container_id:
         raise DokployEvidenceProviderError("runtime-log-read")
     normalized_line_count = dokploy_api.normalize_dokploy_log_line_count(line_count)
+    normalized_search_text = normalize_structured_event_name(search_text)
+    query: dict[str, str | int] = {
+        "composeId": normalized_compose_id,
+        "containerId": normalized_container_id,
+        "tail": normalized_line_count,
+        "since": "1d",
+    }
+    if normalized_search_text:
+        query["search"] = normalized_search_text
     try:
         payload = dokploy_api.dokploy_request(
             host=host,
             token=token,
             path="/api/compose.readLogs",
-            query={
-                "composeId": normalized_compose_id,
-                "containerId": normalized_container_id,
-                "tail": normalized_line_count,
-                "since": "1d",
-            },
+            query=query,
         )
     except click.ClickException as error:
         raise DokployEvidenceProviderError("runtime-log-read") from error

--- a/control_plane/dokploy_target_inspect.py
+++ b/control_plane/dokploy_target_inspect.py
@@ -44,6 +44,7 @@ class FetchDokployComposeLogs(Protocol):
         compose_id: str,
         container_id: str,
         line_count: int,
+        search_text: str,
     ) -> tuple[str, ...]: ...
 
 
@@ -198,32 +199,43 @@ def inspect_dokploy_target(
             raise dokploy_runtime_evidence.DokployEvidenceProviderError("service-select")
         logs_fetcher = fetch_compose_logs or dokploy_runtime_evidence.fetch_compose_container_logs
         try:
-            logs = logs_fetcher(
+            classification_logs = logs_fetcher(
                 host=host,
                 token=token,
                 compose_id=target_id,
                 container_id=container_id,
                 line_count=_RUNTIME_EVIDENCE_LOG_LINE_COUNT,
+                search_text="",
+            )
+            event_logs = logs_fetcher(
+                host=host,
+                token=token,
+                compose_id=target_id,
+                container_id=container_id,
+                line_count=_RUNTIME_EVIDENCE_LOG_LINE_COUNT,
+                search_text=request.event,
             )
         except click.ClickException as error:
             raise dokploy_runtime_evidence.DokployEvidenceProviderError(
                 "runtime-log-read"
             ) from error
         matching_event_count = dokploy_runtime_evidence.count_structured_log_events(
-            logs,
+            event_logs,
             event_name=request.event,
         )
         event_observed = matching_event_count > 0
         activation_proof_eligible = dokploy_runtime_evidence.structured_event_is_activation_proof(
             request.event
         )
-        log_classification = dokploy_runtime_evidence.summarize_runtime_log_lines(logs)
+        log_classification = dokploy_runtime_evidence.summarize_runtime_log_lines(
+            classification_logs
+        )
         event_evidence: dict[str, object] = {
             "name": request.event,
             "observed": event_observed,
             "activation_proof_eligible": activation_proof_eligible,
             "matching_line_count": matching_event_count,
-            "candidate_line_count": len(logs),
+            "candidate_line_count": len(event_logs),
             "log_classification": log_classification,
         }
         running = runtime_payload.get("running") is True

--- a/docs/privileged-operations.md
+++ b/docs/privileged-operations.md
@@ -89,7 +89,10 @@ localization markers and can never make the response proof-ready. Failed proof
 responses also include only structural JSON/non-JSON counts and a fixed
 provider-error classification; they never include a runtime log line. Any
 recognized provider error keeps the response fail-closed even if retained logs
-also contain a matching activation event.
+also contain a matching activation event. The protected reader passes only the
+code-owned allow-listed event name to Dokploy's fixed-string search and still
+requires an exact JSON event field match. A separate bounded unfiltered read
+preserves provider-error classification so search cannot hide a failure.
 
 ## Records And Lifecycle
 

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -2224,8 +2224,11 @@ Callers may additionally provide an exact compose `service`, expected immutable
 `expected_image`, and the allow-listed structured `event` name. That bounded
 runtime-evidence mode resolves exactly one service container for both image and
 log evidence, reads only its state and immutable image identity, and searches at
-most 1,000 redacted candidate log lines from the last day for the exact JSON
-event field. It returns image-match state, event counts, bounded JSON/non-JSON
+most 1,000 redacted candidate log lines from the last day twice: one unfiltered
+read for independent provider-error classification and one read using the
+code-owned allow-listed event name as the provider-side fixed-string filter
+before requiring an exact JSON event field match. It returns image-match state,
+event counts, bounded JSON/non-JSON
 line counts, fixed provider-error classification, and a `proof_ready` decision;
 it never returns container IDs, container config, environment values,
 configured mutable image text, or raw log lines. Provider-error kinds are

--- a/tests/test_dokploy_runtime_evidence.py
+++ b/tests/test_dokploy_runtime_evidence.py
@@ -336,6 +336,38 @@ class DokployRuntimeEvidenceTests(unittest.TestCase):
             ),
         )
 
+    def test_fetch_compose_container_logs_uses_allowlisted_event_search(self) -> None:
+        requests: list[dict[str, object]] = []
+
+        def capture_request(**kwargs: object) -> object:
+            requests.append(kwargs)
+            return '{"event":"privileged_operation_worker_poll_succeeded"}'
+
+        with patch(
+            "control_plane.dokploy.runtime_evidence.dokploy_api.dokploy_request",
+            side_effect=capture_request,
+        ):
+            lines = runtime_evidence.fetch_compose_container_logs(
+                host="https://dokploy.example.com",
+                token="secret-token",
+                compose_id="compose-123",
+                container_id="worker-container",
+                line_count=200,
+                search_text="privileged_operation_worker_poll_succeeded",
+            )
+
+        self.assertEqual(
+            requests[0]["query"],
+            {
+                "composeId": "compose-123",
+                "containerId": "worker-container",
+                "tail": 200,
+                "since": "1d",
+                "search": "privileged_operation_worker_poll_succeeded",
+            },
+        )
+        self.assertEqual(lines, ('{"event":"privileged_operation_worker_poll_succeeded"}',))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_dokploy_target_runtime_inspect.py
+++ b/tests/test_dokploy_target_runtime_inspect.py
@@ -57,8 +57,14 @@ def _fetch_logs(
     compose_id: str,
     container_id: str,
     line_count: int,
+    search_text: str,
 ) -> tuple[str, ...]:
     del host, token, compose_id, container_id, line_count
+    if search_text:
+        assert search_text == "privileged_operation_worker_poll_succeeded"
+        return (
+            '{"event":"privileged_operation_worker_poll_succeeded","processed":0,"statuses":[]}',
+        )
     return (
         '{"event":"privileged_operation_worker_poll_succeeded","processed":0,"statuses":[]}',
         "LAUNCHPLANE_DATABASE_URL=secret",
@@ -138,7 +144,7 @@ class DokployTargetRuntimeInspectTests(unittest.TestCase):
         self.assertTrue(runtime_evidence["image_matches_expected"])
         self.assertTrue(runtime_evidence["proof_ready"])
         self.assertEqual(structured_event["matching_line_count"], 1)
-        self.assertEqual(structured_event["candidate_line_count"], 2)
+        self.assertEqual(structured_event["candidate_line_count"], 1)
         self.assertEqual(
             structured_event["log_classification"],
             {
@@ -210,6 +216,15 @@ class DokployTargetRuntimeInspectTests(unittest.TestCase):
         self.assertFalse(runtime_evidence["proof_ready"])
 
     def test_provider_error_line_invalidates_matching_activation_event(self) -> None:
+        def fetch_provider_error_and_event(
+            *, search_text: str, **_kwargs: object
+        ) -> tuple[str, ...]:
+            if search_text:
+                return ('{"event":"privileged_operation_worker_poll_succeeded"}',)
+            return (
+                "Error response from daemon: configured logging driver does not support reading",
+            )
+
         result = inspect_dokploy_target(
             record_store=_UNUSED_STORE,
             host="https://dokploy.example.invalid",
@@ -223,10 +238,7 @@ class DokployTargetRuntimeInspectTests(unittest.TestCase):
             ),
             fetch_target_payload=_fetch_target_payload,
             fetch_compose_service_runtime=_fetch_service_runtime,
-            fetch_compose_logs=lambda **_kwargs: (
-                "Error response from daemon: configured logging driver does not support reading",
-                '{"event":"privileged_operation_worker_poll_succeeded"}',
-            ),
+            fetch_compose_logs=fetch_provider_error_and_event,
         )
 
         runtime_evidence = result["runtime_evidence"]


### PR DESCRIPTION
## Summary
- use the code-owned allow-listed event name as Dokploy's provider-side fixed-string filter
- preserve a separate unfiltered bounded read for independent provider-error classification
- keep exact parsed JSON event matching and fail-closed proof eligibility unchanged
- cover empty search, allow-listed search, and hidden-provider-error regression behavior

## Why
The exact deployed worker remains running while the general runtime log read returns one unrelated non-JSON candidate. Filtering the bounded read to the requested lifecycle event can recover the canonical event without weakening proof, while the independent unfiltered read ensures provider errors cannot be hidden by search.

## Validation
- focused runtime evidence, target inspection, and HTTP tests (29 tests)
- `uv run --extra dev launchplane ci unittest-shard local` (3,080 targets; 12/12 shards)
- `uv run --extra dev mypy control_plane tests` (759 files)
- changed-file Ruff and format checks
- production image build
- independent exact-diff review approved

Refs #2219
