### PR TITLE
Add explicit secret key-ring deployment transport

### DIFF
--- a/.github/workflows/deploy-launchplane.yml
+++ b/.github/workflows/deploy-launchplane.yml
@@ -12,6 +12,19 @@ on:
         description: Exact immutable Launchplane image digest to deploy instead of building a new one.
         required: false
         type: string
+      bootstrap_secret_operation:
+        description: Preserve, install, or remove the canonical managed-secret key ring.
+        required: false
+        default: preserve
+        type: choice
+        options:
+          - preserve
+          - install
+          - remove
+      self_deploy_idempotency_key:
+        description: Exact bounded idempotency key for a reviewed manual self-deploy.
+        required: false
+        type: string
       omit_every_code_env:
         description: Temporarily omit Every Code env for one compatibility deploy.
         required: false
@@ -120,7 +133,9 @@ jobs:
         id: prep
         shell: bash
         env:
+          DISPATCH_BOOTSTRAP_SECRET_OPERATION: ${{ inputs.bootstrap_secret_operation }}
           DISPATCH_IMAGE_REFERENCE: ${{ inputs.image_reference }}
+          DISPATCH_SELF_DEPLOY_IDEMPOTENCY_KEY: ${{ inputs.self_deploy_idempotency_key }}
           EVENT_NAME: ${{ github.event_name }}
           WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
           WORKFLOW_SHA: ${{ github.sha }}
@@ -178,6 +193,32 @@ jobs:
             should_build="true"
           fi
 
+          bootstrap_secret_operation="${DISPATCH_BOOTSTRAP_SECRET_OPERATION:-preserve}"
+          case "$bootstrap_secret_operation" in
+            preserve | install | remove) ;;
+            *)
+              echo "bootstrap_secret_operation must be preserve, install, or remove." >&2
+              exit 1
+              ;;
+          esac
+          if [ "$EVENT_NAME" != "workflow_dispatch" ] &&
+            [ "$bootstrap_secret_operation" != "preserve" ]; then
+            echo "Automatic deploys must preserve bootstrap secret configuration." >&2
+            exit 1
+          fi
+
+          self_deploy_idempotency_key="$DISPATCH_SELF_DEPLOY_IDEMPOTENCY_KEY"
+          if [ -n "$self_deploy_idempotency_key" ]; then
+            if [[ ! "$self_deploy_idempotency_key" =~ ^[A-Za-z0-9._:/-]{8,200}$ ]]; then
+              echo "self_deploy_idempotency_key must be an 8-200 character safe token." >&2
+              exit 1
+            fi
+            if [ "$EVENT_NAME" != "workflow_dispatch" ]; then
+              echo "Only manual deploys may supply self_deploy_idempotency_key." >&2
+              exit 1
+            fi
+          fi
+
           for omit_environment_variable in \
             OMIT_EVERY_CODE_ENV \
             OMIT_TERMINAL_AGENT_ENV \
@@ -195,6 +236,8 @@ jobs:
             printf 'image_repository=%s\n' "$image_repository"
             printf 'should_build=%s\n' "$should_build"
             printf 'deploy_image_reference=%s\n' "$deploy_image_reference"
+            printf 'bootstrap_secret_operation=%s\n' "$bootstrap_secret_operation"
+            printf 'self_deploy_idempotency_key=%s\n' "$self_deploy_idempotency_key"
           } >> "$GITHUB_OUTPUT"
 
       - name: Validate deploy configuration
@@ -319,8 +362,10 @@ jobs:
         id: self_deploy
         shell: bash
         env:
+          BOOTSTRAP_SECRET_OPERATION: ${{ steps.prep.outputs.bootstrap_secret_operation }}
           DEPLOY_IMAGE_REFERENCE: ${{ steps.image.outputs.image_reference }}
           IMAGE_REPOSITORY: ${{ steps.prep.outputs.image_repository }}
+          LAUNCHPLANE_SECRET_KEYS_JSON: ${{ secrets.LAUNCHPLANE_SECRET_KEYS_JSON }}
           PREVIOUS_RUNTIME_RESPONSE_FILE: ${{ runner.temp }}/launchplane-previous-runtime.json
         run: |
           set -euo pipefail
@@ -341,12 +386,44 @@ jobs:
           fi
           printf 'previous_image_reference=%s\n' "$previous_image_reference" >> "$GITHUB_OUTPUT"
 
+          if [ "$BOOTSTRAP_SECRET_OPERATION" != "preserve" ]; then
+            if [ -z "$previous_image_reference" ]; then
+              echo "Bootstrap secret operations require the current deployed image." >&2
+              exit 1
+            fi
+            if [ "$DEPLOY_IMAGE_REFERENCE" != "$previous_image_reference" ]; then
+              echo "Bootstrap secret operations must retain the current deployed image." >&2
+              exit 1
+            fi
+          fi
+
+          secret_keys_json=""
+          case "$BOOTSTRAP_SECRET_OPERATION" in
+            install)
+              if [ -z "${LAUNCHPLANE_SECRET_KEYS_JSON:-}" ]; then
+                echo "bootstrap_secret_operation=install requires LAUNCHPLANE_SECRET_KEYS_JSON." >&2
+                exit 1
+              fi
+              secret_keys_json="$(
+                jq -ce 'if type == "object" then . else error("expected object") end' \
+                  <<<"$LAUNCHPLANE_SECRET_KEYS_JSON"
+              )"
+              echo "::add-mask::$secret_keys_json"
+              ;;
+            preserve | remove) ;;
+            *)
+              echo "Unexpected bootstrap secret operation." >&2
+              exit 1
+              ;;
+          esac
+
           service_env_json="$({
             jq -n \
               --arg github_client_id "${LAUNCHPLANE_GITHUB_CLIENT_ID:-}" \
               --arg github_client_secret "${LAUNCHPLANE_GITHUB_CLIENT_SECRET:-}" \
               --arg public_url "${LAUNCHPLANE_PUBLIC_URL:-}" \
               --arg session_secret "${LAUNCHPLANE_SESSION_SECRET:-}" \
+              --arg secret_keys_json "$secret_keys_json" \
               --arg cookie_secure "${LAUNCHPLANE_COOKIE_SECURE:-}" \
               --arg bootstrap_admin_emails "${LAUNCHPLANE_BOOTSTRAP_ADMIN_EMAILS:-}" \
               --arg work_graph_project_owner "${LAUNCHPLANE_WORK_GRAPH_PROJECT_OWNER:-}" \
@@ -381,6 +458,7 @@ jobs:
               --argjson omit_terminal_agent_env "$OMIT_TERMINAL_AGENT_ENV" \
               --argjson omit_owner_agent_env "$OMIT_OWNER_AGENT_ENV" \
               --argjson omit_npmplus_env "$OMIT_NPMPLUS_ENV" \
+              --arg bootstrap_secret_operation "$BOOTSTRAP_SECRET_OPERATION" \
               '(
                 {
                 LAUNCHPLANE_GITHUB_CLIENT_ID: $github_client_id,
@@ -391,6 +469,13 @@ jobs:
                 LAUNCHPLANE_BOOTSTRAP_ADMIN_EMAILS: $bootstrap_admin_emails,
                 LAUNCHPLANE_MANAGER_PREVIEW_GITHUB_WEBHOOK_SECRET: $manager_preview_webhook_secret
                 }
+                + (
+                  if $bootstrap_secret_operation == "install" then
+                    {LAUNCHPLANE_SECRET_KEYS_JSON: $secret_keys_json}
+                  else
+                    {}
+                  end
+                )
                 + (
                   if ($omit_terminal_agent_env | not) then
                     {
@@ -485,6 +570,7 @@ jobs:
           service_env_removals_json="$({
             jq -n \
               --arg public_ingress_github_token "${LAUNCHPLANE_PUBLIC_INGRESS_GITHUB_TOKEN:-}" \
+              --arg bootstrap_secret_operation "$BOOTSTRAP_SECRET_OPERATION" \
               --argjson omit_npmplus_env "$OMIT_NPMPLUS_ENV" \
               '(
                 if $omit_npmplus_env then
@@ -493,6 +579,13 @@ jobs:
                     "LAUNCHPLANE_NPMPLUS_IDENTITY",
                     "LAUNCHPLANE_NPMPLUS_SECRET"
                   ]
+                else
+                  []
+                end
+              )
+              + (
+                if $bootstrap_secret_operation == "remove" then
+                  ["LAUNCHPLANE_SECRET_KEYS_JSON"]
                 else
                   []
                 end
@@ -516,7 +609,9 @@ jobs:
           })"
 
           request_payload_file="$RUNNER_TEMP/launchplane-self-deploy-payload.json"
+          umask 077
           printf '%s\n' "$request_payload" > "$request_payload_file"
+          chmod 600 "$request_payload_file"
           echo "payload_file=$request_payload_file" >> "$GITHUB_OUTPUT"
 
       - name: Request Launchplane self deploy
@@ -528,7 +623,12 @@ jobs:
           audience: ${{ steps.service.outputs.service_audience }}
           route-path: /v1/drivers/launchplane/self-deploy
           payload-file: ${{ steps.self_deploy.outputs.payload_file }}
-          idempotency-key: launchplane-self-deploy:${{ steps.image.outputs.image_reference }}:${{ github.run_id }}:${{ github.run_attempt }}:db-authz
+          idempotency-key: >-
+            ${{ steps.prep.outputs.self_deploy_idempotency_key ||
+              format('launchplane-self-deploy:{0}:{1}:{2}:db-authz',
+                steps.image.outputs.image_reference,
+                github.run_id,
+                github.run_attempt) }}
           expected-status: "200,202"
           fail-result-paths: ""
           timeout-ms: "30000"
@@ -1158,6 +1258,15 @@ jobs:
             jq -r '.results[] | "- \(.method) \(.route_path): HTTP \(.http_status) ok=\(.ok) classification=\(.classification) trace=\(.trace_id)"' \
               launchplane-v2-deployed-smoke.json
           } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Remove Launchplane self deploy request material
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -f -- \
+            "$RUNNER_TEMP/launchplane-self-deploy-payload.json" \
+            "$RUNNER_TEMP/launchplane-self-deploy-rollback-payload.json"
 
   emergency-dokploy-rollback:
     if: >-

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1648,6 +1648,19 @@ DB-backed Launchplane records:
   provider-target authority changes should use the deployed service route or
   operator workflow.
 
+For a reviewed canonical key-ring install or rollback, manually dispatch
+`Deploy Launchplane` from the default branch with the exact immutable current
+image, an explicit `bootstrap_secret_operation`, and a bounded
+`self_deploy_idempotency_key`. `install` reads only the repository secret
+`LAUNCHPLANE_SECRET_KEYS_JSON`; `remove` explicitly removes that target env key;
+`preserve` changes neither state. Automatic deploys always preserve bootstrap
+secret state. Keep `LAUNCHPLANE_MASTER_ENCRYPTION_KEY` present through the
+migration and rollback window, verify health/runtime and a new privileged
+re-encryption dry-run after restart, and stop before re-encryption apply unless
+the owner approves the exact new plan digest. If install verification fails,
+dispatch `remove` against the same immutable image with a distinct rollback
+idempotency key, then require the legacy-only dry-run baseline to return clean.
+
 For an invalid tracked Dokploy target domain authority, use the `Dokploy Target
 Setup` workflow with `operation=repair-domain-authority`. Supply the exact
 tracked target type and target ID, a comma-separated tuple of bare DNS hosts,

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -201,6 +201,17 @@ before provider mutation. It may remove the migration-only legacy root only
 when the remaining canonical configuration is valid; malformed, mismatched, or
 rootless target state fails closed before deployment.
 
+The `Deploy Launchplane` workflow accepts the canonical key ring only from the
+repository secret `LAUNCHPLANE_SECRET_KEYS_JSON`. Manual dispatch chooses an
+explicit `bootstrap_secret_operation` of `preserve`, `install`, or `remove`.
+Automatic deployments always preserve the target value; a missing repository
+secret never removes the active key ring. `install` requires non-empty JSON,
+minifies it before the private self-deploy request is written, and may use an
+operator-reviewed `self_deploy_idempotency_key`. `remove` is an explicit
+rollback or retirement action and never follows merely from secret absence.
+The workflow removes private self-deploy payload files at job completion and
+must not copy the key-ring value into outputs, summaries, artifacts, or logs.
+
 Old ciphertext versions and audit metadata retain the old/new key ids and
 version ids as rollback evidence. To roll back before destroying an old root,
 restore that root as an allowed active key and run the same audited dry-run/apply

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -1685,6 +1685,261 @@ class ProductOnboardingTests(unittest.TestCase):
             workflow_text,
         )
 
+    def test_deploy_launchplane_manages_key_ring_only_by_explicit_operation(self) -> None:
+        workflow_path = Path(".github/workflows/deploy-launchplane.yml")
+        workflow = load_workflow(workflow_path)
+        trigger = workflow.data["on"]
+        assert isinstance(trigger, dict)
+        workflow_dispatch = trigger["workflow_dispatch"]
+        assert isinstance(workflow_dispatch, dict)
+        inputs = workflow_dispatch["inputs"]
+        assert isinstance(inputs, dict)
+        bootstrap_operation = inputs["bootstrap_secret_operation"]
+        assert isinstance(bootstrap_operation, dict)
+        self.assertEqual(bootstrap_operation["default"], "preserve")
+        self.assertEqual(bootstrap_operation["options"], ["preserve", "install", "remove"])
+        idempotency_key = inputs["self_deploy_idempotency_key"]
+        assert isinstance(idempotency_key, dict)
+        self.assertEqual(idempotency_key["required"], False)
+
+        workflow_text = workflow_path.read_text(encoding="utf-8")
+        self.assertIn(
+            "LAUNCHPLANE_SECRET_KEYS_JSON: ${{ secrets.LAUNCHPLANE_SECRET_KEYS_JSON }}",
+            workflow_text,
+        )
+        deploy_job = workflow.job("deploy")
+        deploy_environment = deploy_job["env"]
+        assert isinstance(deploy_environment, dict)
+        self.assertNotIn("LAUNCHPLANE_SECRET_KEYS_JSON", deploy_environment)
+        render_step = workflow.step_named("deploy", "Render Launchplane self deploy request")
+        self.assertIsNotNone(render_step)
+        assert render_step is not None
+        render_environment = render_step.data["env"]
+        assert isinstance(render_environment, dict)
+        self.assertEqual(
+            render_environment["LAUNCHPLANE_SECRET_KEYS_JSON"],
+            "${{ secrets.LAUNCHPLANE_SECRET_KEYS_JSON }}",
+        )
+        self.assertIn(
+            "bootstrap_secret_operation must be preserve, install, or remove.",
+            workflow_text,
+        )
+        self.assertIn(
+            "self_deploy_idempotency_key must be an 8-200 character safe token.",
+            workflow_text,
+        )
+        self.assertIn(
+            "Automatic deploys must preserve bootstrap secret configuration.",
+            workflow_text,
+        )
+        self.assertIn(
+            "bootstrap_secret_operation=install requires LAUNCHPLANE_SECRET_KEYS_JSON.",
+            workflow_text,
+        )
+        self.assertIn(
+            "Bootstrap secret operations must retain the current deployed image.",
+            workflow_text,
+        )
+        self.assertIn('echo "::add-mask::$secret_keys_json"', workflow_text)
+        self.assertIn(
+            "{LAUNCHPLANE_SECRET_KEYS_JSON: $secret_keys_json}",
+            workflow_text,
+        )
+        self.assertIn('["LAUNCHPLANE_SECRET_KEYS_JSON"]', workflow_text)
+        self.assertIn(
+            "steps.prep.outputs.self_deploy_idempotency_key ||",
+            workflow_text,
+        )
+        cleanup_step = workflow.step_named(
+            "deploy", "Remove Launchplane self deploy request material"
+        )
+        self.assertIsNotNone(cleanup_step)
+        assert cleanup_step is not None
+        self.assertEqual(cleanup_step.data["if"], "always()")
+        self.assertNotIn("steps.self_deploy.outputs.payload_file", cleanup_step.run)
+        self.assertIn(
+            '"$RUNNER_TEMP/launchplane-self-deploy-payload.json"',
+            cleanup_step.run,
+        )
+
+    def test_deploy_launchplane_validates_manual_bootstrap_inputs(self) -> None:
+        workflow = load_workflow(".github/workflows/deploy-launchplane.yml")
+        prep_step = workflow.step_named("deploy", "Resolve deploy inputs")
+        self.assertIsNotNone(prep_step)
+        assert prep_step is not None
+        image_reference = "ghcr.io/cbusillo/launchplane@sha256:" + ("a" * 64)
+
+        with TemporaryDirectory() as temporary_directory_name:
+            temporary_directory = Path(temporary_directory_name)
+
+            def prepare(
+                *,
+                event_name: str,
+                operation: str,
+                idempotency_key: str,
+            ) -> subprocess.CompletedProcess[str]:
+                output_file = temporary_directory / "github-output.txt"
+                output_file.unlink(missing_ok=True)
+                return subprocess.run(
+                    ["bash", "-ceu", prep_step.run],
+                    check=False,
+                    capture_output=True,
+                    env={
+                        **os.environ,
+                        "DISPATCH_BOOTSTRAP_SECRET_OPERATION": operation,
+                        "DISPATCH_IMAGE_REFERENCE": image_reference,
+                        "DISPATCH_SELF_DEPLOY_IDEMPOTENCY_KEY": idempotency_key,
+                        "EVENT_NAME": event_name,
+                        "GITHUB_OUTPUT": str(output_file),
+                        "GITHUB_REPOSITORY": "cbusillo/launchplane",
+                        "LAUNCHPLANE_IMAGE_REPOSITORY": "ghcr.io/cbusillo/launchplane",
+                        "OMIT_EVERY_CODE_ENV": "false",
+                        "OMIT_NPMPLUS_ENV": "false",
+                        "OMIT_OWNER_AGENT_ENV": "false",
+                        "OMIT_TERMINAL_AGENT_ENV": "false",
+                        "WORKFLOW_RUN_HEAD_SHA": "b" * 40,
+                        "WORKFLOW_SHA": "c" * 40,
+                    },
+                    text=True,
+                )
+
+            valid_key = "launchplane-self-deploy:issue-2204:root-2026-08-25:install:v1"
+            valid = prepare(
+                event_name="workflow_dispatch",
+                operation="install",
+                idempotency_key=valid_key,
+            )
+            self.assertEqual(valid.returncode, 0, valid.stderr)
+            outputs = _read_github_outputs(temporary_directory)
+            self.assertEqual(outputs["bootstrap_secret_operation"], "install")
+            self.assertEqual(outputs["self_deploy_idempotency_key"], valid_key)
+
+            unsafe = prepare(
+                event_name="workflow_dispatch",
+                operation="install",
+                idempotency_key="unsafe value",
+            )
+            self.assertNotEqual(unsafe.returncode, 0)
+            self.assertIn("8-200 character safe token", unsafe.stderr)
+
+            automatic = prepare(
+                event_name="workflow_run",
+                operation="remove",
+                idempotency_key="",
+            )
+            self.assertNotEqual(automatic.returncode, 0)
+            self.assertIn("Automatic deploys must preserve", automatic.stderr)
+
+    def test_deploy_launchplane_renders_key_ring_install_preserve_and_remove(self) -> None:
+        workflow = load_workflow(".github/workflows/deploy-launchplane.yml")
+        render_step = workflow.step_named("deploy", "Render Launchplane self deploy request")
+        self.assertIsNotNone(render_step)
+        assert render_step is not None
+        image_reference = "ghcr.io/cbusillo/launchplane@sha256:" + ("a" * 64)
+        key_ring = {
+            "active_key_id": "root-test",
+            "keys": {"root-test": "test-canonical-key-material"},
+        }
+        pretty_key_ring = json.dumps(key_ring, indent=2)
+
+        with TemporaryDirectory() as temporary_directory_name:
+            temporary_directory = Path(temporary_directory_name)
+            previous_runtime = temporary_directory / "runtime.json"
+            previous_runtime.write_text(
+                json.dumps({"runtime": {"docker_image_reference": image_reference}}),
+                encoding="utf-8",
+            )
+
+            def render(operation: str, secret_keys_json: str) -> subprocess.CompletedProcess[str]:
+                output_file = temporary_directory / "github-output.txt"
+                output_file.unlink(missing_ok=True)
+                result = subprocess.run(
+                    ["bash", "-ceu", render_step.run],
+                    check=False,
+                    capture_output=True,
+                    env={
+                        **os.environ,
+                        "BOOTSTRAP_SECRET_OPERATION": operation,
+                        "DEPLOY_IMAGE_REFERENCE": image_reference,
+                        "GITHUB_OUTPUT": str(output_file),
+                        "IMAGE_REPOSITORY": "ghcr.io/cbusillo/launchplane",
+                        "LAUNCHPLANE_DOKPLOY_TARGET_ID": "launchplane-target",
+                        "LAUNCHPLANE_DOKPLOY_TARGET_TYPE": "compose",
+                        "LAUNCHPLANE_SECRET_KEYS_JSON": secret_keys_json,
+                        "OMIT_EVERY_CODE_ENV": "false",
+                        "OMIT_NPMPLUS_ENV": "false",
+                        "OMIT_OWNER_AGENT_ENV": "false",
+                        "OMIT_TERMINAL_AGENT_ENV": "false",
+                        "PREVIOUS_RUNTIME_RESPONSE_FILE": str(previous_runtime),
+                        "RUNNER_TEMP": str(temporary_directory),
+                    },
+                    text=True,
+                )
+                return result
+
+            install = render("install", pretty_key_ring)
+            self.assertEqual(install.returncode, 0, install.stderr)
+            install_outputs = _read_github_outputs(temporary_directory)
+            install_payload = json.loads(
+                Path(install_outputs["payload_file"]).read_text(encoding="utf-8")
+            )
+            installed_value = install_payload["deploy"]["oauth_env"]["LAUNCHPLANE_SECRET_KEYS_JSON"]
+            self.assertEqual(json.loads(installed_value), key_ring)
+            self.assertNotIn(
+                "LAUNCHPLANE_SECRET_KEYS_JSON",
+                install_payload["deploy"].get("oauth_env_removals", []),
+            )
+
+            preserve = render("preserve", pretty_key_ring)
+            self.assertEqual(preserve.returncode, 0, preserve.stderr)
+            preserve_outputs = _read_github_outputs(temporary_directory)
+            preserve_payload = json.loads(
+                Path(preserve_outputs["payload_file"]).read_text(encoding="utf-8")
+            )
+            self.assertNotIn(
+                "LAUNCHPLANE_SECRET_KEYS_JSON",
+                preserve_payload["deploy"].get("oauth_env", {}),
+            )
+            self.assertNotIn(
+                "LAUNCHPLANE_SECRET_KEYS_JSON",
+                preserve_payload["deploy"].get("oauth_env_removals", []),
+            )
+
+            remove = render("remove", pretty_key_ring)
+            self.assertEqual(remove.returncode, 0, remove.stderr)
+            remove_outputs = _read_github_outputs(temporary_directory)
+            remove_payload = json.loads(
+                Path(remove_outputs["payload_file"]).read_text(encoding="utf-8")
+            )
+            self.assertNotIn(
+                "LAUNCHPLANE_SECRET_KEYS_JSON",
+                remove_payload["deploy"].get("oauth_env", {}),
+            )
+            self.assertIn(
+                "LAUNCHPLANE_SECRET_KEYS_JSON",
+                remove_payload["deploy"]["oauth_env_removals"],
+            )
+
+            missing = render("install", "")
+            self.assertNotEqual(missing.returncode, 0)
+            self.assertIn("requires LAUNCHPLANE_SECRET_KEYS_JSON", missing.stderr)
+
+            previous_runtime.write_text(
+                json.dumps(
+                    {
+                        "runtime": {
+                            "docker_image_reference": (
+                                "ghcr.io/cbusillo/launchplane@sha256:" + ("b" * 64)
+                            )
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+            changed_image = render("install", pretty_key_ring)
+            self.assertNotEqual(changed_image.returncode, 0)
+            self.assertIn("must retain the current deployed image", changed_image.stderr)
+
     def test_deploy_launchplane_omit_npmplus_env_removes_existing_keys(self) -> None:
         workflow_text = Path(".github/workflows/deploy-launchplane.yml").read_text(encoding="utf-8")
 
@@ -1746,6 +2001,9 @@ class ProductOnboardingTests(unittest.TestCase):
                     "--arg",
                     "public_ingress_github_token",
                     public_ingress_github_token,
+                    "--arg",
+                    "bootstrap_secret_operation",
+                    "preserve",
                     "--argjson",
                     "omit_npmplus_env",
                     json.dumps(omit_npmplus_env),
@@ -2041,10 +2299,9 @@ class ProductOnboardingTests(unittest.TestCase):
             "payload-file: ${{ steps.self_deploy.outputs.payload_file }}",
             workflow_text,
         )
+        self.assertIn("steps.prep.outputs.self_deploy_idempotency_key ||", workflow_text)
         self.assertIn(
-            "idempotency-key: launchplane-self-deploy:${{ "
-            "steps.image.outputs.image_reference }}:${{ github.run_id }}:${{ "
-            "github.run_attempt }}:db-authz",
+            "format('launchplane-self-deploy:{0}:{1}:{2}:db-authz'",
             workflow_text,
         )
         self.assertIn('expected-status: "200,202"', workflow_text)


### PR DESCRIPTION
## Summary

- add explicit `preserve`, `install`, and `remove` bootstrap-secret operations to the protected Launchplane deployment workflow
- preserve target key-ring state during automatic deployments and when the GitHub secret is absent
- bind install/remove to the exact currently deployed immutable image and a bounded operator idempotency key
- scope, mask, validate, protect, and fail-safe-clean the temporary key-ring payload
- document the bootstrap transport and add fail-closed workflow contract coverage

## Validation

- `actionlint -config-file .github/actionlint.yaml .github/workflows/deploy-launchplane.yml`
- 124 targeted tests across product onboarding, self-deploy, GitHub Actions security, and docs contracts
- Ruff check and format check for `tests/test_product_onboarding.py`
- Mypy for `tests/test_product_onboarding.py`
- `uv run launchplane service audit-config-authority --control-plane-root .`
- `git diff --check`
- independent security-focused review: PASS

Closes #2204