### PR TITLE
Add temporary policy-operation bootstrap lane

### DIFF
--- a/.github/workflows/authz-policy-reconcile.yml
+++ b/.github/workflows/authz-policy-reconcile.yml
@@ -20,6 +20,7 @@ name: Manage Launchplane Authorization
         options:
           - primary
           - authz-policy-reconcile
+          - privileged-operation-bootstrap
           - generic-web-onboarding
           - manager-preview-approval
           - owner-acceptance
@@ -81,6 +82,48 @@ jobs:
       related_issue: ${{ inputs.related_issue }}
     secrets:
       managed_set_json: ${{ secrets.LAUNCHPLANE_AUTHZ_POLICY_RECONCILE_MANAGED_SET_JSON }}
+
+  reconcile-privileged-operation-bootstrap:
+    if: ${{ inputs.managed_set == 'privileged-operation-bootstrap' }}
+    uses: cbusillo/launchplane/.github/workflows/reusable-authz-policy-reconcile.yml@39aecc250d6dee91204e24673725bd1ea1ca6bda # main
+    with:
+      mode: ${{ inputs.mode }}
+      expected_managed_set_id: operator.privileged-operation-bootstrap
+      reviewed_plan_sha256: ${{ inputs.reviewed_plan_sha256 }}
+      reason: ${{ inputs.reason }}
+      related_issue: ${{ inputs.related_issue }}
+    secrets:
+      managed_set_json: >-
+        ${{ format(
+          '{{"schema_version":2,
+          "product":"launchplane",
+          "managed_set_id":"operator.privileged-operation-bootstrap",
+          "schema_migration":"reject",
+          "unmanaged_adoption":"reject",
+          "desired_policy":{{"schema_version":2,
+          "github_humans":[{{
+          "managed_set_id":"operator.privileged-operation-bootstrap",
+          "managed_rule_id":"github-owner-policy-operation-review",
+          "github_ids":[{0}],
+          "roles":["admin"],
+          "products":["launchplane"],
+          "contexts":["launchplane"],
+          "actions":["authz_policy_operation.read",
+          "authz_policy_operation.cancel",
+          "authz_policy_operation.approve",
+          "authz_policy_operation.revoke"]}}],
+          "terminal_agents":[{{
+          "managed_set_id":"operator.privileged-operation-bootstrap",
+          "managed_rule_id":"terminal-agent-policy-operation-propose",
+          "subjects":[{1}],
+          "token_labels":[{2}],
+          "products":["launchplane"],
+          "contexts":["launchplane"],
+          "actions":["authz_policy_operation.propose"]}}]}}}}',
+          github.event.repository.owner.type == 'User' &&
+            github.event.repository.owner.id || null,
+          toJSON(vars.LAUNCHPLANE_TERMINAL_AGENT_SUBJECT || null),
+          toJSON(vars.LAUNCHPLANE_TERMINAL_AGENT_TOKEN_LABEL || null)) }}
 
   reconcile-manager-preview-approval:
     if: ${{ inputs.managed_set == 'manager-preview-approval' }}

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -751,6 +751,19 @@ a local CLI from an arbitrary checkout. The protected secret/workflow model
 below is transitional compatibility for already-existing managed sets, not the
 routine path for new grants. Do not create a managed set or modify production
 authorization merely to resolve another task's `authorization_denied` result.
+The owner-approved August 25, 2026 root-of-trust exception adds the temporary
+`privileged-operation-bootstrap` selection without a new GitHub secret. The
+protected wrapper derives the immutable repository-owner GitHub ID from the
+dispatch event and reads the existing terminal-agent subject and token label
+bootstrap variables. Its exact `operator.privileged-operation-bootstrap` set
+grants only terminal-agent policy proposal plus GitHub-owner policy
+read/cancel/approve/revoke. It grants no `authz_policy_grant.write`, secret
+operation action, execute action, summary read, product/runtime action, or
+workflow identity. Missing owner or terminal-agent selectors fail request
+validation rather than widening a rule. Use dry-run and exact reviewed-digest
+apply, then remove the
+temporary selection after the DB-native policy-operation path removes its own
+bootstrap set and read-back proves the exception is gone.
 `LAUNCHPLANE_AUTHZ_MANAGED_SET_JSON` currently carries the primary operator set;
 `LAUNCHPLANE_AUTHZ_POLICY_RECONCILE_MANAGED_SET_JSON` owns the exact immutable
 policy-admin worker rules for the standalone authz wrapper and must declare the

--- a/tests/test_authz_operator_workflow.py
+++ b/tests/test_authz_operator_workflow.py
@@ -3,10 +3,14 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
+import re
 import subprocess
 from tempfile import TemporaryDirectory
 import unittest
 
+from pydantic import ValidationError
+
+from control_plane.authz_grant_service import AuthzManagedPolicyReconcileEnvelope
 from tests.support.workflows import load_workflow
 
 
@@ -32,6 +36,7 @@ class AuthzOperatorWorkflowTests(unittest.TestCase):
             [
                 "primary",
                 "authz-policy-reconcile",
+                "privileged-operation-bootstrap",
                 "generic-web-onboarding",
                 "manager-preview-approval",
                 "owner-acceptance",
@@ -62,6 +67,10 @@ class AuthzOperatorWorkflowTests(unittest.TestCase):
             "reconcile-authz-policy-reconcile": (
                 "${{ inputs.managed_set == 'authz-policy-reconcile' }}",
                 "${{ secrets.LAUNCHPLANE_AUTHZ_POLICY_RECONCILE_MANAGED_SET_JSON }}",
+            ),
+            "reconcile-privileged-operation-bootstrap": (
+                "${{ inputs.managed_set == 'privileged-operation-bootstrap' }}",
+                None,
             ),
             "reconcile-manager-preview-approval": (
                 "${{ inputs.managed_set == 'manager-preview-approval' }}",
@@ -174,6 +183,9 @@ class AuthzOperatorWorkflowTests(unittest.TestCase):
                 expected_managed_set_ids = {
                     "reconcile-primary": "operator.primary",
                     "reconcile-authz-policy-reconcile": "operator.authz-policy-reconcile",
+                    "reconcile-privileged-operation-bootstrap": (
+                        "operator.privileged-operation-bootstrap"
+                    ),
                     "reconcile-generic-web-onboarding": "operator.generic-web-onboarding",
                     "reconcile-manager-preview-approval": "operator.manager-preview-approval",
                     "reconcile-owner-acceptance": "operator.owner-acceptance",
@@ -213,7 +225,98 @@ class AuthzOperatorWorkflowTests(unittest.TestCase):
                 )
                 dispatch_secrets = dispatch_job["secrets"]
                 assert isinstance(dispatch_secrets, dict)
-                self.assertEqual(dispatch_secrets["managed_set_json"], expected_secret)
+                managed_set_json = dispatch_secrets["managed_set_json"]
+                assert isinstance(managed_set_json, str)
+                if expected_secret is None:
+                    self.assertIn("github.event.repository.owner.id", managed_set_json)
+                    self.assertIn(
+                        "toJSON(vars.LAUNCHPLANE_TERMINAL_AGENT_SUBJECT || null)",
+                        managed_set_json,
+                    )
+                    self.assertIn(
+                        "toJSON(vars.LAUNCHPLANE_TERMINAL_AGENT_TOKEN_LABEL || null)",
+                        managed_set_json,
+                    )
+                    self.assertIn("authz_policy_operation.propose", managed_set_json)
+                    self.assertIn("authz_policy_operation.read", managed_set_json)
+                    self.assertIn("authz_policy_operation.cancel", managed_set_json)
+                    self.assertIn("authz_policy_operation.approve", managed_set_json)
+                    self.assertIn("authz_policy_operation.revoke", managed_set_json)
+                    self.assertNotIn("authz_policy_grant.write", managed_set_json)
+                    self.assertNotIn("privileged_secret_operation", managed_set_json)
+                    self.assertNotIn("privileged_policy_operation_summary", managed_set_json)
+                    self.assertNotIn("secrets.LAUNCHPLANE_AUTHZ_", managed_set_json)
+                else:
+                    self.assertEqual(managed_set_json, expected_secret)
+
+    def test_privileged_operation_bootstrap_is_exact_and_fails_closed(self) -> None:
+        job = self.dispatch_workflow.job("reconcile-privileged-operation-bootstrap")
+        secrets = job["secrets"]
+        assert isinstance(secrets, dict)
+        managed_set_json = secrets["managed_set_json"]
+        assert isinstance(managed_set_json, str)
+        match = re.search(
+            r"format\(\s*'(.*)',\s*github\.event\.repository\.owner\.type",
+            managed_set_json,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(match)
+        assert match is not None
+        template = match.group(1)
+
+        def render(owner_id: str, subject: str, token_label: str) -> dict[str, object]:
+            payload = template.replace("{{", "\x00").replace("}}", "\x01")
+            payload = payload.replace("{0}", owner_id)
+            payload = payload.replace("{1}", subject)
+            payload = payload.replace("{2}", token_label)
+            payload = payload.replace("\x00", "{").replace("\x01", "}")
+            parsed = json.loads(payload)
+            assert isinstance(parsed, dict)
+            return parsed
+
+        configuration = render("123", json.dumps("terminal-agent"), json.dumps("owner"))
+        envelope = AuthzManagedPolicyReconcileEnvelope.model_validate(
+            {
+                **configuration,
+                "mode": "dry_run",
+                "reason": "Review the explicit bootstrap canary.",
+                "related_issue": "cbusillo/launchplane#2204",
+            }
+        )
+        self.assertEqual(
+            set(envelope.desired_policy.github_humans[0].actions),
+            {
+                "authz_policy_operation.read",
+                "authz_policy_operation.cancel",
+                "authz_policy_operation.approve",
+                "authz_policy_operation.revoke",
+            },
+        )
+        self.assertEqual(envelope.desired_policy.github_humans[0].github_ids, (123,))
+        self.assertEqual(
+            set(envelope.desired_policy.terminal_agents[0].actions),
+            {"authz_policy_operation.propose"},
+        )
+        self.assertEqual(
+            envelope.desired_policy.terminal_agents[0].subjects,
+            ("terminal-agent",),
+        )
+        self.assertEqual(envelope.desired_policy.terminal_agents[0].token_labels, ("owner",))
+
+        for values in (
+            ("null", json.dumps("terminal-agent"), json.dumps("owner")),
+            ("123", "null", json.dumps("owner")),
+            ("123", json.dumps("terminal-agent"), "null"),
+        ):
+            with self.subTest(values=values), self.assertRaises(ValidationError):
+                AuthzManagedPolicyReconcileEnvelope.model_validate(
+                    {
+                        **render(*values),
+                        "mode": "dry_run",
+                        "reason": "Reject incomplete bootstrap selectors.",
+                        "related_issue": "cbusillo/launchplane#2204",
+                    }
+                )
 
     def test_deploy_workflow_does_not_administer_authorization(self) -> None:
         deploy_job = self.deploy_workflow.job("deploy")


### PR DESCRIPTION
# Temporary Policy-Operation Bootstrap Lane

## Summary

- add an owner-approved temporary protected workflow selection for the exact
  `operator.privileged-operation-bootstrap` managed set
- derive the immutable personal-repository owner GitHub ID and existing
  terminal-agent bootstrap selectors at dispatch time instead of creating a
  new GitHub authorization secret
- grant only terminal-agent `authz_policy_operation.propose` and immutable
  GitHub-owner policy read/cancel/approve/revoke
- preserve the existing reusable workflow's protected environment,
  dry-run/apply digest binding, OIDC transport, evidence, and concurrency

## Safety

- adds no `authz_policy_grant.write`, secret-operation, execute, summary-read,
  product/runtime, or workflow-identity action
- missing/non-human owner identity, terminal-agent subject, or token label
  renders as JSON `null` and fails schema validation instead of widening a rule
- does not modify or replace any existing managed-set secret or desired set
- remains an explicit removable bridge; after DB-native policy operations prove
  self-sustaining, the governed path removes the bootstrap set and this workflow
  selection is deleted

## Verification

- `uv run --extra dev python -m unittest tests.test_authz_operator_workflow`
- `uv run --extra dev python -m unittest tests.test_docs_contracts tests.test_github_actions_security`
- `actionlint -config-file .github/actionlint.yaml .github/workflows/authz-policy-reconcile.yml`
- `uv run --extra dev ruff check tests/test_authz_operator_workflow.py`
- `uv run --extra dev ruff format --check tests/test_authz_operator_workflow.py`
- `uv run --extra dev mypy tests/test_authz_operator_workflow.py`

## Authorization

The owner explicitly selected the one-time protected workflow exception after
the deployed terminal-agent proposal route returned `403 authorization_denied`
and the Engineering UI proved review-only. No production authorization or
secret mutation occurs merely by landing this workflow option.

Refs #2204
