### PR TITLE
Refresh runtime stage for container security scans

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,8 @@ jobs:
           context: .
           load: true
           tags: ${{ env.LAUNCHPLANE_CI_IMAGE_TAG }}
+          pull: true
+          no-cache-filters: runtime
           cache-from: >-
             type=gha,scope=launchplane-ci
           cache-to: >-
@@ -172,6 +174,8 @@ jobs:
           context: .
           load: true
           tags: ${{ env.LAUNCHPLANE_CI_IMAGE_TAG }}
+          pull: true
+          no-cache-filters: runtime
           cache-from: >-
             type=gha,scope=launchplane-ci
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN github_cli_x_mod_version=v0.40.0 \
     && go version -m /go/bin/gh | grep -F "golang.org/x/mod" | grep -F "${github_cli_x_mod_version}" \
     && go version -m /go/bin/gh | grep -F "golang.org/x/text" | grep -F "${GITHUB_CLI_X_TEXT_VERSION}"
 
-FROM mirror.gcr.io/library/python:3.13-slim
+FROM mirror.gcr.io/library/python:3.13-slim AS runtime
 
 LABEL org.opencontainers.image.source="https://github.com/cbusillo/launchplane"
 

--- a/docs/github-actions-security.md
+++ b/docs/github-actions-security.md
@@ -92,6 +92,11 @@ written to the workflow log by the upstream implementation.
   use a release tag plus a 64-character `sha256` manifest digest. Mutable tags
   without a digest are rejected.
 
+Container vulnerability scans pull current base-image references and invalidate
+only the named `runtime` build stage. This preserves cache for the frontend and
+GitHub CLI build stages while forcing runtime OS package upgrades and dependency
+installation to run against current security repositories on every scan.
+
 The security workflow runs this policy for both same-repository and fork pull
 requests before actionlint. The unit-test suite runs it as well, so a mutable
 reference cannot pass the required CI path.

--- a/tests/test_service_image_contract.py
+++ b/tests/test_service_image_contract.py
@@ -140,7 +140,7 @@ class ServiceImageContractTests(unittest.TestCase):
 
         dockerfile_text = dockerfile.read_text(encoding="utf-8")
         runtime_stage = re.search(
-            r"(?ms)^FROM\s+\S*python:3\.13-slim\s*$"
+            r"(?ms)^FROM\s+\S*python:3\.13-slim\s+AS\s+runtime\s*$"
             r"(?P<body>.*?)(?=^FROM\s|\Z)",
             dockerfile_text,
         )

--- a/tests/test_workflow_invariants.py
+++ b/tests/test_workflow_invariants.py
@@ -10,6 +10,22 @@ from tests.support.workflows import load_workflow
 
 
 class WorkflowInvariantCheckerTests(unittest.TestCase):
+    def test_container_scans_refresh_runtime_security_packages(self) -> None:
+        workflow = load_workflow(".github/workflows/ci.yml")
+        dockerfile = Path("Dockerfile").read_text(encoding="utf-8")
+
+        self.assertIn("FROM mirror.gcr.io/library/python:3.13-slim AS runtime", dockerfile)
+        for job_id in ("container_scan", "container_scan_fork"):
+            with self.subTest(job_id=job_id):
+                step = workflow.step_named(job_id, "Build runtime image")
+                self.assertIsNotNone(step)
+                assert step is not None
+                build_inputs = step.data.get("with")
+                self.assertIsInstance(build_inputs, dict)
+                assert isinstance(build_inputs, dict)
+                self.assertTrue(build_inputs.get("pull"))
+                self.assertEqual(build_inputs.get("no-cache-filters"), "runtime")
+
     def test_postgres_service_uses_ipv4_only_dynamic_host_port(self) -> None:
         workflow_text = Path(".github/workflows/ci.yml").read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary
- name the final Docker stage `runtime`
- pull current base references for container scan builds
- invalidate only the runtime stage so OS security upgrades and runtime dependencies refresh while frontend/GitHub CLI stages remain cacheable
- add workflow invariant coverage and document the security boundary

## Incident Evidence
PR #2253 exposed a newly fixed Debian OpenSSL CVE, but repeated CI reruns reused the cached runtime stage and kept `3.5.6-1~deb13u2`. A local Buildx run with this change upgraded `libssl3t64`, `openssl`, and `openssl-provider-legacy` to `3.5.7-1~deb13u2`; the exact pinned Trivy scan then reported zero HIGH/CRITICAL vulnerabilities.

## Validation
- `uv run --extra dev python -m unittest tests.test_workflow_invariants tests.test_github_actions_security tests.test_docs_contracts`
- `uv run --extra dev ruff check tests/test_workflow_invariants.py`
- `uv run --extra dev ruff format --check tests/test_workflow_invariants.py`
- `docker buildx build --pull --no-cache-filter runtime --load -t launchplane-ci:runtime-refresh .`
- pinned Trivy HIGH/CRITICAL scan: clean
- JetBrains changed-files inspection: GREEN

Blocks #2253