### PR TITLE
Replace authorization activation preflight

### DIFF
--- a/contracts/agent-operator-contract.json
+++ b/contracts/agent-operator-contract.json
@@ -72,34 +72,6 @@
         ]
       },
       {
-        "idempotency": "none",
-        "identity_dependencies": [
-          "read_bearer_identity"
-        ],
-        "method": "POST",
-        "modes": [
-          "read"
-        ],
-        "operation_id": "read_authz_activation_preflight",
-        "path": "/v1/authz-diagnostics/activation-preflight/read",
-        "purpose": "Read bounded authorization activation preflight evidence for one GitHub human.",
-        "response_statuses": [
-          "200",
-          "400",
-          "401",
-          "403",
-          "409",
-          "503"
-        ],
-        "reviewed_evidence": [],
-        "schema_fingerprint_sha256": "f6694025126227a2a5e0e2dfea3451ee6657effdd006f39379273181a4be4155",
-        "supported_surfaces": [
-          "agent_helper",
-          "operator_cli",
-          "read_only_service"
-        ]
-      },
-      {
         "idempotency": "optional",
         "identity_dependencies": [
           "read_browser_mutation_identity"
@@ -451,8 +423,8 @@
   },
   "normalization_version": 1,
   "provenance": {
-    "source_commit_sha": "71926f3e9e66389b0fdebd8f6fe4b7c47f815ce4"
+    "source_commit_sha": "3c962efb02ff1d4abaf7405c41353fe00b183c08"
   },
   "schema_version": 1,
-  "semantic_digest_sha256": "f4cdc0e0546831c78eb05e0194b59aa1ae0fad650af25a78b36b255e7ee469d8"
+  "semantic_digest_sha256": "5ca368e08c9d1d094eba3ed5cf47a789b144bb81e6ff8722138440ebaff23b64"
 }

--- a/control_plane/agent_operator_contract.py
+++ b/control_plane/agent_operator_contract.py
@@ -91,15 +91,6 @@ OPERATION_SPECS = (
     ),
     OperationSpec(
         "POST",
-        "/v1/authz-diagnostics/activation-preflight/read",
-        "Read bounded authorization activation preflight evidence for one GitHub human.",
-        ("agent_helper", "operator_cli", "read_only_service"),
-        ("read",),
-        "none",
-        (),
-    ),
-    OperationSpec(
-        "POST",
         "/v1/agent/write-intents/evaluate",
         "Evaluate a bounded agent write intent before mutation.",
         ("agent_helper", "service_api"),

--- a/control_plane/authz_activation_preflight.py
+++ b/control_plane/authz_activation_preflight.py
@@ -1,50 +1,21 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
-from datetime import datetime, timedelta, timezone
-import json
-import math
-from typing import Protocol
+from datetime import datetime, timezone
 
 from control_plane import secrets as control_plane_secrets
 from control_plane.contracts.authz_access_read import (
-    AUTHZ_ACTIVATION_PREFLIGHT_MAX_SESSIONS,
-    AuthzActivationPreflightDecision,
-    AuthzActivationPreflightPolicySummary,
-    AuthzActivationPreflightResponse,
-    AuthzActivationPreflightScope,
-    AuthzActivationPreflightSessionSummary,
-    AuthzUnmanagedActionEmptyRuleCounts,
+    AuthzActivationPreflightSelfResponse,
 )
 from control_plane.contracts.authz_policy_record import LaunchplaneAuthzPolicyRecord
-from control_plane.service_auth import (
-    AuthorizationTarget,
-    GitHubHumanIdentity,
-    LaunchplaneAuthzPolicy,
-)
-from control_plane.service_human_auth import (
-    LaunchplaneHumanSession,
-    SESSION_AUTHORIZATION_CLAIMS_TTL_SECONDS,
-)
+from control_plane.service_auth import AuthorizationTarget, GitHubHumanIdentity
+from control_plane.service_human_auth import LaunchplaneHumanSession
 
 
 ACTIVATION_PREFLIGHT_ACTION = "authz_policy_grant.write"
 ACTIVATION_PREFLIGHT_PRODUCT = "launchplane"
 ACTIVATION_PREFLIGHT_CONTEXT = "launchplane"
-ACTIVATION_PREFLIGHT_STORAGE_SCAN_LIMIT = 256
-ACTIVATION_PREFLIGHT_STORAGE_SESSION_LIMIT = ACTIVATION_PREFLIGHT_STORAGE_SCAN_LIMIT + 1
-AUTHZ_ACTIVATION_PREFLIGHT_GITHUB_ID_MAX = 2**63 - 1
-_IDENTITY_FINGERPRINT_PURPOSE = "authz-activation-preflight-identity-v1"
-
-
-class ActivationPreflightStore(Protocol):
-    def read_human_sessions_for_github_id_without_cleanup(
-        self,
-        github_id: int,
-        *,
-        limit: int,
-        created_at_not_after: datetime,
-    ) -> tuple[LaunchplaneHumanSession, ...]: ...
+ACTIVATION_PREFLIGHT_TARGET = AuthorizationTarget(scope="global")
+_POLICY_GENERATION_PURPOSE = "authz-activation-preflight-self-v1"
 
 
 class ActivationPreflightFailure(RuntimeError):
@@ -54,40 +25,29 @@ class ActivationPreflightFailure(RuntimeError):
         self.status_code = status_code
 
 
-def _utc_timestamp(value: datetime) -> datetime:
-    if value.tzinfo is None:
-        return value.replace(tzinfo=timezone.utc)
-    return value.astimezone(timezone.utc)
+def _utc_hour_timestamp(value: datetime) -> str:
+    normalized = value.astimezone(timezone.utc).replace(minute=0, second=0, microsecond=0)
+    return normalized.isoformat().replace("+00:00", "Z")
 
 
-def _whole_hours(value: float) -> int:
-    return max(0, math.floor(value / 3600))
-
-
-def _whole_hours_remaining(value: float) -> int:
-    return max(0, math.ceil(value / 3600))
-
-
-def _identity_fingerprint(identity: GitHubHumanIdentity) -> str:
-    payload = json.dumps(
-        {
-            "github_id": identity.github_id,
-            "login": identity.login,
-            "organizations": sorted(identity.organizations),
-            "teams": sorted(identity.teams),
-        },
-        sort_keys=True,
-        separators=(",", ":"),
+def _policy_generation(record: LaunchplaneAuthzPolicyRecord) -> str:
+    payload = "\0".join(
+        (
+            _POLICY_GENERATION_PURPOSE,
+            record.record_id,
+            str(record.revision),
+            record.policy_sha256,
+        )
     )
     try:
         fingerprint = control_plane_secrets.keyed_secret_payload_fingerprint(
             payload,
-            purpose=_IDENTITY_FINGERPRINT_PURPOSE,
+            purpose=_POLICY_GENERATION_PURPOSE,
         )
     except Exception as error:
         raise ActivationPreflightFailure(
-            "activation_identity_fingerprint_unavailable",
-            "Activation preflight identity fingerprinting is unavailable.",
+            "activation_policy_generation_unavailable",
+            "Activation preflight policy generation is unavailable.",
             status_code=503,
         ) from error
     algorithm, separator, remainder = fingerprint.partition(":")
@@ -101,141 +61,58 @@ def _identity_fingerprint(identity: GitHubHumanIdentity) -> str:
         or any(character not in "0123456789abcdef" for character in digest)
     ):
         raise ActivationPreflightFailure(
-            "activation_identity_fingerprint_unavailable",
-            "Activation preflight identity fingerprinting is unavailable.",
+            "activation_policy_generation_unavailable",
+            "Activation preflight policy generation is unavailable.",
             status_code=503,
         )
-    return f"identity_{digest}"
+    return digest
 
 
-def _unmanaged_action_empty_rule_counts(
-    policy: LaunchplaneAuthzPolicy,
-) -> AuthzUnmanagedActionEmptyRuleCounts:
-    rule_collections = (
-        ("github_actions", policy.github_actions),
-        ("github_humans", policy.github_humans),
-        ("terminal_agents", policy.terminal_agents),
-        ("local_operators", policy.local_operators),
-        ("local_admins", policy.local_admins),
-    )
-    counts = {
-        principal_type: sum(
-            not rule.actions and rule.managed_set_id is None and rule.managed_rule_id is None
-            for rule in rules
-        )
-        for principal_type, rules in rule_collections
-    }
-    return AuthzUnmanagedActionEmptyRuleCounts(total=sum(counts.values()), **counts)
-
-
-def _resolve_session(
-    *,
-    sessions: Sequence[LaunchplaneHumanSession],
-    github_id: int,
-    now: datetime,
-) -> tuple[LaunchplaneHumanSession, GitHubHumanIdentity, int, datetime]:
-    if len(sessions) > ACTIVATION_PREFLIGHT_STORAGE_SESSION_LIMIT:
-        raise ActivationPreflightFailure(
-            "activation_session_history_truncated",
-            "Activation preflight session history exceeded the bounded scan limit.",
-        )
-    unexpired_sessions: list[LaunchplaneHumanSession] = []
-    for candidate_session in sessions:
-        session_github_id = candidate_session.identity.github_id
-        if session_github_id != github_id:
-            raise ActivationPreflightFailure(
-                "activation_session_payload_mismatch",
-                "Activation preflight session identity did not match its lookup key.",
-            )
-        if _utc_timestamp(candidate_session.expires_at) <= now:
-            continue
-        unexpired_sessions.append(candidate_session)
-    if not unexpired_sessions:
-        raise ActivationPreflightFailure(
-            "activation_session_not_found",
-            "No unexpired Launchplane session matched the GitHub ID.",
-        )
-    current_sessions = sorted(
-        (
-            candidate_session
-            for candidate_session in unexpired_sessions
-            if _utc_timestamp(candidate_session.created_at)
-            <= now
-            < _utc_timestamp(candidate_session.created_at)
-            + timedelta(seconds=SESSION_AUTHORIZATION_CLAIMS_TTL_SECONDS)
-        ),
-        key=lambda item: _utc_timestamp(item.created_at),
-        reverse=True,
-    )
-    if not current_sessions:
-        raise ActivationPreflightFailure(
-            "activation_session_claims_stale",
-            "All matching Launchplane session authorization claims are stale.",
-        )
-    if len(current_sessions) > AUTHZ_ACTIVATION_PREFLIGHT_MAX_SESSIONS:
-        raise ActivationPreflightFailure(
-            "activation_session_results_truncated",
-            "Activation preflight found too many current sessions.",
-        )
-    canonical_claims = (
-        current_sessions[0].identity.login,
-        current_sessions[0].identity.organizations,
-        current_sessions[0].identity.teams,
-    )
-    if any(
-        (
-            session.identity.login,
-            session.identity.organizations,
-            session.identity.teams,
-        )
-        != canonical_claims
-        for session in current_sessions[1:]
-    ):
-        raise ActivationPreflightFailure(
-            "activation_session_claims_ambiguous",
-            "Current Launchplane session authorization claims are ambiguous.",
-        )
-    canonical_session = current_sessions[0]
-    canonical_identity = GitHubHumanIdentity(
-        login=canonical_session.identity.login,
-        github_id=github_id,
-        name="",
-        email="",
-        organizations=canonical_session.identity.organizations,
-        teams=canonical_session.identity.teams,
-        role="read_only",
-    )
-    latest_expiry = max(_utc_timestamp(session.expires_at) for session in current_sessions)
-    return canonical_session, canonical_identity, len(current_sessions), latest_expiry
-
-
-def build_activation_preflight_response(
+def build_activation_preflight_self_response(
     *,
     trace_id: str,
-    github_id: int,
+    session: LaunchplaneHumanSession,
     active_record: LaunchplaneAuthzPolicyRecord,
-    sessions: Sequence[LaunchplaneHumanSession],
     now: datetime,
-) -> AuthzActivationPreflightResponse:
-    current_time = _utc_timestamp(now)
-    canonical_session, canonical_identity, session_count, latest_expiry = _resolve_session(
-        sessions=sessions,
-        github_id=github_id,
-        now=current_time,
-    )
+) -> AuthzActivationPreflightSelfResponse:
+    normalized_now = now.astimezone(timezone.utc)
+    if session.identity.github_id <= 0:
+        raise ActivationPreflightFailure(
+            "activation_preflight_session_invalid",
+            "The Launchplane session is invalid.",
+            status_code=401,
+        )
+    if session.expires_at.astimezone(timezone.utc) <= normalized_now:
+        raise ActivationPreflightFailure(
+            "activation_preflight_session_expired",
+            "The Launchplane session is expired.",
+            status_code=401,
+        )
+    if session.created_at.astimezone(timezone.utc) > normalized_now:
+        raise ActivationPreflightFailure(
+            "activation_preflight_session_invalid",
+            "The Launchplane session is invalid.",
+            status_code=401,
+        )
+    if not session.identity.login.strip():
+        raise ActivationPreflightFailure(
+            "activation_preflight_session_invalid",
+            "The Launchplane session is invalid.",
+            status_code=401,
+        )
     derived_role = active_record.policy.human_role_for(
-        github_id=github_id,
-        login=canonical_identity.login,
-        organizations=canonical_identity.organizations,
-        teams=canonical_identity.teams,
+        github_id=session.identity.github_id,
+        login=session.identity.login,
+        organizations=session.identity.organizations,
+        teams=session.identity.teams,
     )
     evaluated_identity = GitHubHumanIdentity(
-        login=canonical_identity.login,
-        github_id=github_id,
+        login=session.identity.login,
+        github_id=session.identity.github_id,
         name="",
         email="",
-        organizations=canonical_identity.organizations,
-        teams=canonical_identity.teams,
+        organizations=session.identity.organizations,
+        teams=session.identity.teams,
         role=derived_role or "read_only",
     )
     evaluation = active_record.policy.evaluate(
@@ -243,76 +120,13 @@ def build_activation_preflight_response(
         action=ACTIVATION_PREFLIGHT_ACTION,
         product=ACTIVATION_PREFLIGHT_PRODUCT,
         context=ACTIVATION_PREFLIGHT_CONTEXT,
-        target=AuthorizationTarget(scope="context"),
+        target=ACTIVATION_PREFLIGHT_TARGET,
         record_context=False,
     )
-    claims_age = (current_time - _utc_timestamp(canonical_session.created_at)).total_seconds()
-    expiry_remaining = (latest_expiry - current_time).total_seconds()
-    return AuthzActivationPreflightResponse(
+    return AuthzActivationPreflightSelfResponse(
+        status="ok",
         trace_id=trace_id,
-        policy=AuthzActivationPreflightPolicySummary(
-            record_id=active_record.record_id,
-            revision=active_record.revision,
-            policy_sha256=active_record.policy_sha256,
-            schema_version=active_record.policy.schema_version,
-        ),
-        session=AuthzActivationPreflightSessionSummary(
-            session_count=session_count,
-            claims_current=True,
-            claims_age_bucket_hours=_whole_hours(claims_age),
-            expiry_bucket_hours=_whole_hours_remaining(expiry_remaining),
-            identity_fingerprint=_identity_fingerprint(evaluated_identity),
-        ),
-        scope=AuthzActivationPreflightScope(),
-        evaluation=AuthzActivationPreflightDecision(
-            decision=evaluation.decision,
-            reason_code=evaluation.reason_code,
-        ),
-        unmanaged_action_empty_rules=_unmanaged_action_empty_rule_counts(active_record.policy),
+        decision=evaluation.decision,
+        evaluated_at=_utc_hour_timestamp(now),
+        policy_generation=_policy_generation(active_record),
     )
-
-
-def resolve_activation_preflight(
-    *,
-    store: ActivationPreflightStore,
-    active_record: LaunchplaneAuthzPolicyRecord,
-    github_id: int,
-    now: datetime,
-    trace_id: str,
-) -> AuthzActivationPreflightResponse:
-    if github_id <= 0 or github_id > AUTHZ_ACTIVATION_PREFLIGHT_GITHUB_ID_MAX:
-        raise ActivationPreflightFailure(
-            "invalid_github_id",
-            "Activation preflight requires a bounded positive GitHub ID.",
-            status_code=400,
-        )
-    try:
-        sessions = store.read_human_sessions_for_github_id_without_cleanup(
-            github_id,
-            limit=ACTIVATION_PREFLIGHT_STORAGE_SESSION_LIMIT,
-            created_at_not_after=now,
-        )
-    except ActivationPreflightFailure:
-        raise
-    except Exception as error:
-        raise ActivationPreflightFailure(
-            "activation_preflight_storage_unavailable",
-            "Activation preflight session storage is unavailable.",
-            status_code=503,
-        ) from error
-    try:
-        return build_activation_preflight_response(
-            trace_id=trace_id,
-            github_id=github_id,
-            active_record=active_record,
-            sessions=sessions,
-            now=now,
-        )
-    except ActivationPreflightFailure:
-        raise
-    except Exception as error:
-        raise ActivationPreflightFailure(
-            "activation_preflight_unavailable",
-            "Activation preflight evidence is unavailable.",
-            status_code=503,
-        ) from error

--- a/control_plane/cli_policy_profiles.py
+++ b/control_plane/cli_policy_profiles.py
@@ -279,44 +279,6 @@ def product_profiles() -> None:
     """DB-backed Launchplane product profile commands."""
 
 
-@authz_policies.command("activation-preflight")
-@click.option(
-    "--service-url",
-    required=True,
-    help="Deployed Launchplane service base URL.",
-)
-@click.option(
-    "--bearer-token-env",
-    default="LAUNCHPLANE_LOCAL_ADMIN_TOKEN",
-    show_default=True,
-    help="Environment variable containing the local-admin bearer token.",
-)
-@click.option(
-    "--github-id",
-    type=click.IntRange(min=1, max=2**63 - 1),
-    required=True,
-    help="Immutable numeric GitHub ID to resolve through server-side sessions.",
-)
-def authz_policies_activation_preflight(
-    service_url: str,
-    bearer_token_env: str,
-    github_id: int,
-) -> None:
-    token_env_key = bearer_token_env.strip() or "LAUNCHPLANE_LOCAL_ADMIN_TOKEN"
-    bearer_token = os.environ.get(token_env_key, "").strip()
-    if not bearer_token:
-        raise click.ClickException(f"{token_env_key} is required.")
-    response_payload = _post_launchplane_service_json(
-        service_url=service_url,
-        path="/v1/authz-diagnostics/activation-preflight/read",
-        payload={"github_id": github_id},
-        bearer_token=bearer_token,
-        session_cookie="",
-        idempotency_key="",
-    )
-    click.echo(json.dumps(response_payload, indent=2, sort_keys=True))
-
-
 @authz_policies.command("reconcile-managed")
 @click.option(
     "--service-url",

--- a/control_plane/contracts/authz_access_read.py
+++ b/control_plane/contracts/authz_access_read.py
@@ -21,8 +21,6 @@ AUTHZ_DENIAL_EXPLANATION_READ_ACTION = "authz_denial_explanation.read"
 AUTHZ_POLICY_HEALTH_READ_ACTION = "authz_policy_health.read"
 AUTHZ_POLICY_CANDIDATE_PREVIEW_READ_ACTION = "authz_policy_candidate_preview.read"
 AUTHZ_REPOSITORY_SCOPE_READ_ACTION = "authz_repository_scope.read"
-AUTHZ_ACTIVATION_PREFLIGHT_MAX_SESSIONS = 8
-AUTHZ_ACTIVATION_PREFLIGHT_GITHUB_ID_MAX = 2**63 - 1
 AUTHZ_POLICY_CANDIDATE_PREVIEW_MAX_PROBES = 25
 AUTHZ_POLICY_CANDIDATE_PREVIEW_MAX_RULES = 500
 AUTHZ_REPOSITORY_SCOPE_MAX_CANDIDATES = 100
@@ -670,69 +668,11 @@ class AuthzRepositoryScopeResponse(BaseModel):
     candidates: tuple[AuthzRepositoryScopeCandidateResult, ...]
 
 
-class AuthzActivationPreflightRequest(BaseModel):
-    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
-
-    github_id: int = Field(
-        gt=0,
-        le=AUTHZ_ACTIVATION_PREFLIGHT_GITHUB_ID_MAX,
-        strict=True,
-    )
-
-
-class AuthzActivationPreflightPolicySummary(BaseModel):
-    model_config = ConfigDict(extra="forbid", frozen=True)
-
-    record_id: str
-    revision: int = Field(ge=1)
-    policy_sha256: str
-    schema_version: Literal[1, 2]
-
-
-class AuthzActivationPreflightSessionSummary(BaseModel):
-    model_config = ConfigDict(extra="forbid", frozen=True)
-
-    session_count: int = Field(ge=1, le=AUTHZ_ACTIVATION_PREFLIGHT_MAX_SESSIONS)
-    claims_current: bool
-    claims_age_bucket_hours: int = Field(ge=0)
-    expiry_bucket_hours: int = Field(ge=0)
-    identity_fingerprint: str
-
-
-class AuthzActivationPreflightScope(BaseModel):
-    model_config = ConfigDict(extra="forbid", frozen=True)
-
-    action: Literal["authz_policy_grant.write"] = "authz_policy_grant.write"
-    product: Literal["launchplane"] = "launchplane"
-    context: Literal["launchplane"] = "launchplane"
-    target_scope: Literal["context"] = "context"
-
-
-class AuthzActivationPreflightDecision(BaseModel):
-    model_config = ConfigDict(extra="forbid", frozen=True)
-
-    decision: Literal["allowed", "denied"]
-    reason_code: AuthzDecisionReason
-
-
-class AuthzUnmanagedActionEmptyRuleCounts(BaseModel):
-    model_config = ConfigDict(extra="forbid", frozen=True)
-
-    total: int = Field(ge=0)
-    github_actions: int = Field(ge=0)
-    github_humans: int = Field(ge=0)
-    terminal_agents: int = Field(ge=0)
-    local_operators: int = Field(ge=0)
-    local_admins: int = Field(ge=0)
-
-
-class AuthzActivationPreflightResponse(BaseModel):
+class AuthzActivationPreflightSelfResponse(BaseModel):
     model_config = ConfigDict(extra="forbid", frozen=True)
 
     status: Literal["ok"] = "ok"
     trace_id: str
-    policy: AuthzActivationPreflightPolicySummary
-    session: AuthzActivationPreflightSessionSummary
-    scope: AuthzActivationPreflightScope
-    evaluation: AuthzActivationPreflightDecision
-    unmanaged_action_empty_rules: AuthzUnmanagedActionEmptyRuleCounts
+    decision: Literal["allowed", "denied"]
+    evaluated_at: str = Field(pattern=r"^\d{4}-\d{2}-\d{2}T\d{2}:00:00Z$")
+    policy_generation: str = Field(pattern=r"^[0-9a-f]{64}$")

--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -80,8 +80,7 @@ from control_plane.contracts.authz_access_read import (
     AUTHZ_DENIAL_EXPLANATION_READ_ACTION,
     AUTHZ_POLICY_CANDIDATE_PREVIEW_READ_ACTION,
     AUTHZ_POLICY_HEALTH_READ_ACTION,
-    AuthzActivationPreflightRequest,
-    AuthzActivationPreflightResponse,
+    AuthzActivationPreflightSelfResponse,
     AUTHZ_REPOSITORY_SCOPE_READ_ACTION,
     EFFECTIVE_ACCESS_READ_ACTION,
     AuthzDenialExplanationResponse,
@@ -1037,7 +1036,7 @@ _AUTHZ_POLICY_ACTIVE_ROUTE = "/v1/authz-policies/active"
 _AUTHZ_DIAGNOSTIC_EVALUATE_ROUTE = "/v1/authz-diagnostics/github-actions/evaluate"
 _AUTHZ_EFFECTIVE_ACCESS_EVALUATE_ROUTE = "/v1/authz-diagnostics/effective-access/evaluate"
 _AUTHZ_POLICY_HEALTH_ROUTE = "/v1/authz-diagnostics/active-policy/health"
-_AUTHZ_ACTIVATION_PREFLIGHT_ROUTE = "/v1/authz-diagnostics/activation-preflight/read"
+_AUTHZ_ACTIVATION_PREFLIGHT_ROUTE = "/v1/authz-diagnostics/activation-preflight/self"
 _AUTHZ_POLICY_CANDIDATE_PREVIEW_ROUTE = "/v1/authz-diagnostics/candidate-policy/preview"
 _AUTHZ_REPOSITORY_SCOPE_READ_ROUTE = "/v1/authz-diagnostics/repository-scope/read"
 _AUTHZ_DENIAL_EXPLANATION_ROUTE = "/v1/authz-diagnostics/denials/{trace_id}"
@@ -3979,7 +3978,10 @@ def create_launchplane_fastapi_app(
     ) -> Response:
         clear_authz_evaluation()
         try:
-            return cast(Response, await call_next(request))
+            response = cast(Response, await call_next(request))
+            if request.url.path == _AUTHZ_ACTIVATION_PREFLIGHT_ROUTE:
+                response.headers["Cache-Control"] = "no-store"
+            return response
         finally:
             clear_authz_evaluation()
 
@@ -4073,6 +4075,61 @@ def create_launchplane_fastapi_app(
             session,
             identity=replace(session.identity, role=resolved_role),
         )
+
+    def read_authz_activation_preflight_session(
+        response: Response,
+        authorization: Annotated[str | None, Header(alias="Authorization")] = None,
+        cookie: Annotated[str, Header(alias="Cookie")] = "",
+    ) -> LaunchplaneHumanSession:
+        no_store_headers = {"Cache-Control": "no-store"}
+        response.headers.update(no_store_headers)
+        if authorization is not None:
+            raise _launchplane_http_error(
+                status_code=403,
+                trace_id=next_trace_id(),
+                code="authorization_denied",
+                message="Activation preflight requires a signed Launchplane session cookie.",
+                headers=no_store_headers,
+            )
+        if human_session_manager is None:
+            raise _launchplane_http_error(
+                status_code=503,
+                trace_id=next_trace_id(),
+                code="activation_preflight_unavailable",
+                message="Activation preflight evidence is unavailable.",
+                headers=no_store_headers,
+            )
+        try:
+            session = human_session_manager.read_cookie_without_renewal(cookie)
+            claims_are_current = (
+                session is not None
+                and human_session_manager.authorization_claims_are_current(session)
+            )
+        except Exception as error:
+            raise _launchplane_http_error(
+                status_code=503,
+                trace_id=next_trace_id(),
+                code="activation_preflight_unavailable",
+                message="Activation preflight evidence is unavailable.",
+                headers=no_store_headers,
+            ) from error
+        if session is None or session.identity.github_id <= 0:
+            raise _launchplane_http_error(
+                status_code=401,
+                trace_id=next_trace_id(),
+                code="authentication_required",
+                message="A signed Launchplane session cookie is required.",
+                headers=no_store_headers,
+            )
+        if not claims_are_current:
+            raise _launchplane_http_error(
+                status_code=401,
+                trace_id=next_trace_id(),
+                code="authentication_required",
+                message="A signed Launchplane session cookie is required.",
+                headers=no_store_headers,
+            )
+        return session
 
     def human_identity_response(identity: GitHubHumanIdentity) -> GitHubHumanIdentityResponse:
         return GitHubHumanIdentityResponse(
@@ -14566,40 +14623,23 @@ def create_launchplane_fastapi_app(
             **snapshot.model_dump(),
         )
 
-    async def read_authz_activation_preflight(
-        preflight_request: AuthzActivationPreflightRequest,
+    async def read_authz_activation_preflight_self(
+        request: Request,
         response: Response,
-        identity: Annotated[LaunchplaneIdentity, Depends(read_bearer_identity)],
+        session: Annotated[
+            LaunchplaneHumanSession, Depends(read_authz_activation_preflight_session)
+        ],
         record_store: Annotated[object, Depends(get_record_store)],
-    ) -> AuthzActivationPreflightResponse:
+    ) -> AuthzActivationPreflightSelfResponse:
         trace_id = next_trace_id()
-        no_store_headers = {"Cache-Control": "no-store"}
-        response.headers.update(no_store_headers)
-        if not isinstance(identity, LocalAdminIdentity):
-            raise _launchplane_http_error(
-                status_code=403,
-                trace_id=trace_id,
-                code="authorization_denied",
-                message="Activation preflight requires a local administrator identity.",
-                headers=no_store_headers,
-            )
+        response.headers["Cache-Control"] = "no-store"
         try:
-            for action in (AUTHZ_POLICY_HEALTH_READ_ACTION, EFFECTIVE_ACCESS_READ_ACTION):
-                preflight_evaluation = resolved_authz_policy_runtime.policy.evaluate(
-                    identity=identity,
-                    action=action,
-                    product=_LAUNCHPLANE_SERVICE_CONTEXT,
-                    context=_LAUNCHPLANE_SERVICE_CONTEXT,
-                    record_context=False,
+            if request.query_params or await request.body():
+                raise control_plane_authz_activation_preflight.ActivationPreflightFailure(
+                    "activation_preflight_parameters_not_allowed",
+                    "Activation preflight does not accept request parameters.",
+                    status_code=400,
                 )
-                if preflight_evaluation.decision != "allowed":
-                    raise _launchplane_http_error(
-                        status_code=403,
-                        trace_id=trace_id,
-                        code="authorization_denied",
-                        message="Identity cannot read Launchplane activation preflight evidence.",
-                        headers=no_store_headers,
-                    )
             database_store = require_authz_policy_database_store(
                 record_store=record_store,
                 trace_id=trace_id,
@@ -14609,29 +14649,13 @@ def create_launchplane_fastapi_app(
                 database_store=database_store,
                 trace_id=trace_id,
             )
-            for action in (AUTHZ_POLICY_HEALTH_READ_ACTION, EFFECTIVE_ACCESS_READ_ACTION):
-                active_evaluation = active_record.policy.evaluate(
-                    identity=identity,
-                    action=action,
-                    product=_LAUNCHPLANE_SERVICE_CONTEXT,
-                    context=_LAUNCHPLANE_SERVICE_CONTEXT,
-                    record_context=False,
+            return (
+                control_plane_authz_activation_preflight.build_activation_preflight_self_response(
+                    trace_id=trace_id,
+                    session=session,
+                    active_record=active_record,
+                    now=datetime.now(timezone.utc),
                 )
-                if active_evaluation.decision != "allowed":
-                    raise _launchplane_http_error(
-                        status_code=403,
-                        trace_id=trace_id,
-                        code="authorization_denied",
-                        message="Identity cannot read Launchplane activation preflight evidence.",
-                        headers=no_store_headers,
-                        authz_policy_provenance=AuthzPolicyProvenance.from_record(active_record),
-                    )
-            return control_plane_authz_activation_preflight.resolve_activation_preflight(
-                store=database_store,
-                active_record=active_record,
-                github_id=preflight_request.github_id,
-                now=datetime.now(timezone.utc),
-                trace_id=trace_id,
             )
         except control_plane_authz_activation_preflight.ActivationPreflightFailure as error:
             raise _launchplane_http_error(
@@ -14639,10 +14663,10 @@ def create_launchplane_fastapi_app(
                 trace_id=trace_id,
                 code=error.code,
                 message=str(error),
-                headers=no_store_headers,
+                headers={"Cache-Control": "no-store"},
             ) from error
         except LaunchplaneHTTPException as error:
-            error.headers = {**(error.headers or {}), **no_store_headers}
+            error.headers = {**(error.headers or {}), "Cache-Control": "no-store"}
             raise
         except Exception as error:
             raise _launchplane_http_error(
@@ -14650,7 +14674,7 @@ def create_launchplane_fastapi_app(
                 trace_id=trace_id,
                 code="activation_preflight_unavailable",
                 message="Activation preflight evidence is unavailable.",
-                headers=no_store_headers,
+                headers={"Cache-Control": "no-store"},
             ) from error
 
     async def read_authz_repository_scope(
@@ -22666,12 +22690,12 @@ def create_launchplane_fastapi_app(
 
     app.add_api_route(
         _AUTHZ_ACTIVATION_PREFLIGHT_ROUTE,
-        read_authz_activation_preflight,
-        methods=["POST"],
-        response_model=AuthzActivationPreflightResponse,
+        read_authz_activation_preflight_self,
+        methods=["GET"],
+        response_model=AuthzActivationPreflightSelfResponse,
         response_model_exclude_none=True,
-        operation_id="read_authz_activation_preflight",
-        summary="Read bounded authorization activation preflight evidence",
+        operation_id="read_authz_activation_preflight_self",
+        summary="Read the signed Launchplane activation preflight self-check",
         responses={
             **authz_diagnostic_route_responses,
             409: {"model": LaunchplaneErrorResponse},

--- a/control_plane/service_human_auth.py
+++ b/control_plane/service_human_auth.py
@@ -74,14 +74,6 @@ class HumanSessionStore(Protocol):
         session_id: str,
     ) -> LaunchplaneHumanSession | None: ...
 
-    def read_human_sessions_for_github_id_without_cleanup(
-        self,
-        github_id: int,
-        *,
-        limit: int,
-        created_at_not_after: datetime,
-    ) -> tuple[LaunchplaneHumanSession, ...]: ...
-
     def delete_session(self, session_id: str) -> None: ...
 
     def write_session_if_csrf_generation(
@@ -129,30 +121,6 @@ class InMemoryHumanSessionStore:
     ) -> LaunchplaneHumanSession | None:
         with self._lock:
             return self._sessions.get(session_id)
-
-    def read_human_sessions_for_github_id_without_cleanup(
-        self,
-        github_id: int,
-        *,
-        limit: int,
-        created_at_not_after: datetime,
-    ) -> tuple[LaunchplaneHumanSession, ...]:
-        cutoff = created_at_not_after.astimezone(timezone.utc)
-        with self._lock:
-            matching_sessions = sorted(
-                (
-                    session
-                    for session in self._sessions.values()
-                    if session.identity.github_id == github_id
-                    and session.created_at.astimezone(timezone.utc) <= cutoff
-                ),
-                key=lambda session: (
-                    session.created_at.astimezone(timezone.utc),
-                    session.session_id,
-                ),
-                reverse=True,
-            )
-            return tuple(matching_sessions[: max(limit, 0)])
 
     def delete_session(self, session_id: str) -> None:
         with self._lock:

--- a/control_plane/storage/migrations/versions/e2221b0c2d3e_drop_human_session_github_id_index.py
+++ b/control_plane/storage/migrations/versions/e2221b0c2d3e_drop_human_session_github_id_index.py
@@ -1,0 +1,40 @@
+"""drop obsolete human-session GitHub ID lookup index
+
+Revision ID: e2221b0c2d3e
+Revises: d2219a0b1c2d
+Create Date: 2026-08-25 00:00:00.000000+00:00
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "e2221b0c2d3e"
+down_revision: str | None = "d2219a0b1c2d"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_TABLE = "launchplane_human_sessions"
+_INDEX = "launchplane_human_sessions_github_id_idx"
+
+
+def _index_names() -> set[str] | None:
+    inspector = sa.inspect(op.get_bind())
+    if _TABLE not in set(inspector.get_table_names()):
+        return None
+    return {str(index["name"]) for index in inspector.get_indexes(_TABLE)}
+
+
+def upgrade() -> None:
+    index_names = _index_names()
+    if index_names is not None and _INDEX in index_names:
+        op.drop_index(_INDEX, table_name=_TABLE)
+
+
+def downgrade() -> None:
+    index_names = _index_names()
+    if index_names is not None and _INDEX not in index_names:
+        op.create_index(_INDEX, _TABLE, ["github_id"])

--- a/control_plane/storage/postgres.py
+++ b/control_plane/storage/postgres.py
@@ -16,13 +16,11 @@ from sqlalchemy import (
     BigInteger,
     Boolean,
     CheckConstraint,
-    DateTime,
     JSON,
     Index,
     Integer,
     String,
     create_engine,
-    cast as sql_cast,
     delete,
     desc,
     false,
@@ -3385,10 +3383,6 @@ class LaunchplaneVeriReelProdBackupGateOperationRow(Base):
 class LaunchplaneHumanSessionRow(Base):
     __tablename__ = "launchplane_human_sessions"
     __table_args__ = (
-        Index(
-            "launchplane_human_sessions_github_id_idx",
-            "github_id",
-        ),
         Index("launchplane_human_sessions_login_idx", "login", desc("created_at")),
         Index("launchplane_human_sessions_expires_idx", desc("expires_at")),
     )
@@ -8426,44 +8420,6 @@ class PostgresRecordStore(HumanSessionStore):
             if payload is None:
                 return None
             return _human_session_from_payload(payload)
-
-    def read_human_sessions_for_github_id_without_cleanup(
-        self,
-        github_id: int,
-        *,
-        limit: int,
-        created_at_not_after: datetime,
-    ) -> tuple[LaunchplaneHumanSession, ...]:
-        normalized_limit = max(limit, 0)
-        if normalized_limit == 0:
-            return ()
-        sqlite = self._engine.dialect.name == "sqlite"
-        created_at_order = (
-            func.julianday(LaunchplaneHumanSessionRow.created_at)
-            if sqlite
-            else sql_cast(
-                LaunchplaneHumanSessionRow.created_at,
-                DateTime(timezone=True),
-            )
-        )
-        created_at_upper_bound = (
-            func.julianday(created_at_not_after.isoformat()) if sqlite else created_at_not_after
-        )
-        statement = (
-            select(LaunchplaneHumanSessionRow)
-            .where(
-                LaunchplaneHumanSessionRow.github_id == github_id,
-                created_at_order <= created_at_upper_bound,
-            )
-            .order_by(
-                created_at_order.desc(),
-                LaunchplaneHumanSessionRow.session_id.desc(),
-            )
-            .limit(normalized_limit)
-        )
-        with self._session_factory() as session:
-            rows = session.scalars(statement).all()
-            return tuple(_human_session_from_payload(row.payload) for row in rows)
 
     def delete_session(self, session_id: str) -> None:
         with self._session_factory() as session:

--- a/control_plane/storage/schema_invariants.py
+++ b/control_plane/storage/schema_invariants.py
@@ -10,7 +10,7 @@ from sqlalchemy.engine import Engine
 from sqlalchemy.exc import SQLAlchemyError
 
 AUTHZ_COMPATIBILITY_FLOOR_REVISION = "f3b5d7e9a1c2"
-EXPECTED_ALEMBIC_HEAD_REVISION = "d2219a0b1c2d"
+EXPECTED_ALEMBIC_HEAD_REVISION = "e2221b0c2d3e"
 RUNTIME_COMPATIBLE_ALEMBIC_REVISIONS = (EXPECTED_ALEMBIC_HEAD_REVISION,)
 _AUTHZ_POLICY_TABLE = "launchplane_authz_policies"
 _AUTHZ_POLICY_WRITE_FENCE_TRIGGER = "launchplane_authz_policy_write_fence"
@@ -452,11 +452,6 @@ _ODOO_STABLE_ACTIVE_OPERATION_PREDICATE_TOKENS = (
 )
 
 CRITICAL_SCHEMA_INDEXES: tuple[CriticalIndex, ...] = (
-    CriticalIndex(
-        "launchplane_human_sessions",
-        "launchplane_human_sessions_github_id_idx",
-        ("github_id",),
-    ),
     CriticalIndex(
         "launchplane_merge_admissions",
         "launchplane_merge_admissions_attempt_uidx",

--- a/docs/agent-operator-contract.md
+++ b/docs/agent-operator-contract.md
@@ -61,11 +61,9 @@ Anything not explicitly selected by the generator is absent. The artifact must
 never contain real product, tenant, repository, branch, domain, lane,
 provider-target, credential, operator, or runtime-topology authority.
 
-The contract includes the read-only
-`POST /v1/authz-diagnostics/activation-preflight/read` operation for the
-supported owner-local helper. It is bearer/service-only, accepts one immutable
-GitHub numeric ID, and does not expose browser cookies, token values, direct-DB
-access, or any authorization mutation.
+The browser-only activation self-check is intentionally absent from this
+agent/operator allow-list. It accepts only the signed-in human's Launchplane
+session cookie and has no bearer helper or agent surface.
 
 ## Normalization Version 1
 

--- a/docs/authorization-authority.md
+++ b/docs/authorization-authority.md
@@ -109,25 +109,25 @@ and fails closed when active policy state is missing or ambiguous. It performs
 no policy, provider, runtime, bootstrap, secret, or deployment mutation. Landing
 the action and route does not grant production access to them.
 
-The activation preflight is a separate, read-only service-native proof at
-`POST /v1/authz-diagnostics/activation-preflight/read`. It accepts only one
-positive immutable GitHub numeric ID and requires a bearer-authenticated
-`LocalAdminIdentity` already authorized by both
-`authz_policy_health.read` and `authz_policy_effective_access.read`. It resolves
-the human only from unexpired server-side sessions, re-derives the role from
-the active DB policy, and evaluates the fixed
-`authz_policy_grant.write`/`launchplane`/`launchplane` context scope through the
-ordinary evaluator. A missing, stale, divergent, payload-mismatched, or
-bounded-truncated session result fails closed. No new authorization action or
-grant is introduced.
+The activation preflight is a separate, read-only self-check at
+`GET /v1/authz-diagnostics/activation-preflight/self`. It accepts only the
+signed Launchplane browser-session cookie and rejects every Authorization
+header. The route accepts no body or query parameters, uses the immutable
+GitHub ID and current claims already stored in the session, ignores the
+persisted session role, re-derives the role from the single active DB policy,
+and evaluates the fixed global
+`authz_policy_grant.write`/`launchplane`/`launchplane` request through the
+ordinary evaluator. Missing, invalid, expired, or claims-stale sessions return
+`401`; missing or ambiguous active policy state fails closed.
 
-The response contains only active-policy provenance, bounded session freshness,
-a keyed identity fingerprint, the fixed scope, the ordinary decision/reason,
-and unmanaged action-empty rule counts. It never returns session IDs, cookies,
-tokens, names, emails, logins, memberships, persisted roles, selectors, rule
-contents, managed IDs, hashes, or permission lists. The route and its errors
-are `Cache-Control: no-store`; its bearer-only path performs no session renewal,
-CSRF rotation, denial, audit, idempotency, outbox, policy, or operation write.
+The response contains only the allowed/denied decision, an hour-bounded UTC
+evaluation time, an opaque keyed purpose-separated policy-generation digest, and a
+trace ID. It never returns policy identity, policy rules, session or human
+identity, selectors, memberships, managed IDs, reason codes, permission lists,
+or action inventory. The route and all of its errors are
+`Cache-Control: no-store`; it performs no session renewal, CSRF rotation,
+denial, audit, idempotency, outbox, policy, operation, provider, runtime, or
+secret write. No additional diagnostic grant or credential is required.
 
 The next read-only administration slice adds
 `authz_policy_candidate_preview.read` for an authenticated GitHub administrator

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -593,7 +593,7 @@ Current implementation scope:
 - `POST /v1/authz-policies/managed-rule-sets/reconcile`
 - `POST /v1/authz-diagnostics/github-actions/evaluate`
 - `GET /v1/authz-diagnostics/active-policy/health`
-- `POST /v1/authz-diagnostics/activation-preflight/read`
+- `GET /v1/authz-diagnostics/activation-preflight/self`
 - `POST /v1/authz-diagnostics/candidate-policy/preview`
 - `GET /v1/route-bindings/records/current`
 - `POST /v1/route-bindings/reconcile`
@@ -672,21 +672,16 @@ counts. It never returns managed rule IDs, rule hashes, selectors, actions, or
 principal identities. Missing or multiple active records fail closed, and the
 read does not authorize a policy write or production grant.
 
-`POST /v1/authz-diagnostics/activation-preflight/read` is the supported
-owner-local activation preflight. The operator helper command
-`uv run launchplane authz-policies activation-preflight --service-url ...
---github-id ...` reads its bearer token only from
-`LAUNCHPLANE_LOCAL_ADMIN_TOKEN` (or the explicitly named environment variable)
-and has no browser-cookie, token-argv, or direct-DB mode. The service requires
-a local-admin bearer identity with both existing diagnostic read permissions,
-then reads at most the 257 most recently created server-side session rows for
-the supplied GitHub ID and admits at most eight claims-current sessions.
-Timestamp parsing, expiry filtering, claims-freshness ordering, and ambiguity
-checks happen in application code. It
-re-derives role authority from the active DB policy and returns only bounded
-policy, session, fixed-scope, decision, fingerprint, and unmanaged action-empty
-evidence. Missing, stale, ambiguous, mismatched, or truncated sessions fail
-closed; no grant is created by this route.
+`GET /v1/authz-diagnostics/activation-preflight/self` is the supported owner
+activation self-check. A signed-in browser human calls it with the Launchplane
+session cookie; Authorization headers, bodies, query parameters, and
+caller-selected identities are rejected. The service verifies the cookie
+without renewal, requires current stored claims, ignores the persisted session
+role, re-derives authority from the single active DB policy, and returns only
+the fixed policy-administration decision, an hour-bounded evaluation time, an
+opaque keyed policy generation, and a trace ID. Missing or invalid sessions and
+missing or ambiguous policy state fail closed. No CLI bearer helper or direct
+database fallback exists, and no grant or other durable record is created.
 
 `POST /v1/authz-diagnostics/candidate-policy/preview` is the non-persisting
 administrator preview for one exact schema-v2 candidate policy. The caller must

--- a/docs/operator-experience.md
+++ b/docs/operator-experience.md
@@ -9,13 +9,12 @@ contract before rebuilding the browser UI. The current React UI is transitional;
 do not spend time refining its context picker or product-config layout except
 for secret-safety regressions.
 
-Owner-local authorization activation uses the service API rather than the
-browser. The supported `authz-policies activation-preflight` helper accepts a
-service URL, GitHub numeric ID, and the name of an environment variable holding
-the local-admin bearer token. It does not accept cookies or token values on the
-command line and has no direct-database fallback. The returned evidence is
-bounded and suitable for operator review; a denial remains a truthful blocked
-state and does not trigger a grant or mutation.
+Owner authorization activation uses the signed-in browser session directly.
+The parameterless activation self-check returns only whether that exact
+immutable GitHub identity may administer policy now, plus bounded evaluation
+and opaque policy-generation evidence. It has no local-admin bearer helper,
+caller-selected identity, or direct-database fallback. A denial remains a
+truthful blocked state and does not trigger a grant or mutation.
 
 The rebuilt UI should be a product-delivery and operations surface, not a raw
 record browser. The first screen should show products, their stable

--- a/docs/records.md
+++ b/docs/records.md
@@ -99,15 +99,13 @@ authorize, constrain, display regularly, or act on should be promoted into ORM
 columns/tables and migrated explicitly while keeping the payload copy as
 historical evidence.
 
-Human sessions are DB-backed authentication records with indexed lookup by
-immutable `github_id`. The activation-preflight read fetches at most the 257
-most recently created matching rows using database-native timestamp ordering,
-then admits at most eight claims-current sessions. Timestamp parsing, expiry
-filtering, claims-freshness ordering, and ambiguity checks happen in application
-code. The read never cleans up expired rows, renews sessions,
-rotates CSRF state, commits, or writes session or authorization evidence. The
-indexed row identity and payload identity must agree; session role, name, email,
-session ID, and cookie values are not authorization authority.
+Human sessions are DB-backed authentication records. The activation-preflight
+self-check resolves exactly the session named by the verified browser cookie,
+without cleanup or renewal, and requires that session to be unexpired with
+current authorization claims and a positive immutable GitHub ID. The service
+re-derives the role from the active policy; session role, name, email, session
+ID, and cookie values are not authorization authority. The read never rotates
+CSRF state, commits, or writes session or authorization evidence.
 
 The production schema proof runs against real PostgreSQL, not SQLite:
 

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -735,16 +735,17 @@ workflows, or principal identifiers. Missing active state returns `503`, and
 multiple active records return `409`; the service never falls back to cached
 policy state for the response.
 
-`POST /v1/authz-diagnostics/activation-preflight/read` is the bearer-only
-service boundary for one owner-local activation proof. It accepts only a
-positive GitHub numeric ID, requires a `LocalAdminIdentity` with the existing
-`authz_policy_health.read` and `authz_policy_effective_access.read` permissions,
-and resolves the subject from unexpired DB-backed human sessions rather than
-caller-supplied claims or browser cookies. The server re-derives the human role
-from the active policy and evaluates the fixed context-scoped
-`authz_policy_grant.write` request. The route is read-only, fail-closed, and
-`Cache-Control: no-store` for both success and error responses; it does not add
-an authorization action or expose session, identity, selector, or rule data.
+`GET /v1/authz-diagnostics/activation-preflight/self` is the signed-in
+browser-human self-check for policy-administration authority. It rejects every
+Authorization header and accepts no body, query parameter, caller-selected
+identity, role, organization, team, session identifier, or cookie value. The
+service verifies the signed session cookie without renewal, requires current
+stored claims, re-derives the human role from the single active DB policy, and
+evaluates the fixed global `authz_policy_grant.write` request. The response is
+limited to allowed/denied, an hour-bounded evaluation time, an opaque keyed policy
+generation, and a trace ID. The route and all errors are
+`Cache-Control: no-store`; the path performs no durable write and requires no
+separate diagnostic authorization grant.
 
 `POST /v1/authz-diagnostics/candidate-policy/preview` is a separate
 administrator-read contract protected by `authz_policy_candidate_preview.read`.

--- a/frontend/generated/openapi-canonical.json
+++ b/frontend/generated/openapi-canonical.json
@@ -1104,7 +1104,7 @@
         "title": "AuthorizationTarget",
         "type": "object"
       },
-      "AuthzActivationPreflightDecision": {
+      "AuthzActivationPreflightSelfResponse": {
         "additionalProperties": false,
         "properties": {
           "decision": {
@@ -1115,90 +1115,15 @@
             "title": "Decision",
             "type": "string"
           },
-          "reason_code": {
-            "enum": [
-              "allowed",
-              "authz_policy_schema_incompatible",
-              "instance_scope_required",
-              "principal_role_restricted",
-              "principal_binding_invalid",
-              "no_matching_grant"
-            ],
-            "title": "Reason Code",
-            "type": "string"
-          }
-        },
-        "required": [
-          "decision",
-          "reason_code"
-        ],
-        "title": "AuthzActivationPreflightDecision",
-        "type": "object"
-      },
-      "AuthzActivationPreflightPolicySummary": {
-        "additionalProperties": false,
-        "properties": {
-          "policy_sha256": {
-            "title": "Policy Sha256",
+          "evaluated_at": {
+            "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:00:00Z$",
+            "title": "Evaluated At",
             "type": "string"
           },
-          "record_id": {
-            "title": "Record Id",
+          "policy_generation": {
+            "pattern": "^[0-9a-f]{64}$",
+            "title": "Policy Generation",
             "type": "string"
-          },
-          "revision": {
-            "minimum": 1.0,
-            "title": "Revision",
-            "type": "integer"
-          },
-          "schema_version": {
-            "enum": [
-              1,
-              2
-            ],
-            "title": "Schema Version",
-            "type": "integer"
-          }
-        },
-        "required": [
-          "record_id",
-          "revision",
-          "policy_sha256",
-          "schema_version"
-        ],
-        "title": "AuthzActivationPreflightPolicySummary",
-        "type": "object"
-      },
-      "AuthzActivationPreflightRequest": {
-        "additionalProperties": false,
-        "properties": {
-          "github_id": {
-            "exclusiveMinimum": 0.0,
-            "maximum": 9.223372036854776e+18,
-            "title": "Github Id",
-            "type": "integer"
-          }
-        },
-        "required": [
-          "github_id"
-        ],
-        "title": "AuthzActivationPreflightRequest",
-        "type": "object"
-      },
-      "AuthzActivationPreflightResponse": {
-        "additionalProperties": false,
-        "properties": {
-          "evaluation": {
-            "$ref": "#/components/schemas/AuthzActivationPreflightDecision"
-          },
-          "policy": {
-            "$ref": "#/components/schemas/AuthzActivationPreflightPolicySummary"
-          },
-          "scope": {
-            "$ref": "#/components/schemas/AuthzActivationPreflightScope"
-          },
-          "session": {
-            "$ref": "#/components/schemas/AuthzActivationPreflightSessionSummary"
           },
           "status": {
             "const": "ok",
@@ -1209,89 +1134,15 @@
           "trace_id": {
             "title": "Trace Id",
             "type": "string"
-          },
-          "unmanaged_action_empty_rules": {
-            "$ref": "#/components/schemas/AuthzUnmanagedActionEmptyRuleCounts"
           }
         },
         "required": [
           "trace_id",
-          "policy",
-          "session",
-          "scope",
-          "evaluation",
-          "unmanaged_action_empty_rules"
+          "decision",
+          "evaluated_at",
+          "policy_generation"
         ],
-        "title": "AuthzActivationPreflightResponse",
-        "type": "object"
-      },
-      "AuthzActivationPreflightScope": {
-        "additionalProperties": false,
-        "properties": {
-          "action": {
-            "const": "authz_policy_grant.write",
-            "default": "authz_policy_grant.write",
-            "title": "Action",
-            "type": "string"
-          },
-          "context": {
-            "const": "launchplane",
-            "default": "launchplane",
-            "title": "Context",
-            "type": "string"
-          },
-          "product": {
-            "const": "launchplane",
-            "default": "launchplane",
-            "title": "Product",
-            "type": "string"
-          },
-          "target_scope": {
-            "const": "context",
-            "default": "context",
-            "title": "Target Scope",
-            "type": "string"
-          }
-        },
-        "title": "AuthzActivationPreflightScope",
-        "type": "object"
-      },
-      "AuthzActivationPreflightSessionSummary": {
-        "additionalProperties": false,
-        "properties": {
-          "claims_age_bucket_hours": {
-            "minimum": 0.0,
-            "title": "Claims Age Bucket Hours",
-            "type": "integer"
-          },
-          "claims_current": {
-            "title": "Claims Current",
-            "type": "boolean"
-          },
-          "expiry_bucket_hours": {
-            "minimum": 0.0,
-            "title": "Expiry Bucket Hours",
-            "type": "integer"
-          },
-          "identity_fingerprint": {
-            "title": "Identity Fingerprint",
-            "type": "string"
-          },
-          "session_count": {
-            "maximum": 8.0,
-            "minimum": 1.0,
-            "title": "Session Count",
-            "type": "integer"
-          }
-        },
-        "required": [
-          "session_count",
-          "claims_current",
-          "claims_age_bucket_hours",
-          "expiry_bucket_hours",
-          "identity_fingerprint"
-        ],
-        "title": "AuthzActivationPreflightSessionSummary",
+        "title": "AuthzActivationPreflightSelfResponse",
         "type": "object"
       },
       "AuthzDenialExplanationResponse": {
@@ -2489,51 +2340,6 @@
           "authorization_chain"
         ],
         "title": "AuthzRepositoryScopeSourceCounts",
-        "type": "object"
-      },
-      "AuthzUnmanagedActionEmptyRuleCounts": {
-        "additionalProperties": false,
-        "properties": {
-          "github_actions": {
-            "minimum": 0.0,
-            "title": "Github Actions",
-            "type": "integer"
-          },
-          "github_humans": {
-            "minimum": 0.0,
-            "title": "Github Humans",
-            "type": "integer"
-          },
-          "local_admins": {
-            "minimum": 0.0,
-            "title": "Local Admins",
-            "type": "integer"
-          },
-          "local_operators": {
-            "minimum": 0.0,
-            "title": "Local Operators",
-            "type": "integer"
-          },
-          "terminal_agents": {
-            "minimum": 0.0,
-            "title": "Terminal Agents",
-            "type": "integer"
-          },
-          "total": {
-            "minimum": 0.0,
-            "title": "Total",
-            "type": "integer"
-          }
-        },
-        "required": [
-          "total",
-          "github_actions",
-          "github_humans",
-          "terminal_agents",
-          "local_operators",
-          "local_admins"
-        ],
-        "title": "AuthzUnmanagedActionEmptyRuleCounts",
         "type": "object"
       },
       "BackupGateEvidence": {
@@ -37861,37 +37667,43 @@
         "summary": "Read human auth session"
       }
     },
-    "/v1/authz-diagnostics/activation-preflight/read": {
-      "post": {
-        "operationId": "read_authz_activation_preflight",
+    "/v1/authz-diagnostics/activation-preflight/self": {
+      "get": {
+        "operationId": "read_authz_activation_preflight_self",
         "parameters": [
           {
             "in": "header",
             "name": "Authorization",
             "required": false,
             "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
+            "in": "header",
+            "name": "Cookie",
+            "required": false,
+            "schema": {
               "default": "",
-              "title": "Authorization",
+              "title": "Cookie",
               "type": "string"
             }
           }
         ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/AuthzActivationPreflightRequest"
-              }
-            }
-          },
-          "required": true
-        },
         "responses": {
           "200": {
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/AuthzActivationPreflightResponse"
+                  "$ref": "#/components/schemas/AuthzActivationPreflightSelfResponse"
                 }
               }
             },
@@ -37948,7 +37760,7 @@
             "description": "Service Unavailable"
           }
         },
-        "summary": "Read bounded authorization activation preflight evidence"
+        "summary": "Read the signed Launchplane activation preflight self-check"
       }
     },
     "/v1/authz-diagnostics/active-policy/health": {

--- a/tests/test_agent_operator_contract.py
+++ b/tests/test_agent_operator_contract.py
@@ -33,10 +33,6 @@ class AgentOperatorContractTests(unittest.TestCase):
         )
         expected_operation_ids = {
             ("GET", "/v1/agent/context"): "read_agent_context",
-            (
-                "POST",
-                "/v1/authz-diagnostics/activation-preflight/read",
-            ): "read_authz_activation_preflight",
             ("POST", "/v1/agent/write-intents/evaluate"): "evaluate_agent_write_intent",
             ("POST", "/v1/product-config/apply"): "apply_product_config",
             ("POST", "/v1/change-impact/policies/apply"): "apply_change_impact_policy",
@@ -60,7 +56,6 @@ class AgentOperatorContractTests(unittest.TestCase):
         }
         expected_dependencies = {
             "read_agent_context": ["read_identity"],
-            "read_authz_activation_preflight": ["read_bearer_identity"],
             "evaluate_agent_write_intent": ["read_browser_mutation_identity"],
             "apply_product_config": ["read_browser_mutation_identity"],
             "apply_change_impact_policy": ["read_write_identity"],

--- a/tests/test_authz_activation_preflight.py
+++ b/tests/test_authz_activation_preflight.py
@@ -1,33 +1,24 @@
 from __future__ import annotations
 
+from dataclasses import replace
 from datetime import datetime, timedelta, timezone
 import json
 import os
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from typing import Literal
 import unittest
 from unittest.mock import patch
-from typing import Literal, cast
 
-from click import Command
-from click.testing import CliRunner
 from cryptography.fernet import Fernet
+from fastapi import FastAPI
 
-from control_plane import (
-    authz_activation_preflight,
-    cli_policy_profiles,
-    secrets as control_plane_secrets,
-)
+from control_plane import secrets as control_plane_secrets
 from control_plane.authz_activation_preflight import (
-    ACTIVATION_PREFLIGHT_STORAGE_SCAN_LIMIT,
-    ACTIVATION_PREFLIGHT_STORAGE_SESSION_LIMIT,
     ActivationPreflightFailure,
-    build_activation_preflight_response,
+    build_activation_preflight_self_response,
 )
-from control_plane.cli_policy_profiles import (
-    PolicyProfileCliCallbacks,
-    authz_policies,
-)
+from control_plane.cli_policy_profiles import authz_policies
 from control_plane.contracts.authz_policy_record import (
     LaunchplaneAuthzPolicyRecord,
     authz_policy_sha256,
@@ -35,14 +26,18 @@ from control_plane.contracts.authz_policy_record import (
 )
 from control_plane.http_app import LaunchplaneAuthzPolicyRuntime, create_launchplane_fastapi_app
 from control_plane.service_auth import (
-    BearerIdentityConfig,
     GitHubActionsIdentity,
     GitHubHumanIdentity,
     GitHubHumanPolicyRule,
     LaunchplaneAuthzPolicy,
-    LocalAdminPolicyRule,
 )
-from control_plane.service_human_auth import LaunchplaneHumanSession
+from control_plane.service_human_auth import (
+    GitHubOAuthConfig,
+    HumanSessionManager,
+    InMemoryHumanSessionStore,
+    LaunchplaneHumanSession,
+    SESSION_AUTHORIZATION_CLAIMS_TTL_SECONDS,
+)
 from control_plane.storage.postgres import PostgresRecordStore
 from tests.support.http import lifespan_client
 
@@ -62,13 +57,15 @@ def _key_ring() -> str:
 
 
 def _identity(
-    *, role: Literal["read_only", "admin"] = "read_only", github_id: int = 123
+    *,
+    role: Literal["read_only", "admin"] = "read_only",
+    github_id: int = 123,
 ) -> GitHubHumanIdentity:
     return GitHubHumanIdentity(
         login="alice",
         github_id=github_id,
         name="Sensitive Name",
-        email="alice@example.com",
+        email="alice@example.test",
         organizations=frozenset({"example-org"}),
         teams=frozenset({"example-org/platform"}),
         role=role,
@@ -80,47 +77,19 @@ def _session(
     now: datetime,
     role: Literal["read_only", "admin"] = "read_only",
     github_id: int = 123,
-    created_offset: timedelta = timedelta(hours=1),
-    expires_offset: timedelta = timedelta(days=1),
+    created_at: datetime | None = None,
+    expires_at: datetime | None = None,
+    session_id: str = "session-sensitive-value",
 ) -> LaunchplaneHumanSession:
     return LaunchplaneHumanSession(
-        session_id=f"session-{github_id}-{role}-{created_offset}",
+        session_id=session_id,
         identity=_identity(role=role, github_id=github_id),
-        created_at=now - created_offset,
-        expires_at=now + expires_offset,
+        created_at=created_at or now - timedelta(minutes=5),
+        expires_at=expires_at or now + timedelta(days=1),
     )
 
 
-def _policy(
-    *,
-    human_rule: bool = True,
-    local_admin: bool = True,
-    unmanaged_action_empty_rule: bool = False,
-) -> LaunchplaneAuthzPolicy:
-    local_admin_rules = []
-    if local_admin:
-        local_admin_rules.append(
-            LocalAdminPolicyRule(
-                subjects=("authz-admin",),
-                token_labels=("authz-admin-label",),
-                products=("launchplane",),
-                contexts=("launchplane",),
-                actions=(
-                    "authz_policy_health.read",
-                    "authz_policy_effective_access.read",
-                ),
-            )
-        )
-    if unmanaged_action_empty_rule:
-        local_admin_rules.append(
-            LocalAdminPolicyRule(
-                subjects=("legacy-admin",),
-                token_labels=("legacy-admin-label",),
-                products=("launchplane",),
-                contexts=("launchplane",),
-                actions=(),
-            )
-        )
+def _policy(*, grant: bool = True) -> LaunchplaneAuthzPolicy:
     return LaunchplaneAuthzPolicy(
         schema_version=2,
         github_humans=(
@@ -132,246 +101,172 @@ def _policy(
                 actions=("authz_policy_grant.write",),
             ),
         )
-        if human_rule
+        if grant
         else (),
-        local_admins=tuple(local_admin_rules),
     )
 
 
-def _record(policy: LaunchplaneAuthzPolicy) -> LaunchplaneAuthzPolicyRecord:
+def _record(
+    policy: LaunchplaneAuthzPolicy,
+    *,
+    revision: int = 1,
+) -> LaunchplaneAuthzPolicyRecord:
     digest = authz_policy_sha256(policy)
     return LaunchplaneAuthzPolicyRecord(
-        record_id=build_authz_policy_record_id(revision=1, policy_sha256=digest),
-        revision=1,
-        source="test:activation-preflight",
-        updated_at="2026-08-23T00:00:00+00:00",
+        record_id=build_authz_policy_record_id(revision=revision, policy_sha256=digest),
+        revision=revision,
+        source="test:activation-preflight-self",
+        updated_at="2026-08-25T00:00:00+00:00",
         policy=policy,
         policy_sha256=digest,
     )
 
 
-class AuthzActivationPreflightTests(unittest.IsolatedAsyncioTestCase):
-    def test_domain_rederives_role_and_redacts_session_identity(self) -> None:
-        now = datetime(2026, 8, 23, tzinfo=timezone.utc)
-        newer_session = _session(
-            now=now,
-            created_offset=timedelta(minutes=10),
-            expires_offset=timedelta(minutes=15),
-        )
-        older_session = _session(
-            now=now,
-            role="admin",
-            created_offset=timedelta(hours=2),
-            expires_offset=timedelta(hours=3, minutes=1),
-        )
-        with patch.dict(
+def _session_manager(
+    *,
+    store: InMemoryHumanSessionStore,
+    now: datetime,
+) -> HumanSessionManager:
+    return HumanSessionManager(
+        config=GitHubOAuthConfig(
+            client_id="client-id",
+            client_secret="client-secret",
+            public_url="https://launchplane.example.test",
+            session_secret="session-signing-secret",
+            cookie_secure=False,
+        ),
+        session_store=store,
+        now=lambda: now,
+    )
+
+
+def _app(
+    *,
+    root: Path,
+    store: object,
+    record: LaunchplaneAuthzPolicyRecord,
+    session_manager: HumanSessionManager | None,
+) -> FastAPI:
+    return create_launchplane_fastapi_app(
+        verifier=_RejectingVerifier(),
+        authz_policy=record.policy,
+        authz_policy_runtime=LaunchplaneAuthzPolicyRuntime(
+            record.policy,
+            policy_sha256=record.policy_sha256,
+            source="db",
+            record_id=record.record_id,
+            revision=record.revision,
+        ),
+        record_store_factory=lambda: store,
+        human_session_manager=session_manager,
+        control_plane_root_path=root,
+        state_dir=root / "state",
+    )
+
+
+class AuthzActivationPreflightDomainTests(unittest.TestCase):
+    def setUp(self) -> None:
+        secret_keys = patch.dict(
             os.environ,
             {control_plane_secrets.LAUNCHPLANE_SECRET_KEYS_JSON_ENV_VAR: _key_ring()},
-            clear=True,
-        ):
-            response = build_activation_preflight_response(
-                trace_id="trace",
-                github_id=123,
-                active_record=_record(_policy(unmanaged_action_empty_rule=True)),
-                sessions=(older_session, newer_session),
-                now=now,
-            )
-        payload = response.model_dump(mode="json")
-        self.assertEqual(payload["evaluation"]["decision"], "allowed")
-        self.assertEqual(payload["session"]["session_count"], 2)
-        self.assertEqual(payload["session"]["claims_age_bucket_hours"], 0)
-        self.assertEqual(payload["session"]["expiry_bucket_hours"], 4)
-        self.assertEqual(payload["unmanaged_action_empty_rules"]["total"], 1)
-        self.assertEqual(payload["unmanaged_action_empty_rules"]["local_admins"], 1)
-        self.assertNotIn("alice", json.dumps(payload))
-        self.assertNotIn("example-org", json.dumps(payload))
-        self.assertNotIn("session-", json.dumps(payload))
-        self.assertNotIn("github_id", json.dumps(payload))
+            clear=False,
+        )
+        secret_keys.start()
+        self.addCleanup(secret_keys.stop)
 
-    def test_domain_does_not_trust_persisted_admin_role(self) -> None:
-        now = datetime(2026, 8, 23, tzinfo=timezone.utc)
-        with patch.dict(
-            os.environ,
-            {control_plane_secrets.LAUNCHPLANE_SECRET_KEYS_JSON_ENV_VAR: _key_ring()},
-            clear=True,
-        ):
-            response = build_activation_preflight_response(
-                trace_id="trace",
-                github_id=123,
-                active_record=_record(_policy(human_rule=False)),
-                sessions=(_session(now=now, role="admin"),),
-                now=now,
-            )
-        self.assertEqual(response.evaluation.decision, "denied")
-        self.assertEqual(response.evaluation.reason_code, "principal_role_restricted")
-
-    def test_domain_supports_legacy_managed_secret_key_bootstrap(self) -> None:
-        now = datetime(2026, 8, 23, tzinfo=timezone.utc)
-        legacy_key_env = control_plane_secrets.LAUNCHPLANE_SECRET_MASTER_KEY_ENV_VARS[0]
-        with patch.dict(
-            os.environ,
-            {legacy_key_env: Fernet.generate_key().decode()},
-            clear=True,
-        ):
-            response = build_activation_preflight_response(
-                trace_id="trace",
-                github_id=123,
-                active_record=_record(_policy()),
-                sessions=(_session(now=now),),
-                now=now,
-            )
-        self.assertTrue(response.session.identity_fingerprint.startswith("identity_"))
-
-    def test_domain_fails_closed_for_stale_ambiguous_and_truncated_sessions(self) -> None:
-        now = datetime(2026, 8, 23, tzinfo=timezone.utc)
+    def test_rederives_role_and_returns_only_bounded_self_evidence(self) -> None:
+        now = datetime(2026, 8, 25, 14, 37, 42, tzinfo=timezone.utc)
         record = _record(_policy())
-        with self.subTest("stale"):
-            with self.assertRaisesRegex(ActivationPreflightFailure, "claims are stale"):
-                build_activation_preflight_response(
-                    trace_id="trace",
-                    github_id=123,
-                    active_record=record,
-                    sessions=(
-                        _session(
-                            now=now,
-                            created_offset=timedelta(hours=25),
-                        ),
-                    ),
-                    now=now,
-                )
-        with self.subTest("ambiguous"):
-            divergent = LaunchplaneHumanSession(
-                session_id="divergent",
-                identity=GitHubHumanIdentity(
-                    login="alice",
-                    github_id=123,
-                    name="",
-                    email="",
-                    organizations=frozenset({"other-org"}),
-                    teams=frozenset(),
-                    role="admin",
-                ),
-                created_at=now - timedelta(hours=2),
-                expires_at=now + timedelta(days=1),
-            )
-            with self.assertRaisesRegex(ActivationPreflightFailure, "ambiguous"):
-                build_activation_preflight_response(
-                    trace_id="trace",
-                    github_id=123,
-                    active_record=record,
-                    sessions=(_session(now=now), divergent),
-                    now=now,
-                )
-        with self.subTest("truncated"):
-            with self.assertRaisesRegex(ActivationPreflightFailure, "too many"):
-                build_activation_preflight_response(
-                    trace_id="trace",
-                    github_id=123,
-                    active_record=record,
-                    sessions=tuple(_session(now=now) for _ in range(9)),
-                    now=now,
-                )
-        with self.subTest("stale unexpired sessions do not consume current-session bound"):
-            with patch.dict(
-                os.environ,
-                {control_plane_secrets.LAUNCHPLANE_SECRET_KEYS_JSON_ENV_VAR: _key_ring()},
-                clear=True,
-            ):
-                response = build_activation_preflight_response(
-                    trace_id="trace",
-                    github_id=123,
-                    active_record=record,
-                    sessions=(
-                        _session(now=now),
-                        *(
-                            _session(
-                                now=now,
-                                created_offset=timedelta(hours=25),
-                            )
-                            for _ in range(8)
-                        ),
-                    ),
-                    now=now,
-                )
-            self.assertEqual(response.session.session_count, 1)
-        with self.subTest("history contract violation"):
-            with self.assertRaisesRegex(ActivationPreflightFailure, "history"):
-                build_activation_preflight_response(
-                    trace_id="trace",
-                    github_id=123,
-                    active_record=record,
-                    sessions=tuple(
-                        _session(now=now, expires_offset=timedelta(hours=-1))
-                        for _ in range(ACTIVATION_PREFLIGHT_STORAGE_SESSION_LIMIT + 1)
-                    ),
-                    now=now,
-                )
-        with self.subTest("bounded stale history does not hide current session"):
-            with patch.dict(
-                os.environ,
-                {control_plane_secrets.LAUNCHPLANE_SECRET_KEYS_JSON_ENV_VAR: _key_ring()},
-                clear=True,
-            ):
-                response = build_activation_preflight_response(
-                    trace_id="trace",
-                    github_id=123,
-                    active_record=record,
-                    sessions=(
-                        _session(now=now),
-                        *(
-                            _session(
-                                now=now,
-                                created_offset=timedelta(hours=25),
-                                expires_offset=timedelta(hours=-1),
-                            )
-                            for _ in range(ACTIVATION_PREFLIGHT_STORAGE_SCAN_LIMIT)
-                        ),
-                    ),
-                    now=now,
-                )
-            self.assertEqual(response.session.session_count, 1)
-        with self.subTest("payload mismatch"):
-            with self.assertRaisesRegex(ActivationPreflightFailure, "lookup key"):
-                build_activation_preflight_response(
-                    trace_id="trace",
-                    github_id=123,
-                    active_record=record,
-                    sessions=(_session(now=now, github_id=456),),
-                    now=now,
-                )
+        response = build_activation_preflight_self_response(
+            trace_id="trace-id",
+            session=_session(now=now),
+            active_record=record,
+            now=now,
+        )
 
-    def test_postgres_session_lookup_is_bounded_and_non_mutating(self) -> None:
-        now = datetime(2026, 8, 23, tzinfo=timezone.utc)
-        with TemporaryDirectory() as directory:
-            store = PostgresRecordStore(database_url=f"sqlite+pysqlite:///{Path(directory) / 'db'}")
-            store.ensure_schema()
-            expired = _session(
-                now=now, created_offset=timedelta(hours=2), expires_offset=timedelta(hours=-1)
-            )
-            store.write_session(expired)
-            offset_session = LaunchplaneHumanSession(
-                session_id="offset-session",
-                identity=_identity(),
-                created_at=datetime.fromisoformat("2026-08-23T00:30:00-04:00"),
-                expires_at=datetime.fromisoformat("2026-08-24T00:30:00-04:00"),
-            )
-            other_identity = _session(now=now, github_id=456)
-            store.write_session(offset_session)
-            store.write_session(other_identity)
-            found = store.read_human_sessions_for_github_id_without_cleanup(
-                123,
-                limit=10,
-                created_at_not_after=now + timedelta(days=1),
-            )
-            self.assertEqual(
-                {session.session_id for session in found},
-                {expired.session_id, offset_session.session_id},
-            )
-            self.assertEqual(found[0].session_id, offset_session.session_id)
-            self.assertIsNotNone(store.read_session_without_cleanup(expired.session_id))
-            store.close()
+        self.assertEqual(
+            response.model_dump(mode="json"),
+            {
+                "status": "ok",
+                "trace_id": "trace-id",
+                "decision": "allowed",
+                "evaluated_at": "2026-08-25T14:00:00Z",
+                "policy_generation": response.policy_generation,
+            },
+        )
+        self.assertRegex(response.policy_generation, r"^[0-9a-f]{64}$")
+        response_text = response.model_dump_json()
+        for sensitive_value in (
+            "session-sensitive-value",
+            "alice",
+            "Sensitive Name",
+            "alice@example.test",
+            "example-org",
+            "example-org/platform",
+            record.record_id,
+            record.policy_sha256,
+        ):
+            self.assertNotIn(sensitive_value, response_text)
 
-    async def test_http_route_is_bearer_only_no_store_and_no_writes(self) -> None:
+    def test_ignores_persisted_admin_role_and_changes_generation_with_policy_record(self) -> None:
+        now = datetime(2026, 8, 25, tzinfo=timezone.utc)
+        denied_record = _record(_policy(grant=False))
+        denied = build_activation_preflight_self_response(
+            trace_id="trace-denied",
+            session=_session(now=now, role="admin"),
+            active_record=denied_record,
+            now=now,
+        )
+        next_record = _record(_policy(grant=False), revision=2)
+        next_response = build_activation_preflight_self_response(
+            trace_id="trace-next",
+            session=_session(now=now, role="admin"),
+            active_record=next_record,
+            now=now,
+        )
+
+        self.assertEqual(denied.decision, "denied")
+        self.assertNotEqual(denied.policy_generation, next_response.policy_generation)
+
+    def test_rejects_invalid_session_evidence(self) -> None:
+        now = datetime(2026, 8, 25, tzinfo=timezone.utc)
+        record = _record(_policy())
+        invalid_sessions = (
+            _session(now=now, expires_at=now),
+            _session(now=now, created_at=now + timedelta(seconds=1)),
+            replace(
+                _session(now=now),
+                identity=replace(_identity(), github_id=0),
+            ),
+            replace(
+                _session(now=now),
+                identity=replace(_identity(), login=""),
+            ),
+        )
+
+        for invalid_session in invalid_sessions:
+            with self.subTest(session=invalid_session):
+                with self.assertRaises(ActivationPreflightFailure) as failure:
+                    build_activation_preflight_self_response(
+                        trace_id="trace-invalid",
+                        session=invalid_session,
+                        active_record=record,
+                        now=now,
+                    )
+                self.assertEqual(failure.exception.status_code, 401)
+
+
+class AuthzActivationPreflightHttpTests(unittest.IsolatedAsyncioTestCase):
+    def setUp(self) -> None:
+        secret_keys = patch.dict(
+            os.environ,
+            {control_plane_secrets.LAUNCHPLANE_SECRET_KEYS_JSON_ENV_VAR: _key_ring()},
+            clear=False,
+        )
+        secret_keys.start()
+        self.addCleanup(secret_keys.stop)
+
+    async def test_self_route_is_cookie_only_no_store_redacted_and_non_mutating(self) -> None:
         now = datetime.now(timezone.utc)
         with TemporaryDirectory() as directory:
             root = Path(directory)
@@ -379,188 +274,245 @@ class AuthzActivationPreflightTests(unittest.IsolatedAsyncioTestCase):
             store.ensure_schema()
             record = _record(_policy())
             store.seed_authz_policy_if_absent(record)
-            stored_session = _session(now=now)
-            store.write_session(stored_session)
-            app = create_launchplane_fastapi_app(
-                verifier=_RejectingVerifier(),
-                authz_policy=record.policy,
-                authz_policy_runtime=LaunchplaneAuthzPolicyRuntime(
-                    record.policy,
-                    policy_sha256=record.policy_sha256,
-                    source="db",
-                    record_id=record.record_id,
-                    revision=record.revision,
-                ),
-                record_store_factory=lambda: store,
-                bearer_identity_config=BearerIdentityConfig(
-                    local_admin_token="admin-token",
-                    local_admin_subject="authz-admin",
-                    local_admin_token_label="authz-admin-label",
-                    local_operator_token="operator-token",
-                    local_operator_subject="operator",
-                    local_operator_token_label="operator-label",
-                ),
-                control_plane_root_path=root,
-                state_dir=root / "state",
+            session_store = InMemoryHumanSessionStore()
+            manager = _session_manager(store=session_store, now=now)
+            valid_session = _session(now=now)
+            expired_session = _session(
+                now=now,
+                session_id="expired-session",
+                created_at=now - timedelta(days=2),
+                expires_at=now - timedelta(seconds=1),
             )
-            with patch.dict(
-                os.environ,
-                {control_plane_secrets.LAUNCHPLANE_SECRET_KEYS_JSON_ENV_VAR: _key_ring()},
-                clear=True,
+            stale_session = _session(
+                now=now,
+                session_id="stale-session",
+                created_at=now - timedelta(seconds=SESSION_AUTHORIZATION_CLAIMS_TTL_SECONDS + 1),
+            )
+            for session in (valid_session, expired_session, stale_session):
+                session_store.write_session(session)
+            valid_cookie = manager.session_cookie_header(valid_session)
+            app = _app(
+                root=root,
+                store=store,
+                record=record,
+                session_manager=manager,
+            )
+
+            with (
+                patch.object(session_store, "write_session", side_effect=AssertionError),
+                patch.object(session_store, "delete_session", side_effect=AssertionError),
+                patch.object(
+                    session_store,
+                    "write_session_if_csrf_generation",
+                    side_effect=AssertionError,
+                ),
+                patch.object(store, "write_authz_denial_record", side_effect=AssertionError),
+                patch.object(store, "write_idempotency_record", side_effect=AssertionError),
+                patch.object(store, "write_outbox_delivery_record", side_effect=AssertionError),
+                patch.object(
+                    store,
+                    "write_privileged_operation_plan",
+                    side_effect=AssertionError,
+                ),
             ):
-                with (
-                    patch.object(store, "write_authz_denial_record", side_effect=AssertionError),
-                    patch.object(store, "write_session", side_effect=AssertionError),
-                    patch.object(store, "delete_session", side_effect=AssertionError),
-                    patch.object(
-                        store, "write_session_if_csrf_generation", side_effect=AssertionError
-                    ),
-                    patch.object(store, "write_idempotency_record", side_effect=AssertionError),
-                    patch.object(store, "write_outbox_delivery_record", side_effect=AssertionError),
-                    patch.object(
-                        store, "write_privileged_operation_plan", side_effect=AssertionError
-                    ),
-                    patch.object(store, "write_secret_audit_event", side_effect=AssertionError),
-                ):
-                    async with lifespan_client(app) as client:
-                        response = await client.post(
-                            "/v1/authz-diagnostics/activation-preflight/read",
-                            headers={"Authorization": "Bearer admin-token"},
-                            json={"github_id": 123},
-                        )
-                        operator_response = await client.post(
-                            "/v1/authz-diagnostics/activation-preflight/read",
-                            headers={"Authorization": "Bearer operator-token"},
-                            json={"github_id": 123},
-                        )
-                        invalid_response = await client.post(
-                            "/v1/authz-diagnostics/activation-preflight/read",
-                            headers={"Authorization": "Bearer admin-token"},
-                            json={},
-                        )
-                        oversized_response = await client.post(
-                            "/v1/authz-diagnostics/activation-preflight/read",
-                            headers={"Authorization": "Bearer admin-token"},
-                            json={"github_id": 2**63},
-                        )
-                        with patch.object(
-                            authz_activation_preflight,
-                            "build_activation_preflight_response",
-                            side_effect=RuntimeError("unexpected"),
-                        ):
-                            unavailable_response = await client.post(
-                                "/v1/authz-diagnostics/activation-preflight/read",
-                                headers={"Authorization": "Bearer admin-token"},
-                                json={"github_id": 123},
-                            )
-                        with patch.object(
-                            store,
-                            "list_authz_policy_records",
-                            side_effect=RuntimeError("database unavailable"),
-                        ):
-                            database_unavailable_response = await client.post(
-                                "/v1/authz-diagnostics/activation-preflight/read",
-                                headers={"Authorization": "Bearer admin-token"},
-                                json={"github_id": 123},
-                            )
-            self.assertEqual(response.status_code, 200)
-            self.assertEqual(response.headers["cache-control"], "no-store")
-            response_text = response.text
-            for secret_value in (
-                stored_session.session_id,
-                stored_session.identity.login,
-                stored_session.identity.name,
-                stored_session.identity.email,
-                *stored_session.identity.organizations,
-                *stored_session.identity.teams,
-                "admin-token",
-                "authz-admin",
-                "authz-admin-label",
-            ):
-                self.assertNotIn(secret_value, response_text)
-            self.assertEqual(operator_response.status_code, 403)
-            self.assertEqual(operator_response.headers["cache-control"], "no-store")
-            self.assertEqual(invalid_response.status_code, 400)
-            self.assertEqual(invalid_response.headers["cache-control"], "no-store")
-            self.assertEqual(oversized_response.status_code, 400)
-            self.assertEqual(oversized_response.headers["cache-control"], "no-store")
-            self.assertEqual(unavailable_response.status_code, 503)
-            self.assertEqual(unavailable_response.headers["cache-control"], "no-store")
-            self.assertEqual(database_unavailable_response.status_code, 503)
-            self.assertEqual(database_unavailable_response.headers["cache-control"], "no-store")
+                async with lifespan_client(app) as client:
+                    response = await client.get(
+                        "/v1/authz-diagnostics/activation-preflight/self",
+                        headers={"Cookie": valid_cookie},
+                    )
+                    bearer_response = await client.get(
+                        "/v1/authz-diagnostics/activation-preflight/self",
+                        headers={
+                            "Authorization": "Bearer forbidden",
+                            "Cookie": valid_cookie,
+                        },
+                    )
+                    missing_response = await client.get(
+                        "/v1/authz-diagnostics/activation-preflight/self"
+                    )
+                    invalid_response = await client.get(
+                        "/v1/authz-diagnostics/activation-preflight/self",
+                        headers={"Cookie": "launchplane_session=invalid.signature"},
+                    )
+                    expired_response = await client.get(
+                        "/v1/authz-diagnostics/activation-preflight/self",
+                        headers={"Cookie": manager.session_cookie_header(expired_session)},
+                    )
+                    stale_response = await client.get(
+                        "/v1/authz-diagnostics/activation-preflight/self",
+                        headers={"Cookie": manager.session_cookie_header(stale_session)},
+                    )
+                    query_response = await client.get(
+                        "/v1/authz-diagnostics/activation-preflight/self?github_id=999",
+                        headers={"Cookie": valid_cookie},
+                    )
+                    body_response = await client.request(
+                        "GET",
+                        "/v1/authz-diagnostics/activation-preflight/self",
+                        headers={"Cookie": valid_cookie},
+                        content=b"{}",
+                    )
+                    old_route_response = await client.post(
+                        "/v1/authz-diagnostics/activation-preflight/read",
+                        headers={"Authorization": "Bearer forbidden"},
+                        json={"github_id": 123},
+                    )
+
+            self.assertEqual(response.status_code, 200, response.text)
             self.assertEqual(
-                store.read_session_without_cleanup(stored_session.session_id), stored_session
+                set(response.json()),
+                {"status", "trace_id", "decision", "evaluated_at", "policy_generation"},
+            )
+            self.assertEqual(response.json()["decision"], "allowed")
+            self.assertNotIn("set-cookie", response.headers)
+            for sensitive_value in (
+                valid_session.session_id,
+                valid_session.identity.login,
+                valid_session.identity.name,
+                valid_session.identity.email,
+                *valid_session.identity.organizations,
+                *valid_session.identity.teams,
+                record.record_id,
+                record.policy_sha256,
+                "forbidden",
+            ):
+                self.assertNotIn(sensitive_value, response.text)
+            for rejected_response, status_code in (
+                (bearer_response, 403),
+                (missing_response, 401),
+                (invalid_response, 401),
+                (expired_response, 401),
+                (stale_response, 401),
+                (query_response, 400),
+                (body_response, 400),
+            ):
+                self.assertEqual(rejected_response.status_code, status_code, rejected_response.text)
+                self.assertEqual(rejected_response.headers["cache-control"], "no-store")
+            self.assertEqual(response.headers["cache-control"], "no-store")
+            self.assertEqual(old_route_response.status_code, 404)
+            self.assertEqual(
+                session_store.read_session_without_cleanup(valid_session.session_id), valid_session
             )
             self.assertEqual(store.list_authz_policy_records(status="active"), (record,))
             store.close()
 
-    async def test_http_route_reauthorizes_against_active_database_policy(self) -> None:
+    async def test_self_route_fails_closed_for_policy_storage_states(self) -> None:
         now = datetime.now(timezone.utc)
         with TemporaryDirectory() as directory:
             root = Path(directory)
             store = PostgresRecordStore(database_url=f"sqlite+pysqlite:///{root / 'db'}")
             store.ensure_schema()
-            active_record = _record(_policy(local_admin=False))
-            store.seed_authz_policy_if_absent(active_record)
-            store.write_session(_session(now=now))
-            runtime_policy = _policy()
-            app = create_launchplane_fastapi_app(
-                verifier=_RejectingVerifier(),
-                authz_policy=runtime_policy,
-                authz_policy_runtime=LaunchplaneAuthzPolicyRuntime(runtime_policy),
-                record_store_factory=lambda: store,
-                bearer_identity_config=BearerIdentityConfig(
-                    local_admin_token="admin-token",
-                    local_admin_subject="authz-admin",
-                    local_admin_token_label="authz-admin-label",
-                ),
-                control_plane_root_path=root,
-                state_dir=root / "state",
+            record = _record(_policy())
+            session_store = InMemoryHumanSessionStore()
+            manager = _session_manager(store=session_store, now=now)
+            session = _session(now=now)
+            session_store.write_session(session)
+            app = _app(
+                root=root,
+                store=store,
+                record=record,
+                session_manager=manager,
             )
+            headers = {"Cookie": manager.session_cookie_header(session)}
+
             async with lifespan_client(app) as client:
-                response = await client.post(
-                    "/v1/authz-diagnostics/activation-preflight/read",
-                    headers={"Authorization": "Bearer admin-token"},
-                    json={"github_id": 123},
+                missing_response = await client.get(
+                    "/v1/authz-diagnostics/activation-preflight/self",
+                    headers=headers,
                 )
-            self.assertEqual(response.status_code, 403)
-            self.assertEqual(response.headers["cache-control"], "no-store")
+                store.seed_authz_policy_if_absent(record)
+                with patch.object(
+                    store,
+                    "list_authz_policy_records",
+                    return_value=(record, record),
+                ):
+                    ambiguous_response = await client.get(
+                        "/v1/authz-diagnostics/activation-preflight/self",
+                        headers=headers,
+                    )
+                with patch.object(
+                    control_plane_secrets,
+                    "keyed_secret_payload_fingerprint",
+                    side_effect=RuntimeError("secret key ring unavailable"),
+                ):
+                    generation_unavailable_response = await client.get(
+                        "/v1/authz-diagnostics/activation-preflight/self",
+                        headers=headers,
+                    )
+                with patch.object(
+                    session_store,
+                    "read_session_without_cleanup",
+                    side_effect=RuntimeError("session storage unavailable"),
+                ):
+                    session_unavailable_response = await client.get(
+                        "/v1/authz-diagnostics/activation-preflight/self",
+                        headers=headers,
+                    )
+                denied_record = _record(_policy(grant=False), revision=2)
+                with patch.object(
+                    store,
+                    "list_authz_policy_records",
+                    return_value=(denied_record,),
+                ):
+                    denied_response = await client.get(
+                        "/v1/authz-diagnostics/activation-preflight/self",
+                        headers=headers,
+                    )
+                with patch.object(
+                    store,
+                    "list_authz_policy_records",
+                    side_effect=RuntimeError("database unavailable"),
+                ):
+                    unavailable_response = await client.get(
+                        "/v1/authz-diagnostics/activation-preflight/self",
+                        headers=headers,
+                    )
+
+            self.assertEqual(missing_response.status_code, 503, missing_response.text)
+            self.assertEqual(ambiguous_response.status_code, 409, ambiguous_response.text)
+            self.assertEqual(unavailable_response.status_code, 503, unavailable_response.text)
+            self.assertEqual(
+                generation_unavailable_response.status_code,
+                503,
+                generation_unavailable_response.text,
+            )
+            self.assertEqual(
+                session_unavailable_response.status_code,
+                503,
+                session_unavailable_response.text,
+            )
+            self.assertEqual(denied_response.status_code, 200, denied_response.text)
+            self.assertEqual(denied_response.json()["decision"], "denied")
+            for response in (
+                missing_response,
+                ambiguous_response,
+                unavailable_response,
+                generation_unavailable_response,
+                session_unavailable_response,
+                denied_response,
+            ):
+                self.assertEqual(response.headers["cache-control"], "no-store")
             store.close()
 
+    def test_openapi_exposes_only_parameterless_get_and_old_helper_is_deleted(self) -> None:
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            record = _record(_policy())
+            app = _app(root=root, store=object(), record=record, session_manager=None)
 
-class AuthzActivationPreflightCliTests(unittest.TestCase):
-    def test_cli_reads_named_environment_only(self) -> None:
-        calls: list[dict[str, object]] = []
-
-        def post(**kwargs: object) -> dict[str, object]:
-            calls.append(kwargs)
-            return {"status": "ok"}
-
-        runner = CliRunner()
-        with (
-            patch.object(
-                cli_policy_profiles,
-                "_callbacks",
-                PolicyProfileCliCallbacks(post_launchplane_service_json=post),
-            ),
-            patch.dict(
-                os.environ, {"LOCAL_ADMIN_TEST_TOKEN": "secret-token"}, clear=True
-            ),
-        ):
-            result = runner.invoke(
-                cast(Command, authz_policies),
-                [
-                    "activation-preflight",
-                    "--service-url",
-                    "https://launchplane.example",
-                    "--bearer-token-env",
-                    "LOCAL_ADMIN_TEST_TOKEN",
-                    "--github-id",
-                    "123",
-                ],
-            )
-        self.assertEqual(result.exit_code, 0, result.output)
-        self.assertEqual(calls[0]["bearer_token"], "secret-token")
-        self.assertNotIn("secret-token", result.output)
-        self.assertEqual(calls[0]["session_cookie"], "")
-        self.assertEqual(calls[0]["path"], "/v1/authz-diagnostics/activation-preflight/read")
+        schema = app.openapi()
+        operation = schema["paths"]["/v1/authz-diagnostics/activation-preflight/self"]
+        self.assertEqual(set(operation), {"get"})
+        self.assertEqual(
+            {(parameter["name"], parameter["in"]) for parameter in operation["get"]["parameters"]},
+            {("Authorization", "header"), ("Cookie", "header")},
+        )
+        self.assertFalse(
+            any(parameter["in"] == "query" for parameter in operation["get"]["parameters"])
+        )
+        self.assertNotIn("requestBody", operation["get"])
+        self.assertNotIn("/v1/authz-diagnostics/activation-preflight/read", schema["paths"])
+        self.assertNotIn(
+            "activation-preflight",
+            authz_policies.commands,
+        )

--- a/tests/test_http_app_browser_mutation.py
+++ b/tests/test_http_app_browser_mutation.py
@@ -59,7 +59,6 @@ class FastApiBrowserMutationBoundaryTests(unittest.IsolatedAsyncioTestCase):
             "read_browser_work_graph_rank_identity",
         }
         expected_bearer_only_routes = {
-            "/v1/authz-diagnostics/activation-preflight/read",
             "/v1/authz-diagnostics/github-actions/evaluate",
             "/v1/change-impact/evaluation",
             "/v1/secrets/reencrypt",

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -3877,7 +3877,7 @@ class PostgresRecordStoreTests(unittest.TestCase):
         connection = store._engine.connect.return_value.__enter__.return_value
         connection.execute.return_value.scalars.return_value.all.return_value = []
 
-        with patch.object(store, "schema_revision", return_value="d2219a0b1c2d"):
+        with patch.object(store, "schema_revision", return_value="e2221b0c2d3e"):
             store.verify_runtime_schema_compatibility(
                 required_relations=("required_table", "required_index")
             )
@@ -3896,7 +3896,7 @@ class PostgresRecordStoreTests(unittest.TestCase):
         connection.execute.return_value.scalars.return_value.all.return_value = ["missing_index"]
 
         with (
-            patch.object(store, "schema_revision", return_value="d2219a0b1c2d"),
+            patch.object(store, "schema_revision", return_value="e2221b0c2d3e"),
             self.assertRaisesRegex(RuntimeError, "missing_index"),
         ):
             store.verify_runtime_schema_compatibility(

--- a/tests/test_schema_migration.py
+++ b/tests/test_schema_migration.py
@@ -1491,15 +1491,10 @@ class SchemaMigrationTests(unittest.TestCase):
             for primary_key in CRITICAL_PRIMARY_KEYS
         }
 
-        self.assertEqual(EXPECTED_ALEMBIC_HEAD_REVISION, "d2219a0b1c2d")
-        self.assertEqual(
-            indexes[
-                (
-                    "launchplane_human_sessions",
-                    "launchplane_human_sessions_github_id_idx",
-                )
-            ].column_names,
-            ("github_id",),
+        self.assertEqual(EXPECTED_ALEMBIC_HEAD_REVISION, "e2221b0c2d3e")
+        self.assertNotIn(
+            ("launchplane_human_sessions", "launchplane_human_sessions_github_id_idx"),
+            indexes,
         )
         self.assertEqual(
             column_types[("launchplane_privileged_operations", "payload")],

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -2694,7 +2694,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(payload["normalization_version"], 1)
         self.assertRegex(payload["semantic_digest_sha256"], r"^[0-9a-f]{64}$")
         self.assertEqual(payload["provenance"]["source_commit_sha"], "a" * 40)
-        self.assertEqual(len(payload["contract"]["operations"]), 13)
+        self.assertEqual(len(payload["contract"]["operations"]), 12)
 
     def test_product_onboarding_endpoint_writes_full_launchplane_owned_bundle(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary

- replace the local-admin bearer activation preflight with a signed browser-session self-check
- return only the fixed policy-administration decision, hour-bounded evaluation time, keyed opaque policy generation, and trace ID
- remove the caller-selected GitHub ID/session lookup/CLI/agent-contract path and drop its now-unused database index
- update service/operations/authority/records docs and regenerate public contracts

## Safety

- rejects every Authorization header and all request bodies/query parameters
- requires a valid, unexpired, claims-current signed session but no separate diagnostic grant
- re-derives role from exactly one active DB policy and ignores persisted session role
- performs no session renewal or durable write; all success/error paths are `Cache-Control: no-store`
- introduces no authorization grant, workflow authority, or credential workaround

## Validation

- `uv run --extra dev launchplane ci unittest-shard local` (3,081 targets)
- `uv run --extra dev mypy control_plane tests`
- changed-file Ruff lint and format checks
- `pnpm --dir frontend validate`
- `uv run launchplane service audit-config-authority --control-plane-root .`
- focused activation-preflight, schema migration, Postgres compatibility, docs, agent-contract, and browser-boundary tests
- Opus and Gemini final security reviews: APPROVE
- JetBrains changed-files inspection rerun: the introduced migration duplicate warning was fixed; remaining findings are pre-existing warnings in large touched files outside changed lines

Refs #2221
