### PR TITLE
Add privileged worker entrypoint stage markers

### DIFF
--- a/control_plane/dokploy/runtime_evidence.py
+++ b/control_plane/dokploy/runtime_evidence.py
@@ -14,6 +14,8 @@ _IMMUTABLE_IMAGE_REFERENCE_PATTERN = re.compile(r"^[^\s@]+@sha256:[a-f0-9]{64}$"
 _MAX_RUNTIME_TEXT_LENGTH = 500
 _ALLOWED_STRUCTURED_EVENTS = frozenset(
     {
+        "privileged_operation_worker_entrypoint_started",
+        "privileged_operation_worker_entrypoint_probe_succeeded",
         "privileged_operation_worker_started",
         "privileged_operation_worker_store_build_started",
         "privileged_operation_worker_schema_probe_succeeded",

--- a/docs/privileged-operations.md
+++ b/docs/privileged-operations.md
@@ -93,6 +93,9 @@ also contain a matching activation event. The protected reader passes only the
 code-owned allow-listed event name to Dokploy's fixed-string search and still
 requires an exact JSON event field match. A separate bounded unfiltered read
 preserves provider-error classification so search cannot hide a failure.
+The shell-level `privileged_operation_worker_entrypoint_started` and
+`privileged_operation_worker_entrypoint_probe_succeeded` markers localize the
+boundary before the continuous Python worker starts and remain diagnostic-only.
 
 ## Records And Lifecycle
 

--- a/docs/records.md
+++ b/docs/records.md
@@ -1614,6 +1614,8 @@ run` is the foreground loop intended for an external process supervisor, and
   unavailable or blocked startup probe or poll therefore cannot hang the worker
   loop silently.
   The one-time structured events
+  `privileged_operation_worker_entrypoint_started`,
+  `privileged_operation_worker_entrypoint_probe_succeeded`,
   `privileged_operation_worker_started`,
   `privileged_operation_worker_store_build_started`,
   `privileged_operation_worker_schema_probe_succeeded`,

--- a/scripts/start-launchplane-privileged-operation-workers.sh
+++ b/scripts/start-launchplane-privileged-operation-workers.sh
@@ -21,6 +21,8 @@ if ! command -v timeout >/dev/null 2>&1; then
 	exit 1
 fi
 
+printf '{"event":"privileged_operation_worker_entrypoint_started"}\n'
+
 set +e
 set -- env -i \
 	"PATH=$PATH" \
@@ -57,6 +59,8 @@ if [ "$startup_probe_status" -ne 0 ]; then
 		"$startup_probe_error_type"
 	exit 1
 fi
+
+printf '{"event":"privileged_operation_worker_entrypoint_probe_succeeded"}\n'
 
 schema_probe_evidence_path="$state_dir/.privileged-operation-worker-schema-probe.$$"
 umask 077

--- a/tests/test_dokploy_runtime_evidence.py
+++ b/tests/test_dokploy_runtime_evidence.py
@@ -19,6 +19,8 @@ class DokployRuntimeEvidenceTests(unittest.TestCase):
 
     def test_structured_event_accepts_bounded_worker_lifecycle_markers(self) -> None:
         for event_name in (
+            "privileged_operation_worker_entrypoint_started",
+            "privileged_operation_worker_entrypoint_probe_succeeded",
             "privileged_operation_worker_started",
             "privileged_operation_worker_store_build_started",
             "privileged_operation_worker_schema_probe_succeeded",
@@ -34,6 +36,8 @@ class DokployRuntimeEvidenceTests(unittest.TestCase):
 
     def test_only_successful_poll_is_activation_proof(self) -> None:
         for event_name in (
+            "privileged_operation_worker_entrypoint_started",
+            "privileged_operation_worker_entrypoint_probe_succeeded",
             "privileged_operation_worker_started",
             "privileged_operation_worker_store_build_started",
             "privileged_operation_worker_schema_probe_succeeded",

--- a/tests/test_dokploy_target_runtime_inspect.py
+++ b/tests/test_dokploy_target_runtime_inspect.py
@@ -162,6 +162,8 @@ class DokployTargetRuntimeInspectTests(unittest.TestCase):
 
     def test_diagnostic_worker_event_is_observed_but_not_proof_ready(self) -> None:
         for event_name in (
+            "privileged_operation_worker_entrypoint_started",
+            "privileged_operation_worker_entrypoint_probe_succeeded",
             "privileged_operation_worker_started",
             "privileged_operation_worker_store_build_started",
             "privileged_operation_worker_schema_probe_succeeded",

--- a/tests/test_start_launchplane_service.py
+++ b/tests/test_start_launchplane_service.py
@@ -692,6 +692,13 @@ exit {exit_code}
 
         self.assertEqual(result.returncode, 0, msg=result.stderr)
         self.assertEqual(
+            result.stdout.splitlines(),
+            [
+                '{"event":"privileged_operation_worker_entrypoint_started"}',
+                '{"event":"privileged_operation_worker_entrypoint_probe_succeeded"}',
+            ],
+        )
+        self.assertEqual(
             captured_args[:5],
             ["run", "launchplane", "service", "privileged-operation-workers", "run"],
         )
@@ -750,6 +757,8 @@ exit {exit_code}
             )
 
         self.assertEqual(result.returncode, 1, msg=result.stderr)
+        self.assertIn("privileged_operation_worker_entrypoint_started", result.stdout)
+        self.assertNotIn("privileged_operation_worker_entrypoint_probe_succeeded", result.stdout)
         self.assertIn("privileged_operation_worker_startup_probe_failed", result.stdout)
         self.assertIn('"error_type":"timeout"', result.stdout)
         self.assertFalse(capture_file.exists())


### PR DESCRIPTION
## Summary
- emit fixed JSON markers when the privileged worker entrypoint starts and when its isolated startup probe succeeds
- allow both markers only as diagnostic runtime evidence; neither can satisfy activation proof
- cover successful and timed-out probe ordering in shell tests and docs

## Why
The exact worker image runs locally through `poll_succeeded`, while production event-filtered reads find no Python lifecycle marker. Shell-level markers let the protected inspector distinguish a blocked startup probe from a block between probe completion and continuous Python worker startup without exposing general logs.

## Validation
- focused entrypoint/runtime/HTTP tests (35 tests)
- `uv run --extra dev launchplane ci unittest-shard local` (3,080 targets; 12/12 shards)
- `uv run --extra dev mypy control_plane tests` (759 files)
- Ruff, format, ShellCheck, and shfmt
- production image build
- real production-image entrypoint + disposable PostgreSQL smoke emitted both shell markers and all lifecycle events through `poll_succeeded`

Refs #2219
