### PR TITLE
Add DB-backed privileged worker heartbeat proof

### DIFF
--- a/.github/workflows/dokploy-target-inspect.yml
+++ b/.github/workflows/dokploy-target-inspect.yml
@@ -30,7 +30,7 @@ name: Dokploy Target Inspect
         default: ""
         type: string
       event:
-        description: Optional structured event name that must be observed for runtime proof.
+        description: Optional allow-listed runtime diagnostic event.
         required: false
         default: ""
         type: string
@@ -102,12 +102,6 @@ jobs:
             echo "runtime proof requires the expected immutable image." >&2
             exit 1
           fi
-          if [ -n "$(printf '%s' "$SERVICE" | xargs)" ] \
-            && [ -z "$(printf '%s' "$EVENT" | xargs)" ]; then
-            echo "runtime proof requires the structured event name." >&2
-            exit 1
-          fi
-
       - name: Build inspect request
         id: request
         shell: bash

--- a/control_plane/cli_service.py
+++ b/control_plane/cli_service.py
@@ -26,6 +26,7 @@ from control_plane.openapi_export import write_canonical_openapi
 from control_plane.privileged_operation_worker import (
     PrivilegedOperationExecutionStore,
     execute_approved_privileged_operations_once,
+    record_privileged_operation_worker_poll_heartbeat,
 )
 from control_plane.contracts.driver_descriptor import DriverContextView
 from control_plane.drivers.registry import build_driver_context_view
@@ -555,6 +556,8 @@ def service_privileged_operation_workers_run(
     generated_lease_owner = (
         f"{socket.gethostname()}:{uuid.uuid4()}" if not lease_owner.strip() else lease_owner
     )
+    runtime_identity = socket.gethostname()
+    image_reference = os.environ.get("DOCKER_IMAGE_REFERENCE", "")
     stop_event = Event()
 
     def request_stop(_signal_number: int, _frame: object) -> None:
@@ -629,6 +632,12 @@ def service_privileged_operation_workers_run(
                     record_store=store,
                     lease_owner=generated_lease_owner,
                     limit=limit,
+                )
+                record_privileged_operation_worker_poll_heartbeat(
+                    record_store=store,
+                    runtime_identity=runtime_identity,
+                    image_reference=image_reference,
+                    poll_interval_seconds=poll_seconds,
                 )
             except Exception as error:  # noqa: BLE001 - bounded worker retry loop.
                 consecutive_errors += 1

--- a/control_plane/contracts/privileged_operation_worker_heartbeat.py
+++ b/control_plane/contracts/privileged_operation_worker_heartbeat.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import hashlib
+import re
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+PRIVILEGED_OPERATION_WORKER_KIND = "privileged-operation"
+PRIVILEGED_OPERATION_WORKER_HEARTBEAT_RETENTION_SECONDS = 7 * 24 * 60 * 60
+PRIVILEGED_OPERATION_WORKER_HEARTBEAT_FUTURE_SKEW_SECONDS = 60
+PRIVILEGED_OPERATION_WORKER_HEARTBEAT_MIN_FRESHNESS_SECONDS = 120
+PRIVILEGED_OPERATION_WORKER_HEARTBEAT_MAX_FRESHNESS_SECONDS = 900
+
+_SHA256_PATTERN = re.compile(r"^[a-f0-9]{64}$")
+_IMMUTABLE_IMAGE_REFERENCE_PATTERN = re.compile(r"^[^\s@]+@sha256:[a-f0-9]{64}$")
+
+
+def privileged_operation_worker_identity_sha256(runtime_identity: str) -> str:
+    normalized_identity = runtime_identity.strip().lower()
+    if not normalized_identity:
+        raise ValueError("privileged-operation worker runtime identity is required")
+    return hashlib.sha256(
+        f"privileged-operation-worker:{normalized_identity}".encode("utf-8")
+    ).hexdigest()
+
+
+def normalize_privileged_operation_worker_image_reference(image_reference: str) -> str:
+    normalized_reference = image_reference.strip()
+    if _IMMUTABLE_IMAGE_REFERENCE_PATTERN.fullmatch(normalized_reference):
+        return normalized_reference
+    return ""
+
+
+def privileged_operation_worker_heartbeat_freshness_seconds(poll_interval_seconds: int) -> int:
+    return min(
+        PRIVILEGED_OPERATION_WORKER_HEARTBEAT_MAX_FRESHNESS_SECONDS,
+        max(
+            PRIVILEGED_OPERATION_WORKER_HEARTBEAT_MIN_FRESHNESS_SECONDS,
+            4 * poll_interval_seconds,
+        ),
+    )
+
+
+class PrivilegedOperationWorkerHeartbeatRecord(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: Literal[1] = 1
+    worker_kind: Literal["privileged-operation"] = "privileged-operation"
+    worker_identity_sha256: str
+    image_reference: str = ""
+    poll_interval_seconds: int = Field(ge=1, le=300)
+    last_poll_succeeded_at: str
+
+    @field_validator("worker_identity_sha256", mode="after")
+    @classmethod
+    def _validate_sha256(cls, value: str) -> str:
+        normalized_value = value.strip().lower()
+        if not _SHA256_PATTERN.fullmatch(normalized_value):
+            raise ValueError("privileged-operation worker identity must be a sha256 digest")
+        return normalized_value
+
+    @field_validator("image_reference", mode="after")
+    @classmethod
+    def _validate_image_reference(cls, value: str) -> str:
+        normalized_value = value.strip()
+        if normalized_value and not normalize_privileged_operation_worker_image_reference(
+            normalized_value
+        ):
+            raise ValueError(
+                "privileged-operation worker image must be an immutable repository@sha256 reference"
+            )
+        return normalized_value
+
+    @field_validator("last_poll_succeeded_at", mode="after")
+    @classmethod
+    def _validate_timestamp(cls, value: str) -> str:
+        normalized_value = value.strip()
+        try:
+            parsed_value = datetime.fromisoformat(normalized_value)
+        except ValueError as error:
+            raise ValueError(
+                "privileged-operation worker heartbeat timestamp is invalid"
+            ) from error
+        if parsed_value.tzinfo is None:
+            raise ValueError("privileged-operation worker heartbeat timestamp requires a timezone")
+        return parsed_value.astimezone(timezone.utc).isoformat()

--- a/control_plane/dokploy/runtime_evidence.py
+++ b/control_plane/dokploy/runtime_evidence.py
@@ -6,11 +6,15 @@ from typing import Literal, TypedDict
 
 import click
 
+from control_plane.contracts.privileged_operation_worker_heartbeat import (
+    normalize_privileged_operation_worker_image_reference,
+    privileged_operation_worker_identity_sha256,
+)
 from control_plane.dokploy import api as dokploy_api
 
 _STRUCTURED_EVENT_PATTERN = re.compile(r"^$|^[a-z][a-z0-9_]{0,127}$")
 _IMAGE_ID_PATTERN = re.compile(r"^sha256:[a-f0-9]{64}$")
-_IMMUTABLE_IMAGE_REFERENCE_PATTERN = re.compile(r"^[^\s@]+@sha256:[a-f0-9]{64}$")
+_CONTAINER_RUNTIME_ID_PATTERN = re.compile(r"^[a-f0-9]{12,64}$")
 _MAX_RUNTIME_TEXT_LENGTH = 500
 _ALLOWED_STRUCTURED_EVENTS = frozenset(
     {
@@ -38,6 +42,7 @@ type DokployEvidenceProviderOperation = Literal[
     "container-list",
     "service-select",
     "container-config",
+    "container-identity",
     "image-identity",
     "runtime-log-read",
 ]
@@ -78,13 +83,12 @@ def normalize_expected_image_reference(raw_image_reference: str) -> str:
     image_reference = raw_image_reference.strip()
     if not image_reference:
         return ""
-    if len(image_reference) > _MAX_RUNTIME_TEXT_LENGTH or not (
-        _IMMUTABLE_IMAGE_REFERENCE_PATTERN.fullmatch(image_reference)
-    ):
+    normalized_reference = normalize_privileged_operation_worker_image_reference(image_reference)
+    if len(image_reference) > _MAX_RUNTIME_TEXT_LENGTH or not normalized_reference:
         raise click.ClickException(
             "Expected Dokploy runtime image must be an immutable repository@sha256 reference."
         )
-    return image_reference
+    return normalized_reference
 
 
 def fetch_compose_service_runtime(
@@ -158,6 +162,20 @@ def fetch_compose_service_runtime(
     configured_image = (
         str(raw_config.get("Image") or "").strip() if isinstance(raw_config, dict) else ""
     )
+    configured_hostname = (
+        str(raw_config.get("Hostname") or "").strip() if isinstance(raw_config, dict) else ""
+    )
+    normalized_container_id = container_id.lower()
+    normalized_hostname = configured_hostname.lower()
+    if not (
+        _CONTAINER_RUNTIME_ID_PATTERN.fullmatch(normalized_container_id)
+        and _CONTAINER_RUNTIME_ID_PATTERN.fullmatch(normalized_hostname)
+        and (
+            normalized_container_id.startswith(normalized_hostname)
+            or normalized_hostname.startswith(normalized_container_id)
+        )
+    ):
+        raise DokployEvidenceProviderError("container-identity")
     if not configured_image:
         raise DokployEvidenceProviderError("image-identity")
     image_id = str(container_config.get("Image") or "").strip().lower()
@@ -169,15 +187,15 @@ def fetch_compose_service_runtime(
     status = dokploy_api.redact_dokploy_log_line(
         str(selected_container.get("status") or selected_container.get("Status") or "")
     )
-    immutable_image_reference = (
+    immutable_image_reference = normalize_privileged_operation_worker_image_reference(
         configured_image
-        if len(configured_image) <= _MAX_RUNTIME_TEXT_LENGTH
-        and _IMMUTABLE_IMAGE_REFERENCE_PATTERN.fullmatch(configured_image)
-        else ""
     )
     return {
         "compose_id": normalized_compose_id,
         "container_id": container_id,
+        "container_identity_sha256": privileged_operation_worker_identity_sha256(
+            normalized_hostname
+        ),
         "service": normalized_service_name,
         "state": state.strip()[:_MAX_RUNTIME_TEXT_LENGTH],
         "status": status.strip()[:_MAX_RUNTIME_TEXT_LENGTH],

--- a/control_plane/dokploy_target_inspect.py
+++ b/control_plane/dokploy_target_inspect.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
+from datetime import datetime, timezone
 from typing import Literal, Protocol
 
 import click
@@ -9,11 +10,18 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 from control_plane.contracts.deploy_target import ProviderTargetRecord
 from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
 from control_plane.contracts.dokploy_target_record import DokployTargetRecord
+from control_plane.contracts.privileged_operation_worker_heartbeat import (
+    PRIVILEGED_OPERATION_WORKER_HEARTBEAT_FUTURE_SKEW_SECONDS,
+    PRIVILEGED_OPERATION_WORKER_KIND,
+    PrivilegedOperationWorkerHeartbeatRecord,
+    privileged_operation_worker_heartbeat_freshness_seconds,
+)
 from control_plane.dokploy import api as dokploy_api
 from control_plane.dokploy import runtime_evidence as dokploy_runtime_evidence
 
 DokployTargetType = Literal["application", "compose"]
 _RUNTIME_EVIDENCE_LOG_LINE_COUNT = dokploy_api.MAX_DOKPLOY_LOG_LINE_COUNT
+_MAX_WORKER_HEARTBEAT_RECORDS = 100
 
 
 class FetchDokployTargetPayload(Protocol):
@@ -82,8 +90,6 @@ class DokployTargetInspectRequest(BaseModel):
             raise ValueError("Dokploy runtime event evidence requires a compose service.")
         if self.expected_image and not self.service:
             raise ValueError("Dokploy expected image evidence requires a compose service.")
-        if self.service and not self.event:
-            raise ValueError("Dokploy runtime service evidence requires a structured event.")
         if self.service and not self.expected_image:
             raise ValueError("Dokploy runtime service evidence requires an expected image.")
         has_route = bool(self.context or self.instance)
@@ -116,6 +122,90 @@ class DokployTargetInspectStore(Protocol):
         self, *, context_name: str, instance_name: str
     ) -> ProviderTargetRecord: ...
 
+    def list_privileged_operation_worker_heartbeat_records(
+        self,
+        *,
+        worker_kind: str = "",
+        limit: int | None = None,
+    ) -> tuple[PrivilegedOperationWorkerHeartbeatRecord, ...]: ...
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _worker_heartbeat_evidence(
+    *,
+    records: tuple[PrivilegedOperationWorkerHeartbeatRecord, ...],
+    container_identity_sha256: str,
+    immutable_image_reference: str,
+    now: datetime,
+) -> dict[str, object]:
+    bounded_records = records[:_MAX_WORKER_HEARTBEAT_RECORDS]
+    fresh_records: list[PrivilegedOperationWorkerHeartbeatRecord] = []
+    matching_record: PrivilegedOperationWorkerHeartbeatRecord | None = None
+    matching_age_seconds = 0
+    matching_freshness_limit_seconds = 0
+    matching_last_poll_succeeded_at = ""
+    matching_future_skew_detected = False
+
+    for record in bounded_records:
+        recorded_at = datetime.fromisoformat(record.last_poll_succeeded_at).astimezone(timezone.utc)
+        age_seconds = (now - recorded_at).total_seconds()
+        freshness_limit_seconds = privileged_operation_worker_heartbeat_freshness_seconds(
+            record.poll_interval_seconds
+        )
+        future_skew_detected = (
+            age_seconds < -PRIVILEGED_OPERATION_WORKER_HEARTBEAT_FUTURE_SKEW_SECONDS
+        )
+        if not future_skew_detected and age_seconds <= freshness_limit_seconds:
+            fresh_records.append(record)
+        if record.worker_identity_sha256 != container_identity_sha256:
+            continue
+        if matching_record is not None:
+            continue
+        matching_record = record
+        matching_age_seconds = max(-86_400, min(86_400, int(age_seconds)))
+        matching_freshness_limit_seconds = freshness_limit_seconds
+        matching_last_poll_succeeded_at = record.last_poll_succeeded_at
+        matching_future_skew_detected = future_skew_detected
+
+    matching_fresh = bool(matching_record is not None and matching_record in fresh_records)
+    image_matches = bool(
+        matching_record is not None
+        and matching_record.image_reference
+        and matching_record.image_reference == immutable_image_reference
+    )
+    identity_consistent = matching_record is not None
+
+    if not bounded_records:
+        status = "missing"
+    elif matching_record is None:
+        status = "identity_mismatch"
+    elif matching_future_skew_detected:
+        status = "future_timestamp"
+    elif not matching_fresh:
+        status = "stale"
+    elif not image_matches:
+        status = "image_mismatch"
+    else:
+        status = "ready"
+
+    return {
+        "source": "launchplane_records",
+        "status": status,
+        "observed": bool(bounded_records),
+        "matching_identity_observed": matching_record is not None,
+        "fresh": matching_fresh,
+        "identity_consistent": identity_consistent,
+        "image_matches": image_matches,
+        "fresh_worker_count": min(len(fresh_records), _MAX_WORKER_HEARTBEAT_RECORDS),
+        "age_seconds": matching_age_seconds,
+        "freshness_limit_seconds": matching_freshness_limit_seconds,
+        "last_poll_succeeded_at": matching_last_poll_succeeded_at,
+        "future_skew_detected": matching_future_skew_detected,
+    }
+
 
 def inspect_dokploy_target(
     *,
@@ -126,6 +216,7 @@ def inspect_dokploy_target(
     fetch_target_payload: FetchDokployTargetPayload | None = None,
     fetch_compose_service_runtime: FetchDokployComposeServiceRuntime | None = None,
     fetch_compose_logs: FetchDokployComposeLogs | None = None,
+    now: Callable[[], datetime] = _utc_now,
 ) -> dict[str, object]:
     target_record: DokployTargetRecord | None = None
     target_id_record: DokployTargetIdRecord | None = None
@@ -197,7 +288,13 @@ def inspect_dokploy_target(
         container_id = str(runtime_payload.get("container_id") or "").strip()
         if not container_id:
             raise dokploy_runtime_evidence.DokployEvidenceProviderError("service-select")
+        container_identity_sha256 = str(
+            runtime_payload.get("container_identity_sha256") or ""
+        ).strip()
+        if not container_identity_sha256:
+            raise dokploy_runtime_evidence.DokployEvidenceProviderError("container-identity")
         logs_fetcher = fetch_compose_logs or dokploy_runtime_evidence.fetch_compose_container_logs
+        log_read_status = "available"
         try:
             classification_logs = logs_fetcher(
                 host=host,
@@ -207,18 +304,24 @@ def inspect_dokploy_target(
                 line_count=_RUNTIME_EVIDENCE_LOG_LINE_COUNT,
                 search_text="",
             )
-            event_logs = logs_fetcher(
-                host=host,
-                token=token,
-                compose_id=target_id,
-                container_id=container_id,
-                line_count=_RUNTIME_EVIDENCE_LOG_LINE_COUNT,
-                search_text=request.event,
+            event_logs = (
+                logs_fetcher(
+                    host=host,
+                    token=token,
+                    compose_id=target_id,
+                    container_id=container_id,
+                    line_count=_RUNTIME_EVIDENCE_LOG_LINE_COUNT,
+                    search_text=request.event,
+                )
+                if request.event
+                else ()
             )
-        except click.ClickException as error:
-            raise dokploy_runtime_evidence.DokployEvidenceProviderError(
-                "runtime-log-read"
-            ) from error
+        except dokploy_runtime_evidence.DokployEvidenceProviderError as error:
+            if error.operation != "runtime-log-read":
+                raise
+            classification_logs = ()
+            event_logs = ()
+            log_read_status = "unavailable"
         matching_event_count = dokploy_runtime_evidence.count_structured_log_events(
             event_logs,
             event_name=request.event,
@@ -236,6 +339,7 @@ def inspect_dokploy_target(
             "activation_proof_eligible": activation_proof_eligible,
             "matching_line_count": matching_event_count,
             "candidate_line_count": len(event_logs),
+            "log_read_status": log_read_status,
             "log_classification": log_classification,
         }
         running = runtime_payload.get("running") is True
@@ -243,6 +347,16 @@ def inspect_dokploy_target(
         immutable_image_reference = str(runtime_payload.get("immutable_image_reference") or "")
         image_matches_expected = (
             not request.expected_image or immutable_image_reference == request.expected_image
+        )
+        heartbeat_records = record_store.list_privileged_operation_worker_heartbeat_records(
+            worker_kind=PRIVILEGED_OPERATION_WORKER_KIND,
+            limit=_MAX_WORKER_HEARTBEAT_RECORDS,
+        )
+        worker_heartbeat = _worker_heartbeat_evidence(
+            records=heartbeat_records,
+            container_identity_sha256=container_identity_sha256,
+            immutable_image_reference=immutable_image_reference,
+            now=now().astimezone(timezone.utc),
         )
         result["runtime_evidence"] = {
             "service": request.service,
@@ -255,13 +369,13 @@ def inspect_dokploy_target(
             "expected_image": request.expected_image,
             "image_matches_expected": image_matches_expected,
             "structured_event": event_evidence,
+            "worker_heartbeat": worker_heartbeat,
+            "proof_source": "worker_heartbeat_record",
             "proof_ready": (
                 running
                 and image_reference_immutable
                 and image_matches_expected
-                and event_observed
-                and activation_proof_eligible
-                and log_classification["provider_error_line_count"] == 0
+                and worker_heartbeat["status"] == "ready"
             ),
         }
     if target_record is not None and target_id_record is not None:

--- a/control_plane/http_routes/drivers.py
+++ b/control_plane/http_routes/drivers.py
@@ -306,6 +306,7 @@ def require_dokploy_target_inspect_store(record_store: object) -> DokployTargetI
         "read_dokploy_target_record",
         "read_dokploy_target_id_record",
         "read_provider_target_record",
+        "list_privileged_operation_worker_heartbeat_records",
     )
     missing_methods = [
         method_name

--- a/control_plane/privileged_operation_worker.py
+++ b/control_plane/privileged_operation_worker.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 import hashlib
 import json
 from typing import Any, Literal, Protocol, cast
@@ -26,6 +26,13 @@ from control_plane.contracts.privileged_operation import (
     build_privileged_operation_event_id,
     privileged_operation_pre_state_digest,
     privileged_operation_record_digest,
+)
+from control_plane.contracts.privileged_operation_worker_heartbeat import (
+    PRIVILEGED_OPERATION_WORKER_HEARTBEAT_FUTURE_SKEW_SECONDS,
+    PRIVILEGED_OPERATION_WORKER_HEARTBEAT_RETENTION_SECONDS,
+    PrivilegedOperationWorkerHeartbeatRecord,
+    normalize_privileged_operation_worker_image_reference,
+    privileged_operation_worker_identity_sha256,
 )
 from control_plane.durable_operation_authorization import (
     managed_github_id_rule_allows,
@@ -99,6 +106,16 @@ class PrivilegedOperationExecutionStore(PrivilegedOperationStore, Protocol):
     ) -> Any: ...
 
 
+class PrivilegedOperationWorkerHeartbeatStore(Protocol):
+    def write_privileged_operation_worker_heartbeat_record(
+        self,
+        record: PrivilegedOperationWorkerHeartbeatRecord,
+        *,
+        prune_before: str,
+        prune_after: str,
+    ) -> None: ...
+
+
 def _utc_now() -> datetime:
     return datetime.now(timezone.utc)
 
@@ -151,6 +168,47 @@ def require_privileged_operation_execution_store(
     if any(not callable(getattr(record_store, name, None)) for name in required_methods):
         raise TypeError("Privileged-operation execution requires PostgreSQL mutation storage.")
     return cast(PrivilegedOperationExecutionStore, planning_store)
+
+
+def require_privileged_operation_worker_heartbeat_store(
+    record_store: object,
+) -> PrivilegedOperationWorkerHeartbeatStore:
+    if not callable(
+        getattr(record_store, "write_privileged_operation_worker_heartbeat_record", None)
+    ):
+        raise TypeError(
+            "Privileged-operation worker heartbeat requires PostgreSQL heartbeat storage."
+        )
+    return cast(PrivilegedOperationWorkerHeartbeatStore, record_store)
+
+
+def record_privileged_operation_worker_poll_heartbeat(
+    *,
+    record_store: object,
+    runtime_identity: str,
+    image_reference: str,
+    poll_interval_seconds: int,
+    now: Callable[[], datetime] = _utc_now,
+) -> PrivilegedOperationWorkerHeartbeatRecord:
+    store = require_privileged_operation_worker_heartbeat_store(record_store)
+    recorded_at = now().astimezone(timezone.utc)
+    record = PrivilegedOperationWorkerHeartbeatRecord(
+        worker_identity_sha256=privileged_operation_worker_identity_sha256(runtime_identity),
+        image_reference=normalize_privileged_operation_worker_image_reference(image_reference),
+        poll_interval_seconds=poll_interval_seconds,
+        last_poll_succeeded_at=recorded_at.isoformat(),
+    )
+    store.write_privileged_operation_worker_heartbeat_record(
+        record,
+        prune_before=(
+            recorded_at - timedelta(seconds=PRIVILEGED_OPERATION_WORKER_HEARTBEAT_RETENTION_SECONDS)
+        ).isoformat(),
+        prune_after=(
+            recorded_at
+            + timedelta(seconds=PRIVILEGED_OPERATION_WORKER_HEARTBEAT_FUTURE_SKEW_SECONDS)
+        ).isoformat(),
+    )
+    return record
 
 
 def _construct_approver_authorization(

--- a/control_plane/storage/factory.py
+++ b/control_plane/storage/factory.py
@@ -31,6 +31,8 @@ PRIVILEGED_OPERATION_WORKER_REQUIRED_RELATIONS = (
     "launchplane_secret_bindings_lookup_idx",
     "launchplane_secret_audit_events",
     "launchplane_secret_audit_events_secret_idx",
+    "launchplane_privileged_operation_worker_heartbeats",
+    "launchplane_privop_worker_heartbeats_freshness_idx",
 )
 
 

--- a/control_plane/storage/migrations/versions/d2219a0b1c2d_add_privileged_operation_worker_heartbeats.py
+++ b/control_plane/storage/migrations/versions/d2219a0b1c2d_add_privileged_operation_worker_heartbeats.py
@@ -1,0 +1,68 @@
+"""add privileged-operation worker heartbeats
+
+Revision ID: d2219a0b1c2d
+Revises: c2221a0b1c2d
+Create Date: 2026-08-24 00:00:00.000000+00:00
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision: str = "d2219a0b1c2d"
+down_revision: str | None = "c2221a0b1c2d"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_TABLE = "launchplane_privileged_operation_worker_heartbeats"
+_FRESHNESS_INDEX = "launchplane_privop_worker_heartbeats_freshness_idx"
+
+
+def _table_exists(table_name: str) -> bool:
+    connection = op.get_bind()
+    inspector = sa.inspect(connection)
+    return table_name in set(inspector.get_table_names())
+
+
+def _index_exists(table_name: str, index_name: str) -> bool:
+    connection = op.get_bind()
+    inspector = sa.inspect(connection)
+    return index_name in {str(index["name"]) for index in inspector.get_indexes(table_name)}
+
+
+def _payload_column() -> sa.Column[object]:
+    return sa.Column(
+        "payload",
+        sa.JSON().with_variant(postgresql.JSONB(astext_type=sa.Text()), "postgresql"),
+        nullable=False,
+    )
+
+
+def upgrade() -> None:
+    if not _table_exists(_TABLE):
+        op.create_table(
+            _TABLE,
+            sa.Column("worker_identity_sha256", sa.String(), nullable=False),
+            sa.Column("worker_kind", sa.String(), nullable=False),
+            sa.Column("image_reference", sa.String(), nullable=False),
+            sa.Column("last_poll_succeeded_at", sa.String(), nullable=False),
+            _payload_column(),
+            sa.PrimaryKeyConstraint("worker_identity_sha256"),
+        )
+    if not _index_exists(_TABLE, _FRESHNESS_INDEX):
+        op.create_index(
+            _FRESHNESS_INDEX,
+            _TABLE,
+            ["worker_kind", "last_poll_succeeded_at"],
+        )
+
+
+def downgrade() -> None:
+    if _table_exists(_TABLE):
+        if _index_exists(_TABLE, _FRESHNESS_INDEX):
+            op.drop_index(_FRESHNESS_INDEX, table_name=_TABLE)
+        op.drop_table(_TABLE)

--- a/control_plane/storage/postgres.py
+++ b/control_plane/storage/postgres.py
@@ -184,6 +184,9 @@ from control_plane.contracts.privileged_operation import (
     privileged_operation_record_digest,
     validate_privileged_operation_transition,
 )
+from control_plane.contracts.privileged_operation_worker_heartbeat import (
+    PrivilegedOperationWorkerHeartbeatRecord,
+)
 from control_plane.contracts.preview_desired_state_record import PreviewDesiredStateRecord
 from control_plane.contracts.preview_enablement_record import PreviewEnablementRecord
 from control_plane.contracts.preview_generation_record import PreviewGenerationRecord
@@ -1052,6 +1055,23 @@ class LaunchplanePrivilegedOperationEventRow(Base):
     sequence: Mapped[int] = mapped_column(BigInteger, nullable=False)
     action: Mapped[str] = mapped_column(String, nullable=False)
     occurred_at: Mapped[str] = mapped_column(String, nullable=False)
+    payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
+
+
+class LaunchplanePrivilegedOperationWorkerHeartbeatRow(Base):
+    __tablename__ = "launchplane_privileged_operation_worker_heartbeats"
+    __table_args__ = (
+        Index(
+            "launchplane_privop_worker_heartbeats_freshness_idx",
+            "worker_kind",
+            "last_poll_succeeded_at",
+        ),
+    )
+
+    worker_identity_sha256: Mapped[str] = mapped_column(String, primary_key=True)
+    worker_kind: Mapped[str] = mapped_column(String, nullable=False)
+    image_reference: Mapped[str] = mapped_column(String, nullable=False)
+    last_poll_succeeded_at: Mapped[str] = mapped_column(String, nullable=False)
     payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
 
 
@@ -9170,6 +9190,59 @@ class PostgresRecordStore(HumanSessionStore):
         return tuple(
             self._read_payload(model_type=PrivilegedOperationEventRecord, payload=row.payload)
             for row in rows
+        )
+
+    def write_privileged_operation_worker_heartbeat_record(
+        self,
+        record: PrivilegedOperationWorkerHeartbeatRecord,
+        *,
+        prune_before: str,
+        prune_after: str,
+    ) -> None:
+        with self._session_factory() as session:
+            session.execute(
+                delete(LaunchplanePrivilegedOperationWorkerHeartbeatRow).where(
+                    LaunchplanePrivilegedOperationWorkerHeartbeatRow.worker_kind
+                    == record.worker_kind,
+                    or_(
+                        LaunchplanePrivilegedOperationWorkerHeartbeatRow.last_poll_succeeded_at
+                        < prune_before,
+                        LaunchplanePrivilegedOperationWorkerHeartbeatRow.last_poll_succeeded_at
+                        > prune_after,
+                    ),
+                )
+            )
+            session.merge(
+                LaunchplanePrivilegedOperationWorkerHeartbeatRow(
+                    worker_identity_sha256=record.worker_identity_sha256,
+                    worker_kind=record.worker_kind,
+                    image_reference=record.image_reference,
+                    last_poll_succeeded_at=record.last_poll_succeeded_at,
+                    payload=self._payload_dict(record),
+                )
+            )
+            session.commit()
+
+    def list_privileged_operation_worker_heartbeat_records(
+        self,
+        *,
+        worker_kind: str = "",
+        limit: int | None = None,
+    ) -> tuple[PrivilegedOperationWorkerHeartbeatRecord, ...]:
+        filters: list[object] = []
+        if worker_kind:
+            filters.append(
+                LaunchplanePrivilegedOperationWorkerHeartbeatRow.worker_kind == worker_kind
+            )
+        return self._list_models(
+            model_type=PrivilegedOperationWorkerHeartbeatRecord,
+            orm_model=LaunchplanePrivilegedOperationWorkerHeartbeatRow,
+            filters=filters,
+            order_by=(
+                LaunchplanePrivilegedOperationWorkerHeartbeatRow.last_poll_succeeded_at.desc(),
+                LaunchplanePrivilegedOperationWorkerHeartbeatRow.worker_identity_sha256.asc(),
+            ),
+            limit=limit,
         )
 
     def write_owner_acceptance_event_record(

--- a/control_plane/storage/schema_invariants.py
+++ b/control_plane/storage/schema_invariants.py
@@ -10,7 +10,7 @@ from sqlalchemy.engine import Engine
 from sqlalchemy.exc import SQLAlchemyError
 
 AUTHZ_COMPATIBILITY_FLOOR_REVISION = "f3b5d7e9a1c2"
-EXPECTED_ALEMBIC_HEAD_REVISION = "c2221a0b1c2d"
+EXPECTED_ALEMBIC_HEAD_REVISION = "d2219a0b1c2d"
 RUNTIME_COMPATIBLE_ALEMBIC_REVISIONS = (EXPECTED_ALEMBIC_HEAD_REVISION,)
 _AUTHZ_POLICY_TABLE = "launchplane_authz_policies"
 _AUTHZ_POLICY_WRITE_FENCE_TRIGGER = "launchplane_authz_policy_write_fence"

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -3000,24 +3000,41 @@ Compose runs that loop as `launchplane-privileged-operation-workers` using the
 same image as the API service. Its startup surface accepts only process settings
 for polling, batch limit, error backoff, and consecutive-error threshold; it
 does not accept operation IDs, plan digests, targets, or execution payloads.
+Production compose must pass the exact immutable deployed
+`DOCKER_IMAGE_REFERENCE` into the worker. A mutable local tag is normalized to
+an empty heartbeat image and can never satisfy runtime proof.
 
 Before any canary-rule activation, prove the privileged-operation worker
-container is running the expected image and record one successful DB-backed poll
-from its structured redacted telemetry. Dispatch the protected `Dokploy Target
+container is running the expected image and has persisted one fresh successful
+DB-backed poll heartbeat. Dispatch the protected `Dokploy Target
 Inspect` workflow with the deployed target identity, exact service
 `launchplane-privileged-operation-workers`, and event
 `privileged_operation_worker_poll_succeeded`, plus the exact immutable image
 reference retained from the deployment as `expected_image`. Retain its redacted
 artifact for both success and failure diagnosis, but treat it as activation
 evidence only when `runtime_evidence.proof_ready` is true. The artifact contains
-image/state identity, exact image-match state, and a structured-event count, not
-raw logs or container config.
+image/state identity, exact image-match state, bounded heartbeat freshness and
+identity status, and diagnostic structured-event counts, not raw logs, worker
+identity digests, hostnames, or container config. Proof requires a fresh
+matching heartbeat whose internally hashed runtime hostname matches Dokploy's
+provider-observed Docker-assigned hostname and whose immutable image equals the
+provider-observed and operator-supplied image. The provider hostname must be a
+hexadecimal prefix of the selected container ID; a custom hostname blocks proof.
+Missing, stale, future-dated, identity-mismatched, or image-mismatched
+heartbeats block activation. Other fresh worker rows are diagnostic and cannot
+substitute for the selected container identity.
 The allow-listed `privileged_operation_worker_started` and
 `privileged_operation_worker_store_build_started` events may be queried for
-diagnostic localization, but they are not activation-proof eligible. Runtime
+diagnostic localization, but they are not activation-proof authority. Runtime
 evidence includes bounded JSON/non-JSON counts and a fixed provider-error code
-for diagnosis, never line content. Provider errors are classified only from
-non-JSON provider text and always prevent activation proof.
+for diagnosis, never line content. Provider log errors and unavailable log reads
+remain diagnostic and do not block a valid DB heartbeat. Target lookup, service
+selection, container configuration/identity, and image identity failures remain
+hard failures.
+Because runtime compatibility accepts only the checked-in Alembic head, a code
+rollback across this migration also requires the matching schema downgrade;
+deploying the previous image alone fails closed instead of running against an
+unknown heartbeat schema.
 Activate only
 `privileged_secret_operation.plan`, `privileged_secret_operation.read`, and
 `privileged_secret_operation.cancel` first. Add

--- a/docs/privileged-operations.md
+++ b/docs/privileged-operations.md
@@ -76,23 +76,35 @@ reauthorization.
 
 Use the protected `Dokploy Target Inspect` workflow for that pre-activation
 proof. Its optional runtime-evidence mode requires an exact compose service,
-expected immutable image, and allow-listed structured event, and returns only
-bounded image/state identity and a structured-event match count. For the worker,
+expected immutable image, and optionally an allow-listed structured event for
+diagnostics. It returns only bounded image/state identity, successful-poll
+heartbeat status, and diagnostic structured-event counts. For the worker,
 request service `launchplane-privileged-operation-workers` and event
 `privileged_operation_worker_poll_succeeded`, supply the exact immutable
 deployment reference as `expected_image`, and proceed only when
 `runtime_evidence.proof_ready` is true. Do not retain or expose raw runtime logs,
 container configuration, or environment values as canary evidence. The
-allow-listed `privileged_operation_worker_started` and
-`privileged_operation_worker_store_build_started` events are diagnostic-only
-localization markers and can never make the response proof-ready. Failed proof
-responses also include only structural JSON/non-JSON counts and a fixed
-provider-error classification; they never include a runtime log line. Any
-recognized provider error keeps the response fail-closed even if retained logs
-also contain a matching activation event. The protected reader passes only the
-code-owned allow-listed event name to Dokploy's fixed-string search and still
-requires an exact JSON event field match. A separate bounded unfiltered read
-preserves provider-error classification so search cannot hide a failure.
+canonical poll proof is a DB-backed current heartbeat written only after a
+successful poll transaction. The proof reader requires a fresh heartbeat whose
+internal worker identity matches the selected container. Dokploy first proves
+that its observed hostname is a Docker-assigned prefix of the selected
+container ID, then hashes it for comparison; operator-chosen hostnames fail
+closed. The heartbeat image must also match both provider observation and
+`expected_image`. Missing, stale, future-dated, identity-mismatched, or
+image-mismatched heartbeats fail closed. Heartbeat persistence failure is a
+worker polling error, so the worker never emits successful-poll telemetry for
+evidence it could not persist. Raw hostnames and identity digests never leave
+the service.
+
+Allow-listed worker events remain diagnostic-only localization markers and do
+not make the response proof-ready. Failed log reads and recognized provider log
+errors are reported only through bounded availability and classification fields;
+they do not block a valid DB-backed heartbeat proof and never include a runtime
+log line. Provider failures in target lookup, service selection, container
+configuration, container identity, or image identity remain hard failures.
+When an event is supplied, the protected reader passes only the code-owned
+allow-listed name to Dokploy's fixed-string search and requires an exact JSON
+event field match when logs are available.
 The shell-level `privileged_operation_worker_entrypoint_started` and
 `privileged_operation_worker_entrypoint_probe_succeeded` markers localize the
 boundary before the continuous Python worker starts and remain diagnostic-only.

--- a/docs/records.md
+++ b/docs/records.md
@@ -1613,6 +1613,18 @@ run` is the foreground loop intended for an external process supervisor, and
   existing reservation, transaction, retry, and reconciliation boundaries. An
   unavailable or blocked startup probe or poll therefore cannot hang the worker
   loop silently.
+  `PrivilegedOperationWorkerHeartbeatRecord` is the bounded current projection
+  for successful continuous-worker polls. It stores only domain-separated
+  SHA-256 worker identity, an immutable image reference when one is available,
+  the code-bounded poll interval, and the latest successful-poll timestamp. It
+  never stores a raw hostname, container ID, lease owner, operation ID, payload,
+  credential, or log line. One row is upserted per worker identity. Each write
+  prunes rows older than seven days and rows more than the allowed 60-second
+  future-skew window in the same transaction. The heartbeat write occurs after
+  each successful DB-backed poll; a failed heartbeat write follows the worker's
+  ordinary retry and threshold-exit path and is not reported as poll success.
+  The heartbeat table and freshness index are required by the supervised
+  worker schema probe.
   The one-time structured events
   `privileged_operation_worker_entrypoint_started`,
   `privileged_operation_worker_entrypoint_probe_succeeded`,
@@ -1621,12 +1633,13 @@ run` is the foreground loop intended for an external process supervisor, and
   `privileged_operation_worker_schema_probe_succeeded`,
   `privileged_operation_worker_store_initialized`, and
   `privileged_operation_worker_first_poll_attempted` provide bounded lifecycle
-  localization only; activation evidence still requires
-  `privileged_operation_worker_poll_succeeded`. Runtime evidence may classify
-  candidate lines by JSON/non-JSON structure and fixed provider-error kind,
-  but it does not persist or return line content. A recognized provider error
-  invalidates activation proof even if another retained line contains the
-  successful-poll event.
+  localization only. The `privileged_operation_worker_poll_succeeded` event is
+  also diagnostic; canonical activation evidence comes from the matching fresh
+  DB heartbeat. Runtime evidence may classify candidate lines by JSON/non-JSON
+  structure and fixed provider-error kind, but it does not persist or return
+  line content. Log-read unavailability or provider log errors do not override a
+  valid heartbeat, while missing provider container/image identity or invalid
+  heartbeat freshness, image, or identity remains fail-closed.
   Production operation remains observable through the `launchplane service
   verireel-workers status` and `launchplane service verireel-workers reconcile`
   operator commands, and through

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -2221,34 +2221,53 @@ workflow is the supported shared and production caller when operators need
 provider evidence without mutating Dokploy or Launchplane records.
 
 Callers may additionally provide an exact compose `service`, expected immutable
-`expected_image`, and the allow-listed structured `event` name. That bounded
+`expected_image`, and an optional allow-listed structured `event` name for
+diagnostics. That bounded
 runtime-evidence mode resolves exactly one service container for both image and
-log evidence, reads only its state and immutable image identity, and searches at
-most 1,000 redacted candidate log lines from the last day twice: one unfiltered
-read for independent provider-error classification and one read using the
-code-owned allow-listed event name as the provider-side fixed-string filter
-before requiring an exact JSON event field match. It returns image-match state,
-event counts, bounded JSON/non-JSON
-line counts, fixed provider-error classification, and a `proof_ready` decision;
+bounded internal identity evidence, reads only its state and immutable image
+identity, and searches at most 1,000 redacted candidate log lines from the last
+day for independent provider-error classification. When `event` is present, it
+performs a second read using the code-owned allow-listed event name as the
+provider-side fixed-string filter before requiring an exact JSON event field
+match. It also reads the DB-backed
+privileged-operation worker heartbeat projection and internally compares the
+heartbeat's hashed runtime hostname with the hash of Dokploy's provider-observed
+container hostname. The provider hostname is accepted only when it is a
+Docker-assigned hexadecimal prefix of the selected container ID; configured
+custom hostnames fail closed. It returns image-match state, bounded
+heartbeat freshness/identity status, event counts, bounded JSON/non-JSON line
+counts, fixed provider-error classification, and a `proof_ready` decision;
 it never returns container IDs, container config, environment values,
-configured mutable image text, or raw log lines. Provider-error kinds are
+configured mutable image text, worker identity digests, hostnames, or raw log
+lines. Provider-error kinds are
 `unsupported_logging_driver`, `container_not_found`, `docker_daemon_error`, and
 `provider_command_failed`. The first recognized non-JSON provider error sets the
 reported kind while every recognized provider-error line is counted. Missing or
 ambiguous containers, invalid image identity, and provider failures fail closed.
 The manual workflow treats a requested runtime proof as failed unless the
 service is running, its immutable configured image exactly matches the
-operator-supplied expected image, the requested event was observed, and no
-provider error was classified.
+operator-supplied expected image, and a fresh heartbeat matches the same
+provider-observed container identity and image. Heartbeat timestamps more
+than 60 seconds in the future fail closed; freshness is bounded to four poll
+intervals with a 120-second floor and 900-second ceiling. Missing, stale,
+future-dated, identity-mismatched, or image-mismatched heartbeat records fail
+closed. Other fresh worker rows remain diagnostic because only the exact
+provider-selected container identity can satisfy proof. Structured events and
+provider log classification are diagnostic only. A log-read failure produces
+bounded `unavailable` diagnostics instead of a 503 and does not override a
+valid heartbeat proof.
 
 Provider failures expose only a bounded operation stage such as
 `provider-config`, `target-inspect`, `container-list`, `service-select`,
-`container-config`, `image-identity`, or `runtime-log-read`; raw provider
+`container-config`, `container-identity`, or `image-identity`; raw provider
 messages remain excluded.
 
-Runtime-event evidence remains under `dokploy_target.inspect` because the
+Runtime-event diagnostics and heartbeat proof remain under
+`dokploy_target.inspect` because the
 service accepts only code-owned allow-listed event names and returns counts, not
-log content. It is not an alternate arbitrary log-read surface; caller-selected
+log content, while the DB heartbeat is read-only evidence from existing
+Launchplane records rather than a new authorization surface. It is not an
+alternate arbitrary log-read surface; caller-selected
 log text and raw lines remain exclusively behind `target_logs.read` and exact
 context/instance authorization.
 

--- a/tests/test_dokploy_runtime_evidence.py
+++ b/tests/test_dokploy_runtime_evidence.py
@@ -5,6 +5,9 @@ from unittest.mock import patch
 
 import click
 
+from control_plane.contracts.privileged_operation_worker_heartbeat import (
+    privileged_operation_worker_identity_sha256,
+)
 from control_plane.dokploy import runtime_evidence
 
 
@@ -62,7 +65,7 @@ class DokployRuntimeEvidenceTests(unittest.TestCase):
             if kwargs["path"] == "/api/docker.getContainersByAppNameMatch":
                 return [
                     {
-                        "containerId": "worker-container",
+                        "containerId": "a" * 64,
                         "serviceName": "launchplane-privileged-operation-workers",
                         "state": "running",
                         "status": "Up 5 minutes",
@@ -72,6 +75,7 @@ class DokployRuntimeEvidenceTests(unittest.TestCase):
                 "Image": f"sha256:{image_id}",
                 "Config": {
                     "Image": f"ghcr.io/example/launchplane@sha256:{image_digest}",
+                    "Hostname": "a" * 12,
                     "Env": ["LAUNCHPLANE_DATABASE_URL=secret"],
                 },
             }
@@ -98,7 +102,7 @@ class DokployRuntimeEvidenceTests(unittest.TestCase):
         )
         self.assertEqual(
             requests[1]["query"],
-            {"containerId": "worker-container", "serverId": "server-1"},
+            {"containerId": "a" * 64, "serverId": "server-1"},
         )
         self.assertTrue(runtime["running"])
         self.assertTrue(runtime["image_reference_immutable"])
@@ -107,6 +111,10 @@ class DokployRuntimeEvidenceTests(unittest.TestCase):
             f"ghcr.io/example/launchplane@sha256:{image_digest}",
         )
         self.assertEqual(runtime["image_id"], f"sha256:{image_id}")
+        self.assertEqual(
+            runtime["container_identity_sha256"],
+            privileged_operation_worker_identity_sha256("a" * 12),
+        )
         self.assertNotIn("Env", runtime)
         self.assertNotIn("secret", str(runtime))
 
@@ -116,12 +124,15 @@ class DokployRuntimeEvidenceTests(unittest.TestCase):
             side_effect=[
                 [
                     {
-                        "containerId": "worker-container",
+                        "containerId": "a" * 64,
                         "serviceName": "worker",
                         "state": "running",
                     }
                 ],
-                {"Image": f"sha256:{'b' * 64}", "Config": {"Image": "example:latest"}},
+                {
+                    "Image": f"sha256:{'b' * 64}",
+                    "Config": {"Image": "example:latest", "Hostname": "a" * 12},
+                },
             ],
         ):
             runtime = runtime_evidence.fetch_compose_service_runtime(
@@ -140,13 +151,16 @@ class DokployRuntimeEvidenceTests(unittest.TestCase):
             "control_plane.dokploy.runtime_evidence.dokploy_api.dokploy_request",
             side_effect=[
                 [
-                    {"containerId": "database", "name": "launchplane_database_1"},
-                    {"containerId": "worker", "name": "launchplane_worker_1"},
+                    {"containerId": "c" * 64, "name": "launchplane_database_1"},
+                    {"containerId": "b" * 64, "name": "launchplane_worker_1"},
                 ],
                 [
                     {
                         "Image": f"sha256:{'b' * 64}",
-                        "Config": {"Image": f"example@sha256:{'a' * 64}"},
+                        "Config": {
+                            "Image": f"example@sha256:{'a' * 64}",
+                            "Hostname": "b" * 12,
+                        },
                     }
                 ],
             ],
@@ -188,7 +202,7 @@ class DokployRuntimeEvidenceTests(unittest.TestCase):
             patch(
                 "control_plane.dokploy.runtime_evidence.dokploy_api.dokploy_request",
                 side_effect=[
-                    [{"containerId": "worker", "serviceName": "worker"}],
+                    [{"containerId": "d" * 64, "serviceName": "worker"}],
                     click.ClickException("provider secret detail"),
                 ],
             ),
@@ -229,13 +243,47 @@ class DokployRuntimeEvidenceTests(unittest.TestCase):
             patch(
                 "control_plane.dokploy.runtime_evidence.dokploy_api.dokploy_request",
                 side_effect=[
-                    [{"containerId": "worker", "serviceName": "worker"}],
-                    {"Image": "", "Config": {"Image": "example:latest"}},
+                    [{"containerId": "d" * 64, "serviceName": "worker"}],
+                    {
+                        "Image": "",
+                        "Config": {
+                            "Image": "example:latest",
+                            "Hostname": "d" * 12,
+                        },
+                    },
                 ],
             ),
             self.assertRaisesRegex(
                 runtime_evidence.DokployEvidenceProviderError,
                 "image-identity",
+            ),
+        ):
+            runtime_evidence.fetch_compose_service_runtime(
+                host="https://dokploy.example.com",
+                token="secret-token",
+                compose_id="compose-123",
+                app_name="launchplane",
+                service_name="worker",
+            )
+
+    def test_fetch_compose_service_runtime_rejects_custom_hostname_identity(self) -> None:
+        with (
+            patch(
+                "control_plane.dokploy.runtime_evidence.dokploy_api.dokploy_request",
+                side_effect=[
+                    [{"containerId": "e" * 64, "serviceName": "worker"}],
+                    {
+                        "Image": f"sha256:{'b' * 64}",
+                        "Config": {
+                            "Image": f"example@sha256:{'a' * 64}",
+                            "Hostname": "custom-worker",
+                        },
+                    },
+                ],
+            ),
+            self.assertRaisesRegex(
+                runtime_evidence.DokployEvidenceProviderError,
+                "container-identity",
             ),
         ):
             runtime_evidence.fetch_compose_service_runtime(

--- a/tests/test_dokploy_runtime_evidence_workflow.py
+++ b/tests/test_dokploy_runtime_evidence_workflow.py
@@ -39,7 +39,7 @@ class DokployRuntimeEvidenceWorkflowTests(unittest.TestCase):
         self.assertIsNotNone(validate_inputs)
         assert validate_inputs is not None
         self.assertIn("runtime proof requires the expected immutable image", validate_inputs.run)
-        self.assertIn("runtime proof requires the structured event name", validate_inputs.run)
+        self.assertNotIn("requires the structured event name", validate_inputs.run)
         self.assertEqual(upload_evidence.data.get("if"), "always()")
 
 

--- a/tests/test_dokploy_target_runtime_inspect.py
+++ b/tests/test_dokploy_target_runtime_inspect.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
 
 import unittest
+from datetime import datetime, timedelta, timezone
 from typing import cast
 
 import click
 
 from control_plane.dokploy import api as dokploy_api
 from control_plane.dokploy import runtime_evidence as dokploy_runtime_evidence
+from control_plane.contracts.privileged_operation_worker_heartbeat import (
+    PrivilegedOperationWorkerHeartbeatRecord,
+    privileged_operation_worker_identity_sha256,
+)
 from control_plane.dokploy_target_inspect import (
     DokployTargetInspectRequest,
     DokployTargetInspectStore,
@@ -14,6 +19,43 @@ from control_plane.dokploy_target_inspect import (
 )
 
 _UNUSED_STORE = cast(DokployTargetInspectStore, object())
+_NOW = datetime(2026, 8, 24, 12, 0, tzinfo=timezone.utc)
+_IMAGE_REFERENCE = f"ghcr.io/example/launchplane@sha256:{'a' * 64}"
+_CONTAINER_HOSTNAME = "a" * 12
+_CONTAINER_IDENTITY_SHA256 = privileged_operation_worker_identity_sha256(_CONTAINER_HOSTNAME)
+
+
+def _heartbeat(
+    *,
+    runtime_identity: str = _CONTAINER_HOSTNAME,
+    image_reference: str = _IMAGE_REFERENCE,
+    last_poll_succeeded_at: datetime = _NOW,
+) -> PrivilegedOperationWorkerHeartbeatRecord:
+    return PrivilegedOperationWorkerHeartbeatRecord(
+        worker_identity_sha256=privileged_operation_worker_identity_sha256(runtime_identity),
+        image_reference=image_reference,
+        poll_interval_seconds=15,
+        last_poll_succeeded_at=last_poll_succeeded_at.isoformat(),
+    )
+
+
+class _HeartbeatStore:
+    def __init__(self, *records: PrivilegedOperationWorkerHeartbeatRecord) -> None:
+        self.records = records
+
+    def list_privileged_operation_worker_heartbeat_records(
+        self,
+        *,
+        worker_kind: str = "",
+        limit: int | None = None,
+    ) -> tuple[PrivilegedOperationWorkerHeartbeatRecord, ...]:
+        del worker_kind
+        if limit is None:
+            return self.records
+        return self.records[:limit]
+
+
+_READY_STORE = cast(DokployTargetInspectStore, _HeartbeatStore(_heartbeat()))
 
 
 def _fetch_target_payload(
@@ -39,13 +81,14 @@ def _fetch_service_runtime(
 ) -> dokploy_api.JsonObject:
     del host, token, compose_id, app_name, server_id, service_name
     return {
-        "container_id": "worker-container",
+        "container_id": "a" * 64,
+        "container_identity_sha256": _CONTAINER_IDENTITY_SHA256,
         "state": "running",
         "status": "Up 5 minutes",
         "running": True,
-        "configured_image": f"ghcr.io/example/launchplane@sha256:{'a' * 64}",
+        "configured_image": _IMAGE_REFERENCE,
         "image_id": f"sha256:{'b' * 64}",
-        "immutable_image_reference": f"ghcr.io/example/launchplane@sha256:{'a' * 64}",
+        "immutable_image_reference": _IMAGE_REFERENCE,
         "image_reference_immutable": True,
     }
 
@@ -101,13 +144,13 @@ class DokployTargetRuntimeInspectTests(unittest.TestCase):
             )
 
     def test_request_requires_complete_runtime_proof_selectors(self) -> None:
-        with self.assertRaisesRegex(ValueError, "requires a structured event"):
-            DokployTargetInspectRequest(
-                target_type="compose",
-                target_id="compose-123",
-                service="worker",
-                expected_image=f"example@sha256:{'a' * 64}",
-            )
+        request = DokployTargetInspectRequest(
+            target_type="compose",
+            target_id="compose-123",
+            service="worker",
+            expected_image=f"example@sha256:{'a' * 64}",
+        )
+        self.assertEqual(request.event, "")
         with self.assertRaisesRegex(ValueError, "requires an expected image"):
             DokployTargetInspectRequest(
                 target_type="compose",
@@ -118,7 +161,7 @@ class DokployTargetRuntimeInspectTests(unittest.TestCase):
 
     def test_explicit_compose_target_returns_bounded_runtime_evidence(self) -> None:
         result = inspect_dokploy_target(
-            record_store=_UNUSED_STORE,
+            record_store=_READY_STORE,
             host="https://dokploy.example.invalid",
             token="token",
             request=DokployTargetInspectRequest(
@@ -131,6 +174,7 @@ class DokployTargetRuntimeInspectTests(unittest.TestCase):
             fetch_target_payload=_fetch_target_payload,
             fetch_compose_service_runtime=_fetch_service_runtime,
             fetch_compose_logs=_fetch_logs,
+            now=lambda: _NOW,
         )
 
         runtime_evidence = result["runtime_evidence"]
@@ -143,6 +187,12 @@ class DokployTargetRuntimeInspectTests(unittest.TestCase):
         self.assertTrue(runtime_evidence["image_reference_immutable"])
         self.assertTrue(runtime_evidence["image_matches_expected"])
         self.assertTrue(runtime_evidence["proof_ready"])
+        self.assertEqual(runtime_evidence["proof_source"], "worker_heartbeat_record")
+        worker_heartbeat = runtime_evidence["worker_heartbeat"]
+        assert isinstance(worker_heartbeat, dict)
+        self.assertEqual(worker_heartbeat["status"], "ready")
+        self.assertTrue(worker_heartbeat["identity_consistent"])
+        self.assertTrue(worker_heartbeat["image_matches"])
         self.assertEqual(structured_event["matching_line_count"], 1)
         self.assertEqual(structured_event["candidate_line_count"], 1)
         self.assertEqual(
@@ -157,10 +207,12 @@ class DokployTargetRuntimeInspectTests(unittest.TestCase):
         )
         self.assertTrue(structured_event["observed"])
         self.assertTrue(structured_event["activation_proof_eligible"])
+        self.assertNotIn(_CONTAINER_IDENTITY_SHA256, str(runtime_evidence))
+        self.assertNotIn("worker_identity_sha256", str(runtime_evidence))
         self.assertNotIn("LAUNCHPLANE_DATABASE_URL", str(runtime_evidence))
         self.assertNotIn("secret", str(runtime_evidence))
 
-    def test_diagnostic_worker_event_is_observed_but_not_proof_ready(self) -> None:
+    def test_diagnostic_worker_event_does_not_replace_heartbeat_proof(self) -> None:
         for event_name in (
             "privileged_operation_worker_entrypoint_started",
             "privileged_operation_worker_entrypoint_probe_succeeded",
@@ -172,7 +224,7 @@ class DokployTargetRuntimeInspectTests(unittest.TestCase):
         ):
             with self.subTest(event_name=event_name):
                 result = inspect_dokploy_target(
-                    record_store=_UNUSED_STORE,
+                    record_store=_READY_STORE,
                     host="https://dokploy.example.invalid",
                     token="token",
                     request=DokployTargetInspectRequest(
@@ -185,6 +237,7 @@ class DokployTargetRuntimeInspectTests(unittest.TestCase):
                     fetch_target_payload=_fetch_target_payload,
                     fetch_compose_service_runtime=_fetch_service_runtime,
                     fetch_compose_logs=lambda **_kwargs: (f'{{"event":"{event_name}"}}',),
+                    now=lambda: _NOW,
                 )
 
                 runtime_evidence = result["runtime_evidence"]
@@ -193,11 +246,11 @@ class DokployTargetRuntimeInspectTests(unittest.TestCase):
                 assert isinstance(structured_event, dict)
                 self.assertTrue(structured_event["observed"])
                 self.assertFalse(structured_event["activation_proof_eligible"])
-                self.assertFalse(runtime_evidence["proof_ready"])
+                self.assertTrue(runtime_evidence["proof_ready"])
 
     def test_expected_image_mismatch_is_not_proof_ready(self) -> None:
         result = inspect_dokploy_target(
-            record_store=_UNUSED_STORE,
+            record_store=_READY_STORE,
             host="https://dokploy.example.invalid",
             token="token",
             request=DokployTargetInspectRequest(
@@ -210,6 +263,7 @@ class DokployTargetRuntimeInspectTests(unittest.TestCase):
             fetch_target_payload=_fetch_target_payload,
             fetch_compose_service_runtime=_fetch_service_runtime,
             fetch_compose_logs=_fetch_logs,
+            now=lambda: _NOW,
         )
 
         runtime_evidence = result["runtime_evidence"]
@@ -217,7 +271,7 @@ class DokployTargetRuntimeInspectTests(unittest.TestCase):
         self.assertFalse(runtime_evidence["image_matches_expected"])
         self.assertFalse(runtime_evidence["proof_ready"])
 
-    def test_provider_error_line_invalidates_matching_activation_event(self) -> None:
+    def test_provider_error_line_remains_diagnostic(self) -> None:
         def fetch_provider_error_and_event(
             *, search_text: str, **_kwargs: object
         ) -> tuple[str, ...]:
@@ -228,7 +282,7 @@ class DokployTargetRuntimeInspectTests(unittest.TestCase):
             )
 
         result = inspect_dokploy_target(
-            record_store=_UNUSED_STORE,
+            record_store=_READY_STORE,
             host="https://dokploy.example.invalid",
             token="token",
             request=DokployTargetInspectRequest(
@@ -241,6 +295,7 @@ class DokployTargetRuntimeInspectTests(unittest.TestCase):
             fetch_target_payload=_fetch_target_payload,
             fetch_compose_service_runtime=_fetch_service_runtime,
             fetch_compose_logs=fetch_provider_error_and_event,
+            now=lambda: _NOW,
         )
 
         runtime_evidence = result["runtime_evidence"]
@@ -252,7 +307,7 @@ class DokployTargetRuntimeInspectTests(unittest.TestCase):
         self.assertTrue(structured_event["observed"])
         self.assertEqual(classification["provider_error_line_count"], 1)
         self.assertEqual(classification["provider_error_kind"], "unsupported_logging_driver")
-        self.assertFalse(runtime_evidence["proof_ready"])
+        self.assertTrue(runtime_evidence["proof_ready"])
 
     def test_non_running_service_is_not_proof_ready(self) -> None:
         def fetch_stopped_runtime(**kwargs: str) -> dokploy_api.JsonObject:
@@ -270,7 +325,7 @@ class DokployTargetRuntimeInspectTests(unittest.TestCase):
             return runtime
 
         result = inspect_dokploy_target(
-            record_store=_UNUSED_STORE,
+            record_store=_READY_STORE,
             host="https://dokploy.example.invalid",
             token="token",
             request=DokployTargetInspectRequest(
@@ -283,12 +338,90 @@ class DokployTargetRuntimeInspectTests(unittest.TestCase):
             fetch_target_payload=_fetch_target_payload,
             fetch_compose_service_runtime=fetch_stopped_runtime,
             fetch_compose_logs=_fetch_logs,
+            now=lambda: _NOW,
         )
 
         runtime_evidence = result["runtime_evidence"]
         assert isinstance(runtime_evidence, dict)
         self.assertFalse(runtime_evidence["running"])
         self.assertFalse(runtime_evidence["proof_ready"])
+
+    def test_heartbeat_proof_fails_closed_for_invalid_runtime_states(self) -> None:
+        cases = (
+            ("missing", _HeartbeatStore()),
+            ("identity_mismatch", _HeartbeatStore(_heartbeat(runtime_identity="other-worker"))),
+            (
+                "stale",
+                _HeartbeatStore(_heartbeat(last_poll_succeeded_at=_NOW - timedelta(seconds=121))),
+            ),
+            (
+                "future_timestamp",
+                _HeartbeatStore(_heartbeat(last_poll_succeeded_at=_NOW + timedelta(seconds=61))),
+            ),
+            (
+                "image_mismatch",
+                _HeartbeatStore(
+                    _heartbeat(image_reference=f"ghcr.io/example/launchplane@sha256:{'c' * 64}")
+                ),
+            ),
+        )
+
+        for expected_status, store in cases:
+            with self.subTest(expected_status=expected_status):
+                result = inspect_dokploy_target(
+                    record_store=cast(DokployTargetInspectStore, store),
+                    host="https://dokploy.example.invalid",
+                    token="token",
+                    request=DokployTargetInspectRequest(
+                        target_type="compose",
+                        target_id="compose-123",
+                        service="launchplane-privileged-operation-workers",
+                        event="privileged_operation_worker_poll_succeeded",
+                        expected_image=_IMAGE_REFERENCE,
+                    ),
+                    fetch_target_payload=_fetch_target_payload,
+                    fetch_compose_service_runtime=_fetch_service_runtime,
+                    fetch_compose_logs=_fetch_logs,
+                    now=lambda: _NOW,
+                )
+
+                runtime_evidence = result["runtime_evidence"]
+                assert isinstance(runtime_evidence, dict)
+                heartbeat = runtime_evidence["worker_heartbeat"]
+                assert isinstance(heartbeat, dict)
+                self.assertEqual(heartbeat["status"], expected_status)
+                self.assertFalse(runtime_evidence["proof_ready"])
+
+    def test_unrelated_fresh_heartbeat_does_not_override_exact_identity_match(self) -> None:
+        result = inspect_dokploy_target(
+            record_store=cast(
+                DokployTargetInspectStore,
+                _HeartbeatStore(
+                    _heartbeat(),
+                    _heartbeat(runtime_identity="replacement-worker"),
+                ),
+            ),
+            host="https://dokploy.example.invalid",
+            token="token",
+            request=DokployTargetInspectRequest(
+                target_type="compose",
+                target_id="compose-123",
+                service="launchplane-privileged-operation-workers",
+                expected_image=_IMAGE_REFERENCE,
+            ),
+            fetch_target_payload=_fetch_target_payload,
+            fetch_compose_service_runtime=_fetch_service_runtime,
+            fetch_compose_logs=lambda **_kwargs: (),
+            now=lambda: _NOW,
+        )
+
+        runtime_evidence = result["runtime_evidence"]
+        assert isinstance(runtime_evidence, dict)
+        heartbeat = runtime_evidence["worker_heartbeat"]
+        assert isinstance(heartbeat, dict)
+        self.assertEqual(heartbeat["status"], "ready")
+        self.assertEqual(heartbeat["fresh_worker_count"], 2)
+        self.assertTrue(runtime_evidence["proof_ready"])
 
     def test_application_target_rejects_runtime_service_evidence(self) -> None:
         with self.assertRaisesRegex(ValueError, "supports compose targets only"):
@@ -306,30 +439,35 @@ class DokployTargetRuntimeInspectTests(unittest.TestCase):
                 fetch_target_payload=_fetch_target_payload,
             )
 
-    def test_log_fetch_failure_identifies_runtime_log_stage(self) -> None:
+    def test_log_fetch_failure_is_bounded_diagnostic(self) -> None:
         def fetch_log_failure(**kwargs: str | int) -> tuple[str, ...]:
             del kwargs
-            raise click.ClickException("provider TOKEN=secret")
+            raise dokploy_runtime_evidence.DokployEvidenceProviderError("runtime-log-read")
 
-        with self.assertRaisesRegex(
-            dokploy_runtime_evidence.DokployEvidenceProviderError,
-            "runtime-log-read",
-        ):
-            inspect_dokploy_target(
-                record_store=_UNUSED_STORE,
-                host="https://dokploy.example.invalid",
-                token="token",
-                request=DokployTargetInspectRequest(
-                    target_type="compose",
-                    target_id="compose-123",
-                    service="launchplane-privileged-operation-workers",
-                    event="privileged_operation_worker_poll_succeeded",
-                    expected_image=f"ghcr.io/example/launchplane@sha256:{'a' * 64}",
-                ),
-                fetch_target_payload=_fetch_target_payload,
-                fetch_compose_service_runtime=_fetch_service_runtime,
-                fetch_compose_logs=fetch_log_failure,
-            )
+        result = inspect_dokploy_target(
+            record_store=_READY_STORE,
+            host="https://dokploy.example.invalid",
+            token="token",
+            request=DokployTargetInspectRequest(
+                target_type="compose",
+                target_id="compose-123",
+                service="launchplane-privileged-operation-workers",
+                event="privileged_operation_worker_poll_succeeded",
+                expected_image=_IMAGE_REFERENCE,
+            ),
+            fetch_target_payload=_fetch_target_payload,
+            fetch_compose_service_runtime=_fetch_service_runtime,
+            fetch_compose_logs=fetch_log_failure,
+            now=lambda: _NOW,
+        )
+
+        runtime_evidence = result["runtime_evidence"]
+        assert isinstance(runtime_evidence, dict)
+        structured_event = runtime_evidence["structured_event"]
+        assert isinstance(structured_event, dict)
+        self.assertEqual(structured_event["log_read_status"], "unavailable")
+        self.assertFalse(structured_event["observed"])
+        self.assertTrue(runtime_evidence["proof_ready"])
 
 
 if __name__ == "__main__":

--- a/tests/test_http_dokploy_runtime_evidence.py
+++ b/tests/test_http_dokploy_runtime_evidence.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
 
 import unittest
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest.mock import patch
 
 import click
 
+from control_plane.contracts.privileged_operation_worker_heartbeat import (
+    PrivilegedOperationWorkerHeartbeatRecord,
+    privileged_operation_worker_identity_sha256,
+)
 from control_plane.http_app import create_launchplane_fastapi_app
 from control_plane.storage.postgres import PostgresRecordStore
 from tests.http_app_test_support import _asgi_get, _record_read_policy
@@ -21,6 +26,18 @@ class FastApiDokployRuntimeEvidenceTests(unittest.IsolatedAsyncioTestCase):
             database_url = sqlite_database_url(root / "launchplane.sqlite3")
             store = PostgresRecordStore(database_url=database_url)
             store.ensure_schema()
+            recorded_at = datetime.now(timezone.utc)
+            container_identity_sha256 = privileged_operation_worker_identity_sha256("a" * 12)
+            store.write_privileged_operation_worker_heartbeat_record(
+                PrivilegedOperationWorkerHeartbeatRecord(
+                    worker_identity_sha256=container_identity_sha256,
+                    image_reference=f"ghcr.io/example/launchplane@sha256:{'a' * 64}",
+                    poll_interval_seconds=15,
+                    last_poll_succeeded_at=recorded_at.isoformat(),
+                ),
+                prune_before=(recorded_at - timedelta(days=7)).isoformat(),
+                prune_after=(recorded_at + timedelta(seconds=60)).isoformat(),
+            )
             with (
                 patch(
                     "control_plane.http_routes.drivers.dokploy_source.read_dokploy_config",
@@ -37,7 +54,8 @@ class FastApiDokployRuntimeEvidenceTests(unittest.IsolatedAsyncioTestCase):
                 patch(
                     "control_plane.dokploy_target_inspect.dokploy_runtime_evidence.fetch_compose_service_runtime",
                     return_value={
-                        "container_id": "worker-container",
+                        "container_id": "a" * 64,
+                        "container_identity_sha256": container_identity_sha256,
                         "state": "running",
                         "status": "Up 5 minutes",
                         "running": True,
@@ -82,7 +100,10 @@ class FastApiDokployRuntimeEvidenceTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(response.status_code, 200)
         runtime_payload = response.json()["inspect"]["runtime_evidence"]
         self.assertTrue(runtime_payload["proof_ready"])
+        self.assertEqual(runtime_payload["proof_source"], "worker_heartbeat_record")
+        self.assertEqual(runtime_payload["worker_heartbeat"]["status"], "ready")
         self.assertTrue(runtime_payload["structured_event"]["observed"])
+        self.assertNotIn(container_identity_sha256, str(runtime_payload))
 
     async def test_dokploy_target_inspect_redacts_provider_runtime_failure(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:

--- a/tests/test_postgres_integration.py
+++ b/tests/test_postgres_integration.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import Iterator
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
+from datetime import datetime, timedelta, timezone
 import json
 import os
 import threading
@@ -67,6 +68,9 @@ from control_plane.contracts.outbox_delivery import (
     OutboxDeliveryRecord,
     build_outbox_delivery_id,
     build_outbox_dedupe_key,
+)
+from control_plane.contracts.privileged_operation_worker_heartbeat import (
+    PrivilegedOperationWorkerHeartbeatRecord,
 )
 from control_plane.contracts.product_profile_record import (
     LaunchplaneProductProfileRecord,
@@ -988,6 +992,35 @@ class RealPostgresSchemaIntegrationTests(unittest.TestCase):
                 store.close()
 
         self.assertEqual(records, ())
+
+    def test_privileged_operation_worker_heartbeat_round_trip_and_index(self) -> None:
+        with _store_for_fresh_head_database() as store:
+            recorded_at = datetime(2026, 8, 24, 12, 0, tzinfo=timezone.utc)
+            record = PrivilegedOperationWorkerHeartbeatRecord(
+                worker_identity_sha256="a" * 64,
+                image_reference=f"example@sha256:{'c' * 64}",
+                poll_interval_seconds=15,
+                last_poll_succeeded_at=recorded_at.isoformat(),
+            )
+            store.write_privileged_operation_worker_heartbeat_record(
+                record,
+                prune_before=(recorded_at - timedelta(days=7)).isoformat(),
+                prune_after=(recorded_at + timedelta(seconds=60)).isoformat(),
+            )
+            records = store.list_privileged_operation_worker_heartbeat_records()
+            engine = create_engine(store.database_url)
+            try:
+                index_names = {
+                    index["name"]
+                    for index in inspect(engine).get_indexes(
+                        "launchplane_privileged_operation_worker_heartbeats"
+                    )
+                }
+            finally:
+                engine.dispose()
+
+        self.assertEqual(records, (record,))
+        self.assertIn("launchplane_privop_worker_heartbeats_freshness_idx", index_names)
 
     def test_runtime_schema_compatibility_reports_missing_relation(self) -> None:
         with _store_for_fresh_head_database() as store:

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -3877,7 +3877,7 @@ class PostgresRecordStoreTests(unittest.TestCase):
         connection = store._engine.connect.return_value.__enter__.return_value
         connection.execute.return_value.scalars.return_value.all.return_value = []
 
-        with patch.object(store, "schema_revision", return_value="c2221a0b1c2d"):
+        with patch.object(store, "schema_revision", return_value="d2219a0b1c2d"):
             store.verify_runtime_schema_compatibility(
                 required_relations=("required_table", "required_index")
             )
@@ -3896,7 +3896,7 @@ class PostgresRecordStoreTests(unittest.TestCase):
         connection.execute.return_value.scalars.return_value.all.return_value = ["missing_index"]
 
         with (
-            patch.object(store, "schema_revision", return_value="c2221a0b1c2d"),
+            patch.object(store, "schema_revision", return_value="d2219a0b1c2d"),
             self.assertRaisesRegex(RuntimeError, "missing_index"),
         ):
             store.verify_runtime_schema_compatibility(

--- a/tests/test_privileged_operation_worker.py
+++ b/tests/test_privileged_operation_worker.py
@@ -27,6 +27,9 @@ from control_plane.contracts.privileged_operation import (
     PrivilegedOperationRecord,
     privileged_operation_pre_state_digest,
 )
+from control_plane.contracts.privileged_operation_worker_heartbeat import (
+    PrivilegedOperationWorkerHeartbeatRecord,
+)
 from control_plane.privileged_operation_registry import (
     MANAGED_SECRET_REENCRYPTION_DESCRIPTOR,
     RegisteredPrivilegedOperationDescriptor,
@@ -41,6 +44,7 @@ from control_plane.privileged_operation_worker import (
     privileged_operation_execution_fingerprint,
     privileged_operation_execution_token,
     privileged_operation_provider_target_key,
+    record_privileged_operation_worker_poll_heartbeat,
     require_privileged_operation_execution_store,
 )
 from control_plane.service_auth import LaunchplaneAuthzPolicy
@@ -52,11 +56,29 @@ from tests.support.stores import _sqlite_database_url
 FIXED_NOW = datetime(2026, 8, 22, 20, 10, tzinfo=timezone.utc)
 
 
+class _WorkerStore:
+    def __init__(self, *, fail_heartbeat: bool = False) -> None:
+        self.heartbeat_records: list[PrivilegedOperationWorkerHeartbeatRecord] = []
+        self.fail_heartbeat = fail_heartbeat
+
+    def write_privileged_operation_worker_heartbeat_record(
+        self,
+        record: PrivilegedOperationWorkerHeartbeatRecord,
+        *,
+        prune_before: str,
+        prune_after: str,
+    ) -> None:
+        del prune_before, prune_after
+        if self.fail_heartbeat:
+            raise RuntimeError("heartbeat write failed")
+        self.heartbeat_records.append(record)
+
+
 def _build_worker_store_with_successful_probe(**kwargs: object) -> object:
     report_probe_succeeded = kwargs["on_schema_probe_succeeded"]
     assert callable(report_probe_succeeded)
     report_probe_succeeded()
-    return object()
+    return _WorkerStore()
 
 
 def _fernet_key(offset: int) -> str:
@@ -200,6 +222,56 @@ class PrivilegedOperationWorkerTests(unittest.TestCase):
             with self.assertRaisesRegex(TypeError, "PostgreSQL mutation storage"):
                 require_privileged_operation_execution_store(FilesystemRecordStore(Path(directory)))
 
+    def test_successful_poll_heartbeat_is_hashed_upserted_and_pruned(self) -> None:
+        with TemporaryDirectory() as directory:
+            store = self._store(directory)
+            try:
+                stale_record = PrivilegedOperationWorkerHeartbeatRecord(
+                    worker_identity_sha256="a" * 64,
+                    image_reference=f"example@sha256:{'c' * 64}",
+                    poll_interval_seconds=15,
+                    last_poll_succeeded_at="2026-08-14T20:00:15+00:00",
+                )
+                store.write_privileged_operation_worker_heartbeat_record(
+                    stale_record,
+                    prune_before="2026-08-01T00:00:00+00:00",
+                    prune_after="2026-09-01T00:00:00+00:00",
+                )
+                future_record = stale_record.model_copy(
+                    update={
+                        "worker_identity_sha256": "d" * 64,
+                        "last_poll_succeeded_at": "2030-08-24T20:00:15+00:00",
+                    }
+                )
+                store.write_privileged_operation_worker_heartbeat_record(
+                    future_record,
+                    prune_before="2026-08-01T00:00:00+00:00",
+                    prune_after="2031-09-01T00:00:00+00:00",
+                )
+
+                first = record_privileged_operation_worker_poll_heartbeat(
+                    record_store=store,
+                    runtime_identity="worker-container-hostname",
+                    image_reference=f"example@sha256:{'c' * 64}",
+                    poll_interval_seconds=15,
+                    now=lambda: FIXED_NOW,
+                )
+                second = record_privileged_operation_worker_poll_heartbeat(
+                    record_store=store,
+                    runtime_identity="worker-container-hostname",
+                    image_reference=f"example@sha256:{'c' * 64}",
+                    poll_interval_seconds=15,
+                    now=lambda: FIXED_NOW,
+                )
+
+                records = store.list_privileged_operation_worker_heartbeat_records()
+            finally:
+                store.close()
+
+        self.assertEqual(first.worker_identity_sha256, second.worker_identity_sha256)
+        self.assertEqual(len(records), 1)
+        self.assertNotIn("worker-container-hostname", str(records[0].model_dump()))
+
     def test_worker_commands_are_service_internal(self) -> None:
         runner = CliRunner()
 
@@ -326,6 +398,55 @@ class PrivilegedOperationWorkerTests(unittest.TestCase):
         )
         self.assertEqual(telemetry[7]["consecutive_errors"], 1)
         self.assertEqual(telemetry[8]["consecutive_errors"], 2)
+
+    def test_heartbeat_write_failure_counts_as_poll_failure(self) -> None:
+        class TestStopEvent:
+            def is_set(self) -> bool:
+                return False
+
+            def wait(self, _timeout: int) -> bool:
+                return False
+
+        runner = CliRunner()
+        with (
+            patch("control_plane.cli_service.Event", return_value=TestStopEvent()),
+            patch(
+                "control_plane.cli_service.build_privileged_operation_worker_store",
+                side_effect=lambda **kwargs: (
+                    kwargs["on_schema_probe_succeeded"](),
+                    _WorkerStore(fail_heartbeat=True),
+                )[1],
+            ),
+            patch(
+                "control_plane.cli_service.execute_approved_privileged_operations_once",
+                return_value=[],
+            ),
+            patch(
+                "control_plane.cli_service._consume_privileged_operation_worker_schema_probe_evidence"
+            ),
+            patch("control_plane.cli_service.signal.signal", return_value=object()),
+        ):
+            result = runner.invoke(
+                main,
+                [
+                    "service",
+                    "privileged-operation-workers",
+                    "run",
+                    "--database-url",
+                    "sqlite+pysqlite:///:memory:",
+                    "--schema-probe-fd",
+                    "3",
+                    "--max-consecutive-errors",
+                    "1",
+                ],
+            )
+
+        self.assertEqual(result.exit_code, 1, result.output)
+        telemetry = [
+            json.loads(line) for line in result.output.splitlines() if line.startswith("{")
+        ]
+        self.assertIn("privileged_operation_worker_threshold_exit", str(telemetry))
+        self.assertNotIn("privileged_operation_worker_poll_succeeded", str(telemetry))
 
     def test_worker_loop_stops_cleanly_after_sigterm(self) -> None:
         signal_handlers: dict[int, object] = {}

--- a/tests/test_schema_migration.py
+++ b/tests/test_schema_migration.py
@@ -1491,7 +1491,7 @@ class SchemaMigrationTests(unittest.TestCase):
             for primary_key in CRITICAL_PRIMARY_KEYS
         }
 
-        self.assertEqual(EXPECTED_ALEMBIC_HEAD_REVISION, "c2221a0b1c2d")
+        self.assertEqual(EXPECTED_ALEMBIC_HEAD_REVISION, "d2219a0b1c2d")
         self.assertEqual(
             indexes[
                 (


### PR DESCRIPTION
## Summary
- persist a bounded DB-backed successful-poll heartbeat for the supervised privileged-operation worker
- bind proof to Dokploy's selected Docker container through validated container-ID/hostname identity plus exact immutable image equality
- make runtime logs diagnostic-only while preserving fail-closed provider state, image, freshness, and identity checks
- add Alembic migration, PostgreSQL/storage/HTTP/workflow tests, operational docs, and rollback guidance

## Milestone alignment
Closes #2219. This is the worker-proof prerequisite for #2204 in the Authorization Root-of-Trust Evidence milestone. It adds no authorization action, grant, canary activation, secret mutation, or live target mutation.

## Validation
- `uv run --extra dev launchplane ci unittest-shard local` — 3,081 targets, 12/12 shards
- `uv run --extra dev mypy control_plane tests` — 761 files
- changed-file Ruff check and format check
- real PostgreSQL integration gate — 91 tests; final focused migration/heartbeat checks at revision `d2219a0b1c2d`
- production Docker image build
- real image + entrypoint + disposable PostgreSQL smoke: Docker hostname prefix validated; heartbeat identity and immutable image matched
- Opus final review: approved after findings resolved
- Gemini final review: approved
- JetBrains inspection: UNKNOWN after built-in retry because results remained stale; no changed-file finding was produced