### PR TITLE
Add DB-backed repository inventory records

### DIFF
--- a/control_plane/authz_repository_scope.py
+++ b/control_plane/authz_repository_scope.py
@@ -160,15 +160,12 @@ def build_authz_repository_scope_response(
         source="repository_record",
         truncated_sources=truncated_sources,
     )
-    list_inventory_records = getattr(store, "list_repository_inventory_records", None)
-    inventory_records = (
-        _bounded_records(
-            list_inventory_records(limit=AUTHZ_REPOSITORY_SCOPE_MAX_SOURCE_RECORDS + 1),
-            source="repository_record",
-            truncated_sources=truncated_sources,
-        )
-        if callable(list_inventory_records)
-        else ()
+    inventory_records = _bounded_records(
+        store.list_repository_inventory_records(
+            limit=AUTHZ_REPOSITORY_SCOPE_MAX_SOURCE_RECORDS + 1
+        ),
+        source="repository_record",
+        truncated_sources=truncated_sources,
     )
     work_requests = _bounded_interleaved_records(
         tuple(
@@ -213,7 +210,9 @@ def build_authz_repository_scope_response(
             _classification_evidence(record, current_classification_records)
             for record in classification_records
         )
-        + tuple(_inventory_evidence(record) for record in tracked_inventory_records)
+        + tuple(
+            _inventory_evidence(record, tracked_inventory_records) for record in inventory_records
+        )
         + tuple(_work_request_evidence(record) for record in work_requests)
         + tuple(_authorization_evidence(rule) for rule in authorization_rules)
     )
@@ -545,13 +544,16 @@ def _classification_evidence(
     )
 
 
-def _inventory_evidence(record: RepositoryInventoryRecord) -> _Evidence:
+def _inventory_evidence(
+    record: RepositoryInventoryRecord,
+    tracked_records: tuple[RepositoryInventoryRecord, ...],
+) -> _Evidence:
     return _Evidence(
         repository=record.repository,
         repository_id=record.repository_id,
         repository_owner_id=record.repository_owner_id,
         membership="repository_record",
-        current=True,
+        current=record in tracked_records,
         preserves_repository_case=False,
     )
 

--- a/control_plane/authz_repository_scope.py
+++ b/control_plane/authz_repository_scope.py
@@ -29,6 +29,7 @@ from control_plane.contracts.authz_policy_record import LaunchplaneAuthzPolicyRe
 from control_plane.contracts.every_code_work_request import EveryCodeWorkRequestRecord
 from control_plane.contracts.product_profile_record import LaunchplaneProductProfileRecord
 from control_plane.contracts.repository_human_admission import RepositoryHumanRolePolicyRecord
+from control_plane.contracts.repository_inventory import RepositoryInventoryRecord
 from control_plane.contracts.tenant_merge_eligibility import (
     TenantRepositoryClassificationRecord,
 )
@@ -78,6 +79,13 @@ class AuthzRepositoryScopeStore(Protocol):
         repository_id: str = "",
         limit: int | None = None,
     ) -> tuple[TenantRepositoryClassificationRecord, ...]: ...
+
+    def list_repository_inventory_records(
+        self,
+        *,
+        repository_id: str = "",
+        limit: int | None = None,
+    ) -> tuple[RepositoryInventoryRecord, ...]: ...
 
     def list_every_code_work_request_records(
         self,
@@ -152,6 +160,16 @@ def build_authz_repository_scope_response(
         source="repository_record",
         truncated_sources=truncated_sources,
     )
+    list_inventory_records = getattr(store, "list_repository_inventory_records", None)
+    inventory_records = (
+        _bounded_records(
+            list_inventory_records(limit=AUTHZ_REPOSITORY_SCOPE_MAX_SOURCE_RECORDS + 1),
+            source="repository_record",
+            truncated_sources=truncated_sources,
+        )
+        if callable(list_inventory_records)
+        else ()
+    )
     work_requests = _bounded_interleaved_records(
         tuple(
             store.list_every_code_work_request_records(
@@ -175,6 +193,12 @@ def build_authz_repository_scope_response(
     current_classification_records, classification_ambiguity_count = (
         _current_classification_records(classification_records)
     )
+    current_inventory_records, inventory_ambiguity_count = _current_inventory_records(
+        inventory_records
+    )
+    tracked_inventory_records = tuple(
+        record for record in current_inventory_records if record.inventory_state == "tracked"
+    )
     current_work_requests = tuple(
         record for record in work_requests if record.state in _CURRENT_WORK_REQUEST_STATES
     )
@@ -189,6 +213,7 @@ def build_authz_repository_scope_response(
             _classification_evidence(record, current_classification_records)
             for record in classification_records
         )
+        + tuple(_inventory_evidence(record) for record in tracked_inventory_records)
         + tuple(_work_request_evidence(record) for record in work_requests)
         + tuple(_authorization_evidence(rule) for rule in authorization_rules)
     )
@@ -203,6 +228,8 @@ def build_authz_repository_scope_response(
         gap_counts[("repository_record", "active_record_ambiguous")] += (
             classification_ambiguity_count
         )
+    if inventory_ambiguity_count:
+        gap_counts[("repository_record", "active_record_ambiguous")] += inventory_ambiguity_count
     for source in _GAP_SOURCE_ORDER:
         if count := truncated_sources[source]:
             gap_counts[(source, "source_truncated")] += count
@@ -247,7 +274,11 @@ def build_authz_repository_scope_response(
 
     timestamp_gaps = _timestamp_gap_counts(
         product_profiles=tuple(record for record in product_profiles if record.is_active),
-        repository_records=(*current_role_policy_records, *current_classification_records),
+        repository_records=(
+            *current_role_policy_records,
+            *current_classification_records,
+            *tracked_inventory_records,
+        ),
         work_requests=current_work_requests,
     )
     gap_counts.update(timestamp_gaps)
@@ -323,7 +354,8 @@ def build_authz_repository_scope_response(
             source_counts=AuthzRepositoryScopeSourceCounts(
                 product=sum(record.is_active for record in product_profiles),
                 repository_record=len(current_role_policy_records)
-                + len(current_classification_records),
+                + len(current_classification_records)
+                + len(tracked_inventory_records),
                 work_graph=len(current_work_requests),
                 authorization_chain=sum(
                     "authorization_chain" in node.memberships for node in nodes.values()
@@ -346,6 +378,7 @@ def build_authz_repository_scope_response(
             repository_record=_record_provenance(
                 tuple(record.effective_at for record in current_role_policy_records)
                 + tuple(record.classified_at for record in current_classification_records)
+                + tuple(record.recorded_at for record in tracked_inventory_records)
             ),
             work_graph=_record_provenance(
                 tuple(record.updated_at for record in current_work_requests)
@@ -442,6 +475,16 @@ def _current_classification_records(
     )
 
 
+def _current_inventory_records(
+    records: tuple[RepositoryInventoryRecord, ...],
+) -> tuple[tuple[RepositoryInventoryRecord, ...], int]:
+    return _latest_unique_records(
+        records,
+        key=lambda record: record.repository_id,
+        revision=lambda record: record.inventory_revision,
+    )
+
+
 def _latest_unique_records(
     records: tuple[_RecordT, ...],
     *,
@@ -498,6 +541,17 @@ def _classification_evidence(
         repository_owner_id=record.repository_owner_id,
         membership="repository_record",
         current=record in current_records,
+        preserves_repository_case=False,
+    )
+
+
+def _inventory_evidence(record: RepositoryInventoryRecord) -> _Evidence:
+    return _Evidence(
+        repository=record.repository,
+        repository_id=record.repository_id,
+        repository_owner_id=record.repository_owner_id,
+        membership="repository_record",
+        current=True,
         preserves_repository_case=False,
     )
 
@@ -561,7 +615,9 @@ def _timestamp_gap_counts(
     *,
     product_profiles: tuple[LaunchplaneProductProfileRecord, ...],
     repository_records: tuple[
-        RepositoryHumanRolePolicyRecord | TenantRepositoryClassificationRecord,
+        RepositoryHumanRolePolicyRecord
+        | TenantRepositoryClassificationRecord
+        | RepositoryInventoryRecord,
         ...,
     ],
     work_requests: tuple[EveryCodeWorkRequestRecord, ...],
@@ -574,7 +630,11 @@ def _timestamp_gap_counts(
             tuple(
                 record.effective_at
                 if isinstance(record, RepositoryHumanRolePolicyRecord)
-                else record.classified_at
+                else (
+                    record.classified_at
+                    if isinstance(record, TenantRepositoryClassificationRecord)
+                    else record.recorded_at
+                )
                 for record in repository_records
             ),
         ),

--- a/control_plane/contracts/repository_inventory.py
+++ b/control_plane/contracts/repository_inventory.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from datetime import datetime, timedelta, timezone
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+RepositoryInventoryState = Literal["tracked", "retired"]
+
+REPOSITORY_INVENTORY_READ_ACTION = "repository_inventory.read"
+REPOSITORY_INVENTORY_WRITE_ACTION = "repository_inventory.write"
+
+_SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+
+
+class RepositoryInventoryRecord(BaseModel):
+    """Append-only, inert inventory evidence for one immutable GitHub repository."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    record_id: str = ""
+    repository_id: str
+    repository_owner_id: str
+    repository: str
+    inventory_state: RepositoryInventoryState
+    inventory_revision: int = Field(ge=1)
+    recorded_at: str
+    source: str
+    reason: str
+    supersedes_record_id: str | None = None
+    inventory_digest: str = ""
+
+    @model_validator(mode="after")
+    def _validate_record(self) -> RepositoryInventoryRecord:
+        if self.schema_version != 1:
+            raise ValueError("Unsupported repository inventory schema version.")
+        self.repository_id = required_decimal_id(self.repository_id, "repository_id")
+        self.repository_owner_id = required_decimal_id(
+            self.repository_owner_id, "repository_owner_id"
+        )
+        self.repository = normalize_repository(self.repository, "repository")
+        self.recorded_at = normalize_utc_timestamp(self.recorded_at, "recorded_at")
+        self.source = required_token(self.source, "source")
+        self.reason = required_token(self.reason, "reason")
+        if self.supersedes_record_id is not None:
+            self.supersedes_record_id = required_token(
+                self.supersedes_record_id, "supersedes_record_id"
+            )
+        expected_record_id = build_repository_inventory_record_id(
+            repository_id=self.repository_id,
+            inventory_revision=self.inventory_revision,
+        )
+        if self.record_id:
+            self.record_id = required_token(self.record_id, "record_id")
+            if self.record_id != expected_record_id:
+                raise ValueError(
+                    "repository inventory record_id must include repository_id and inventory_revision"
+                )
+        else:
+            self.record_id = expected_record_id
+        expected_digest = repository_inventory_digest(self)
+        if self.inventory_digest:
+            self.inventory_digest = normalize_sha256(self.inventory_digest, "inventory_digest")
+            if self.inventory_digest != expected_digest:
+                raise ValueError("repository inventory inventory_digest does not match payload")
+        else:
+            self.inventory_digest = expected_digest
+        return self
+
+
+def build_repository_inventory_record_id(*, repository_id: str, inventory_revision: int) -> str:
+    return f"repository-inventory-{required_decimal_id(repository_id, 'repository_id')}-r{inventory_revision}"
+
+
+def repository_inventory_digest(record: RepositoryInventoryRecord) -> str:
+    payload = {
+        "schema_version": record.schema_version,
+        "record_id": record.record_id,
+        "repository_id": record.repository_id,
+        "repository_owner_id": record.repository_owner_id,
+        "repository": record.repository,
+        "inventory_state": record.inventory_state,
+        "inventory_revision": record.inventory_revision,
+        "recorded_at": record.recorded_at,
+        "source": record.source,
+        "reason": record.reason,
+        "supersedes_record_id": record.supersedes_record_id,
+    }
+    return hashlib.sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+
+
+def required_token(value: str, label: str) -> str:
+    normalized = value.strip()
+    if not normalized:
+        raise ValueError(f"repository inventory {label} is required")
+    return normalized
+
+
+def required_decimal_id(value: str, label: str) -> str:
+    normalized = required_token(value, label)
+    if not normalized.isdecimal() or int(normalized) <= 0:
+        raise ValueError(f"repository inventory {label} requires a positive numeric ID")
+    return normalized
+
+
+def normalize_repository(value: str, label: str) -> str:
+    normalized = required_token(value, label).lower()
+    owner, separator, name = normalized.partition("/")
+    if not separator or not owner or not name or "/" in name:
+        raise ValueError(f"repository inventory {label} must be a GitHub owner/name")
+    return normalized
+
+
+def normalize_utc_timestamp(value: str, label: str) -> str:
+    normalized = required_token(value, label)
+    try:
+        parsed = datetime.fromisoformat(normalized.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise ValueError(f"repository inventory {label} must be an ISO-8601 timestamp") from error
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ValueError(f"repository inventory {label} requires a timezone-aware UTC timestamp")
+    if parsed.utcoffset() != timedelta(0):
+        raise ValueError(f"repository inventory {label} must be UTC")
+    return parsed.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def normalize_sha256(value: str, label: str) -> str:
+    normalized = required_token(value, label).lower()
+    if _SHA256_PATTERN.fullmatch(normalized) is None:
+        raise ValueError(f"repository inventory {label} must be a lowercase SHA-256")
+    return normalized

--- a/control_plane/contracts/repository_inventory.py
+++ b/control_plane/contracts/repository_inventory.py
@@ -91,7 +91,7 @@ def repository_inventory_digest(record: RepositoryInventoryRecord) -> str:
         "supersedes_record_id": record.supersedes_record_id,
     }
     return hashlib.sha256(
-        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
     ).hexdigest()
 
 
@@ -125,7 +125,7 @@ def normalize_utc_timestamp(value: str, label: str) -> str:
         raise ValueError(f"repository inventory {label} must be an ISO-8601 timestamp") from error
     if parsed.tzinfo is None or parsed.utcoffset() is None:
         raise ValueError(f"repository inventory {label} requires a timezone-aware UTC timestamp")
-    if parsed.utcoffset() != timedelta(0):
+    if parsed.utcoffset() != timedelta():
         raise ValueError(f"repository inventory {label} must be UTC")
     return parsed.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
 

--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -175,6 +175,9 @@ from control_plane.http_routes import (
     register_product_profile_read_routes,
     register_protected_artifact_read_routes,
     register_runner_host_hygiene_read_routes,
+    RepositoryInventoryWriteRouteDependencies,
+    register_repository_inventory_read_routes,
+    register_repository_inventory_write_routes,
     REPOSITORY_HUMAN_ROLE_POLICY_APPLY_ROUTE,
     TENANT_ADMISSION_CONTROLLER_RUN_ONCE_ROUTE,
     TENANT_ADMISSION_STATUS_RECONCILE_ROUTE,
@@ -21902,6 +21905,7 @@ def create_launchplane_fastapi_app(
             github_token=resolve_launchplane_github_token,
         ),
     )
+    register_repository_inventory_read_routes(app, dependencies=read_route_dependencies)
 
     app.add_api_route(
         "/v1/work-graph/github/issues/reconcile",
@@ -22920,6 +22924,17 @@ def create_launchplane_fastapi_app(
     register_tenant_admission_write_routes(
         app,
         dependencies=tenant_admission_write_route_dependencies,
+    )
+    register_repository_inventory_write_routes(
+        app,
+        dependencies=RepositoryInventoryWriteRouteDependencies(
+            read_write_identity=read_bearer_identity,
+            get_record_store=get_record_store,
+            next_trace_id=next_trace_id,
+            authorization_allows=resolved_authz_policy_runtime.allows,
+            http_error=_launchplane_http_error,
+            error_response_model=LaunchplaneErrorResponse,
+        ),
     )
     register_product_owner_write_routes(
         app,

--- a/control_plane/http_routes/__init__.py
+++ b/control_plane/http_routes/__init__.py
@@ -113,6 +113,11 @@ from control_plane.http_routes.products import (
     require_product_profile_read_store,
 )
 from control_plane.http_routes.support import ReadRouteDependencies
+from control_plane.http_routes.repository_inventory import (
+    RepositoryInventoryWriteRouteDependencies,
+    register_repository_inventory_read_routes,
+    register_repository_inventory_write_routes,
+)
 from control_plane.http_routes.tenant_admission import (
     REPOSITORY_HUMAN_ROLE_POLICY_APPLY_ROUTE,
     TENANT_ADMISSION_CONTROLLER_RUN_ONCE_ROUTE,
@@ -175,6 +180,7 @@ __all__ = (
     "TENANT_TECHNICAL_HUMAN_WAIVER_APPLY_ROUTE",
     "TRUSTED_MAINTENANCE_POLICY_APPLY_ROUTE",
     "ReadRouteDependencies",
+    "RepositoryInventoryWriteRouteDependencies",
     "TenantAdmissionReadRouteDependencies",
     "TenantAdmissionWriteRouteDependencies",
     "WorkGraphReadRouteDependencies",
@@ -220,6 +226,8 @@ __all__ = (
     "register_product_profile_read_routes",
     "register_protected_artifact_read_routes",
     "register_runner_host_hygiene_read_routes",
+    "register_repository_inventory_read_routes",
+    "register_repository_inventory_write_routes",
     "register_tenant_admission_read_routes",
     "register_tenant_admission_write_routes",
     "TENANT_REPOSITORY_CLASSIFICATION_APPLY_ROUTE",

--- a/control_plane/http_routes/repository_inventory.py
+++ b/control_plane/http_routes/repository_inventory.py
@@ -1,9 +1,9 @@
 from dataclasses import dataclass
 from collections.abc import Callable
-from typing import Annotated, Literal
+from typing import Annotated, Literal, cast
 
-from fastapi import Depends, Header, Query
-from pydantic import BaseModel, ConfigDict
+from fastapi import Depends, Header, Query, Request
+from pydantic import BaseModel, ConfigDict, Field
 
 from control_plane.contracts.repository_inventory import (
     REPOSITORY_INVENTORY_READ_ACTION,
@@ -16,18 +16,19 @@ from control_plane.http_routes.support import (
     HttpErrorFactory,
     ReadRouteDependencies,
 )
+from control_plane.http_routes.mutation_support import idempotency_scope, request_fingerprint
 from control_plane.repository_inventory import (
     RepositoryInventoryApplyEnvelope,
     RepositoryInventoryApplyResult,
     RepositoryInventoryConflictError,
     RepositoryInventoryReadModel,
     RepositoryInventorySequenceError,
-    apply_repository_inventory,
+    dry_run_repository_inventory,
     get_repository_inventory_read_model,
     require_repository_inventory_read_store,
 )
 from control_plane.service_auth import LaunchplaneIdentity, TerminalAgentIdentity
-from control_plane.storage.postgres import PostgresRecordStore
+from control_plane.storage.postgres import DbOnlyMutationRequest, PostgresRecordStore
 
 REPOSITORY_INVENTORY_READ_ROUTE = "/v1/repository-inventory"
 REPOSITORY_INVENTORY_APPLY_ROUTE = "/v1/repository-inventory/apply"
@@ -55,6 +56,14 @@ class RepositoryInventoryApplyResponse(BaseModel):
     status: Literal["ok"] = "ok"
     trace_id: str
     result: RepositoryInventoryApplyResult
+    replayed: bool | None = Field(
+        default=None,
+        json_schema_extra={"x-launchplane-optional-response": True},
+    )
+    original_trace_id: str | None = Field(
+        default=None,
+        json_schema_extra={"x-launchplane-optional-response": True},
+    )
 
 
 def register_repository_inventory_read_routes(
@@ -73,7 +82,9 @@ def register_repository_inventory_read_routes(
             context=LAUNCHPLANE_SERVICE_CONTEXT,
         ):
             raise dependencies.http_error(
-                status_code=403, trace_id=trace_id, code="authorization_denied",
+                status_code=403,
+                trace_id=trace_id,
+                code="authorization_denied",
                 message="Identity cannot read repository inventory records.",
             )
         try:
@@ -85,7 +96,9 @@ def register_repository_inventory_read_routes(
             raise dependencies.http_error(
                 status_code=503 if isinstance(error, TypeError) else 400,
                 trace_id=trace_id,
-                code="database_storage_required" if isinstance(error, TypeError) else "invalid_request",
+                code="database_storage_required"
+                if isinstance(error, TypeError)
+                else "invalid_request",
                 message=str(error),
             ) from error
         return RepositoryInventoryReadResponse(trace_id=trace_id, read_model=read_model)
@@ -97,13 +110,18 @@ def register_repository_inventory_read_routes(
         response_model=RepositoryInventoryReadResponse,
         operation_id="read_repository_inventory",
         summary="Read the current inert repository inventory record",
+        responses={
+            status_code: {"model": dependencies.error_response_model}
+            for status_code in (400, 401, 403, 503)
+        },
     )
 
 
 def register_repository_inventory_write_routes(
     app: ApiRouteRegistrar, *, dependencies: RepositoryInventoryWriteRouteDependencies
 ) -> None:
-    def apply_repository_inventory_route(
+    async def apply_repository_inventory_route(
+        request: Request,
         envelope: RepositoryInventoryApplyEnvelope,
         identity: Annotated[LaunchplaneIdentity, Depends(dependencies.read_write_identity)],
         record_store: Annotated[object, Depends(dependencies.get_record_store)],
@@ -117,32 +135,139 @@ def register_repository_inventory_write_routes(
             context=LAUNCHPLANE_SERVICE_CONTEXT,
         ):
             raise dependencies.http_error(
-                status_code=403, trace_id=trace_id, code="authorization_denied",
+                status_code=403,
+                trace_id=trace_id,
+                code="authorization_denied",
                 message="Terminal agents and unauthorized identities cannot write repository inventory.",
             )
-        if envelope.mode == "apply" and (not isinstance(record_store, PostgresRecordStore) or not idempotency_key.strip()):
-            raise dependencies.http_error(
-                status_code=503 if not isinstance(record_store, PostgresRecordStore) else 400,
-                trace_id=trace_id,
-                code="database_storage_required" if not isinstance(record_store, PostgresRecordStore) else "idempotency_key_required",
-                message="Repository inventory apply requires PostgreSQL and an Idempotency-Key.",
+        if envelope.mode == "apply":
+            normalized_idempotency_key = idempotency_key.strip()
+            if not normalized_idempotency_key:
+                raise dependencies.http_error(
+                    status_code=400,
+                    trace_id=trace_id,
+                    code="idempotency_key_required",
+                    message="Repository inventory apply requires an Idempotency-Key header.",
+                )
+            if (
+                not isinstance(record_store, PostgresRecordStore)
+                or record_store.database_dialect_name != "postgresql"
+            ):
+                raise dependencies.http_error(
+                    status_code=503,
+                    trace_id=trace_id,
+                    code="database_storage_required",
+                    message=(
+                        "Repository inventory apply requires PostgreSQL-backed Launchplane storage."
+                    ),
+                )
+
+            result = RepositoryInventoryApplyResult(
+                status="applied",
+                mode="apply",
+                repository_id=envelope.record.repository_id,
+                inventory_revision=envelope.record.inventory_revision,
+                record_id=envelope.record.record_id,
+                inventory_digest=envelope.record.inventory_digest,
+                supersedes_record_id=envelope.record.supersedes_record_id,
+                applied_at=envelope.record.recorded_at,
             )
+            response = RepositoryInventoryApplyResponse(trace_id=trace_id, result=result)
+            raw_payload = await request.json()
+            try:
+                write_result = record_store.compare_and_write_repository_inventory_record(
+                    record=envelope.record,
+                    expected_current_record_id=envelope.expected_current_record_id,
+                    mutation=DbOnlyMutationRequest(
+                        scope=idempotency_scope(identity),
+                        route_path=REPOSITORY_INVENTORY_APPLY_ROUTE,
+                        idempotency_key=normalized_idempotency_key,
+                        request_fingerprint=request_fingerprint(
+                            cast(dict[str, object], raw_payload)
+                        ),
+                        lease_owner=trace_id,
+                        response_status_code=200,
+                        response_trace_id=trace_id,
+                        response_payload=response.model_dump(mode="json"),
+                    ),
+                )
+            except RepositoryInventoryConflictError as error:
+                raise dependencies.http_error(
+                    status_code=409,
+                    trace_id=trace_id,
+                    code="repository_inventory_conflict",
+                    message=str(error),
+                ) from error
+            except RepositoryInventorySequenceError as error:
+                raise dependencies.http_error(
+                    status_code=400,
+                    trace_id=trace_id,
+                    code="invalid_sequence",
+                    message=str(error),
+                ) from error
+            except ValueError as error:
+                raise dependencies.http_error(
+                    status_code=400,
+                    trace_id=trace_id,
+                    code="invalid_request",
+                    message=str(error),
+                ) from error
+
+            if write_result.status == "idempotency_conflict":
+                raise dependencies.http_error(
+                    status_code=409,
+                    trace_id=trace_id,
+                    code="idempotency_key_reused",
+                    message=(
+                        "Idempotency-Key was already used for a different Launchplane request "
+                        "payload on this route."
+                    ),
+                )
+            if write_result.status == "replayed" and write_result.idempotency_record is not None:
+                payload = dict(write_result.idempotency_record.response_payload)
+                payload["replayed"] = True
+                payload["original_trace_id"] = write_result.idempotency_record.response_trace_id
+                return RepositoryInventoryApplyResponse.model_validate(payload)
+            if write_result.status == "reservation_in_progress":
+                raise dependencies.http_error(
+                    status_code=409,
+                    trace_id=trace_id,
+                    code="mutation_in_progress",
+                    message="Repository inventory apply is already in progress.",
+                )
+            if write_result.status == "reconciliation_required":
+                raise dependencies.http_error(
+                    status_code=409,
+                    trace_id=trace_id,
+                    code="mutation_reconciliation_required",
+                    message="Repository inventory apply requires reconciliation before retry.",
+                )
+            return response
+
         try:
-            result = apply_repository_inventory(
+            result = dry_run_repository_inventory(
                 store=require_repository_inventory_read_store(record_store),
                 record=envelope.record,
                 expected_current_record_id=envelope.expected_current_record_id,
-                mode=envelope.mode,
             )
-        except (RepositoryInventoryConflictError, RepositoryInventorySequenceError) as error:
+        except RepositoryInventoryConflictError as error:
             raise dependencies.http_error(
-                status_code=409, trace_id=trace_id, code="repository_inventory_conflict", message=str(error)
+                status_code=409,
+                trace_id=trace_id,
+                code="repository_inventory_conflict",
+                message=str(error),
+            ) from error
+        except RepositoryInventorySequenceError as error:
+            raise dependencies.http_error(
+                status_code=400, trace_id=trace_id, code="invalid_sequence", message=str(error)
             ) from error
         except (TypeError, ValueError) as error:
             raise dependencies.http_error(
                 status_code=503 if isinstance(error, TypeError) else 400,
                 trace_id=trace_id,
-                code="database_storage_required" if isinstance(error, TypeError) else "invalid_request",
+                code="database_storage_required"
+                if isinstance(error, TypeError)
+                else "invalid_request",
                 message=str(error),
             ) from error
         return RepositoryInventoryApplyResponse(trace_id=trace_id, result=result)
@@ -154,4 +279,8 @@ def register_repository_inventory_write_routes(
         response_model=RepositoryInventoryApplyResponse,
         operation_id="apply_repository_inventory",
         summary="Apply or dry-run an inert repository inventory record",
+        responses={
+            status_code: {"model": dependencies.error_response_model}
+            for status_code in (400, 401, 403, 409, 503)
+        },
     )

--- a/control_plane/http_routes/repository_inventory.py
+++ b/control_plane/http_routes/repository_inventory.py
@@ -1,0 +1,157 @@
+from dataclasses import dataclass
+from collections.abc import Callable
+from typing import Annotated, Literal
+
+from fastapi import Depends, Header, Query
+from pydantic import BaseModel, ConfigDict
+
+from control_plane.contracts.repository_inventory import (
+    REPOSITORY_INVENTORY_READ_ACTION,
+    REPOSITORY_INVENTORY_WRITE_ACTION,
+)
+from control_plane.http_routes.support import (
+    LAUNCHPLANE_SERVICE_CONTEXT,
+    ApiRouteRegistrar,
+    AuthorizationAllows,
+    HttpErrorFactory,
+    ReadRouteDependencies,
+)
+from control_plane.repository_inventory import (
+    RepositoryInventoryApplyEnvelope,
+    RepositoryInventoryApplyResult,
+    RepositoryInventoryConflictError,
+    RepositoryInventoryReadModel,
+    RepositoryInventorySequenceError,
+    apply_repository_inventory,
+    get_repository_inventory_read_model,
+    require_repository_inventory_read_store,
+)
+from control_plane.service_auth import LaunchplaneIdentity, TerminalAgentIdentity
+from control_plane.storage.postgres import PostgresRecordStore
+
+REPOSITORY_INVENTORY_READ_ROUTE = "/v1/repository-inventory"
+REPOSITORY_INVENTORY_APPLY_ROUTE = "/v1/repository-inventory/apply"
+
+
+@dataclass(frozen=True, slots=True)
+class RepositoryInventoryWriteRouteDependencies:
+    read_write_identity: Callable[..., LaunchplaneIdentity]
+    get_record_store: Callable[[], object]
+    next_trace_id: Callable[[], str]
+    authorization_allows: AuthorizationAllows
+    http_error: HttpErrorFactory
+    error_response_model: type[BaseModel]
+
+
+class RepositoryInventoryReadResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    status: Literal["ok"] = "ok"
+    trace_id: str
+    read_model: RepositoryInventoryReadModel
+
+
+class RepositoryInventoryApplyResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    status: Literal["ok"] = "ok"
+    trace_id: str
+    result: RepositoryInventoryApplyResult
+
+
+def register_repository_inventory_read_routes(
+    app: ApiRouteRegistrar, *, dependencies: ReadRouteDependencies
+) -> None:
+    def read_repository_inventory(
+        repository_id: Annotated[str, Query(...)],
+        identity: Annotated[LaunchplaneIdentity, Depends(dependencies.read_identity)],
+        record_store: Annotated[object, Depends(dependencies.get_record_store)],
+    ) -> RepositoryInventoryReadResponse:
+        trace_id = dependencies.next_trace_id()
+        if not dependencies.authorization_allows(
+            identity=identity,
+            action=REPOSITORY_INVENTORY_READ_ACTION,
+            product=LAUNCHPLANE_SERVICE_CONTEXT,
+            context=LAUNCHPLANE_SERVICE_CONTEXT,
+        ):
+            raise dependencies.http_error(
+                status_code=403, trace_id=trace_id, code="authorization_denied",
+                message="Identity cannot read repository inventory records.",
+            )
+        try:
+            read_model = get_repository_inventory_read_model(
+                repository_id=repository_id,
+                store=require_repository_inventory_read_store(record_store),
+            )
+        except (TypeError, ValueError) as error:
+            raise dependencies.http_error(
+                status_code=503 if isinstance(error, TypeError) else 400,
+                trace_id=trace_id,
+                code="database_storage_required" if isinstance(error, TypeError) else "invalid_request",
+                message=str(error),
+            ) from error
+        return RepositoryInventoryReadResponse(trace_id=trace_id, read_model=read_model)
+
+    app.add_api_route(
+        REPOSITORY_INVENTORY_READ_ROUTE,
+        read_repository_inventory,
+        methods=["GET"],
+        response_model=RepositoryInventoryReadResponse,
+        operation_id="read_repository_inventory",
+        summary="Read the current inert repository inventory record",
+    )
+
+
+def register_repository_inventory_write_routes(
+    app: ApiRouteRegistrar, *, dependencies: RepositoryInventoryWriteRouteDependencies
+) -> None:
+    def apply_repository_inventory_route(
+        envelope: RepositoryInventoryApplyEnvelope,
+        identity: Annotated[LaunchplaneIdentity, Depends(dependencies.read_write_identity)],
+        record_store: Annotated[object, Depends(dependencies.get_record_store)],
+        idempotency_key: Annotated[str, Header(alias="Idempotency-Key")] = "",
+    ) -> RepositoryInventoryApplyResponse:
+        trace_id = dependencies.next_trace_id()
+        if isinstance(identity, TerminalAgentIdentity) or not dependencies.authorization_allows(
+            identity=identity,
+            action=REPOSITORY_INVENTORY_WRITE_ACTION,
+            product=LAUNCHPLANE_SERVICE_CONTEXT,
+            context=LAUNCHPLANE_SERVICE_CONTEXT,
+        ):
+            raise dependencies.http_error(
+                status_code=403, trace_id=trace_id, code="authorization_denied",
+                message="Terminal agents and unauthorized identities cannot write repository inventory.",
+            )
+        if envelope.mode == "apply" and (not isinstance(record_store, PostgresRecordStore) or not idempotency_key.strip()):
+            raise dependencies.http_error(
+                status_code=503 if not isinstance(record_store, PostgresRecordStore) else 400,
+                trace_id=trace_id,
+                code="database_storage_required" if not isinstance(record_store, PostgresRecordStore) else "idempotency_key_required",
+                message="Repository inventory apply requires PostgreSQL and an Idempotency-Key.",
+            )
+        try:
+            result = apply_repository_inventory(
+                store=require_repository_inventory_read_store(record_store),
+                record=envelope.record,
+                expected_current_record_id=envelope.expected_current_record_id,
+                mode=envelope.mode,
+            )
+        except (RepositoryInventoryConflictError, RepositoryInventorySequenceError) as error:
+            raise dependencies.http_error(
+                status_code=409, trace_id=trace_id, code="repository_inventory_conflict", message=str(error)
+            ) from error
+        except (TypeError, ValueError) as error:
+            raise dependencies.http_error(
+                status_code=503 if isinstance(error, TypeError) else 400,
+                trace_id=trace_id,
+                code="database_storage_required" if isinstance(error, TypeError) else "invalid_request",
+                message=str(error),
+            ) from error
+        return RepositoryInventoryApplyResponse(trace_id=trace_id, result=result)
+
+    app.add_api_route(
+        REPOSITORY_INVENTORY_APPLY_ROUTE,
+        apply_repository_inventory_route,
+        methods=["POST"],
+        response_model=RepositoryInventoryApplyResponse,
+        operation_id="apply_repository_inventory",
+        summary="Apply or dry-run an inert repository inventory record",
+    )

--- a/control_plane/repository_inventory.py
+++ b/control_plane/repository_inventory.py
@@ -1,0 +1,209 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal, Protocol, cast
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from control_plane.contracts.repository_inventory import (
+    RepositoryInventoryRecord,
+    normalize_utc_timestamp,
+    required_decimal_id,
+)
+from control_plane.workflows.ship import utc_now_timestamp
+
+
+class RepositoryInventoryConflictError(ValueError):
+    """Raised when an append-only repository inventory stream conflicts."""
+
+
+class RepositoryInventorySequenceError(ValueError):
+    """Raised when a repository inventory stream is not contiguous."""
+
+
+class RepositoryInventoryReadStore(Protocol):
+    def list_repository_inventory_records(
+        self, *, repository_id: str = "", limit: int | None = None
+    ) -> tuple[RepositoryInventoryRecord, ...]: ...
+
+
+class RepositoryInventoryStore(RepositoryInventoryReadStore, Protocol):
+    def write_repository_inventory_record(
+        self, record: RepositoryInventoryRecord
+    ) -> Literal["written", "replayed"]: ...
+
+
+RepositoryInventoryLookupStatus = Literal["available", "missing", "ambiguous"]
+RepositoryInventoryApplyMode = Literal["dry_run", "apply"]
+RepositoryInventoryApplyStatus = Literal["would_apply", "would_replay", "applied", "replayed"]
+
+
+class RepositoryInventoryReadModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    status: RepositoryInventoryLookupStatus
+    repository_id: str
+    current_record: RepositoryInventoryRecord | None = None
+    history_count: int = Field(default=0, ge=0)
+    generated_at: str
+
+    @model_validator(mode="after")
+    def _validate(self) -> RepositoryInventoryReadModel:
+        self.repository_id = required_decimal_id(self.repository_id, "repository_id")
+        self.generated_at = normalize_utc_timestamp(self.generated_at, "generated_at")
+        if (self.status == "available") != (self.current_record is not None):
+            raise ValueError("repository inventory availability must match current_record")
+        return self
+
+
+class RepositoryInventoryApplyEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    mode: RepositoryInventoryApplyMode = "apply"
+    expected_current_record_id: str = ""
+    record: RepositoryInventoryRecord
+
+    @model_validator(mode="after")
+    def _validate(self) -> RepositoryInventoryApplyEnvelope:
+        if self.schema_version != 1:
+            raise ValueError("Unsupported repository inventory apply schema version.")
+        self.expected_current_record_id = self.expected_current_record_id.strip()
+        return self
+
+
+class RepositoryInventoryApplyResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    status: RepositoryInventoryApplyStatus
+    mode: RepositoryInventoryApplyMode
+    repository_id: str
+    inventory_revision: int
+    record_id: str
+    inventory_digest: str
+    supersedes_record_id: str | None = None
+    applied_at: str
+
+
+@dataclass(frozen=True)
+class RepositoryInventoryAppendPlan:
+    status: Literal["written", "replayed"]
+    current_record: RepositoryInventoryRecord | None
+
+
+def require_repository_inventory_read_store(record_store: object) -> RepositoryInventoryReadStore:
+    if not callable(getattr(record_store, "list_repository_inventory_records", None)):
+        raise TypeError("Launchplane record store does not support repository inventory reads")
+    return cast(RepositoryInventoryReadStore, record_store)
+
+
+def require_repository_inventory_store(record_store: object) -> RepositoryInventoryStore:
+    read_store = require_repository_inventory_read_store(record_store)
+    if not callable(getattr(record_store, "write_repository_inventory_record", None)):
+        raise TypeError("Launchplane record store does not support repository inventory writes")
+    return cast(RepositoryInventoryStore, read_store)
+
+
+def get_repository_inventory_read_model(
+    *, repository_id: str, store: RepositoryInventoryReadStore
+) -> RepositoryInventoryReadModel:
+    normalized_id = required_decimal_id(repository_id, "repository_id")
+    records = tuple(
+        record
+        for record in store.list_repository_inventory_records(repository_id=normalized_id)
+        if record.repository_id == normalized_id
+    )
+    if not records:
+        return RepositoryInventoryReadModel(
+            status="missing", repository_id=normalized_id, generated_at=utc_now_timestamp()
+        )
+    highest_revision = max(record.inventory_revision for record in records)
+    current_records = tuple(
+        record for record in records if record.inventory_revision == highest_revision
+    )
+    if len(current_records) != 1:
+        return RepositoryInventoryReadModel(
+            status="ambiguous",
+            repository_id=normalized_id,
+            history_count=len(records),
+            generated_at=utc_now_timestamp(),
+        )
+    return RepositoryInventoryReadModel(
+        status="available",
+        repository_id=normalized_id,
+        current_record=current_records[0],
+        history_count=len(records),
+        generated_at=utc_now_timestamp(),
+    )
+
+
+def plan_repository_inventory_append(
+    *, records: tuple[RepositoryInventoryRecord, ...], record: RepositoryInventoryRecord
+) -> RepositoryInventoryAppendPlan:
+    stream = tuple(existing for existing in records if existing.repository_id == record.repository_id)
+    if not stream:
+        if record.inventory_revision != 1 or record.supersedes_record_id:
+            raise RepositoryInventorySequenceError(
+                "First repository inventory record requires revision 1 and no supersedes_record_id."
+            )
+        return RepositoryInventoryAppendPlan(status="written", current_record=None)
+    highest_revision = max(existing.inventory_revision for existing in stream)
+    current = tuple(existing for existing in stream if existing.inventory_revision == highest_revision)
+    if len(current) != 1:
+        raise RepositoryInventoryConflictError("Repository inventory history has an ambiguous current revision.")
+    current_record = current[0]
+    same_revision = tuple(
+        existing for existing in stream if existing.inventory_revision == record.inventory_revision
+    )
+    if len(same_revision) > 1:
+        raise RepositoryInventoryConflictError("Repository inventory revision is ambiguous.")
+    if same_revision:
+        if same_revision[0] == record and same_revision[0].inventory_digest == record.inventory_digest:
+            return RepositoryInventoryAppendPlan(status="replayed", current_record=current_record)
+        raise RepositoryInventoryConflictError(
+            "Repository inventory revision already exists with a different payload."
+        )
+    if record.inventory_revision != current_record.inventory_revision + 1:
+        raise RepositoryInventorySequenceError("Repository inventory revision must append contiguously.")
+    if record.supersedes_record_id != current_record.record_id:
+        raise RepositoryInventorySequenceError(
+            "Repository inventory supersedes_record_id must equal the current record ID."
+        )
+    return RepositoryInventoryAppendPlan(status="written", current_record=current_record)
+
+
+def apply_repository_inventory(
+    *,
+    store: RepositoryInventoryReadStore,
+    record: RepositoryInventoryRecord,
+    expected_current_record_id: str = "",
+    mode: RepositoryInventoryApplyMode = "apply",
+) -> RepositoryInventoryApplyResult:
+    plan = plan_repository_inventory_append(
+        records=store.list_repository_inventory_records(repository_id=record.repository_id), record=record
+    )
+    expected = expected_current_record_id.strip()
+    current_id = plan.current_record.record_id if plan.current_record else ""
+    if plan.status == "written" and expected != current_id:
+        raise RepositoryInventoryConflictError("Expected current repository inventory record does not match.")
+    if mode == "apply" and plan.status == "written":
+        require_repository_inventory_store(store).write_repository_inventory_record(record)
+        status: RepositoryInventoryApplyStatus = "applied"
+    elif mode == "apply":
+        status = "replayed"
+    elif plan.status == "written":
+        status = "would_apply"
+    else:
+        status = "would_replay"
+    return RepositoryInventoryApplyResult(
+        status=status,
+        mode=mode,
+        repository_id=record.repository_id,
+        inventory_revision=record.inventory_revision,
+        record_id=record.record_id,
+        inventory_digest=record.inventory_digest,
+        supersedes_record_id=record.supersedes_record_id,
+        applied_at=record.recorded_at,
+    )

--- a/control_plane/repository_inventory.py
+++ b/control_plane/repository_inventory.py
@@ -7,8 +7,10 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from control_plane.contracts.repository_inventory import (
     RepositoryInventoryRecord,
+    normalize_sha256,
     normalize_utc_timestamp,
     required_decimal_id,
+    required_token,
 )
 from control_plane.workflows.ship import utc_now_timestamp
 
@@ -27,15 +29,9 @@ class RepositoryInventoryReadStore(Protocol):
     ) -> tuple[RepositoryInventoryRecord, ...]: ...
 
 
-class RepositoryInventoryStore(RepositoryInventoryReadStore, Protocol):
-    def write_repository_inventory_record(
-        self, record: RepositoryInventoryRecord
-    ) -> Literal["written", "replayed"]: ...
-
-
 RepositoryInventoryLookupStatus = Literal["available", "missing", "ambiguous"]
 RepositoryInventoryApplyMode = Literal["dry_run", "apply"]
-RepositoryInventoryApplyStatus = Literal["would_apply", "would_replay", "applied", "replayed"]
+RepositoryInventoryApplyStatus = Literal["would_apply", "applied"]
 
 
 class RepositoryInventoryReadModel(BaseModel):
@@ -86,6 +82,20 @@ class RepositoryInventoryApplyResult(BaseModel):
     supersedes_record_id: str | None = None
     applied_at: str
 
+    @model_validator(mode="after")
+    def _validate(self) -> RepositoryInventoryApplyResult:
+        if self.schema_version != 1:
+            raise ValueError("Unsupported repository inventory apply result schema version.")
+        self.repository_id = required_decimal_id(self.repository_id, "repository_id")
+        self.record_id = required_token(self.record_id, "record_id")
+        self.inventory_digest = normalize_sha256(self.inventory_digest, "inventory_digest")
+        self.applied_at = normalize_utc_timestamp(self.applied_at, "applied_at")
+        if self.supersedes_record_id is not None:
+            self.supersedes_record_id = required_token(
+                self.supersedes_record_id, "supersedes_record_id"
+            )
+        return self
+
 
 @dataclass(frozen=True)
 class RepositoryInventoryAppendPlan:
@@ -97,13 +107,6 @@ def require_repository_inventory_read_store(record_store: object) -> RepositoryI
     if not callable(getattr(record_store, "list_repository_inventory_records", None)):
         raise TypeError("Launchplane record store does not support repository inventory reads")
     return cast(RepositoryInventoryReadStore, record_store)
-
-
-def require_repository_inventory_store(record_store: object) -> RepositoryInventoryStore:
-    read_store = require_repository_inventory_read_store(record_store)
-    if not callable(getattr(record_store, "write_repository_inventory_record", None)):
-        raise TypeError("Launchplane record store does not support repository inventory writes")
-    return cast(RepositoryInventoryStore, read_store)
 
 
 def get_repository_inventory_read_model(
@@ -142,7 +145,9 @@ def get_repository_inventory_read_model(
 def plan_repository_inventory_append(
     *, records: tuple[RepositoryInventoryRecord, ...], record: RepositoryInventoryRecord
 ) -> RepositoryInventoryAppendPlan:
-    stream = tuple(existing for existing in records if existing.repository_id == record.repository_id)
+    stream = tuple(
+        existing for existing in records if existing.repository_id == record.repository_id
+    )
     if not stream:
         if record.inventory_revision != 1 or record.supersedes_record_id:
             raise RepositoryInventorySequenceError(
@@ -150,9 +155,13 @@ def plan_repository_inventory_append(
             )
         return RepositoryInventoryAppendPlan(status="written", current_record=None)
     highest_revision = max(existing.inventory_revision for existing in stream)
-    current = tuple(existing for existing in stream if existing.inventory_revision == highest_revision)
+    current = tuple(
+        existing for existing in stream if existing.inventory_revision == highest_revision
+    )
     if len(current) != 1:
-        raise RepositoryInventoryConflictError("Repository inventory history has an ambiguous current revision.")
+        raise RepositoryInventoryConflictError(
+            "Repository inventory history has an ambiguous current revision."
+        )
     current_record = current[0]
     same_revision = tuple(
         existing for existing in stream if existing.inventory_revision == record.inventory_revision
@@ -160,13 +169,18 @@ def plan_repository_inventory_append(
     if len(same_revision) > 1:
         raise RepositoryInventoryConflictError("Repository inventory revision is ambiguous.")
     if same_revision:
-        if same_revision[0] == record and same_revision[0].inventory_digest == record.inventory_digest:
+        if (
+            same_revision[0] == record
+            and same_revision[0].inventory_digest == record.inventory_digest
+        ):
             return RepositoryInventoryAppendPlan(status="replayed", current_record=current_record)
         raise RepositoryInventoryConflictError(
             "Repository inventory revision already exists with a different payload."
         )
     if record.inventory_revision != current_record.inventory_revision + 1:
-        raise RepositoryInventorySequenceError("Repository inventory revision must append contiguously.")
+        raise RepositoryInventorySequenceError(
+            "Repository inventory revision must append contiguously."
+        )
     if record.supersedes_record_id != current_record.record_id:
         raise RepositoryInventorySequenceError(
             "Repository inventory supersedes_record_id must equal the current record ID."
@@ -174,32 +188,30 @@ def plan_repository_inventory_append(
     return RepositoryInventoryAppendPlan(status="written", current_record=current_record)
 
 
-def apply_repository_inventory(
+def dry_run_repository_inventory(
     *,
     store: RepositoryInventoryReadStore,
     record: RepositoryInventoryRecord,
     expected_current_record_id: str = "",
-    mode: RepositoryInventoryApplyMode = "apply",
 ) -> RepositoryInventoryApplyResult:
     plan = plan_repository_inventory_append(
-        records=store.list_repository_inventory_records(repository_id=record.repository_id), record=record
+        records=store.list_repository_inventory_records(repository_id=record.repository_id),
+        record=record,
     )
     expected = expected_current_record_id.strip()
     current_id = plan.current_record.record_id if plan.current_record else ""
     if plan.status == "written" and expected != current_id:
-        raise RepositoryInventoryConflictError("Expected current repository inventory record does not match.")
-    if mode == "apply" and plan.status == "written":
-        require_repository_inventory_store(store).write_repository_inventory_record(record)
-        status: RepositoryInventoryApplyStatus = "applied"
-    elif mode == "apply":
-        status = "replayed"
-    elif plan.status == "written":
-        status = "would_apply"
-    else:
-        status = "would_replay"
+        raise RepositoryInventoryConflictError(
+            "Expected current repository inventory record does not match."
+        )
+    if plan.status == "replayed":
+        raise RepositoryInventoryConflictError(
+            "Repository inventory record already exists; apply retries require the original "
+            "Idempotency-Key."
+        )
     return RepositoryInventoryApplyResult(
-        status=status,
-        mode=mode,
+        status="would_apply",
+        mode="dry_run",
         repository_id=record.repository_id,
         inventory_revision=record.inventory_revision,
         record_id=record.record_id,

--- a/control_plane/storage/filesystem.py
+++ b/control_plane/storage/filesystem.py
@@ -202,6 +202,7 @@ from control_plane.contracts.tenant_merge_eligibility import (
     TenantRepositoryClassificationLookup,
     TenantRepositoryClassificationRecord,
 )
+from control_plane.contracts.repository_inventory import RepositoryInventoryRecord
 from control_plane.contracts.runtime_key_safety_policy import RuntimeKeySafetyPolicyRecord
 from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneApplyAuditRecord
 from control_plane.contracts.runner_host_hygiene import (
@@ -215,6 +216,7 @@ from control_plane.contracts.verireel_prod_backup_gate_operation import (
 from control_plane.tenant_repository_classification import (
     plan_tenant_repository_classification_append,
 )
+from control_plane.repository_inventory import plan_repository_inventory_append
 from control_plane.storage.product_authority_bundle import (
     ProductAuthorityBundle,
     ProviderTargetWrite,
@@ -965,6 +967,41 @@ class FilesystemRecordStore:
                 record for record in records if record.classification_revision == latest_revision
             )
         )
+
+    def write_repository_inventory_record(
+        self, record: RepositoryInventoryRecord
+    ) -> Literal["written", "replayed"]:
+        record_type = "launchplane_repository_inventory_records"
+        with self._product_authority_bundle_lock():
+            records = tuple(
+                existing
+                for existing in self._list_models_locked(RepositoryInventoryRecord, record_type)
+                if existing.repository_id == record.repository_id
+            )
+            plan = plan_repository_inventory_append(records=records, record=record)
+            if plan.status == "replayed":
+                return "replayed"
+            self._write_model_locked(record_type, record.record_id, record)
+            return "written"
+
+    def list_repository_inventory_records(
+        self,
+        *,
+        repository_id: str = "",
+        limit: int | None = None,
+    ) -> tuple[RepositoryInventoryRecord, ...]:
+        records = [
+            record
+            for record in self._list_models(
+                RepositoryInventoryRecord, "launchplane_repository_inventory_records"
+            )
+            if not repository_id or record.repository_id == repository_id
+        ]
+        records.sort(
+            key=lambda record: (record.inventory_revision, record.repository_id, record.record_id),
+            reverse=True,
+        )
+        return tuple(records if limit is None else records[:limit])
 
     def write_repository_human_role_policy_record(
         self,

--- a/control_plane/storage/migrations/versions/f2241a0b1c2d_add_repository_inventory_records.py
+++ b/control_plane/storage/migrations/versions/f2241a0b1c2d_add_repository_inventory_records.py
@@ -1,0 +1,77 @@
+"""add repository inventory records
+
+Revision ID: f2241a0b1c2d
+Revises: f2239a0b1c2d
+Create Date: 2026-08-26 00:00:00.000000+00:00
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision: str = "f2241a0b1c2d"
+down_revision: str | None = "f2239a0b1c2d"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_TABLE = "launchplane_repository_inventory_records"
+_REVISION_INDEX = "launchplane_repository_inventory_revision_uidx"
+_CURRENT_INDEX = "launchplane_repository_inventory_current_idx"
+
+
+def _table_exists() -> bool:
+    return _TABLE in set(sa.inspect(op.get_bind()).get_table_names())
+
+
+def _index_exists(index_name: str) -> bool:
+    return _table_exists() and index_name in {
+        str(index["name"]) for index in sa.inspect(op.get_bind()).get_indexes(_TABLE)
+    }
+
+
+def upgrade() -> None:
+    if not _table_exists():
+        op.create_table(
+            _TABLE,
+            sa.Column("record_id", sa.String(), nullable=False),
+            sa.Column("repository_id", sa.String(), nullable=False),
+            sa.Column("repository_owner_id", sa.String(), nullable=False),
+            sa.Column("repository", sa.String(), nullable=False),
+            sa.Column("inventory_state", sa.String(), nullable=False),
+            sa.Column("inventory_revision", sa.BigInteger(), nullable=False),
+            sa.Column("recorded_at", sa.String(), nullable=False),
+            sa.Column("inventory_digest", sa.String(), nullable=False),
+            sa.Column(
+                "payload",
+                sa.JSON().with_variant(postgresql.JSONB(astext_type=sa.Text()), "postgresql"),
+                nullable=False,
+            ),
+            sa.CheckConstraint(
+                "inventory_state IN ('tracked', 'retired')",
+                name="launchplane_repository_inventory_state_ck",
+            ),
+            sa.CheckConstraint(
+                "inventory_revision >= 1",
+                name="launchplane_repository_inventory_revision_ck",
+            ),
+            sa.PrimaryKeyConstraint("record_id"),
+        )
+    if not _index_exists(_REVISION_INDEX):
+        op.create_index(
+            _REVISION_INDEX, _TABLE, ["repository_id", "inventory_revision"], unique=True
+        )
+    if not _index_exists(_CURRENT_INDEX):
+        op.create_index(_CURRENT_INDEX, _TABLE, ["repository_id", sa.text("inventory_revision DESC")])
+
+
+def downgrade() -> None:
+    if not _table_exists():
+        return
+    for index_name in (_CURRENT_INDEX, _REVISION_INDEX):
+        if _index_exists(index_name):
+            op.drop_index(index_name, table_name=_TABLE)
+    op.drop_table(_TABLE)

--- a/control_plane/storage/migrations/versions/f2241a0b1c2d_add_repository_inventory_records.py
+++ b/control_plane/storage/migrations/versions/f2241a0b1c2d_add_repository_inventory_records.py
@@ -29,7 +29,9 @@ def _table_exists() -> bool:
 
 def _index_exists(index_name: str) -> bool:
     return _table_exists() and index_name in {
-        str(index["name"]) for index in sa.inspect(op.get_bind()).get_indexes(_TABLE)
+        name
+        for index in sa.inspect(op.get_bind()).get_indexes(_TABLE)
+        if (name := index.get("name")) is not None
     }
 
 
@@ -65,7 +67,9 @@ def upgrade() -> None:
             _REVISION_INDEX, _TABLE, ["repository_id", "inventory_revision"], unique=True
         )
     if not _index_exists(_CURRENT_INDEX):
-        op.create_index(_CURRENT_INDEX, _TABLE, ["repository_id", sa.text("inventory_revision DESC")])
+        op.create_index(
+            _CURRENT_INDEX, _TABLE, ["repository_id", sa.text("inventory_revision DESC")]
+        )
 
 
 def downgrade() -> None:

--- a/control_plane/storage/postgres.py
+++ b/control_plane/storage/postgres.py
@@ -266,6 +266,7 @@ from control_plane.contracts.tenant_merge_eligibility import (
     TenantRepositoryClassificationLookup,
     TenantRepositoryClassificationRecord,
 )
+from control_plane.contracts.repository_inventory import RepositoryInventoryRecord
 from control_plane.contracts.repository_human_admission import (
     RepositoryHumanRolePolicyRecord,
     TenantTechnicalHumanWaiverEventRecord,
@@ -294,6 +295,9 @@ from control_plane.tenant_repository_classification import (
     TenantRepositoryClassificationConflictError,
     TenantRepositoryClassificationSequenceError,
     plan_tenant_repository_classification_append,
+)
+from control_plane.repository_inventory import (
+    plan_repository_inventory_append,
 )
 from control_plane.trusted_maintenance import (
     TrustedMaintenanceAuthorityError,
@@ -1111,6 +1115,33 @@ class LaunchplaneTenantRepositoryClassificationRow(Base):
     classification_revision: Mapped[int] = mapped_column(BigInteger, nullable=False)
     classified_at: Mapped[str] = mapped_column(String, nullable=False)
     classification_digest: Mapped[str] = mapped_column(String, nullable=False)
+    payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
+
+
+class LaunchplaneRepositoryInventoryRow(Base):
+    __tablename__ = "launchplane_repository_inventory_records"
+    __table_args__ = (
+        Index(
+            "launchplane_repository_inventory_revision_uidx",
+            "repository_id",
+            "inventory_revision",
+            unique=True,
+        ),
+        Index(
+            "launchplane_repository_inventory_current_idx",
+            "repository_id",
+            desc("inventory_revision"),
+        ),
+    )
+
+    record_id: Mapped[str] = mapped_column(String, primary_key=True)
+    repository_id: Mapped[str] = mapped_column(String, nullable=False)
+    repository_owner_id: Mapped[str] = mapped_column(String, nullable=False)
+    repository: Mapped[str] = mapped_column(String, nullable=False)
+    inventory_state: Mapped[str] = mapped_column(String, nullable=False)
+    inventory_revision: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    recorded_at: Mapped[str] = mapped_column(String, nullable=False)
+    inventory_digest: Mapped[str] = mapped_column(String, nullable=False)
     payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
 
 
@@ -11562,6 +11593,86 @@ class PostgresRecordStore(HumanSessionStore):
             records=tuple(
                 record for record in records if record.classification_revision == latest_revision
             )
+        )
+
+    def _repository_inventory_row(
+        self, record: RepositoryInventoryRecord
+    ) -> LaunchplaneRepositoryInventoryRow:
+        return LaunchplaneRepositoryInventoryRow(
+            record_id=record.record_id,
+            repository_id=record.repository_id,
+            repository_owner_id=record.repository_owner_id,
+            repository=record.repository,
+            inventory_state=record.inventory_state,
+            inventory_revision=record.inventory_revision,
+            recorded_at=record.recorded_at,
+            inventory_digest=record.inventory_digest,
+            payload=self._payload_dict(record),
+        )
+
+    def _lock_repository_inventory_write(self, session: Any, *, repository_id: str) -> None:
+        if self.database_url.startswith("sqlite"):
+            return
+        session.execute(
+            text("select pg_advisory_xact_lock(hashtextextended(:lock_name, 0))"),
+            {"lock_name": f"launchplane:repository-inventory:{repository_id}"},
+        )
+
+    def write_repository_inventory_record(
+        self, record: RepositoryInventoryRecord
+    ) -> Literal["written", "replayed"]:
+        insert_error: IntegrityError | None = None
+        with self._session_factory() as session:
+            self._begin_serialized_write(session)
+            self._lock_repository_inventory_write(session, repository_id=record.repository_id)
+            statement = select(LaunchplaneRepositoryInventoryRow).where(
+                LaunchplaneRepositoryInventoryRow.repository_id == record.repository_id
+            )
+            if not self.database_url.startswith("sqlite"):
+                statement = statement.with_for_update()
+            existing_records = tuple(
+                self._read_payload(model_type=RepositoryInventoryRecord, payload=row.payload)
+                for row in session.scalars(statement).all()
+            )
+            plan = plan_repository_inventory_append(records=existing_records, record=record)
+            if plan.status == "replayed":
+                session.rollback()
+                return "replayed"
+            session.add(self._repository_inventory_row(record))
+            try:
+                session.commit()
+                return "written"
+            except IntegrityError as error:
+                session.rollback()
+                insert_error = error
+        replay_plan = plan_repository_inventory_append(
+            records=self.list_repository_inventory_records(repository_id=record.repository_id),
+            record=record,
+        )
+        if replay_plan.status == "replayed":
+            return "replayed"
+        assert insert_error is not None
+        raise insert_error
+
+    def list_repository_inventory_records(
+        self,
+        *,
+        repository_id: str = "",
+        limit: int | None = None,
+    ) -> tuple[RepositoryInventoryRecord, ...]:
+        filters: list[object] = []
+        if repository_id:
+            filters.append(LaunchplaneRepositoryInventoryRow.repository_id == repository_id)
+        return self._list_models(
+            model_type=RepositoryInventoryRecord,
+            orm_model=LaunchplaneRepositoryInventoryRow,
+            filters=filters,
+            order_by=(
+                LaunchplaneRepositoryInventoryRow.inventory_revision.desc(),
+                LaunchplaneRepositoryInventoryRow.repository_id.desc(),
+                LaunchplaneRepositoryInventoryRow.record_id.desc(),
+            ),
+            limit=limit,
         )
 
     def list_manager_preview_approval_event_records(

--- a/control_plane/storage/postgres.py
+++ b/control_plane/storage/postgres.py
@@ -297,6 +297,8 @@ from control_plane.tenant_repository_classification import (
     plan_tenant_repository_classification_append,
 )
 from control_plane.repository_inventory import (
+    RepositoryInventoryConflictError,
+    RepositoryInventorySequenceError,
     plan_repository_inventory_append,
 )
 from control_plane.trusted_maintenance import (
@@ -359,6 +361,13 @@ ProductProfileCompareWriteStatus = Literal[
     "reconciliation_required",
 ]
 TenantRepositoryClassificationCompareWriteStatus = Literal[
+    "written",
+    "replayed",
+    "idempotency_conflict",
+    "reservation_in_progress",
+    "reconciliation_required",
+]
+RepositoryInventoryCompareWriteStatus = Literal[
     "written",
     "replayed",
     "idempotency_conflict",
@@ -491,6 +500,11 @@ class ProductProfileCompareWriteResult(NamedTuple):
 
 class TenantRepositoryClassificationCompareWriteResult(NamedTuple):
     status: TenantRepositoryClassificationCompareWriteStatus
+    idempotency_record: LaunchplaneIdempotencyRecord | None = None
+
+
+class RepositoryInventoryCompareWriteResult(NamedTuple):
+    status: RepositoryInventoryCompareWriteStatus
     idempotency_record: LaunchplaneIdempotencyRecord | None = None
 
 
@@ -1121,6 +1135,14 @@ class LaunchplaneTenantRepositoryClassificationRow(Base):
 class LaunchplaneRepositoryInventoryRow(Base):
     __tablename__ = "launchplane_repository_inventory_records"
     __table_args__ = (
+        CheckConstraint(
+            "inventory_state IN ('tracked', 'retired')",
+            name="launchplane_repository_inventory_state_ck",
+        ),
+        CheckConstraint(
+            "inventory_revision >= 1",
+            name="launchplane_repository_inventory_revision_ck",
+        ),
         Index(
             "launchplane_repository_inventory_revision_uidx",
             "repository_id",
@@ -11618,6 +11640,196 @@ class PostgresRecordStore(HumanSessionStore):
             {"lock_name": f"launchplane:repository-inventory:{repository_id}"},
         )
 
+    def compare_and_write_repository_inventory_record(
+        self,
+        *,
+        record: RepositoryInventoryRecord,
+        expected_current_record_id: str,
+        mutation: DbOnlyMutationRequest,
+    ) -> RepositoryInventoryCompareWriteResult:
+        if not 100 <= mutation.response_status_code <= 599:
+            raise ValueError("DB-only mutation response status must be between 100 and 599.")
+        if not mutation.response_trace_id.strip():
+            raise ValueError("DB-only mutation response trace id is required.")
+        normalized_expected = expected_current_record_id.strip()
+
+        reservation_insert_error: IntegrityError | None = None
+        with self._session_factory() as session:
+            self._begin_serialized_write(session)
+            observed_at = self._database_mutation_timestamp(session)
+            stored_reservation = build_launchplane_mutation_reservation(
+                scope=mutation.scope,
+                route_path=mutation.route_path,
+                idempotency_key=mutation.idempotency_key,
+                request_fingerprint=mutation.request_fingerprint,
+                lease_owner=mutation.lease_owner,
+                lease_expires_at=self._mutation_lease_expiry(
+                    observed_at=observed_at,
+                    lease_seconds=mutation.lease_seconds,
+                ),
+                reserved_at=observed_at,
+            )
+            reservation_row = self._idempotency_row(stored_reservation)
+            session.add(reservation_row)
+            try:
+                session.flush()
+            except IntegrityError as error:
+                session.rollback()
+                reservation_insert_error = error
+            if reservation_insert_error is None:
+                return self._compare_and_write_repository_inventory_locked(
+                    session=session,
+                    record=record,
+                    expected_current_record_id=normalized_expected,
+                    reservation_row=reservation_row,
+                    mutation_reservation=stored_reservation,
+                    mutation=mutation,
+                )
+
+        with self._session_factory() as session:
+            self._begin_serialized_write(session)
+            reservation_row = session.scalar(
+                self._idempotency_statement(
+                    scope=mutation.scope,
+                    route_path=mutation.route_path,
+                    idempotency_key=mutation.idempotency_key,
+                    for_update=True,
+                )
+            )
+            if reservation_row is None:
+                assert reservation_insert_error is not None
+                raise reservation_insert_error
+            current_reservation = self._read_payload(
+                model_type=LaunchplaneIdempotencyRecord,
+                payload=reservation_row.payload,
+            )
+            if current_reservation.request_fingerprint != mutation.request_fingerprint:
+                return RepositoryInventoryCompareWriteResult(
+                    status="idempotency_conflict",
+                    idempotency_record=current_reservation,
+                )
+            if current_reservation.state == "completed":
+                return RepositoryInventoryCompareWriteResult(
+                    status="replayed",
+                    idempotency_record=current_reservation,
+                )
+            if current_reservation.state == "reconcile_required":
+                return RepositoryInventoryCompareWriteResult(
+                    status="reconciliation_required",
+                    idempotency_record=current_reservation,
+                )
+            observed_at = self._database_mutation_timestamp(session)
+            if parse_launchplane_mutation_timestamp(
+                current_reservation.lease_expires_at,
+                field_name="lease_expires_at",
+            ) > parse_launchplane_mutation_timestamp(
+                observed_at,
+                field_name="observed_at",
+            ):
+                return RepositoryInventoryCompareWriteResult(
+                    status="reservation_in_progress",
+                    idempotency_record=current_reservation,
+                )
+            if current_reservation.reconciliation_key:
+                reconcile_record = self._updated_idempotency_record(
+                    current_reservation,
+                    state="reconcile_required",
+                    updated_at=observed_at,
+                )
+                self._sync_idempotency_row(reservation_row, reconcile_record)
+                session.commit()
+                return RepositoryInventoryCompareWriteResult(
+                    status="reconciliation_required",
+                    idempotency_record=reconcile_record,
+                )
+            reclaimed_reservation = self._updated_idempotency_record(
+                current_reservation,
+                lease_owner=mutation.lease_owner,
+                lease_expires_at=self._mutation_lease_expiry(
+                    observed_at=observed_at,
+                    lease_seconds=mutation.lease_seconds,
+                ),
+                attempt=current_reservation.attempt + 1,
+                updated_at=observed_at,
+                response_status_code=None,
+                response_trace_id="",
+                recorded_at="",
+                response_payload={},
+            )
+            self._sync_idempotency_row(reservation_row, reclaimed_reservation)
+            return self._compare_and_write_repository_inventory_locked(
+                session=session,
+                record=record,
+                expected_current_record_id=normalized_expected,
+                reservation_row=reservation_row,
+                mutation_reservation=reclaimed_reservation,
+                mutation=mutation,
+            )
+
+    def _compare_and_write_repository_inventory_locked(
+        self,
+        *,
+        session: Any,
+        record: RepositoryInventoryRecord,
+        expected_current_record_id: str,
+        reservation_row: LaunchplaneIdempotencyRow,
+        mutation_reservation: LaunchplaneIdempotencyRecord,
+        mutation: DbOnlyMutationRequest,
+    ) -> RepositoryInventoryCompareWriteResult:
+        self._lock_repository_inventory_write(session, repository_id=record.repository_id)
+        statement = select(LaunchplaneRepositoryInventoryRow).where(
+            LaunchplaneRepositoryInventoryRow.repository_id == record.repository_id
+        )
+        if not self.database_url.startswith("sqlite"):
+            statement = statement.with_for_update()
+        existing_records = tuple(
+            self._read_payload(model_type=RepositoryInventoryRecord, payload=row.payload)
+            for row in session.scalars(statement).all()
+        )
+        try:
+            plan = plan_repository_inventory_append(records=existing_records, record=record)
+            if plan.status == "replayed":
+                raise RepositoryInventoryConflictError(
+                    "Repository inventory record already exists; retry the original request "
+                    "with the same Idempotency-Key."
+                )
+            if plan.current_record is None and expected_current_record_id:
+                raise RepositoryInventoryConflictError(
+                    f"Expected current repository inventory record ID "
+                    f"'{expected_current_record_id}' does not match current state: repository "
+                    "has no existing inventory record."
+                )
+            if (
+                plan.current_record is not None
+                and expected_current_record_id != plan.current_record.record_id
+            ):
+                raise RepositoryInventoryConflictError(
+                    f"Expected current repository inventory record ID "
+                    f"'{expected_current_record_id}' does not match active current record ID "
+                    f"'{plan.current_record.record_id}'."
+                )
+        except (RepositoryInventoryConflictError, RepositoryInventorySequenceError):
+            session.delete(reservation_row)
+            session.commit()
+            raise
+
+        session.add(self._repository_inventory_row(record))
+        session.flush()
+        completed_at = self._database_mutation_timestamp(session)
+        completion = complete_launchplane_mutation_reservation(
+            mutation_reservation,
+            response_status_code=mutation.response_status_code,
+            response_trace_id=mutation.response_trace_id,
+            completed_at=completed_at,
+            response_payload=mutation.response_payload,
+        )
+        self._sync_idempotency_row(reservation_row, completion)
+        session.commit()
+        return RepositoryInventoryCompareWriteResult(
+            status="written",
+            idempotency_record=completion,
+        )
+
     def write_repository_inventory_record(
         self, record: RepositoryInventoryRecord
     ) -> Literal["written", "replayed"]:
@@ -17572,6 +17784,7 @@ class PostgresRecordStore(HumanSessionStore):
             "release_tuples": 0,
             "runtime_key_safety_policies": 0,
             "tenant_repository_classifications": 0,
+            "repository_inventory": 0,
         }
         for artifact_manifest in filesystem_store.list_artifact_manifests():
             self.write_artifact_manifest(artifact_manifest)
@@ -17591,6 +17804,18 @@ class PostgresRecordStore(HumanSessionStore):
             for classification_record in classification_records:
                 self.write_tenant_repository_classification_record(classification_record)
                 counts["tenant_repository_classifications"] += 1
+        if hasattr(filesystem_store, "list_repository_inventory_records"):
+            repository_inventory_records = sorted(
+                filesystem_store.list_repository_inventory_records(),
+                key=lambda record: (
+                    record.repository_id,
+                    record.inventory_revision,
+                    record.record_id,
+                ),
+            )
+            for repository_inventory_record in repository_inventory_records:
+                self.write_repository_inventory_record(repository_inventory_record)
+                counts["repository_inventory"] += 1
         for owner_policy in sorted(
             filesystem_store.list_product_owner_policy_records(),
             key=lambda record: (record.product, record.system, record.policy_revision),

--- a/control_plane/storage/schema_invariants.py
+++ b/control_plane/storage/schema_invariants.py
@@ -10,7 +10,7 @@ from sqlalchemy.engine import Engine
 from sqlalchemy.exc import SQLAlchemyError
 
 AUTHZ_COMPATIBILITY_FLOOR_REVISION = "f3b5d7e9a1c2"
-EXPECTED_ALEMBIC_HEAD_REVISION = "f2239a0b1c2d"
+EXPECTED_ALEMBIC_HEAD_REVISION = "f2241a0b1c2d"
 RUNTIME_COMPATIBLE_ALEMBIC_REVISIONS = (EXPECTED_ALEMBIC_HEAD_REVISION,)
 _AUTHZ_POLICY_TABLE = "launchplane_authz_policies"
 _AUTHZ_POLICY_WRITE_FENCE_TRIGGER = "launchplane_authz_policy_write_fence"
@@ -138,6 +138,11 @@ CRITICAL_POSTGRES_COLUMN_TYPES: tuple[CriticalColumnType, ...] = (
     ),
     CriticalColumnType(
         "launchplane_odoo_stable_bootstrap_operations",
+        "payload",
+        ("jsonb",),
+    ),
+    CriticalColumnType(
+        "launchplane_repository_inventory_records",
         "payload",
         ("jsonb",),
     ),
@@ -787,6 +792,17 @@ CRITICAL_SCHEMA_INDEXES: tuple[CriticalIndex, ...] = (
         ("repository_id", "classification_revision"),
     ),
     CriticalIndex(
+        "launchplane_repository_inventory_records",
+        "launchplane_repository_inventory_revision_uidx",
+        ("repository_id", "inventory_revision"),
+        unique=True,
+    ),
+    CriticalIndex(
+        "launchplane_repository_inventory_records",
+        "launchplane_repository_inventory_current_idx",
+        ("repository_id", "inventory_revision"),
+    ),
+    CriticalIndex(
         "launchplane_repository_human_role_policies",
         "launchplane_repo_human_role_revision_uidx",
         ("repository_id", "product", "context", "role_policy_revision"),
@@ -988,6 +1004,10 @@ CRITICAL_PRIMARY_KEYS: tuple[CriticalPrimaryKey, ...] = (
     ),
     CriticalPrimaryKey(
         "launchplane_tenant_repository_classifications",
+        ("record_id",),
+    ),
+    CriticalPrimaryKey(
+        "launchplane_repository_inventory_records",
         ("record_id",),
     ),
     CriticalPrimaryKey(

--- a/docs/authorization-authority.md
+++ b/docs/authorization-authority.md
@@ -18,7 +18,17 @@ independent review remain incomplete.
 Until that work closes:
 
 - do not add new routine grants or managed sets through GitHub secrets or
-  workflows;
+workflows;
+
+## Repository inventory
+
+Repository inventory has separate `repository_inventory.read` and
+`repository_inventory.write` actions at `product=launchplane` and
+`context=launchplane`. This change grants neither action: the active DB-native
+authorization policy remains the only authority. Active tracked inventory
+records are repository-record evidence for the redacted repository-scope read
+model; retired records contribute no node and do not alter that public response
+contract.
 - do not create, edit, retarget, or dispatch a workflow merely to make an
   `authorization_denied` operation succeed;
 - route authorization gaps to `#2058` and add a native `blocked-by` relationship

--- a/docs/authorization-authority.md
+++ b/docs/authorization-authority.md
@@ -18,17 +18,7 @@ independent review remain incomplete.
 Until that work closes:
 
 - do not add new routine grants or managed sets through GitHub secrets or
-workflows;
-
-## Repository inventory
-
-Repository inventory has separate `repository_inventory.read` and
-`repository_inventory.write` actions at `product=launchplane` and
-`context=launchplane`. This change grants neither action: the active DB-native
-authorization policy remains the only authority. Active tracked inventory
-records are repository-record evidence for the redacted repository-scope read
-model; retired records contribute no node and do not alter that public response
-contract.
+  workflows;
 - do not create, edit, retarget, or dispatch a workflow merely to make an
   `authorization_denied` operation succeed;
 - route authorization gaps to `#2058` and add a native `blocked-by` relationship
@@ -40,6 +30,15 @@ contract.
 
 This freeze does not prohibit code, tests, documentation, threat-model work, or
 dry-run-only validation that cannot mutate live policy.
+
+Repository inventory follows the same authority boundary. Its
+`repository_inventory.read` and `repository_inventory.write` actions use the
+Launchplane service scope (`product=launchplane`, `context=launchplane`), but
+defining those actions grants neither one. Active tracked inventory records are
+repository-record evidence for the redacted repository-scope read model;
+retired records contribute no active inventory membership. When authorization
+rules are the only remaining active source, the read model reports stale
+authorization membership rather than complete coverage.
 
 ## Current Transitional Model
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -18,6 +18,15 @@ base/tree observations; this evidence does not claim that GitHub rejected the
 request. Only then may Launchplane recompute L2 for a fresh admission.
 Contradictory or incomplete evidence remains `reconcile_required` and needs
 operator investigation. Candidate-ref cleanup failures are separate from
+
+## Repository inventory
+
+Use the deployed service for repository inventory reads and mutations. Submit
+an exact immutable GitHub repository identity and a deterministic append-only
+record. Run `dry_run` before apply; apply is PostgreSQL-only, requires
+`Idempotency-Key`, and must use the current record ID for CAS. Retiring a
+repository removes its active repository-scope inventory membership without
+granting or revoking any authorization.
 landing truth and may be retried without changing the outcome record.
 
 Use the controller phase when diagnosing a failed landing. An active

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -18,15 +18,6 @@ base/tree observations; this evidence does not claim that GitHub rejected the
 request. Only then may Launchplane recompute L2 for a fresh admission.
 Contradictory or incomplete evidence remains `reconcile_required` and needs
 operator investigation. Candidate-ref cleanup failures are separate from
-
-## Repository inventory
-
-Use the deployed service for repository inventory reads and mutations. Submit
-an exact immutable GitHub repository identity and a deterministic append-only
-record. Run `dry_run` before apply; apply is PostgreSQL-only, requires
-`Idempotency-Key`, and must use the current record ID for CAS. Retiring a
-repository removes its active repository-scope inventory membership without
-granting or revoking any authorization.
 landing truth and may be retried without changing the outcome record.
 
 Use the controller phase when diagnosing a failed landing. An active
@@ -46,6 +37,18 @@ clear controller state or treat the result as a GitHub merge conflict: no
 provider effect was attempted for the blocked entry and the controller lease is
 released cleanly. Earlier entries in a multi-PR batch may already be merged; the
 returned landing plan identifies their persisted status.
+
+## Repository Inventory
+
+Use the deployed service for repository inventory reads and mutations. Submit
+an exact immutable GitHub repository identity and a deterministic append-only
+record. Run `dry_run` before apply. Apply is PostgreSQL-only, requires an
+`Idempotency-Key`, and compares the supplied current record ID inside the same
+transaction that appends the revision and completes the idempotency response.
+Retiring a repository removes its active repository-scope inventory membership
+without granting or revoking authorization. A dry-run of an already-persisted
+record returns a conflict because replay is valid only when apply reuses the
+original idempotency key.
 
 ## Command Groups
 

--- a/docs/records.md
+++ b/docs/records.md
@@ -4,15 +4,6 @@ title: Records
 
 ## Storage Policy
 
-### Repository inventory
-
-`RepositoryInventoryRecord` is an append-only, inert repository inventory stream. It records only
-immutable GitHub repository identity, normalized owner/name, tracked/retired state, revision,
-timestamp, source, reason, predecessor, and deterministic digest. It is not product, tenant,
-role, authorization, branch, workflow, provider, runtime, or merge authority. Revision one has
-no predecessor; later revisions must supersede the exact current record. The PostgreSQL table is
-`launchplane_repository_inventory_records`; filesystem storage provides rehearsal parity only.
-
 - Persist local-dev records as JSON files in a local state directory.
 - Use Postgres-backed Launchplane core-record tables for shared-service ingress
   when Launchplane is running with `LAUNCHPLANE_DATABASE_URL` or
@@ -33,6 +24,18 @@ no predecessor; later revisions must supersede the exact current record. The Pos
   `--allow-direct-db-mutation` bootstrap/repair boundary.
 - Keep git history separate from operational history.
 - Favor append-style writes for promotion records.
+
+### Repository Inventory
+
+`RepositoryInventoryRecord` is an append-only, inert repository inventory
+stream. It records only immutable GitHub repository identity, normalized
+owner/name, tracked or retired state, revision, timestamp, source, reason,
+predecessor, and deterministic digest. It is not product, tenant, role,
+authorization, branch, workflow, provider, runtime, or merge authority.
+Revision one has no predecessor; later revisions must supersede the exact
+current record. Shared writes use
+`launchplane_repository_inventory_records`; filesystem storage provides local
+rehearsal parity only.
 
 ## Schema Migrations
 

--- a/docs/records.md
+++ b/docs/records.md
@@ -4,6 +4,15 @@ title: Records
 
 ## Storage Policy
 
+### Repository inventory
+
+`RepositoryInventoryRecord` is an append-only, inert repository inventory stream. It records only
+immutable GitHub repository identity, normalized owner/name, tracked/retired state, revision,
+timestamp, source, reason, predecessor, and deterministic digest. It is not product, tenant,
+role, authorization, branch, workflow, provider, runtime, or merge authority. Revision one has
+no predecessor; later revisions must supersede the exact current record. The PostgreSQL table is
+`launchplane_repository_inventory_records`; filesystem storage provides rehearsal parity only.
+
 - Persist local-dev records as JSON files in a local state directory.
 - Use Postgres-backed Launchplane core-record tables for shared-service ingress
   when Launchplane is running with `LAUNCHPLANE_DATABASE_URL` or

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -4,14 +4,6 @@ title: Launchplane Service Boundary
 
 ## Purpose
 
-## Repository inventory boundary
-
-The repository-inventory service surface owns generic inventory evidence only. `GET
-/v1/repository-inventory` is bounded by repository ID. `POST /v1/repository-inventory/apply`
-supports dry-run and PostgreSQL-backed apply; apply requires an idempotency key and is denied to
-terminal agents. Inventory records do not establish product, tenant, role, authorization, branch,
-workflow, provider, runtime, or merge semantics.
-
 This document defines the first explicit Launchplane service boundary: the initial
 HTTP ingress, the GitHub Actions OIDC trust model, the claim-to-permission
 mapping, and the first stable API payloads Launchplane should accept.
@@ -37,6 +29,16 @@ boundary with minimal trigger facts. They should not carry Launchplane lifecycle
 truth, provider mutation logic, rendered evidence payloads, or copied driver
 behavior. See [product-repo-contract.md](product-repo-contract.md) for the
 approval gate.
+
+### Repository Inventory
+
+The repository-inventory surface owns generic identity and existence evidence
+only. `GET /v1/repository-inventory` reads one repository stream by immutable
+repository ID. `POST /v1/repository-inventory/apply` supports dry-run and
+PostgreSQL-backed apply; apply requires an idempotency key, performs atomic CAS,
+and is denied to terminal agents. Inventory records do not establish product,
+tenant, role, authorization, branch, workflow, provider, runtime, or merge
+semantics.
 
 ## Current Implementation Status
 

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -4,6 +4,14 @@ title: Launchplane Service Boundary
 
 ## Purpose
 
+## Repository inventory boundary
+
+The repository-inventory service surface owns generic inventory evidence only. `GET
+/v1/repository-inventory` is bounded by repository ID. `POST /v1/repository-inventory/apply`
+supports dry-run and PostgreSQL-backed apply; apply requires an idempotency key and is denied to
+terminal agents. Inventory records do not establish product, tenant, role, authorization, branch,
+workflow, provider, runtime, or merge semantics.
+
 This document defines the first explicit Launchplane service boundary: the initial
 HTTP ingress, the GitHub Actions OIDC trust model, the claim-to-permission
 mapping, and the first stable API payloads Launchplane should accept.

--- a/frontend/generated/openapi-canonical.json
+++ b/frontend/generated/openapi-canonical.json
@@ -29650,6 +29650,30 @@
       "RepositoryInventoryApplyResponse": {
         "additionalProperties": false,
         "properties": {
+          "original_trace_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Original Trace Id",
+            "x-launchplane-optional-response": true
+          },
+          "replayed": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Replayed",
+            "x-launchplane-optional-response": true
+          },
           "result": {
             "$ref": "#/components/schemas/RepositoryInventoryApplyResult"
           },
@@ -29711,9 +29735,7 @@
           "status": {
             "enum": [
               "would_apply",
-              "would_replay",
-              "applied",
-              "replayed"
+              "applied"
             ],
             "title": "Status",
             "type": "string"
@@ -69739,6 +69761,36 @@
             },
             "description": "Successful Response"
           },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
           "409": {
             "content": {
               "application/json": {
@@ -69808,6 +69860,36 @@
               }
             },
             "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Forbidden"
           },
           "409": {
             "content": {

--- a/frontend/generated/openapi-canonical.json
+++ b/frontend/generated/openapi-canonical.json
@@ -29614,6 +29614,291 @@
         "title": "RepositoryHumanRolePolicyRecord",
         "type": "object"
       },
+      "RepositoryInventoryApplyEnvelope": {
+        "additionalProperties": false,
+        "properties": {
+          "expected_current_record_id": {
+            "default": "",
+            "title": "Expected Current Record Id",
+            "type": "string"
+          },
+          "mode": {
+            "default": "apply",
+            "enum": [
+              "dry_run",
+              "apply"
+            ],
+            "title": "Mode",
+            "type": "string"
+          },
+          "record": {
+            "$ref": "#/components/schemas/RepositoryInventoryRecord"
+          },
+          "schema_version": {
+            "default": 1,
+            "minimum": 1.0,
+            "title": "Schema Version",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "record"
+        ],
+        "title": "RepositoryInventoryApplyEnvelope",
+        "type": "object"
+      },
+      "RepositoryInventoryApplyResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "result": {
+            "$ref": "#/components/schemas/RepositoryInventoryApplyResult"
+          },
+          "status": {
+            "const": "ok",
+            "default": "ok",
+            "title": "Status",
+            "type": "string"
+          },
+          "trace_id": {
+            "title": "Trace Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "trace_id",
+          "result"
+        ],
+        "title": "RepositoryInventoryApplyResponse",
+        "type": "object"
+      },
+      "RepositoryInventoryApplyResult": {
+        "additionalProperties": false,
+        "properties": {
+          "applied_at": {
+            "title": "Applied At",
+            "type": "string"
+          },
+          "inventory_digest": {
+            "title": "Inventory Digest",
+            "type": "string"
+          },
+          "inventory_revision": {
+            "title": "Inventory Revision",
+            "type": "integer"
+          },
+          "mode": {
+            "enum": [
+              "dry_run",
+              "apply"
+            ],
+            "title": "Mode",
+            "type": "string"
+          },
+          "record_id": {
+            "title": "Record Id",
+            "type": "string"
+          },
+          "repository_id": {
+            "title": "Repository Id",
+            "type": "string"
+          },
+          "schema_version": {
+            "default": 1,
+            "minimum": 1.0,
+            "title": "Schema Version",
+            "type": "integer"
+          },
+          "status": {
+            "enum": [
+              "would_apply",
+              "would_replay",
+              "applied",
+              "replayed"
+            ],
+            "title": "Status",
+            "type": "string"
+          },
+          "supersedes_record_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Supersedes Record Id"
+          }
+        },
+        "required": [
+          "status",
+          "mode",
+          "repository_id",
+          "inventory_revision",
+          "record_id",
+          "inventory_digest",
+          "applied_at"
+        ],
+        "title": "RepositoryInventoryApplyResult",
+        "type": "object"
+      },
+      "RepositoryInventoryReadModel": {
+        "additionalProperties": false,
+        "properties": {
+          "current_record": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/RepositoryInventoryRecord"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "generated_at": {
+            "title": "Generated At",
+            "type": "string"
+          },
+          "history_count": {
+            "default": 0,
+            "minimum": 0.0,
+            "title": "History Count",
+            "type": "integer"
+          },
+          "repository_id": {
+            "title": "Repository Id",
+            "type": "string"
+          },
+          "schema_version": {
+            "default": 1,
+            "minimum": 1.0,
+            "title": "Schema Version",
+            "type": "integer"
+          },
+          "status": {
+            "enum": [
+              "available",
+              "missing",
+              "ambiguous"
+            ],
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "status",
+          "repository_id",
+          "generated_at"
+        ],
+        "title": "RepositoryInventoryReadModel",
+        "type": "object"
+      },
+      "RepositoryInventoryReadResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "read_model": {
+            "$ref": "#/components/schemas/RepositoryInventoryReadModel"
+          },
+          "status": {
+            "const": "ok",
+            "default": "ok",
+            "title": "Status",
+            "type": "string"
+          },
+          "trace_id": {
+            "title": "Trace Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "trace_id",
+          "read_model"
+        ],
+        "title": "RepositoryInventoryReadResponse",
+        "type": "object"
+      },
+      "RepositoryInventoryRecord": {
+        "additionalProperties": false,
+        "description": "Append-only, inert inventory evidence for one immutable GitHub repository.",
+        "properties": {
+          "inventory_digest": {
+            "default": "",
+            "title": "Inventory Digest",
+            "type": "string"
+          },
+          "inventory_revision": {
+            "minimum": 1.0,
+            "title": "Inventory Revision",
+            "type": "integer"
+          },
+          "inventory_state": {
+            "enum": [
+              "tracked",
+              "retired"
+            ],
+            "title": "Inventory State",
+            "type": "string"
+          },
+          "reason": {
+            "title": "Reason",
+            "type": "string"
+          },
+          "record_id": {
+            "default": "",
+            "title": "Record Id",
+            "type": "string"
+          },
+          "recorded_at": {
+            "title": "Recorded At",
+            "type": "string"
+          },
+          "repository": {
+            "title": "Repository",
+            "type": "string"
+          },
+          "repository_id": {
+            "title": "Repository Id",
+            "type": "string"
+          },
+          "repository_owner_id": {
+            "title": "Repository Owner Id",
+            "type": "string"
+          },
+          "schema_version": {
+            "default": 1,
+            "minimum": 1.0,
+            "title": "Schema Version",
+            "type": "integer"
+          },
+          "source": {
+            "title": "Source",
+            "type": "string"
+          },
+          "supersedes_record_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Supersedes Record Id"
+          }
+        },
+        "required": [
+          "repository_id",
+          "repository_owner_id",
+          "repository",
+          "inventory_state",
+          "inventory_revision",
+          "recorded_at",
+          "source",
+          "reason"
+        ],
+        "title": "RepositoryInventoryRecord",
+        "type": "object"
+      },
       "ResolvedTargetEvidence": {
         "additionalProperties": false,
         "properties": {
@@ -69407,6 +69692,145 @@
           }
         },
         "summary": "Read repository product mapping"
+      }
+    },
+    "/v1/repository-inventory": {
+      "get": {
+        "operationId": "read_repository_inventory",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "repository_id",
+            "required": true,
+            "schema": {
+              "title": "Repository Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "Authorization",
+            "required": false,
+            "schema": {
+              "default": "",
+              "title": "Authorization",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "Cookie",
+            "required": false,
+            "schema": {
+              "default": "",
+              "title": "Cookie",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RepositoryInventoryReadResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "summary": "Read the current inert repository inventory record"
+      }
+    },
+    "/v1/repository-inventory/apply": {
+      "post": {
+        "operationId": "apply_repository_inventory",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Idempotency-Key",
+            "required": false,
+            "schema": {
+              "default": "",
+              "title": "Idempotency-Key",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "Authorization",
+            "required": false,
+            "schema": {
+              "default": "",
+              "title": "Authorization",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RepositoryInventoryApplyEnvelope"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RepositoryInventoryApplyResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "summary": "Apply or dry-run an inert repository inventory record"
       }
     },
     "/v1/route-bindings/external/reconcile": {

--- a/tests/test_authz_repository_scope.py
+++ b/tests/test_authz_repository_scope.py
@@ -27,6 +27,7 @@ from control_plane.contracts.product_profile_record import (
     LaunchplaneProductProfileRecord,
     ProductImageProfile,
 )
+from control_plane.contracts.repository_inventory import RepositoryInventoryRecord
 from control_plane.contracts.repository_human_admission import RepositoryHumanRolePolicyRecord
 from control_plane.contracts.tenant_merge_eligibility import (
     TenantRepositoryClassificationRecord,
@@ -48,11 +49,13 @@ class _Store:
         product_profiles: tuple[LaunchplaneProductProfileRecord, ...] = (),
         role_policies: tuple[RepositoryHumanRolePolicyRecord, ...] = (),
         classifications: tuple[TenantRepositoryClassificationRecord, ...] = (),
+        inventory_records: tuple[RepositoryInventoryRecord, ...] = (),
         work_requests: tuple[EveryCodeWorkRequestRecord, ...] = (),
     ) -> None:
         self.product_profiles = product_profiles
         self.role_policies = role_policies
         self.classifications = classifications
+        self.inventory_records = inventory_records
         self.work_requests = work_requests
 
     def list_product_profile_records(
@@ -86,6 +89,19 @@ class _Store:
         del repository_id
         return self.classifications if limit is None else self.classifications[:limit]
 
+    def list_repository_inventory_records(
+        self,
+        *,
+        repository_id: str = "",
+        limit: int | None = None,
+    ) -> tuple[RepositoryInventoryRecord, ...]:
+        records = tuple(
+            record
+            for record in self.inventory_records
+            if not repository_id or record.repository_id == repository_id
+        )
+        return records if limit is None else records[:limit]
+
     def list_every_code_work_request_records(
         self,
         *,
@@ -113,12 +129,14 @@ class _CliStore(_Store):
         product_profiles: tuple[LaunchplaneProductProfileRecord, ...] = (),
         role_policies: tuple[RepositoryHumanRolePolicyRecord, ...] = (),
         classifications: tuple[TenantRepositoryClassificationRecord, ...] = (),
+        inventory_records: tuple[RepositoryInventoryRecord, ...] = (),
         work_requests: tuple[EveryCodeWorkRequestRecord, ...] = (),
     ) -> None:
         super().__init__(
             product_profiles=product_profiles,
             role_policies=role_policies,
             classifications=classifications,
+            inventory_records=inventory_records,
             work_requests=work_requests,
         )
         self.active_policy_records = active_policy_records
@@ -425,6 +443,104 @@ class AuthzRepositoryScopeTests(unittest.TestCase):
             ("product", "repository_record", "authorization_chain"),
         )
 
+    def test_tracked_inventory_supplies_immutable_repository_identity(self) -> None:
+        request = AuthzRepositoryScopeReadRequest.model_validate(
+            {
+                "candidates": [
+                    {
+                        "repository": REPOSITORY,
+                        "repository_id": REPOSITORY_ID,
+                        "repository_owner_id": REPOSITORY_OWNER_ID,
+                    }
+                ]
+            }
+        )
+        with _handle_key("repository-scope-inventory-key"):
+            response = build_authz_repository_scope_response(
+                trace_id="trace-inventory",
+                generated_at="2026-08-26T12:00:00+00:00",
+                request=request,
+                active_policy_record=_policy_record(repository=REPOSITORY, include_identity=False),
+                store=_Store(inventory_records=(_inventory_record(),)),
+            )
+
+        self.assertEqual(response.coverage.state, "complete")
+        self.assertEqual(response.candidates[0].state, "matched")
+        self.assertEqual(
+            response.candidates[0].memberships,
+            ("repository_record", "authorization_chain"),
+        )
+
+    def test_retired_inventory_does_not_supply_active_repository_membership(self) -> None:
+        tracked = _inventory_record()
+        retired = _inventory_record(
+            revision=2,
+            state="retired",
+            supersedes_record_id=tracked.record_id,
+        )
+        request = AuthzRepositoryScopeReadRequest.model_validate(
+            {
+                "candidates": [
+                    {
+                        "repository": REPOSITORY,
+                        "repository_id": REPOSITORY_ID,
+                        "repository_owner_id": REPOSITORY_OWNER_ID,
+                    }
+                ]
+            }
+        )
+        with _handle_key("repository-scope-retired-key"):
+            response = build_authz_repository_scope_response(
+                trace_id="trace-retired",
+                generated_at="2026-08-26T12:00:00+00:00",
+                request=request,
+                active_policy_record=_policy_record(repository=REPOSITORY),
+                store=_Store(inventory_records=(tracked, retired)),
+            )
+
+        self.assertEqual(response.coverage.state, "partial")
+        self.assertEqual(response.candidates[0].state, "matched")
+        self.assertEqual(response.candidates[0].memberships, ("authorization_chain",))
+        self.assertIn(
+            ("authorization_chain", "stale_authorization_membership", 1),
+            {(gap.source, gap.reason_code, gap.count) for gap in response.coverage.gaps},
+        )
+
+    def test_inventory_can_cover_seventeen_exact_candidates(self) -> None:
+        inventory_records = tuple(
+            _inventory_record(
+                repository=f"example/repository-{index}",
+                repository_id=str(120000 + index),
+                repository_owner_id=str(220000 + index),
+            )
+            for index in range(17)
+        )
+        request = AuthzRepositoryScopeReadRequest.model_validate(
+            {
+                "candidates": [
+                    {
+                        "repository": record.repository,
+                        "repository_id": record.repository_id,
+                        "repository_owner_id": record.repository_owner_id,
+                    }
+                    for record in inventory_records
+                ]
+            }
+        )
+        with _handle_key("repository-scope-seventeen-key"):
+            response = build_authz_repository_scope_response(
+                trace_id="trace-seventeen",
+                generated_at="2026-08-26T12:00:00+00:00",
+                request=request,
+                active_policy_record=_empty_policy_record(),
+                store=_Store(inventory_records=inventory_records),
+            )
+
+        self.assertEqual(response.coverage.state, "complete")
+        self.assertEqual(response.coverage.repository_count, 17)
+        self.assertEqual(response.coverage.matched_repository_count, 17)
+        self.assertEqual({candidate.state for candidate in response.candidates}, {"matched"})
+
     def test_stale_records_cannot_make_authorization_membership_complete(self) -> None:
         request = AuthzRepositoryScopeReadRequest.model_validate(
             {"candidates": [{"repository": REPOSITORY}]}
@@ -605,18 +721,23 @@ def _policy_record(
     *,
     repository: str,
     schema_version: int = 2,
+    include_identity: bool = True,
 ) -> LaunchplaneAuthzPolicyRecord:
+    rule: dict[str, object] = {
+        "repository": repository,
+        "actions": ["deploy.write"],
+    }
+    if include_identity:
+        rule.update(
+            {
+                "repository_id": REPOSITORY_ID,
+                "repository_owner_id": REPOSITORY_OWNER_ID,
+            }
+        )
     policy = LaunchplaneAuthzPolicy.model_validate(
         {
             "schema_version": schema_version,
-            "github_actions": [
-                {
-                    "repository": repository,
-                    "repository_id": REPOSITORY_ID,
-                    "repository_owner_id": REPOSITORY_OWNER_ID,
-                    "actions": ["deploy.write"],
-                }
-            ],
+            "github_actions": [rule],
         }
     )
     digest = authz_policy_sha256(policy)
@@ -626,6 +747,20 @@ def _policy_record(
         status="active",
         source="test:authz-repository-scope",
         updated_at="2026-08-20T22:00:00+00:00",
+        policy_sha256=digest,
+        policy=policy,
+    )
+
+
+def _empty_policy_record() -> LaunchplaneAuthzPolicyRecord:
+    policy = LaunchplaneAuthzPolicy(schema_version=2)
+    digest = authz_policy_sha256(policy)
+    return LaunchplaneAuthzPolicyRecord(
+        record_id=build_authz_policy_record_id(revision=1, policy_sha256=digest),
+        revision=1,
+        status="active",
+        source="test:authz-repository-scope",
+        updated_at="2026-08-26T11:00:00+00:00",
         policy_sha256=digest,
         policy=policy,
     )
@@ -679,6 +814,30 @@ def _classification() -> TenantRepositoryClassificationRecord:
         classified_at="2026-08-20T20:30:00Z",
         source="test:authz-repository-scope",
         reason="repository scope test",
+    )
+
+
+def _inventory_record(
+    *,
+    repository: str = REPOSITORY,
+    repository_id: str = REPOSITORY_ID,
+    repository_owner_id: str = REPOSITORY_OWNER_ID,
+    revision: int = 1,
+    state: str = "tracked",
+    supersedes_record_id: str | None = None,
+) -> RepositoryInventoryRecord:
+    return RepositoryInventoryRecord.model_validate(
+        {
+            "repository_id": repository_id,
+            "repository_owner_id": repository_owner_id,
+            "repository": repository,
+            "inventory_state": state,
+            "inventory_revision": revision,
+            "recorded_at": f"2026-08-26T10:00:0{revision}Z",
+            "source": "test:authz-repository-scope",
+            "reason": "repository inventory evidence",
+            "supersedes_record_id": supersedes_record_id,
+        }
     )
 
 

--- a/tests/test_http_app_browser_mutation.py
+++ b/tests/test_http_app_browser_mutation.py
@@ -63,6 +63,7 @@ class FastApiBrowserMutationBoundaryTests(unittest.IsolatedAsyncioTestCase):
             "/v1/change-impact/evaluation",
             "/v1/agent/privileged-operations/plans",
             "/v1/secrets/reencrypt",
+            "/v1/repository-inventory/apply",
             "/v1/tenant-admission/repository-classifications/apply",
             "/v1/tenant-admission/repository-human-role-policies/apply",
             "/v1/tenant-admission/status/reconcile",

--- a/tests/test_postgres_integration.py
+++ b/tests/test_postgres_integration.py
@@ -89,6 +89,7 @@ from control_plane.contracts.route_binding_record import (
     RouteBindingTls,
 )
 from control_plane.contracts.runtime_identity import RuntimeIdentity
+from control_plane.contracts.repository_inventory import RepositoryInventoryRecord
 from control_plane.contracts.tenant_merge_eligibility import (
     TenantRepositoryClassificationRecord,
 )
@@ -113,6 +114,7 @@ from control_plane.repository_human_admission import (
     TenantTechnicalHumanWaiverEventConflictError,
     TenantTechnicalHumanWaiverStaleAuthorityError,
 )
+from control_plane.repository_inventory import RepositoryInventoryConflictError
 from control_plane.provider_operations import (
     DurableProviderOperationResult,
     ProviderMutationOutcome,
@@ -262,6 +264,29 @@ def _tenant_repository_classification_record(
             "classification_kind": classification_kind,
             "classification_revision": revision,
             "classified_at": classified_at,
+            "source": "postgres-integration",
+            "reason": reason,
+            "supersedes_record_id": supersedes_record_id,
+        }
+    )
+
+
+def _repository_inventory_record(
+    *,
+    revision: int,
+    state: str = "tracked",
+    recorded_at: str = "2026-08-26T10:00:00Z",
+    reason: str = "postgres integration inventory",
+    supersedes_record_id: str | None = None,
+) -> RepositoryInventoryRecord:
+    return RepositoryInventoryRecord.model_validate(
+        {
+            "repository_id": "911001",
+            "repository_owner_id": "912001",
+            "repository": "example/postgres-inventory",
+            "inventory_state": state,
+            "inventory_revision": revision,
+            "recorded_at": recorded_at,
             "source": "postgres-integration",
             "reason": reason,
             "supersedes_record_id": supersedes_record_id,
@@ -2696,6 +2721,125 @@ class RealPostgresStorageConcurrencyTests(unittest.TestCase):
         self.assertEqual(sorted(statuses), ["classification_conflict", "written"])
         self.assertEqual(len(records), 2)
         self.assertEqual(records[0].classification_revision, 2)
+        self.assertEqual(records[1], revision_1)
+        self.assertEqual(len(idempotency_records), 1)
+        self.assertEqual(idempotency_records[0].state, "completed")
+
+    def test_repository_inventory_compare_write_rolls_back_with_idempotency(self) -> None:
+        with _store_for_fresh_head_database() as store:
+            record = _repository_inventory_record(revision=1)
+            mutation = DbOnlyMutationRequest(
+                scope="github-actions:repository-inventory",
+                route_path="/v1/repository-inventory/apply",
+                idempotency_key="postgres-repository-inventory-rollback",
+                request_fingerprint="postgres-repository-inventory-rollback-fingerprint",
+                lease_owner="trace-postgres-repository-inventory-rollback",
+                response_status_code=200,
+                response_trace_id="trace-postgres-repository-inventory-rollback",
+                response_payload={"status": "ok", "record_id": record.record_id},
+            )
+
+            with (
+                patch.object(
+                    store,
+                    "_sync_idempotency_row",
+                    side_effect=RuntimeError("injected completion failure"),
+                ),
+                self.assertRaisesRegex(RuntimeError, "injected completion failure"),
+            ):
+                store.compare_and_write_repository_inventory_record(
+                    record=record,
+                    expected_current_record_id="",
+                    mutation=mutation,
+                )
+
+            records = store.list_repository_inventory_records(repository_id=record.repository_id)
+            idempotency_record = store.read_idempotency_record(
+                scope=mutation.scope,
+                route_path=mutation.route_path,
+                idempotency_key=mutation.idempotency_key,
+            )
+
+        self.assertEqual(records, ())
+        self.assertIsNone(idempotency_record)
+
+    def test_repository_inventory_compare_write_serializes_concurrent_updates(self) -> None:
+        with _store_for_fresh_head_database() as store:
+            revision_1 = _repository_inventory_record(revision=1)
+            store.write_repository_inventory_record(revision_1)
+            revision_2a = _repository_inventory_record(
+                revision=2,
+                state="retired",
+                recorded_at="2026-08-26T10:05:00Z",
+                reason="postgres integration writer one",
+                supersedes_record_id=revision_1.record_id,
+            )
+            revision_2b = _repository_inventory_record(
+                revision=2,
+                state="tracked",
+                recorded_at="2026-08-26T10:05:01Z",
+                reason="postgres integration writer two",
+                supersedes_record_id=revision_1.record_id,
+            )
+            second_store = PostgresRecordStore(database_url=store.database_url)
+            barrier = threading.Barrier(2)
+
+            def apply_revision(
+                active_store: PostgresRecordStore,
+                record: RepositoryInventoryRecord,
+                suffix: str,
+            ) -> str:
+                barrier.wait(timeout=5)
+                try:
+                    return active_store.compare_and_write_repository_inventory_record(
+                        record=record,
+                        expected_current_record_id=revision_1.record_id,
+                        mutation=DbOnlyMutationRequest(
+                            scope="github-actions:repository-inventory",
+                            route_path="/v1/repository-inventory/apply",
+                            idempotency_key=f"postgres-repository-inventory-{suffix}",
+                            request_fingerprint=f"postgres-inventory-fingerprint-{suffix}",
+                            lease_owner=f"trace-postgres-inventory-{suffix}",
+                            response_status_code=200,
+                            response_trace_id=f"trace-postgres-inventory-{suffix}",
+                            response_payload={"status": "ok", "suffix": suffix},
+                        ),
+                    ).status
+                except RepositoryInventoryConflictError:
+                    return "inventory_conflict"
+
+            try:
+                with ThreadPoolExecutor(max_workers=2) as executor:
+                    statuses = tuple(
+                        executor.map(
+                            lambda arguments: apply_revision(*arguments),
+                            (
+                                (store, revision_2a, "writer-1"),
+                                (second_store, revision_2b, "writer-2"),
+                            ),
+                        )
+                    )
+                records = store.list_repository_inventory_records(
+                    repository_id=revision_1.repository_id
+                )
+                idempotency_records = tuple(
+                    record
+                    for suffix in ("writer-1", "writer-2")
+                    if (
+                        record := store.read_idempotency_record(
+                            scope="github-actions:repository-inventory",
+                            route_path="/v1/repository-inventory/apply",
+                            idempotency_key=f"postgres-repository-inventory-{suffix}",
+                        )
+                    )
+                    is not None
+                )
+            finally:
+                second_store.close()
+
+        self.assertEqual(sorted(statuses), ["inventory_conflict", "written"])
+        self.assertEqual(len(records), 2)
+        self.assertEqual(records[0].inventory_revision, 2)
         self.assertEqual(records[1], revision_1)
         self.assertEqual(len(idempotency_records), 1)
         self.assertEqual(idempotency_records[0].state, "completed")

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -158,6 +158,7 @@ from control_plane.contracts.runtime_key_safety_policy import (
     RuntimeKeySafetyPolicyRecord,
     RuntimeSecretSafetyRule,
 )
+from control_plane.contracts.repository_inventory import RepositoryInventoryRecord
 from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneApplyAuditRecord
 from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneApplyAuditStatus
 from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneApplyPolicy
@@ -291,6 +292,33 @@ def _tenant_repository_classification_record(
             "classification_kind": classification_kind,
             "classification_revision": classification_revision,
             "classified_at": classified_at,
+            "source": source,
+            "reason": reason,
+            "supersedes_record_id": supersedes_record_id,
+        }
+    )
+
+
+def _repository_inventory_record(
+    *,
+    repository_id: str = "1101",
+    repository_owner_id: str = "2101",
+    repository: str = "example/repository-inventory",
+    inventory_state: str = "tracked",
+    inventory_revision: int = 1,
+    recorded_at: str = "2026-08-26T10:00:00Z",
+    source: str = "test-source",
+    reason: str = "test-inventory",
+    supersedes_record_id: str | None = None,
+) -> RepositoryInventoryRecord:
+    return RepositoryInventoryRecord.model_validate(
+        {
+            "repository_id": repository_id,
+            "repository_owner_id": repository_owner_id,
+            "repository": repository,
+            "inventory_state": inventory_state,
+            "inventory_revision": inventory_revision,
+            "recorded_at": recorded_at,
             "source": source,
             "reason": reason,
             "supersedes_record_id": supersedes_record_id,
@@ -8426,6 +8454,16 @@ env_var = "GH_TOKEN"
                 _promotion_record(record_id="promotion-20260420T160500Z-opw-testing-to-prod")
             )
             filesystem_store.write_environment_inventory(_inventory_record())
+            repository_inventory_revision_1 = _repository_inventory_record()
+            filesystem_store.write_repository_inventory_record(repository_inventory_revision_1)
+            filesystem_store.write_repository_inventory_record(
+                _repository_inventory_record(
+                    inventory_revision=2,
+                    recorded_at="2026-08-26T10:05:00Z",
+                    reason="updated test inventory",
+                    supersedes_record_id=repository_inventory_revision_1.record_id,
+                )
+            )
             filesystem_store.write_artifact_manifest(_artifact_manifest())
             filesystem_store.write_odoo_instance_override_record(_odoo_instance_override_record())
             filesystem_store.write_preview_record(
@@ -8680,6 +8718,7 @@ env_var = "GH_TOKEN"
                     "release_tuples": 1,
                     "runtime_key_safety_policies": 1,
                     "tenant_repository_classifications": 2,
+                    "repository_inventory": 2,
                 },
             )
             self.assertEqual(
@@ -8690,6 +8729,10 @@ env_var = "GH_TOKEN"
             )
             self.assertEqual(
                 len(store.list_tenant_repository_classification_records(repository_id="1001")),
+                2,
+            )
+            self.assertEqual(
+                len(store.list_repository_inventory_records(repository_id="1101")),
                 2,
             )
             self.assertEqual(

--- a/tests/test_repository_inventory.py
+++ b/tests/test_repository_inventory.py
@@ -6,9 +6,10 @@ from pathlib import Path
 
 from control_plane.contracts.repository_inventory import RepositoryInventoryRecord
 from control_plane.repository_inventory import (
+    RepositoryInventoryApplyResult,
     RepositoryInventoryConflictError,
     RepositoryInventorySequenceError,
-    apply_repository_inventory,
+    dry_run_repository_inventory,
     get_repository_inventory_read_model,
 )
 from control_plane.storage.filesystem import FilesystemRecordStore
@@ -52,28 +53,60 @@ class RepositoryInventoryTests(unittest.TestCase):
         with TemporaryDirectory() as temporary_directory_name:
             store = FilesystemRecordStore(Path(temporary_directory_name))
             first = _record()
-            applied = apply_repository_inventory(store=store, record=first)
-            replay = apply_repository_inventory(store=store, record=first)
-            self.assertEqual(applied.status, "applied")
-            self.assertEqual(replay.status, "replayed")
+            dry_run = dry_run_repository_inventory(store=store, record=first)
+            self.assertEqual(dry_run.status, "would_apply")
+            self.assertEqual(store.write_repository_inventory_record(first), "written")
+            self.assertEqual(store.write_repository_inventory_record(first), "replayed")
             retired = _record(revision=2, state="retired", supersedes_record_id=first.record_id)
             self.assertEqual(
-                apply_repository_inventory(
-                    store=store,
-                    record=retired,
-                    expected_current_record_id=first.record_id,
+                dry_run_repository_inventory(
+                    store=store, record=retired, expected_current_record_id=first.record_id
                 ).status,
-                "applied",
+                "would_apply",
             )
+            self.assertEqual(store.write_repository_inventory_record(retired), "written")
             read_model = get_repository_inventory_read_model(repository_id="1001", store=store)
             self.assertEqual(read_model.current_record, retired)
             with self.assertRaises(RepositoryInventoryConflictError):
-                apply_repository_inventory(store=store, record=_record(revision=2))
+                dry_run_repository_inventory(store=store, record=_record(revision=2))
 
     def test_first_revision_requires_no_predecessor(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             with self.assertRaises(RepositoryInventorySequenceError):
-                apply_repository_inventory(
+                dry_run_repository_inventory(
                     store=FilesystemRecordStore(Path(temporary_directory_name)),
                     record=_record(revision=2),
                 )
+
+    def test_dry_run_rejects_existing_record_without_original_idempotency_key(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(Path(temporary_directory_name))
+            record = _record()
+            store.write_repository_inventory_record(record)
+            with self.assertRaises(RepositoryInventoryConflictError):
+                dry_run_repository_inventory(store=store, record=record)
+
+    def test_record_rejects_tampered_identity_and_digest(self) -> None:
+        record = _record()
+        with self.assertRaises(ValueError):
+            RepositoryInventoryRecord.model_validate(
+                {**record.model_dump(), "record_id": "repository-inventory-1001-r2"}
+            )
+        with self.assertRaises(ValueError):
+            RepositoryInventoryRecord.model_validate(
+                {**record.model_dump(), "inventory_digest": "0" * 64}
+            )
+
+    def test_apply_result_rejects_unsupported_schema_version(self) -> None:
+        record = _record()
+        with self.assertRaises(ValueError):
+            RepositoryInventoryApplyResult(
+                schema_version=2,
+                status="would_apply",
+                mode="dry_run",
+                repository_id=record.repository_id,
+                inventory_revision=record.inventory_revision,
+                record_id=record.record_id,
+                inventory_digest=record.inventory_digest,
+                applied_at=record.recorded_at,
+            )

--- a/tests/test_repository_inventory.py
+++ b/tests/test_repository_inventory.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from tempfile import TemporaryDirectory
+import unittest
+from pathlib import Path
+
+from control_plane.contracts.repository_inventory import RepositoryInventoryRecord
+from control_plane.repository_inventory import (
+    RepositoryInventoryConflictError,
+    RepositoryInventorySequenceError,
+    apply_repository_inventory,
+    get_repository_inventory_read_model,
+)
+from control_plane.storage.filesystem import FilesystemRecordStore
+
+
+def _record(
+    *,
+    revision: int = 1,
+    state: str = "tracked",
+    supersedes_record_id: str | None = None,
+) -> RepositoryInventoryRecord:
+    return RepositoryInventoryRecord.model_validate(
+        {
+            "repository_id": "1001",
+            "repository_owner_id": "100",
+            "repository": "Example-Owner/Example-Repository",
+            "inventory_state": state,
+            "inventory_revision": revision,
+            "recorded_at": "2026-08-26T00:00:00Z",
+            "source": "test",
+            "reason": "synthetic inventory evidence",
+            "supersedes_record_id": supersedes_record_id,
+        }
+    )
+
+
+class RepositoryInventoryTests(unittest.TestCase):
+    def test_record_normalizes_and_hashes_deterministically(self) -> None:
+        record = _record()
+        self.assertEqual(record.repository, "example-owner/example-repository")
+        self.assertEqual(record.record_id, "repository-inventory-1001-r1")
+        self.assertEqual(len(record.inventory_digest), 64)
+
+    def test_record_requires_utc_timestamp(self) -> None:
+        with self.assertRaises(ValueError):
+            _record().model_validate(
+                {**_record().model_dump(), "recorded_at": "2026-08-26T01:00:00+01:00"}
+            )
+
+    def test_append_replay_conflict_and_retirement_read_model(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(Path(temporary_directory_name))
+            first = _record()
+            applied = apply_repository_inventory(store=store, record=first)
+            replay = apply_repository_inventory(store=store, record=first)
+            self.assertEqual(applied.status, "applied")
+            self.assertEqual(replay.status, "replayed")
+            retired = _record(revision=2, state="retired", supersedes_record_id=first.record_id)
+            self.assertEqual(
+                apply_repository_inventory(
+                    store=store,
+                    record=retired,
+                    expected_current_record_id=first.record_id,
+                ).status,
+                "applied",
+            )
+            read_model = get_repository_inventory_read_model(repository_id="1001", store=store)
+            self.assertEqual(read_model.current_record, retired)
+            with self.assertRaises(RepositoryInventoryConflictError):
+                apply_repository_inventory(store=store, record=_record(revision=2))
+
+    def test_first_revision_requires_no_predecessor(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            with self.assertRaises(RepositoryInventorySequenceError):
+                apply_repository_inventory(
+                    store=FilesystemRecordStore(Path(temporary_directory_name)),
+                    record=_record(revision=2),
+                )

--- a/tests/test_repository_inventory_http.py
+++ b/tests/test_repository_inventory_http.py
@@ -1,0 +1,377 @@
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Any, cast
+import unittest
+
+from control_plane.contracts.authz_policy_record import LaunchplaneAuthzPolicyRecord
+from control_plane.contracts.repository_inventory import (
+    REPOSITORY_INVENTORY_READ_ACTION,
+    REPOSITORY_INVENTORY_WRITE_ACTION,
+)
+from control_plane.http_app import create_launchplane_fastapi_app
+from control_plane.service_auth import LaunchplaneAuthzPolicy, TerminalAgentIdentity
+from control_plane.storage.filesystem import FilesystemRecordStore
+from control_plane.storage.postgres import PostgresRecordStore
+from tests.http_app_test_support import _asgi_get, _asgi_request
+from tests.support.auth import StubVerifier, identity
+
+REPOSITORY_ID = "1001"
+REPOSITORY_OWNER_ID = "2001"
+REPOSITORY = "example/repository"
+
+
+class _TestPostgresRecordStore(PostgresRecordStore):
+    @property
+    def database_dialect_name(self) -> str:
+        return "postgresql"
+
+
+def _postgres_store(root: Path) -> PostgresRecordStore:
+    store = _TestPostgresRecordStore(
+        database_url=f"sqlite+pysqlite:///{root / 'launchplane.sqlite3'}"
+    )
+    store.ensure_schema()
+    store.seed_authz_policy_if_absent(
+        LaunchplaneAuthzPolicyRecord(
+            record_id="test-repository-inventory-authz-policy",
+            revision=1,
+            status="active",
+            source="test",
+            updated_at="2026-08-26T00:00:00Z",
+            policy=_authz_policy(
+                actions=(
+                    REPOSITORY_INVENTORY_READ_ACTION,
+                    REPOSITORY_INVENTORY_WRITE_ACTION,
+                )
+            ),
+        )
+    )
+    return store
+
+
+def _authz_policy(*, actions: tuple[str, ...]) -> LaunchplaneAuthzPolicy:
+    return LaunchplaneAuthzPolicy.model_validate(
+        {
+            "schema_version": 2,
+            "github_actions": [
+                {
+                    "repository": "every/verireel",
+                    "workflow_refs": [
+                        "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                    ],
+                    "event_names": ["pull_request"],
+                    "products": ["launchplane"],
+                    "contexts": ["launchplane"],
+                    "actions": list(actions),
+                }
+            ],
+        }
+    )
+
+
+def _payload(
+    *,
+    revision: int = 1,
+    mode: str = "apply",
+    state: str = "tracked",
+    reason: str = "synthetic inventory evidence",
+    expected_current_record_id: str = "",
+    supersedes_record_id: str | None = None,
+) -> dict[str, object]:
+    record: dict[str, object] = {
+        "schema_version": 1,
+        "repository_id": REPOSITORY_ID,
+        "repository_owner_id": REPOSITORY_OWNER_ID,
+        "repository": REPOSITORY,
+        "inventory_state": state,
+        "inventory_revision": revision,
+        "recorded_at": f"2026-08-26T00:00:0{revision}Z",
+        "source": "test",
+        "reason": reason,
+    }
+    if supersedes_record_id is not None:
+        record["supersedes_record_id"] = supersedes_record_id
+    return {
+        "schema_version": 1,
+        "mode": mode,
+        "expected_current_record_id": expected_current_record_id,
+        "record": record,
+    }
+
+
+class RepositoryInventoryHttpTests(unittest.IsolatedAsyncioTestCase):
+    async def test_openapi_documents_repository_inventory_error_contracts(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(Path(temporary_directory_name))
+            app = create_launchplane_fastapi_app(
+                verifier=StubVerifier(identity()),
+                authz_policy=_authz_policy(
+                    actions=(
+                        REPOSITORY_INVENTORY_READ_ACTION,
+                        REPOSITORY_INVENTORY_WRITE_ACTION,
+                    )
+                ),
+                record_store_factory=lambda: store,
+            )
+            paths = app.openapi()["paths"]
+
+        self.assertEqual(
+            set(paths["/v1/repository-inventory"]["get"]["responses"]),
+            {"200", "400", "401", "403", "409", "503"},
+        )
+        self.assertEqual(
+            set(paths["/v1/repository-inventory/apply"]["post"]["responses"]),
+            {"200", "400", "401", "403", "409", "503"},
+        )
+
+    async def test_dry_run_works_with_filesystem_rehearsal_store(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(Path(temporary_directory_name))
+            app = create_launchplane_fastapi_app(
+                verifier=StubVerifier(identity()),
+                authz_policy=_authz_policy(actions=(REPOSITORY_INVENTORY_WRITE_ACTION,)),
+                record_store_factory=lambda: store,
+            )
+            response = await _asgi_request(
+                app,
+                "POST",
+                "/v1/repository-inventory/apply",
+                headers={"Authorization": "Bearer valid-token"},
+                payload=_payload(mode="dry_run"),
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["result"]["status"], "would_apply")
+
+    async def test_apply_is_durable_and_idempotent(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = _postgres_store(Path(temporary_directory_name))
+            app = create_launchplane_fastapi_app(
+                verifier=StubVerifier(identity()),
+                authz_policy=_authz_policy(actions=(REPOSITORY_INVENTORY_WRITE_ACTION,)),
+                record_store_factory=lambda: store,
+            )
+            headers = {
+                "Authorization": "Bearer valid-token",
+                "Idempotency-Key": "repository-inventory-apply-1",
+            }
+            first_response = await _asgi_request(
+                app,
+                "POST",
+                "/v1/repository-inventory/apply",
+                headers=headers,
+                payload=_payload(),
+            )
+            replay_response = await _asgi_request(
+                app,
+                "POST",
+                "/v1/repository-inventory/apply",
+                headers=headers,
+                payload=_payload(),
+            )
+            records = store.list_repository_inventory_records(repository_id=REPOSITORY_ID)
+            store.close()
+
+        self.assertEqual(first_response.status_code, 200)
+        self.assertEqual(first_response.json()["result"]["status"], "applied")
+        self.assertEqual(replay_response.status_code, 200)
+        self.assertTrue(replay_response.json()["replayed"])
+        self.assertEqual(len(records), 1)
+
+    async def test_idempotency_key_conflict_is_fail_closed(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = _postgres_store(Path(temporary_directory_name))
+            app = create_launchplane_fastapi_app(
+                verifier=StubVerifier(identity()),
+                authz_policy=_authz_policy(actions=(REPOSITORY_INVENTORY_WRITE_ACTION,)),
+                record_store_factory=lambda: store,
+            )
+            headers = {
+                "Authorization": "Bearer valid-token",
+                "Idempotency-Key": "repository-inventory-reused",
+            }
+            first_response = await _asgi_request(
+                app,
+                "POST",
+                "/v1/repository-inventory/apply",
+                headers=headers,
+                payload=_payload(),
+            )
+            conflict_response = await _asgi_request(
+                app,
+                "POST",
+                "/v1/repository-inventory/apply",
+                headers=headers,
+                payload=_payload(reason="different payload"),
+            )
+            store.close()
+
+        self.assertEqual(first_response.status_code, 200)
+        self.assertEqual(conflict_response.status_code, 409)
+        self.assertEqual(conflict_response.json()["error"]["code"], "idempotency_key_reused")
+
+    async def test_same_record_with_different_key_conflicts(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = _postgres_store(Path(temporary_directory_name))
+            app = create_launchplane_fastapi_app(
+                verifier=StubVerifier(identity()),
+                authz_policy=_authz_policy(actions=(REPOSITORY_INVENTORY_WRITE_ACTION,)),
+                record_store_factory=lambda: store,
+            )
+            first_response = await _asgi_request(
+                app,
+                "POST",
+                "/v1/repository-inventory/apply",
+                headers={
+                    "Authorization": "Bearer valid-token",
+                    "Idempotency-Key": "repository-inventory-original",
+                },
+                payload=_payload(),
+            )
+            conflict_response = await _asgi_request(
+                app,
+                "POST",
+                "/v1/repository-inventory/apply",
+                headers={
+                    "Authorization": "Bearer valid-token",
+                    "Idempotency-Key": "repository-inventory-different",
+                },
+                payload=_payload(),
+            )
+            store.close()
+
+        self.assertEqual(first_response.status_code, 200)
+        self.assertEqual(conflict_response.status_code, 409)
+        self.assertEqual(
+            conflict_response.json()["error"]["code"],
+            "repository_inventory_conflict",
+        )
+
+    async def test_compare_and_write_rejects_stale_current_record(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = _postgres_store(Path(temporary_directory_name))
+            app = create_launchplane_fastapi_app(
+                verifier=StubVerifier(identity()),
+                authz_policy=_authz_policy(actions=(REPOSITORY_INVENTORY_WRITE_ACTION,)),
+                record_store_factory=lambda: store,
+            )
+            first_response = await _asgi_request(
+                app,
+                "POST",
+                "/v1/repository-inventory/apply",
+                headers={
+                    "Authorization": "Bearer valid-token",
+                    "Idempotency-Key": "repository-inventory-revision-1",
+                },
+                payload=_payload(),
+            )
+            record_id = first_response.json()["result"]["record_id"]
+            conflict_response = await _asgi_request(
+                app,
+                "POST",
+                "/v1/repository-inventory/apply",
+                headers={
+                    "Authorization": "Bearer valid-token",
+                    "Idempotency-Key": "repository-inventory-revision-2",
+                },
+                payload=_payload(
+                    revision=2,
+                    state="retired",
+                    expected_current_record_id="repository-inventory-1001-r0",
+                    supersedes_record_id=record_id,
+                ),
+            )
+            records = store.list_repository_inventory_records(repository_id=REPOSITORY_ID)
+            store.close()
+
+        self.assertEqual(conflict_response.status_code, 409)
+        self.assertEqual(len(records), 1)
+
+    async def test_read_returns_current_inventory_record(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = _postgres_store(Path(temporary_directory_name))
+            app = create_launchplane_fastapi_app(
+                verifier=StubVerifier(identity()),
+                authz_policy=_authz_policy(
+                    actions=(
+                        REPOSITORY_INVENTORY_READ_ACTION,
+                        REPOSITORY_INVENTORY_WRITE_ACTION,
+                    )
+                ),
+                record_store_factory=lambda: store,
+            )
+            await _asgi_request(
+                app,
+                "POST",
+                "/v1/repository-inventory/apply",
+                headers={
+                    "Authorization": "Bearer valid-token",
+                    "Idempotency-Key": "repository-inventory-read-setup",
+                },
+                payload=_payload(),
+            )
+            response = await _asgi_get(
+                app,
+                f"/v1/repository-inventory?repository_id={REPOSITORY_ID}",
+                headers={"Authorization": "Bearer valid-token"},
+            )
+            store.close()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["read_model"]["status"], "available")
+        self.assertEqual(
+            response.json()["read_model"]["current_record"]["repository_id"],
+            REPOSITORY_ID,
+        )
+
+    async def test_apply_requires_shared_postgresql_storage(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=(
+                    f"sqlite+pysqlite:///{Path(temporary_directory_name) / 'launchplane.sqlite3'}"
+                )
+            )
+            store.ensure_schema()
+            app = create_launchplane_fastapi_app(
+                verifier=StubVerifier(identity()),
+                authz_policy=_authz_policy(actions=(REPOSITORY_INVENTORY_WRITE_ACTION,)),
+                record_store_factory=lambda: store,
+            )
+            response = await _asgi_request(
+                app,
+                "POST",
+                "/v1/repository-inventory/apply",
+                headers={
+                    "Authorization": "Bearer valid-token",
+                    "Idempotency-Key": "repository-inventory-sqlite",
+                },
+                payload=_payload(),
+            )
+            store.close()
+
+        self.assertEqual(response.status_code, 503)
+        self.assertEqual(response.json()["error"]["code"], "database_storage_required")
+
+    async def test_terminal_agent_write_is_denied(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(Path(temporary_directory_name))
+            app = create_launchplane_fastapi_app(
+                verifier=StubVerifier(
+                    cast(
+                        Any,
+                        TerminalAgentIdentity(subject="agent", token_label="agent-token"),
+                    )
+                ),
+                authz_policy=LaunchplaneAuthzPolicy(),
+                record_store_factory=lambda: store,
+            )
+            response = await _asgi_request(
+                app,
+                "POST",
+                "/v1/repository-inventory/apply",
+                headers={"Authorization": "Bearer valid-token"},
+                payload=_payload(mode="dry_run"),
+            )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.json()["error"]["code"], "authorization_denied")

--- a/tests/test_schema_migration.py
+++ b/tests/test_schema_migration.py
@@ -1505,7 +1505,7 @@ class SchemaMigrationTests(unittest.TestCase):
             for primary_key in CRITICAL_PRIMARY_KEYS
         }
 
-        self.assertEqual(EXPECTED_ALEMBIC_HEAD_REVISION, "f2239a0b1c2d")
+        self.assertEqual(EXPECTED_ALEMBIC_HEAD_REVISION, "f2241a0b1c2d")
         self.assertNotIn(
             ("launchplane_human_sessions", "launchplane_human_sessions_github_id_idx"),
             indexes,


### PR DESCRIPTION
## Summary
- add inert append-only repository inventory records with PostgreSQL and filesystem storage
- add durable idempotent atomic CAS apply/read service endpoints
- include tracked inventory in repository-scope evidence and preserve retired-state gaps
- add migration, schema invariants, OpenAPI, docs, and focused unit/PostgreSQL coverage

## Validation
- `uv run --extra dev launchplane ci unittest-shard local` (3,137 targets)
- `LAUNCHPLANE_TEST_POSTGRES_URL=... uv run --extra dev launchplane ci postgres-integration` (93 tests)
- `uv run --extra dev ruff check .`
- `uv run --extra dev mypy control_plane tests`
- `pnpm --dir frontend validate`
- `uv run launchplane service audit-config-authority --control-plane-root .`
- JetBrains inspection: only two duplicate-code warnings for standard route dependency/response scaffolding; no correctness findings

Refs #2251
Refs #2177