### PR TITLE
Authorize exact owner policy-administration bootstrap

### DIFF
--- a/.github/workflows/authz-policy-reconcile.yml
+++ b/.github/workflows/authz-policy-reconcile.yml
@@ -111,7 +111,8 @@ jobs:
           "actions":["authz_policy_operation.read",
           "authz_policy_operation.cancel",
           "authz_policy_operation.approve",
-          "authz_policy_operation.revoke"]}}],
+          "authz_policy_operation.revoke",
+          "authz_policy_grant.write"]}}],
           "terminal_agents":[{{
           "managed_set_id":"operator.privileged-operation-bootstrap",
           "managed_rule_id":"terminal-agent-policy-operation-propose",

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -757,7 +757,10 @@ protected wrapper derives the immutable repository-owner GitHub ID from the
 dispatch event and reads the existing terminal-agent subject and token label
 bootstrap variables. Its exact `operator.privileged-operation-bootstrap` set
 grants only terminal-agent policy proposal plus GitHub-owner policy
-read/cancel/approve/revoke. It grants no `authz_policy_grant.write`, secret
+read/cancel/approve/revoke. After the initial owner-approved attempt proved that
+the existing self-preflight authority was not an immutable-ID policy
+administrator rule, the owner explicitly approved adding
+`authz_policy_grant.write` to that same exact-ID rule. The set grants no secret
 operation action, execute action, summary read, product/runtime action, or
 workflow identity. Missing owner or terminal-agent selectors fail request
 validation rather than widening a rule. Use dry-run and exact reviewed-digest

--- a/tests/test_authz_operator_workflow.py
+++ b/tests/test_authz_operator_workflow.py
@@ -242,7 +242,7 @@ class AuthzOperatorWorkflowTests(unittest.TestCase):
                     self.assertIn("authz_policy_operation.cancel", managed_set_json)
                     self.assertIn("authz_policy_operation.approve", managed_set_json)
                     self.assertIn("authz_policy_operation.revoke", managed_set_json)
-                    self.assertNotIn("authz_policy_grant.write", managed_set_json)
+                    self.assertIn("authz_policy_grant.write", managed_set_json)
                     self.assertNotIn("privileged_secret_operation", managed_set_json)
                     self.assertNotIn("privileged_policy_operation_summary", managed_set_json)
                     self.assertNotIn("secrets.LAUNCHPLANE_AUTHZ_", managed_set_json)
@@ -290,6 +290,7 @@ class AuthzOperatorWorkflowTests(unittest.TestCase):
                 "authz_policy_operation.cancel",
                 "authz_policy_operation.approve",
                 "authz_policy_operation.revoke",
+                "authz_policy_grant.write",
             },
         )
         self.assertEqual(envelope.desired_policy.github_humans[0].github_ids, (123,))


### PR DESCRIPTION
# Exact Owner Policy-Administration Bootstrap

## Summary

- add `authz_policy_grant.write` only to the existing temporary exact-owner
  bootstrap rule
- retain immutable repository-owner GitHub ID, `admin` role,
  `launchplane/launchplane` scope, and fail-closed null selector behavior
- leave the terminal-agent rule limited to `authz_policy_operation.propose`

## Evidence

- the owner explicitly authorized this exact temporary rule after the live
  Stage 1 approval returned `403 authorization_denied`
- the signed-in self-preflight was allowed, but the stricter approval boundary
  proved the existing authority was not an immutable-ID DB policy-admin rule
- no secret-operation action, execute action, product/runtime authority, new
  principal, new managed set, or GitHub authorization secret is added

## Verification

- 34 targeted workflow, docs, and GitHub Actions security tests passed
- targeted Actionlint, Ruff, and mypy passed
- independent security review returned PASS

The rule remains temporary. After the governed DB-native policy-operation path
removes both canary sets and active-policy read-back confirms removal, the
workflow bootstrap selection will be deleted.

Refs #2204
