### PR TITLE
Add owner-control conformance contract

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -30,6 +30,7 @@
     "runnerHostHygiene": "docs/runner-host-hygiene.md",
     "productOwnerPolicy": "docs/product-owner-policy.md",
     "ownerAcceptance": "docs/owner-acceptance.md",
+    "ownerControlChannel": "docs/owner-control-channel.md",
     "privilegedOperations": "docs/privileged-operations.md",
     "changeImpactPolicy": "docs/change-impact-policy.md",
     "agentContextBoundary": "docs/agent-context-boundary.md",
@@ -80,6 +81,11 @@
       "artifact": "contracts/agent-operator-contract.json",
       "export": "uv run launchplane service export-agent-contract --output contracts/agent-operator-contract.json",
       "drift": "pnpm --dir frontend check:openapi-drift"
+    },
+    "ownerControlContract": {
+      "artifact": "contracts/owner-control-contract.json",
+      "export": "uv run launchplane service export-owner-control-contract --output contracts/owner-control-contract.json",
+      "drift": "uv run --extra dev python -m unittest tests.test_owner_control_contract.OwnerControlArtifactTests.test_checked_artifact_matches_generated_contract"
     },
     "audit": {
       "pythonDependencies": "uv run --with pip-audit pip-audit --ignore-vuln PYSEC-2025-183",

--- a/contracts/owner-control-contract.json
+++ b/contracts/owner-control-contract.json
@@ -1,0 +1,1251 @@
+{
+  "canonical_json": {
+    "encoding": "utf-8",
+    "ensure_ascii": true,
+    "integer_max": 9223372036854775807,
+    "integer_min": -9223372036854775808,
+    "non_finite_numbers": "rejected",
+    "number_domain": "signed-64-bit-integers-only",
+    "object_key_order": "unicode-code-point",
+    "object_keys": "strings-only",
+    "separators": [
+      ",",
+      ":"
+    ],
+    "trailing_newline": false
+  },
+  "canonicalization_vectors": [
+    {
+      "canonical_json": "{\"array\":[true,false,null,7],\"integer_max\":9223372036854775807,\"integer_min\":-9223372036854775808}",
+      "name": "primitive-types",
+      "payload": {
+        "array": [
+          true,
+          false,
+          null,
+          7
+        ],
+        "integer_max": 9223372036854775807,
+        "integer_min": -9223372036854775808
+      },
+      "sha256": "7a00552de9224a55b740cd0883ecc246fa89b4a9a18442a35d5e072ba4621b87"
+    },
+    {
+      "canonical_json": "{\"controls\":\"null\\u0000unit\\u001fdelete\\u007fline\\n\\ttab\\\\quote\\\"\",\"text\":\"\\u03bc\\ud83d\\ude00\"}",
+      "name": "unicode-and-escapes",
+      "payload": {
+        "controls": "null\u0000unit\u001fdelete\u007fline\n\ttab\\quote\"",
+        "text": "\u03bc\ud83d\ude00"
+      },
+      "sha256": "cffd0f153013c382f49535b543d7bb9c72c3179dec4f44d8052e9b232f33e820"
+    },
+    {
+      "canonical_json": "{\"a\":1,\"\\uff3a\":2,\"\\ud83d\\ude00\":3}",
+      "name": "unicode-key-order",
+      "payload": {
+        "a": 1,
+        "\uff3a": 2,
+        "\ud83d\ude00": 3
+      },
+      "sha256": "c761396384dc740b5064bd3afd53e474ee5f342a34ef3a4600a9dafd361bf1be"
+    },
+    {
+      "canonical_json": "{\"empty_array\":[],\"empty_object\":{},\"nested\":[{\"x\":[]}]}",
+      "name": "empty-and-nested",
+      "payload": {
+        "empty_array": [],
+        "empty_object": {},
+        "nested": [
+          {
+            "x": []
+          }
+        ]
+      },
+      "sha256": "07db6c156108fd238db2691d759e6fe5d8f8649fb5e9c8130dc3f98342ba5ae2"
+    }
+  ],
+  "golden_vectors": [
+    {
+      "approval_request": {
+        "canonical_json": "{\"descriptor_id\":\"managed-authz-policy-set\",\"descriptor_version\":1,\"evidence_digest\":\"df6da961581b149a28639add56e3b08401b3bed6afb07ad0c7b5ca3d51632be9\",\"expires_at\":\"2030-01-02T03:09:05+00:00\",\"issued_at\":\"2030-01-02T03:00:05+00:00\",\"nonce\":\"owner-control-b565a7b3115d408e250eeffe65af9513\",\"operation_id\":\"privileged-operation-1d762a6ac3895594ed85ba7aa9c39330\",\"owner_github_id\":494383370,\"plan_digest\":\"edf23f94b33d1188e34e143e7aff91075ec941053b3b95d367a45de67b1fe1d7\",\"policy_record_id\":\"owner-policy-1d762a6ac3895594ed85\",\"policy_revision\":1,\"policy_sha256\":\"b379db2fe113e77eef0b3bb05aec804189d9f0b359e67d941d837c7de59e6f8e\",\"pre_state_digest\":\"46df3876ade6b39b0edfbd3b8ea1a408173bbe5d8cc7154cea4d63e5d057239f\",\"request_digest\":\"e0e31f55312d2562bf610587d7a21b5badeed50224284b08d1662924379b4539\",\"schema_version\":1,\"server_review\":{\"items\":[{\"key\":\"descriptor\",\"label\":\"Operation class\",\"value\":\"managed-authz-policy-set\"},{\"key\":\"safety_class\",\"label\":\"Safety class\",\"value\":\"policy_admin\"}],\"review_id\":\"review-1d762a6ac3895594ed85ba7a\",\"schema_version\":1,\"summary\":\"Review this exact privileged operation before confirming.\",\"title\":\"Owner approval required\"}}",
+        "payload": {
+          "descriptor_id": "managed-authz-policy-set",
+          "descriptor_version": 1,
+          "evidence_digest": "df6da961581b149a28639add56e3b08401b3bed6afb07ad0c7b5ca3d51632be9",
+          "expires_at": "2030-01-02T03:09:05+00:00",
+          "issued_at": "2030-01-02T03:00:05+00:00",
+          "nonce": "owner-control-b565a7b3115d408e250eeffe65af9513",
+          "operation_id": "privileged-operation-1d762a6ac3895594ed85ba7aa9c39330",
+          "owner_github_id": 494383370,
+          "plan_digest": "edf23f94b33d1188e34e143e7aff91075ec941053b3b95d367a45de67b1fe1d7",
+          "policy_record_id": "owner-policy-1d762a6ac3895594ed85",
+          "policy_revision": 1,
+          "policy_sha256": "b379db2fe113e77eef0b3bb05aec804189d9f0b359e67d941d837c7de59e6f8e",
+          "pre_state_digest": "46df3876ade6b39b0edfbd3b8ea1a408173bbe5d8cc7154cea4d63e5d057239f",
+          "request_digest": "e0e31f55312d2562bf610587d7a21b5badeed50224284b08d1662924379b4539",
+          "schema_version": 1,
+          "server_review": {
+            "items": [
+              {
+                "key": "descriptor",
+                "label": "Operation class",
+                "value": "managed-authz-policy-set"
+              },
+              {
+                "key": "safety_class",
+                "label": "Safety class",
+                "value": "policy_admin"
+              }
+            ],
+            "review_id": "review-1d762a6ac3895594ed85ba7a",
+            "schema_version": 1,
+            "summary": "Review this exact privileged operation before confirming.",
+            "title": "Owner approval required"
+          }
+        },
+        "sha256": "a60572025b121241d44c3f28ce22715841e348765dd50cfa514861e89334d9eb"
+      },
+      "challenge_response": {
+        "canonical_json": "{\"approval_request\":{\"descriptor_id\":\"managed-authz-policy-set\",\"descriptor_version\":1,\"evidence_digest\":\"df6da961581b149a28639add56e3b08401b3bed6afb07ad0c7b5ca3d51632be9\",\"expires_at\":\"2030-01-02T03:09:05+00:00\",\"issued_at\":\"2030-01-02T03:00:05+00:00\",\"nonce\":\"owner-control-b565a7b3115d408e250eeffe65af9513\",\"operation_id\":\"privileged-operation-1d762a6ac3895594ed85ba7aa9c39330\",\"owner_github_id\":494383370,\"plan_digest\":\"edf23f94b33d1188e34e143e7aff91075ec941053b3b95d367a45de67b1fe1d7\",\"policy_record_id\":\"owner-policy-1d762a6ac3895594ed85\",\"policy_revision\":1,\"policy_sha256\":\"b379db2fe113e77eef0b3bb05aec804189d9f0b359e67d941d837c7de59e6f8e\",\"pre_state_digest\":\"46df3876ade6b39b0edfbd3b8ea1a408173bbe5d8cc7154cea4d63e5d057239f\",\"request_digest\":\"e0e31f55312d2562bf610587d7a21b5badeed50224284b08d1662924379b4539\",\"schema_version\":1,\"server_review\":{\"items\":[{\"key\":\"descriptor\",\"label\":\"Operation class\",\"value\":\"managed-authz-policy-set\"},{\"key\":\"safety_class\",\"label\":\"Safety class\",\"value\":\"policy_admin\"}],\"review_id\":\"review-1d762a6ac3895594ed85ba7a\",\"schema_version\":1,\"summary\":\"Review this exact privileged operation before confirming.\",\"title\":\"Owner approval required\"}},\"approval_request_digest\":\"a60572025b121241d44c3f28ce22715841e348765dd50cfa514861e89334d9eb\",\"channel_binding_sha256\":\"023b40df5087274959331ae05a557806bcc6bd01682ed7d464bfc6985ef846a6\",\"confirmed_at\":\"2030-01-02T03:04:05+00:00\",\"decision\":\"approved\",\"schema_version\":1}",
+        "payload": {
+          "approval_request": {
+            "descriptor_id": "managed-authz-policy-set",
+            "descriptor_version": 1,
+            "evidence_digest": "df6da961581b149a28639add56e3b08401b3bed6afb07ad0c7b5ca3d51632be9",
+            "expires_at": "2030-01-02T03:09:05+00:00",
+            "issued_at": "2030-01-02T03:00:05+00:00",
+            "nonce": "owner-control-b565a7b3115d408e250eeffe65af9513",
+            "operation_id": "privileged-operation-1d762a6ac3895594ed85ba7aa9c39330",
+            "owner_github_id": 494383370,
+            "plan_digest": "edf23f94b33d1188e34e143e7aff91075ec941053b3b95d367a45de67b1fe1d7",
+            "policy_record_id": "owner-policy-1d762a6ac3895594ed85",
+            "policy_revision": 1,
+            "policy_sha256": "b379db2fe113e77eef0b3bb05aec804189d9f0b359e67d941d837c7de59e6f8e",
+            "pre_state_digest": "46df3876ade6b39b0edfbd3b8ea1a408173bbe5d8cc7154cea4d63e5d057239f",
+            "request_digest": "e0e31f55312d2562bf610587d7a21b5badeed50224284b08d1662924379b4539",
+            "schema_version": 1,
+            "server_review": {
+              "items": [
+                {
+                  "key": "descriptor",
+                  "label": "Operation class",
+                  "value": "managed-authz-policy-set"
+                },
+                {
+                  "key": "safety_class",
+                  "label": "Safety class",
+                  "value": "policy_admin"
+                }
+              ],
+              "review_id": "review-1d762a6ac3895594ed85ba7a",
+              "schema_version": 1,
+              "summary": "Review this exact privileged operation before confirming.",
+              "title": "Owner approval required"
+            }
+          },
+          "approval_request_digest": "a60572025b121241d44c3f28ce22715841e348765dd50cfa514861e89334d9eb",
+          "channel_binding_sha256": "023b40df5087274959331ae05a557806bcc6bd01682ed7d464bfc6985ef846a6",
+          "confirmed_at": "2030-01-02T03:04:05+00:00",
+          "decision": "approved",
+          "schema_version": 1
+        },
+        "sha256": "4506266fb13d70228e460dc724dd02337d1367f87003ca118c0eb44dea6d0fd1"
+      },
+      "descriptor_id": "managed-authz-policy-set",
+      "descriptor_version": 1
+    },
+    {
+      "approval_request": {
+        "canonical_json": "{\"descriptor_id\":\"managed-secret-reencryption\",\"descriptor_version\":1,\"evidence_digest\":\"9823b32b0823bd4004bacdbe08391b3e0120e8f24c36f91474115ef9fa01155d\",\"expires_at\":\"2030-01-02T03:09:05+00:00\",\"issued_at\":\"2030-01-02T03:00:05+00:00\",\"nonce\":\"owner-control-1bb1a85cd3cf848e5c7a0ee17410addb\",\"operation_id\":\"privileged-operation-9a9d1838b14102ef23bc2528687abda0\",\"owner_github_id\":2594086616,\"plan_digest\":\"f87d15dd32b95865b4fe98cc67c5c418757a0559488488355bb0cf52a06cdf95\",\"policy_record_id\":\"owner-policy-9a9d1838b14102ef23bc\",\"policy_revision\":1,\"policy_sha256\":\"158ffbbe76bc73789a3e644e339411d8569ed880328b1e7728e7db3a25f1be8f\",\"pre_state_digest\":\"96cb3e8e7bc9a596d31b699bd6ea1681651eda477f9b7a6c482f9378e6798d58\",\"request_digest\":\"4a9624ebacf973b34eeb4762279d052e3c637d8090cb79ecbb217fa320a58d68\",\"schema_version\":1,\"server_review\":{\"items\":[{\"key\":\"descriptor\",\"label\":\"Operation class\",\"value\":\"managed-secret-reencryption\"},{\"key\":\"safety_class\",\"label\":\"Safety class\",\"value\":\"secret_backed\"}],\"review_id\":\"review-9a9d1838b14102ef23bc2528\",\"schema_version\":1,\"summary\":\"Review this exact privileged operation before confirming.\",\"title\":\"Owner approval required\"}}",
+        "payload": {
+          "descriptor_id": "managed-secret-reencryption",
+          "descriptor_version": 1,
+          "evidence_digest": "9823b32b0823bd4004bacdbe08391b3e0120e8f24c36f91474115ef9fa01155d",
+          "expires_at": "2030-01-02T03:09:05+00:00",
+          "issued_at": "2030-01-02T03:00:05+00:00",
+          "nonce": "owner-control-1bb1a85cd3cf848e5c7a0ee17410addb",
+          "operation_id": "privileged-operation-9a9d1838b14102ef23bc2528687abda0",
+          "owner_github_id": 2594086616,
+          "plan_digest": "f87d15dd32b95865b4fe98cc67c5c418757a0559488488355bb0cf52a06cdf95",
+          "policy_record_id": "owner-policy-9a9d1838b14102ef23bc",
+          "policy_revision": 1,
+          "policy_sha256": "158ffbbe76bc73789a3e644e339411d8569ed880328b1e7728e7db3a25f1be8f",
+          "pre_state_digest": "96cb3e8e7bc9a596d31b699bd6ea1681651eda477f9b7a6c482f9378e6798d58",
+          "request_digest": "4a9624ebacf973b34eeb4762279d052e3c637d8090cb79ecbb217fa320a58d68",
+          "schema_version": 1,
+          "server_review": {
+            "items": [
+              {
+                "key": "descriptor",
+                "label": "Operation class",
+                "value": "managed-secret-reencryption"
+              },
+              {
+                "key": "safety_class",
+                "label": "Safety class",
+                "value": "secret_backed"
+              }
+            ],
+            "review_id": "review-9a9d1838b14102ef23bc2528",
+            "schema_version": 1,
+            "summary": "Review this exact privileged operation before confirming.",
+            "title": "Owner approval required"
+          }
+        },
+        "sha256": "a158dabb09e35c75932985b8682c34f7f598a2b1404ac80a9e4fa0d4a19313c4"
+      },
+      "challenge_response": {
+        "canonical_json": "{\"approval_request\":{\"descriptor_id\":\"managed-secret-reencryption\",\"descriptor_version\":1,\"evidence_digest\":\"9823b32b0823bd4004bacdbe08391b3e0120e8f24c36f91474115ef9fa01155d\",\"expires_at\":\"2030-01-02T03:09:05+00:00\",\"issued_at\":\"2030-01-02T03:00:05+00:00\",\"nonce\":\"owner-control-1bb1a85cd3cf848e5c7a0ee17410addb\",\"operation_id\":\"privileged-operation-9a9d1838b14102ef23bc2528687abda0\",\"owner_github_id\":2594086616,\"plan_digest\":\"f87d15dd32b95865b4fe98cc67c5c418757a0559488488355bb0cf52a06cdf95\",\"policy_record_id\":\"owner-policy-9a9d1838b14102ef23bc\",\"policy_revision\":1,\"policy_sha256\":\"158ffbbe76bc73789a3e644e339411d8569ed880328b1e7728e7db3a25f1be8f\",\"pre_state_digest\":\"96cb3e8e7bc9a596d31b699bd6ea1681651eda477f9b7a6c482f9378e6798d58\",\"request_digest\":\"4a9624ebacf973b34eeb4762279d052e3c637d8090cb79ecbb217fa320a58d68\",\"schema_version\":1,\"server_review\":{\"items\":[{\"key\":\"descriptor\",\"label\":\"Operation class\",\"value\":\"managed-secret-reencryption\"},{\"key\":\"safety_class\",\"label\":\"Safety class\",\"value\":\"secret_backed\"}],\"review_id\":\"review-9a9d1838b14102ef23bc2528\",\"schema_version\":1,\"summary\":\"Review this exact privileged operation before confirming.\",\"title\":\"Owner approval required\"}},\"approval_request_digest\":\"a158dabb09e35c75932985b8682c34f7f598a2b1404ac80a9e4fa0d4a19313c4\",\"channel_binding_sha256\":\"4a000cc8036cc97f077bc431ad78ce27f5a940d5766377ef2de3d964229b8a9c\",\"confirmed_at\":\"2030-01-02T03:04:05+00:00\",\"decision\":\"approved\",\"schema_version\":1}",
+        "payload": {
+          "approval_request": {
+            "descriptor_id": "managed-secret-reencryption",
+            "descriptor_version": 1,
+            "evidence_digest": "9823b32b0823bd4004bacdbe08391b3e0120e8f24c36f91474115ef9fa01155d",
+            "expires_at": "2030-01-02T03:09:05+00:00",
+            "issued_at": "2030-01-02T03:00:05+00:00",
+            "nonce": "owner-control-1bb1a85cd3cf848e5c7a0ee17410addb",
+            "operation_id": "privileged-operation-9a9d1838b14102ef23bc2528687abda0",
+            "owner_github_id": 2594086616,
+            "plan_digest": "f87d15dd32b95865b4fe98cc67c5c418757a0559488488355bb0cf52a06cdf95",
+            "policy_record_id": "owner-policy-9a9d1838b14102ef23bc",
+            "policy_revision": 1,
+            "policy_sha256": "158ffbbe76bc73789a3e644e339411d8569ed880328b1e7728e7db3a25f1be8f",
+            "pre_state_digest": "96cb3e8e7bc9a596d31b699bd6ea1681651eda477f9b7a6c482f9378e6798d58",
+            "request_digest": "4a9624ebacf973b34eeb4762279d052e3c637d8090cb79ecbb217fa320a58d68",
+            "schema_version": 1,
+            "server_review": {
+              "items": [
+                {
+                  "key": "descriptor",
+                  "label": "Operation class",
+                  "value": "managed-secret-reencryption"
+                },
+                {
+                  "key": "safety_class",
+                  "label": "Safety class",
+                  "value": "secret_backed"
+                }
+              ],
+              "review_id": "review-9a9d1838b14102ef23bc2528",
+              "schema_version": 1,
+              "summary": "Review this exact privileged operation before confirming.",
+              "title": "Owner approval required"
+            }
+          },
+          "approval_request_digest": "a158dabb09e35c75932985b8682c34f7f598a2b1404ac80a9e4fa0d4a19313c4",
+          "channel_binding_sha256": "4a000cc8036cc97f077bc431ad78ce27f5a940d5766377ef2de3d964229b8a9c",
+          "confirmed_at": "2030-01-02T03:04:05+00:00",
+          "decision": "approved",
+          "schema_version": 1
+        },
+        "sha256": "76b409c883d422aef5378d03dfe1527c16f2f1ac41b8b81202a71c2375641a28"
+      },
+      "descriptor_id": "managed-secret-reencryption",
+      "descriptor_version": 1
+    }
+  ],
+  "negative_vectors": [
+    {
+      "error_location": [
+        "schema_version"
+      ],
+      "model": "approval_request",
+      "payload": {
+        "descriptor_id": "managed-authz-policy-set",
+        "descriptor_version": 1,
+        "evidence_digest": "df6da961581b149a28639add56e3b08401b3bed6afb07ad0c7b5ca3d51632be9",
+        "expires_at": "2030-01-02T03:09:05+00:00",
+        "issued_at": "2030-01-02T03:00:05+00:00",
+        "nonce": "owner-control-b565a7b3115d408e250eeffe65af9513",
+        "operation_id": "privileged-operation-1d762a6ac3895594ed85ba7aa9c39330",
+        "owner_github_id": 494383370,
+        "plan_digest": "edf23f94b33d1188e34e143e7aff91075ec941053b3b95d367a45de67b1fe1d7",
+        "policy_record_id": "owner-policy-1d762a6ac3895594ed85",
+        "policy_revision": 1,
+        "policy_sha256": "b379db2fe113e77eef0b3bb05aec804189d9f0b359e67d941d837c7de59e6f8e",
+        "pre_state_digest": "46df3876ade6b39b0edfbd3b8ea1a408173bbe5d8cc7154cea4d63e5d057239f",
+        "request_digest": "e0e31f55312d2562bf610587d7a21b5badeed50224284b08d1662924379b4539",
+        "schema_version": 2,
+        "server_review": {
+          "items": [
+            {
+              "key": "descriptor",
+              "label": "Operation class",
+              "value": "managed-authz-policy-set"
+            },
+            {
+              "key": "safety_class",
+              "label": "Safety class",
+              "value": "policy_admin"
+            }
+          ],
+          "review_id": "review-1d762a6ac3895594ed85ba7a",
+          "schema_version": 1,
+          "summary": "Review this exact privileged operation before confirming.",
+          "title": "Owner approval required"
+        }
+      },
+      "rule": "schema-version-is-one"
+    },
+    {
+      "error_location": [
+        "descriptor_version"
+      ],
+      "model": "approval_request",
+      "payload": {
+        "descriptor_id": "managed-authz-policy-set",
+        "descriptor_version": 2,
+        "evidence_digest": "df6da961581b149a28639add56e3b08401b3bed6afb07ad0c7b5ca3d51632be9",
+        "expires_at": "2030-01-02T03:09:05+00:00",
+        "issued_at": "2030-01-02T03:00:05+00:00",
+        "nonce": "owner-control-b565a7b3115d408e250eeffe65af9513",
+        "operation_id": "privileged-operation-1d762a6ac3895594ed85ba7aa9c39330",
+        "owner_github_id": 494383370,
+        "plan_digest": "edf23f94b33d1188e34e143e7aff91075ec941053b3b95d367a45de67b1fe1d7",
+        "policy_record_id": "owner-policy-1d762a6ac3895594ed85",
+        "policy_revision": 1,
+        "policy_sha256": "b379db2fe113e77eef0b3bb05aec804189d9f0b359e67d941d837c7de59e6f8e",
+        "pre_state_digest": "46df3876ade6b39b0edfbd3b8ea1a408173bbe5d8cc7154cea4d63e5d057239f",
+        "request_digest": "e0e31f55312d2562bf610587d7a21b5badeed50224284b08d1662924379b4539",
+        "schema_version": 1,
+        "server_review": {
+          "items": [
+            {
+              "key": "descriptor",
+              "label": "Operation class",
+              "value": "managed-authz-policy-set"
+            },
+            {
+              "key": "safety_class",
+              "label": "Safety class",
+              "value": "policy_admin"
+            }
+          ],
+          "review_id": "review-1d762a6ac3895594ed85ba7a",
+          "schema_version": 1,
+          "summary": "Review this exact privileged operation before confirming.",
+          "title": "Owner approval required"
+        }
+      },
+      "rule": "descriptor-version-is-one"
+    },
+    {
+      "error_location": [
+        "request_digest"
+      ],
+      "model": "approval_request",
+      "payload": {
+        "descriptor_id": "managed-authz-policy-set",
+        "descriptor_version": 1,
+        "evidence_digest": "df6da961581b149a28639add56e3b08401b3bed6afb07ad0c7b5ca3d51632be9",
+        "expires_at": "2030-01-02T03:09:05+00:00",
+        "issued_at": "2030-01-02T03:00:05+00:00",
+        "nonce": "owner-control-b565a7b3115d408e250eeffe65af9513",
+        "operation_id": "privileged-operation-1d762a6ac3895594ed85ba7aa9c39330",
+        "owner_github_id": 494383370,
+        "plan_digest": "edf23f94b33d1188e34e143e7aff91075ec941053b3b95d367a45de67b1fe1d7",
+        "policy_record_id": "owner-policy-1d762a6ac3895594ed85",
+        "policy_revision": 1,
+        "policy_sha256": "b379db2fe113e77eef0b3bb05aec804189d9f0b359e67d941d837c7de59e6f8e",
+        "pre_state_digest": "46df3876ade6b39b0edfbd3b8ea1a408173bbe5d8cc7154cea4d63e5d057239f",
+        "request_digest": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        "schema_version": 1,
+        "server_review": {
+          "items": [
+            {
+              "key": "descriptor",
+              "label": "Operation class",
+              "value": "managed-authz-policy-set"
+            },
+            {
+              "key": "safety_class",
+              "label": "Safety class",
+              "value": "policy_admin"
+            }
+          ],
+          "review_id": "review-1d762a6ac3895594ed85ba7a",
+          "schema_version": 1,
+          "summary": "Review this exact privileged operation before confirming.",
+          "title": "Owner approval required"
+        }
+      },
+      "rule": "digests-are-lowercase-sha256"
+    },
+    {
+      "error_location": [
+        "expires_at"
+      ],
+      "model": "approval_request",
+      "payload": {
+        "descriptor_id": "managed-authz-policy-set",
+        "descriptor_version": 1,
+        "evidence_digest": "df6da961581b149a28639add56e3b08401b3bed6afb07ad0c7b5ca3d51632be9",
+        "expires_at": "2030-01-02T03:09:05Z",
+        "issued_at": "2030-01-02T03:00:05+00:00",
+        "nonce": "owner-control-b565a7b3115d408e250eeffe65af9513",
+        "operation_id": "privileged-operation-1d762a6ac3895594ed85ba7aa9c39330",
+        "owner_github_id": 494383370,
+        "plan_digest": "edf23f94b33d1188e34e143e7aff91075ec941053b3b95d367a45de67b1fe1d7",
+        "policy_record_id": "owner-policy-1d762a6ac3895594ed85",
+        "policy_revision": 1,
+        "policy_sha256": "b379db2fe113e77eef0b3bb05aec804189d9f0b359e67d941d837c7de59e6f8e",
+        "pre_state_digest": "46df3876ade6b39b0edfbd3b8ea1a408173bbe5d8cc7154cea4d63e5d057239f",
+        "request_digest": "e0e31f55312d2562bf610587d7a21b5badeed50224284b08d1662924379b4539",
+        "schema_version": 1,
+        "server_review": {
+          "items": [
+            {
+              "key": "descriptor",
+              "label": "Operation class",
+              "value": "managed-authz-policy-set"
+            },
+            {
+              "key": "safety_class",
+              "label": "Safety class",
+              "value": "policy_admin"
+            }
+          ],
+          "review_id": "review-1d762a6ac3895594ed85ba7a",
+          "schema_version": 1,
+          "summary": "Review this exact privileged operation before confirming.",
+          "title": "Owner approval required"
+        }
+      },
+      "rule": "timestamps-use-canonical-utc-form"
+    },
+    {
+      "error_location": [],
+      "model": "approval_request",
+      "payload": {
+        "descriptor_id": "managed-authz-policy-set",
+        "descriptor_version": 1,
+        "evidence_digest": "df6da961581b149a28639add56e3b08401b3bed6afb07ad0c7b5ca3d51632be9",
+        "expires_at": "2030-02-30T03:09:05+00:00",
+        "issued_at": "2030-01-02T03:00:05+00:00",
+        "nonce": "owner-control-b565a7b3115d408e250eeffe65af9513",
+        "operation_id": "privileged-operation-1d762a6ac3895594ed85ba7aa9c39330",
+        "owner_github_id": 494383370,
+        "plan_digest": "edf23f94b33d1188e34e143e7aff91075ec941053b3b95d367a45de67b1fe1d7",
+        "policy_record_id": "owner-policy-1d762a6ac3895594ed85",
+        "policy_revision": 1,
+        "policy_sha256": "b379db2fe113e77eef0b3bb05aec804189d9f0b359e67d941d837c7de59e6f8e",
+        "pre_state_digest": "46df3876ade6b39b0edfbd3b8ea1a408173bbe5d8cc7154cea4d63e5d057239f",
+        "request_digest": "e0e31f55312d2562bf610587d7a21b5badeed50224284b08d1662924379b4539",
+        "schema_version": 1,
+        "server_review": {
+          "items": [
+            {
+              "key": "descriptor",
+              "label": "Operation class",
+              "value": "managed-authz-policy-set"
+            },
+            {
+              "key": "safety_class",
+              "label": "Safety class",
+              "value": "policy_admin"
+            }
+          ],
+          "review_id": "review-1d762a6ac3895594ed85ba7a",
+          "schema_version": 1,
+          "summary": "Review this exact privileged operation before confirming.",
+          "title": "Owner approval required"
+        }
+      },
+      "rule": "timestamps-are-calendar-valid"
+    },
+    {
+      "error_location": [
+        "nonce"
+      ],
+      "model": "approval_request",
+      "payload": {
+        "descriptor_id": "managed-authz-policy-set",
+        "descriptor_version": 1,
+        "evidence_digest": "df6da961581b149a28639add56e3b08401b3bed6afb07ad0c7b5ca3d51632be9",
+        "expires_at": "2030-01-02T03:09:05+00:00",
+        "issued_at": "2030-01-02T03:00:05+00:00",
+        "nonce": "short",
+        "operation_id": "privileged-operation-1d762a6ac3895594ed85ba7aa9c39330",
+        "owner_github_id": 494383370,
+        "plan_digest": "edf23f94b33d1188e34e143e7aff91075ec941053b3b95d367a45de67b1fe1d7",
+        "policy_record_id": "owner-policy-1d762a6ac3895594ed85",
+        "policy_revision": 1,
+        "policy_sha256": "b379db2fe113e77eef0b3bb05aec804189d9f0b359e67d941d837c7de59e6f8e",
+        "pre_state_digest": "46df3876ade6b39b0edfbd3b8ea1a408173bbe5d8cc7154cea4d63e5d057239f",
+        "request_digest": "e0e31f55312d2562bf610587d7a21b5badeed50224284b08d1662924379b4539",
+        "schema_version": 1,
+        "server_review": {
+          "items": [
+            {
+              "key": "descriptor",
+              "label": "Operation class",
+              "value": "managed-authz-policy-set"
+            },
+            {
+              "key": "safety_class",
+              "label": "Safety class",
+              "value": "policy_admin"
+            }
+          ],
+          "review_id": "review-1d762a6ac3895594ed85ba7a",
+          "schema_version": 1,
+          "summary": "Review this exact privileged operation before confirming.",
+          "title": "Owner approval required"
+        }
+      },
+      "rule": "nonce-is-canonical"
+    },
+    {
+      "error_location": [],
+      "model": "approval_request",
+      "payload": {
+        "descriptor_id": "managed-authz-policy-set",
+        "descriptor_version": 1,
+        "evidence_digest": "df6da961581b149a28639add56e3b08401b3bed6afb07ad0c7b5ca3d51632be9",
+        "expires_at": "2030-01-02T03:00:05+00:00",
+        "issued_at": "2030-01-02T03:00:05+00:00",
+        "nonce": "owner-control-b565a7b3115d408e250eeffe65af9513",
+        "operation_id": "privileged-operation-1d762a6ac3895594ed85ba7aa9c39330",
+        "owner_github_id": 494383370,
+        "plan_digest": "edf23f94b33d1188e34e143e7aff91075ec941053b3b95d367a45de67b1fe1d7",
+        "policy_record_id": "owner-policy-1d762a6ac3895594ed85",
+        "policy_revision": 1,
+        "policy_sha256": "b379db2fe113e77eef0b3bb05aec804189d9f0b359e67d941d837c7de59e6f8e",
+        "pre_state_digest": "46df3876ade6b39b0edfbd3b8ea1a408173bbe5d8cc7154cea4d63e5d057239f",
+        "request_digest": "e0e31f55312d2562bf610587d7a21b5badeed50224284b08d1662924379b4539",
+        "schema_version": 1,
+        "server_review": {
+          "items": [
+            {
+              "key": "descriptor",
+              "label": "Operation class",
+              "value": "managed-authz-policy-set"
+            },
+            {
+              "key": "safety_class",
+              "label": "Safety class",
+              "value": "policy_admin"
+            }
+          ],
+          "review_id": "review-1d762a6ac3895594ed85ba7a",
+          "schema_version": 1,
+          "summary": "Review this exact privileged operation before confirming.",
+          "title": "Owner approval required"
+        }
+      },
+      "rule": "expiry-follows-issuance"
+    },
+    {
+      "error_location": [],
+      "model": "challenge_response",
+      "payload": {
+        "approval_request": {
+          "descriptor_id": "managed-authz-policy-set",
+          "descriptor_version": 1,
+          "evidence_digest": "df6da961581b149a28639add56e3b08401b3bed6afb07ad0c7b5ca3d51632be9",
+          "expires_at": "2030-01-02T03:09:05+00:00",
+          "issued_at": "2030-01-02T03:00:05+00:00",
+          "nonce": "owner-control-b565a7b3115d408e250eeffe65af9513",
+          "operation_id": "privileged-operation-1d762a6ac3895594ed85ba7aa9c39330",
+          "owner_github_id": 494383370,
+          "plan_digest": "edf23f94b33d1188e34e143e7aff91075ec941053b3b95d367a45de67b1fe1d7",
+          "policy_record_id": "owner-policy-1d762a6ac3895594ed85",
+          "policy_revision": 1,
+          "policy_sha256": "b379db2fe113e77eef0b3bb05aec804189d9f0b359e67d941d837c7de59e6f8e",
+          "pre_state_digest": "46df3876ade6b39b0edfbd3b8ea1a408173bbe5d8cc7154cea4d63e5d057239f",
+          "request_digest": "e0e31f55312d2562bf610587d7a21b5badeed50224284b08d1662924379b4539",
+          "schema_version": 1,
+          "server_review": {
+            "items": [
+              {
+                "key": "descriptor",
+                "label": "Operation class",
+                "value": "managed-authz-policy-set"
+              },
+              {
+                "key": "safety_class",
+                "label": "Safety class",
+                "value": "policy_admin"
+              }
+            ],
+            "review_id": "review-1d762a6ac3895594ed85ba7a",
+            "schema_version": 1,
+            "summary": "Review this exact privileged operation before confirming.",
+            "title": "Owner approval required"
+          }
+        },
+        "approval_request_digest": "0000000000000000000000000000000000000000000000000000000000000000",
+        "channel_binding_sha256": "023b40df5087274959331ae05a557806bcc6bd01682ed7d464bfc6985ef846a6",
+        "confirmed_at": "2030-01-02T03:04:05+00:00",
+        "decision": "approved",
+        "schema_version": 1
+      },
+      "rule": "request-digest-binds-exact-request"
+    },
+    {
+      "error_location": [],
+      "model": "challenge_response",
+      "payload": {
+        "approval_request": {
+          "descriptor_id": "managed-authz-policy-set",
+          "descriptor_version": 1,
+          "evidence_digest": "df6da961581b149a28639add56e3b08401b3bed6afb07ad0c7b5ca3d51632be9",
+          "expires_at": "2030-01-02T03:09:05+00:00",
+          "issued_at": "2030-01-02T03:00:05+00:00",
+          "nonce": "owner-control-b565a7b3115d408e250eeffe65af9513",
+          "operation_id": "privileged-operation-1d762a6ac3895594ed85ba7aa9c39330",
+          "owner_github_id": 494383370,
+          "plan_digest": "edf23f94b33d1188e34e143e7aff91075ec941053b3b95d367a45de67b1fe1d7",
+          "policy_record_id": "owner-policy-1d762a6ac3895594ed85",
+          "policy_revision": 1,
+          "policy_sha256": "b379db2fe113e77eef0b3bb05aec804189d9f0b359e67d941d837c7de59e6f8e",
+          "pre_state_digest": "46df3876ade6b39b0edfbd3b8ea1a408173bbe5d8cc7154cea4d63e5d057239f",
+          "request_digest": "e0e31f55312d2562bf610587d7a21b5badeed50224284b08d1662924379b4539",
+          "schema_version": 1,
+          "server_review": {
+            "items": [
+              {
+                "key": "descriptor",
+                "label": "Operation class",
+                "value": "managed-authz-policy-set"
+              },
+              {
+                "key": "safety_class",
+                "label": "Safety class",
+                "value": "policy_admin"
+              }
+            ],
+            "review_id": "review-1d762a6ac3895594ed85ba7a",
+            "schema_version": 1,
+            "summary": "Review this exact privileged operation before confirming.",
+            "title": "Owner approval required"
+          }
+        },
+        "approval_request_digest": "a60572025b121241d44c3f28ce22715841e348765dd50cfa514861e89334d9eb",
+        "channel_binding_sha256": "023b40df5087274959331ae05a557806bcc6bd01682ed7d464bfc6985ef846a6",
+        "confirmed_at": "2030-01-02T02:59:05+00:00",
+        "decision": "approved",
+        "schema_version": 1
+      },
+      "rule": "confirmation-is-not-before-issuance"
+    },
+    {
+      "error_location": [],
+      "model": "challenge_response",
+      "payload": {
+        "approval_request": {
+          "descriptor_id": "managed-authz-policy-set",
+          "descriptor_version": 1,
+          "evidence_digest": "df6da961581b149a28639add56e3b08401b3bed6afb07ad0c7b5ca3d51632be9",
+          "expires_at": "2030-01-02T03:09:05+00:00",
+          "issued_at": "2030-01-02T03:00:05+00:00",
+          "nonce": "owner-control-b565a7b3115d408e250eeffe65af9513",
+          "operation_id": "privileged-operation-1d762a6ac3895594ed85ba7aa9c39330",
+          "owner_github_id": 494383370,
+          "plan_digest": "edf23f94b33d1188e34e143e7aff91075ec941053b3b95d367a45de67b1fe1d7",
+          "policy_record_id": "owner-policy-1d762a6ac3895594ed85",
+          "policy_revision": 1,
+          "policy_sha256": "b379db2fe113e77eef0b3bb05aec804189d9f0b359e67d941d837c7de59e6f8e",
+          "pre_state_digest": "46df3876ade6b39b0edfbd3b8ea1a408173bbe5d8cc7154cea4d63e5d057239f",
+          "request_digest": "e0e31f55312d2562bf610587d7a21b5badeed50224284b08d1662924379b4539",
+          "schema_version": 1,
+          "server_review": {
+            "items": [
+              {
+                "key": "descriptor",
+                "label": "Operation class",
+                "value": "managed-authz-policy-set"
+              },
+              {
+                "key": "safety_class",
+                "label": "Safety class",
+                "value": "policy_admin"
+              }
+            ],
+            "review_id": "review-1d762a6ac3895594ed85ba7a",
+            "schema_version": 1,
+            "summary": "Review this exact privileged operation before confirming.",
+            "title": "Owner approval required"
+          }
+        },
+        "approval_request_digest": "a60572025b121241d44c3f28ce22715841e348765dd50cfa514861e89334d9eb",
+        "channel_binding_sha256": "023b40df5087274959331ae05a557806bcc6bd01682ed7d464bfc6985ef846a6",
+        "confirmed_at": "2030-01-02T03:10:05+00:00",
+        "decision": "approved",
+        "schema_version": 1
+      },
+      "rule": "confirmation-is-not-after-expiry"
+    },
+    {
+      "error_location": [],
+      "model": "server_review_payload",
+      "payload": {
+        "items": [
+          {
+            "key": "descriptor",
+            "label": "Operation class",
+            "value": "managed-authz-policy-set"
+          },
+          {
+            "key": "descriptor",
+            "label": "Operation class",
+            "value": "managed-authz-policy-set"
+          }
+        ],
+        "review_id": "review-1d762a6ac3895594ed85ba7a",
+        "schema_version": 1,
+        "summary": "Review this exact privileged operation before confirming.",
+        "title": "Owner approval required"
+      },
+      "rule": "review-item-keys-are-unique"
+    },
+    {
+      "error_location": [],
+      "model": "server_review_payload",
+      "payload": {
+        "items": [
+          {
+            "key": "descriptor",
+            "label": "Operation class",
+            "value": "managed-authz-policy-set"
+          },
+          {
+            "key": "safety_class",
+            "label": "Safety class",
+            "value": "policy_admin"
+          }
+        ],
+        "review_id": "review-1d762a6ac3895594ed85ba7a",
+        "schema_version": 1,
+        "summary": "Review this exact privileged operation before confirming.",
+        "title": " Owner approval required"
+      },
+      "rule": "review-text-has-no-surrounding-whitespace"
+    },
+    {
+      "error_location": [
+        "items",
+        0
+      ],
+      "model": "server_review_payload",
+      "payload": {
+        "items": [
+          {
+            "key": "descriptor",
+            "label": " Operation class",
+            "value": "managed-authz-policy-set"
+          },
+          {
+            "key": "safety_class",
+            "label": "Safety class",
+            "value": "policy_admin"
+          }
+        ],
+        "review_id": "review-1d762a6ac3895594ed85ba7a",
+        "schema_version": 1,
+        "summary": "Review this exact privileged operation before confirming.",
+        "title": "Owner approval required"
+      },
+      "rule": "review-item-text-has-no-surrounding-whitespace"
+    }
+  ],
+  "schema_version": 1,
+  "schemas": {
+    "approval_request": {
+      "$defs": {
+        "ReviewItem": {
+          "additionalProperties": false,
+          "description": "One server-authored, display-ready field in an owner review payload.",
+          "properties": {
+            "key": {
+              "pattern": "^[a-z][a-z0-9_]{0,63}$",
+              "title": "Key",
+              "type": "string"
+            },
+            "label": {
+              "maxLength": 120,
+              "minLength": 1,
+              "title": "Label",
+              "type": "string"
+            },
+            "value": {
+              "maxLength": 4000,
+              "minLength": 1,
+              "title": "Value",
+              "type": "string"
+            }
+          },
+          "required": [
+            "key",
+            "label",
+            "value"
+          ],
+          "title": "ReviewItem",
+          "type": "object"
+        },
+        "ServerReviewPayload": {
+          "additionalProperties": false,
+          "description": "Canonical server-authored review content rendered for one owner decision.",
+          "properties": {
+            "items": {
+              "items": {
+                "$ref": "#/$defs/ReviewItem"
+              },
+              "maxItems": 32,
+              "minItems": 1,
+              "title": "Items",
+              "type": "array"
+            },
+            "review_id": {
+              "pattern": "^[a-z][a-z0-9_-]{0,127}$",
+              "title": "Review Id",
+              "type": "string"
+            },
+            "schema_version": {
+              "const": 1,
+              "default": 1,
+              "title": "Schema Version",
+              "type": "integer"
+            },
+            "summary": {
+              "maxLength": 4000,
+              "minLength": 1,
+              "title": "Summary",
+              "type": "string"
+            },
+            "title": {
+              "maxLength": 200,
+              "minLength": 1,
+              "title": "Title",
+              "type": "string"
+            }
+          },
+          "required": [
+            "review_id",
+            "title",
+            "summary",
+            "items"
+          ],
+          "title": "ServerReviewPayload",
+          "type": "object"
+        }
+      },
+      "additionalProperties": false,
+      "description": "Exact, versioned owner-control challenge input issued by Launchplane.",
+      "properties": {
+        "descriptor_id": {
+          "enum": [
+            "managed-secret-reencryption",
+            "managed-authz-policy-set"
+          ],
+          "title": "Descriptor Id",
+          "type": "string"
+        },
+        "descriptor_version": {
+          "const": 1,
+          "title": "Descriptor Version",
+          "type": "integer"
+        },
+        "evidence_digest": {
+          "pattern": "^[0-9a-f]{64}$",
+          "title": "Evidence Digest",
+          "type": "string"
+        },
+        "expires_at": {
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\+00:00$",
+          "title": "Expires At",
+          "type": "string"
+        },
+        "issued_at": {
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\+00:00$",
+          "title": "Issued At",
+          "type": "string"
+        },
+        "nonce": {
+          "pattern": "^[A-Za-z0-9_-]{16,128}$",
+          "title": "Nonce",
+          "type": "string"
+        },
+        "operation_id": {
+          "pattern": "^privileged-operation-[0-9a-f]{32}$",
+          "title": "Operation Id",
+          "type": "string"
+        },
+        "owner_github_id": {
+          "maximum": 9223372036854775807,
+          "minimum": 1,
+          "title": "Owner Github Id",
+          "type": "integer"
+        },
+        "plan_digest": {
+          "pattern": "^[0-9a-f]{64}$",
+          "title": "Plan Digest",
+          "type": "string"
+        },
+        "policy_record_id": {
+          "pattern": "^[a-z][a-z0-9_-]{0,127}$",
+          "title": "Policy Record Id",
+          "type": "string"
+        },
+        "policy_revision": {
+          "maximum": 9223372036854775807,
+          "minimum": 1,
+          "title": "Policy Revision",
+          "type": "integer"
+        },
+        "policy_sha256": {
+          "pattern": "^[0-9a-f]{64}$",
+          "title": "Policy Sha256",
+          "type": "string"
+        },
+        "pre_state_digest": {
+          "pattern": "^[0-9a-f]{64}$",
+          "title": "Pre State Digest",
+          "type": "string"
+        },
+        "request_digest": {
+          "pattern": "^[0-9a-f]{64}$",
+          "title": "Request Digest",
+          "type": "string"
+        },
+        "schema_version": {
+          "const": 1,
+          "default": 1,
+          "title": "Schema Version",
+          "type": "integer"
+        },
+        "server_review": {
+          "$ref": "#/$defs/ServerReviewPayload"
+        }
+      },
+      "required": [
+        "operation_id",
+        "descriptor_id",
+        "descriptor_version",
+        "request_digest",
+        "plan_digest",
+        "evidence_digest",
+        "pre_state_digest",
+        "policy_record_id",
+        "policy_revision",
+        "policy_sha256",
+        "owner_github_id",
+        "server_review",
+        "nonce",
+        "issued_at",
+        "expires_at"
+      ],
+      "title": "ApprovalRequest",
+      "type": "object"
+    },
+    "challenge_response": {
+      "$defs": {
+        "ApprovalRequest": {
+          "additionalProperties": false,
+          "description": "Exact, versioned owner-control challenge input issued by Launchplane.",
+          "properties": {
+            "descriptor_id": {
+              "enum": [
+                "managed-secret-reencryption",
+                "managed-authz-policy-set"
+              ],
+              "title": "Descriptor Id",
+              "type": "string"
+            },
+            "descriptor_version": {
+              "const": 1,
+              "title": "Descriptor Version",
+              "type": "integer"
+            },
+            "evidence_digest": {
+              "pattern": "^[0-9a-f]{64}$",
+              "title": "Evidence Digest",
+              "type": "string"
+            },
+            "expires_at": {
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\+00:00$",
+              "title": "Expires At",
+              "type": "string"
+            },
+            "issued_at": {
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\+00:00$",
+              "title": "Issued At",
+              "type": "string"
+            },
+            "nonce": {
+              "pattern": "^[A-Za-z0-9_-]{16,128}$",
+              "title": "Nonce",
+              "type": "string"
+            },
+            "operation_id": {
+              "pattern": "^privileged-operation-[0-9a-f]{32}$",
+              "title": "Operation Id",
+              "type": "string"
+            },
+            "owner_github_id": {
+              "maximum": 9223372036854775807,
+              "minimum": 1,
+              "title": "Owner Github Id",
+              "type": "integer"
+            },
+            "plan_digest": {
+              "pattern": "^[0-9a-f]{64}$",
+              "title": "Plan Digest",
+              "type": "string"
+            },
+            "policy_record_id": {
+              "pattern": "^[a-z][a-z0-9_-]{0,127}$",
+              "title": "Policy Record Id",
+              "type": "string"
+            },
+            "policy_revision": {
+              "maximum": 9223372036854775807,
+              "minimum": 1,
+              "title": "Policy Revision",
+              "type": "integer"
+            },
+            "policy_sha256": {
+              "pattern": "^[0-9a-f]{64}$",
+              "title": "Policy Sha256",
+              "type": "string"
+            },
+            "pre_state_digest": {
+              "pattern": "^[0-9a-f]{64}$",
+              "title": "Pre State Digest",
+              "type": "string"
+            },
+            "request_digest": {
+              "pattern": "^[0-9a-f]{64}$",
+              "title": "Request Digest",
+              "type": "string"
+            },
+            "schema_version": {
+              "const": 1,
+              "default": 1,
+              "title": "Schema Version",
+              "type": "integer"
+            },
+            "server_review": {
+              "$ref": "#/$defs/ServerReviewPayload"
+            }
+          },
+          "required": [
+            "operation_id",
+            "descriptor_id",
+            "descriptor_version",
+            "request_digest",
+            "plan_digest",
+            "evidence_digest",
+            "pre_state_digest",
+            "policy_record_id",
+            "policy_revision",
+            "policy_sha256",
+            "owner_github_id",
+            "server_review",
+            "nonce",
+            "issued_at",
+            "expires_at"
+          ],
+          "title": "ApprovalRequest",
+          "type": "object"
+        },
+        "ReviewItem": {
+          "additionalProperties": false,
+          "description": "One server-authored, display-ready field in an owner review payload.",
+          "properties": {
+            "key": {
+              "pattern": "^[a-z][a-z0-9_]{0,63}$",
+              "title": "Key",
+              "type": "string"
+            },
+            "label": {
+              "maxLength": 120,
+              "minLength": 1,
+              "title": "Label",
+              "type": "string"
+            },
+            "value": {
+              "maxLength": 4000,
+              "minLength": 1,
+              "title": "Value",
+              "type": "string"
+            }
+          },
+          "required": [
+            "key",
+            "label",
+            "value"
+          ],
+          "title": "ReviewItem",
+          "type": "object"
+        },
+        "ServerReviewPayload": {
+          "additionalProperties": false,
+          "description": "Canonical server-authored review content rendered for one owner decision.",
+          "properties": {
+            "items": {
+              "items": {
+                "$ref": "#/$defs/ReviewItem"
+              },
+              "maxItems": 32,
+              "minItems": 1,
+              "title": "Items",
+              "type": "array"
+            },
+            "review_id": {
+              "pattern": "^[a-z][a-z0-9_-]{0,127}$",
+              "title": "Review Id",
+              "type": "string"
+            },
+            "schema_version": {
+              "const": 1,
+              "default": 1,
+              "title": "Schema Version",
+              "type": "integer"
+            },
+            "summary": {
+              "maxLength": 4000,
+              "minLength": 1,
+              "title": "Summary",
+              "type": "string"
+            },
+            "title": {
+              "maxLength": 200,
+              "minLength": 1,
+              "title": "Title",
+              "type": "string"
+            }
+          },
+          "required": [
+            "review_id",
+            "title",
+            "summary",
+            "items"
+          ],
+          "title": "ServerReviewPayload",
+          "type": "object"
+        }
+      },
+      "additionalProperties": false,
+      "description": "Owner-channel confirmation bound to one exact approval request.",
+      "properties": {
+        "approval_request": {
+          "$ref": "#/$defs/ApprovalRequest"
+        },
+        "approval_request_digest": {
+          "pattern": "^[0-9a-f]{64}$",
+          "title": "Approval Request Digest",
+          "type": "string"
+        },
+        "channel_binding_sha256": {
+          "pattern": "^[0-9a-f]{64}$",
+          "title": "Channel Binding Sha256",
+          "type": "string"
+        },
+        "confirmed_at": {
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\+00:00$",
+          "title": "Confirmed At",
+          "type": "string"
+        },
+        "decision": {
+          "const": "approved",
+          "title": "Decision",
+          "type": "string"
+        },
+        "schema_version": {
+          "const": 1,
+          "default": 1,
+          "title": "Schema Version",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "approval_request",
+        "approval_request_digest",
+        "decision",
+        "channel_binding_sha256",
+        "confirmed_at"
+      ],
+      "title": "ChallengeResponse",
+      "type": "object"
+    },
+    "server_review_payload": {
+      "$defs": {
+        "ReviewItem": {
+          "additionalProperties": false,
+          "description": "One server-authored, display-ready field in an owner review payload.",
+          "properties": {
+            "key": {
+              "pattern": "^[a-z][a-z0-9_]{0,63}$",
+              "title": "Key",
+              "type": "string"
+            },
+            "label": {
+              "maxLength": 120,
+              "minLength": 1,
+              "title": "Label",
+              "type": "string"
+            },
+            "value": {
+              "maxLength": 4000,
+              "minLength": 1,
+              "title": "Value",
+              "type": "string"
+            }
+          },
+          "required": [
+            "key",
+            "label",
+            "value"
+          ],
+          "title": "ReviewItem",
+          "type": "object"
+        }
+      },
+      "additionalProperties": false,
+      "description": "Canonical server-authored review content rendered for one owner decision.",
+      "properties": {
+        "items": {
+          "items": {
+            "$ref": "#/$defs/ReviewItem"
+          },
+          "maxItems": 32,
+          "minItems": 1,
+          "title": "Items",
+          "type": "array"
+        },
+        "review_id": {
+          "pattern": "^[a-z][a-z0-9_-]{0,127}$",
+          "title": "Review Id",
+          "type": "string"
+        },
+        "schema_version": {
+          "const": 1,
+          "default": 1,
+          "title": "Schema Version",
+          "type": "integer"
+        },
+        "summary": {
+          "maxLength": 4000,
+          "minLength": 1,
+          "title": "Summary",
+          "type": "string"
+        },
+        "title": {
+          "maxLength": 200,
+          "minLength": 1,
+          "title": "Title",
+          "type": "string"
+        }
+      },
+      "required": [
+        "review_id",
+        "title",
+        "summary",
+        "items"
+      ],
+      "title": "ServerReviewPayload",
+      "type": "object"
+    }
+  }
+}

--- a/control_plane/cli_service.py
+++ b/control_plane/cli_service.py
@@ -13,6 +13,7 @@ import click
 
 from control_plane.agent_operator_contract import write_agent_operator_contract
 from control_plane.cli_shared import DATABASE_URL_ENV_KEYS as _DATABASE_URL_ENV_KEYS
+from control_plane.owner_control_contract import write_owner_control_contract
 from control_plane.outbox_worker import (
     DEFAULT_OUTBOX_WORKER_ERROR_BACKOFF_SECONDS,
     DEFAULT_OUTBOX_WORKER_LEASE_SECONDS,
@@ -1492,4 +1493,16 @@ def service_export_openapi(output: Path) -> None:
 )
 def service_export_agent_contract(output: Path, source_sha: str | None) -> None:
     written_path = write_agent_operator_contract(output, source_commit_sha=source_sha)
+    click.echo(str(written_path))
+
+
+@service.command("export-owner-control-contract")
+@click.option(
+    "--output",
+    type=click.Path(path_type=Path),
+    required=True,
+    help="Write the public owner-control conformance contract to this path.",
+)
+def service_export_owner_control_contract(output: Path) -> None:
+    written_path = write_owner_control_contract(output)
     click.echo(str(written_path))

--- a/control_plane/contracts/canonical_json.py
+++ b/control_plane/contracts/canonical_json.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import hashlib
+import json
+
+
+CANONICAL_JSON_INTEGER_MIN = -(2**63)
+CANONICAL_JSON_INTEGER_MAX = 2**63 - 1
+
+
+def _validate_canonical_json_value(payload: object, *, location: str = "$") -> None:
+    if payload is None or isinstance(payload, (bool, str)):
+        return
+    if isinstance(payload, int):
+        if not CANONICAL_JSON_INTEGER_MIN <= payload <= CANONICAL_JSON_INTEGER_MAX:
+            raise ValueError(f"canonical JSON integer at {location} must fit signed 64-bit range")
+        return
+    if isinstance(payload, float):
+        raise ValueError(f"canonical JSON number at {location} must be an integer")
+    if isinstance(payload, (list, tuple)):
+        for index, item in enumerate(payload):
+            _validate_canonical_json_value(item, location=f"{location}[{index}]")
+        return
+    if isinstance(payload, dict):
+        for key, value in payload.items():
+            if not isinstance(key, str):
+                raise ValueError(f"canonical JSON object key at {location} must be a string")
+            _validate_canonical_json_value(value, location=f"{location}.{key}")
+        return
+    raise TypeError(f"unsupported canonical JSON value at {location}: {type(payload).__name__}")
+
+
+def canonical_json_bytes(payload: object) -> bytes:
+    """Return the public canonical UTF-8 JSON representation for a JSON payload."""
+
+    _validate_canonical_json_value(payload)
+    return json.dumps(
+        payload,
+        allow_nan=False,
+        ensure_ascii=True,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+
+def canonical_json_sha256(payload: object) -> str:
+    """Return the lowercase SHA-256 digest of public canonical JSON bytes."""
+
+    return hashlib.sha256(canonical_json_bytes(payload)).hexdigest()

--- a/control_plane/contracts/owner_control.py
+++ b/control_plane/contracts/owner_control.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import re
+from typing import Final, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from control_plane.contracts.canonical_json import canonical_json_sha256
+from control_plane.contracts.privileged_operation import PrivilegedOperationDescriptorId
+
+
+OWNER_CONTROL_SCHEMA_VERSION: Final[Literal[1]] = 1
+
+_SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+_OPERATION_ID_PATTERN = re.compile(r"^privileged-operation-[0-9a-f]{32}$")
+_NONCE_PATTERN = re.compile(r"^[A-Za-z0-9_-]{16,128}$")
+_IDENTIFIER_PATTERN = re.compile(r"^[a-z][a-z0-9_-]{0,127}$")
+_REVIEW_KEY_PATTERN = re.compile(r"^[a-z][a-z0-9_]{0,63}$")
+_CANONICAL_TIMESTAMP_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\+00:00$")
+
+
+def _canonical_sha256(value: str, field_name: str) -> str:
+    if _SHA256_PATTERN.fullmatch(value) is None:
+        raise ValueError(f"{field_name} must be a lowercase SHA-256 digest")
+    return value
+
+
+def _canonical_identifier(value: str, field_name: str) -> str:
+    if _IDENTIFIER_PATTERN.fullmatch(value) is None:
+        raise ValueError(f"{field_name} must be a canonical identifier")
+    return value
+
+
+def _canonical_timestamp(value: str, field_name: str) -> str:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise ValueError(f"{field_name} must be an ISO-8601 timestamp") from error
+    if parsed.tzinfo is None:
+        raise ValueError(f"{field_name} must include a timezone")
+    canonical = parsed.astimezone(timezone.utc).isoformat()
+    if value != canonical:
+        raise ValueError(f"{field_name} must use canonical UTC ISO-8601 form")
+    return value
+
+
+class ReviewItem(BaseModel):
+    """One server-authored, display-ready field in an owner review payload."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    key: str = Field(pattern=_REVIEW_KEY_PATTERN.pattern)
+    label: str = Field(min_length=1, max_length=120)
+    value: str = Field(min_length=1, max_length=4000)
+
+    @model_validator(mode="after")
+    def _validate_review_item(self) -> "ReviewItem":
+        if _REVIEW_KEY_PATTERN.fullmatch(self.key) is None:
+            raise ValueError("review item key must be canonical snake case")
+        if self.label != self.label.strip() or self.value != self.value.strip():
+            raise ValueError("review item labels and values must not have surrounding whitespace")
+        return self
+
+
+class ServerReviewPayload(BaseModel):
+    """Canonical server-authored review content rendered for one owner decision."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    schema_version: Literal[1] = OWNER_CONTROL_SCHEMA_VERSION
+    review_id: str = Field(pattern=_IDENTIFIER_PATTERN.pattern)
+    title: str = Field(min_length=1, max_length=200)
+    summary: str = Field(min_length=1, max_length=4000)
+    items: tuple[ReviewItem, ...] = Field(min_length=1, max_length=32)
+
+    @model_validator(mode="after")
+    def _validate_review_payload(self) -> "ServerReviewPayload":
+        if self.schema_version != OWNER_CONTROL_SCHEMA_VERSION:
+            raise ValueError("Unsupported owner-control review payload schema version.")
+        _canonical_identifier(self.review_id, "review_id")
+        if self.title != self.title.strip() or self.summary != self.summary.strip():
+            raise ValueError("review title and summary must not have surrounding whitespace")
+        if len({item.key for item in self.items}) != len(self.items):
+            raise ValueError("review item keys must be unique")
+        return self
+
+
+class ApprovalRequest(BaseModel):
+    """Exact, versioned owner-control challenge input issued by Launchplane."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    schema_version: Literal[1] = OWNER_CONTROL_SCHEMA_VERSION
+    operation_id: str = Field(pattern=_OPERATION_ID_PATTERN.pattern)
+    descriptor_id: PrivilegedOperationDescriptorId
+    descriptor_version: Literal[1]
+    request_digest: str = Field(pattern=_SHA256_PATTERN.pattern)
+    plan_digest: str = Field(pattern=_SHA256_PATTERN.pattern)
+    evidence_digest: str = Field(pattern=_SHA256_PATTERN.pattern)
+    pre_state_digest: str = Field(pattern=_SHA256_PATTERN.pattern)
+    policy_record_id: str = Field(pattern=_IDENTIFIER_PATTERN.pattern)
+    policy_revision: int = Field(ge=1, le=2**63 - 1)
+    policy_sha256: str = Field(pattern=_SHA256_PATTERN.pattern)
+    owner_github_id: int = Field(ge=1, le=2**63 - 1)
+    server_review: ServerReviewPayload
+    nonce: str = Field(pattern=_NONCE_PATTERN.pattern)
+    issued_at: str = Field(pattern=_CANONICAL_TIMESTAMP_PATTERN.pattern)
+    expires_at: str = Field(pattern=_CANONICAL_TIMESTAMP_PATTERN.pattern)
+
+    @model_validator(mode="after")
+    def _validate_approval_request(self) -> "ApprovalRequest":
+        if self.schema_version != OWNER_CONTROL_SCHEMA_VERSION:
+            raise ValueError("Unsupported owner-control approval request schema version.")
+        if _OPERATION_ID_PATTERN.fullmatch(self.operation_id) is None:
+            raise ValueError("operation_id must be a canonical privileged-operation identifier")
+        if self.descriptor_version != 1:
+            raise ValueError("Unsupported owner-control privileged-operation descriptor version.")
+        for field_name in (
+            "request_digest",
+            "plan_digest",
+            "evidence_digest",
+            "pre_state_digest",
+            "policy_sha256",
+        ):
+            _canonical_sha256(str(getattr(self, field_name)), field_name)
+        _canonical_identifier(self.policy_record_id, "policy_record_id")
+        if _NONCE_PATTERN.fullmatch(self.nonce) is None:
+            raise ValueError("nonce must be a canonical owner-control nonce")
+        _canonical_timestamp(self.issued_at, "issued_at")
+        _canonical_timestamp(self.expires_at, "expires_at")
+        issued_at = datetime.fromisoformat(self.issued_at)
+        expires_at = datetime.fromisoformat(self.expires_at)
+        if expires_at <= issued_at:
+            raise ValueError("expires_at must be later than issued_at")
+        return self
+
+
+class ChallengeResponse(BaseModel):
+    """Owner-channel confirmation bound to one exact approval request."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    schema_version: Literal[1] = OWNER_CONTROL_SCHEMA_VERSION
+    approval_request: ApprovalRequest
+    approval_request_digest: str = Field(pattern=_SHA256_PATTERN.pattern)
+    decision: Literal["approved"]
+    channel_binding_sha256: str = Field(pattern=_SHA256_PATTERN.pattern)
+    confirmed_at: str = Field(pattern=_CANONICAL_TIMESTAMP_PATTERN.pattern)
+
+    @model_validator(mode="after")
+    def _validate_challenge_response(self) -> "ChallengeResponse":
+        if self.schema_version != OWNER_CONTROL_SCHEMA_VERSION:
+            raise ValueError("Unsupported owner-control challenge response schema version.")
+        _canonical_sha256(self.approval_request_digest, "approval_request_digest")
+        if self.approval_request_digest != owner_control_approval_request_digest(
+            self.approval_request
+        ):
+            raise ValueError("approval_request_digest must bind the exact approval request")
+        _canonical_sha256(self.channel_binding_sha256, "channel_binding_sha256")
+        _canonical_timestamp(self.confirmed_at, "confirmed_at")
+        confirmed_at = datetime.fromisoformat(self.confirmed_at)
+        issued_at = datetime.fromisoformat(self.approval_request.issued_at)
+        expires_at = datetime.fromisoformat(self.approval_request.expires_at)
+        if confirmed_at < issued_at:
+            raise ValueError("confirmed_at must not be earlier than challenge issuance")
+        if confirmed_at > expires_at:
+            raise ValueError("confirmed_at must not be later than the approval request expiry")
+        return self
+
+
+def owner_control_approval_request_digest(request: ApprovalRequest) -> str:
+    """Return the canonical digest shared by Launchplane and the owner-control host."""
+
+    return canonical_json_sha256(request.model_dump(mode="json"))
+
+
+def owner_control_challenge_response_digest(response: ChallengeResponse) -> str:
+    """Return the canonical digest of an owner-control challenge response."""
+
+    return canonical_json_sha256(response.model_dump(mode="json"))

--- a/control_plane/contracts/privileged_operation.py
+++ b/control_plane/contracts/privileged_operation.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
-import hashlib
-import json
 import re
 from typing import Literal, TypeAlias
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from control_plane.contracts.canonical_json import canonical_json_sha256
 from control_plane.authz_grant_service import (
     AuthzManagedPolicyDiff,
     AuthzManagedPolicyReconcileEnvelope,
@@ -102,9 +101,7 @@ def _timestamp(value: str, field_name: str) -> str:
 
 
 def _digest_payload(payload: object) -> str:
-    return hashlib.sha256(
-        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
-    ).hexdigest()
+    return canonical_json_sha256(payload)
 
 
 class PrivilegedOperationActor(BaseModel):

--- a/control_plane/owner_control_contract.py
+++ b/control_plane/owner_control_contract.py
@@ -1,0 +1,356 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from control_plane.contracts.canonical_json import canonical_json_bytes, canonical_json_sha256
+from control_plane.contracts.owner_control import (
+    ApprovalRequest,
+    ChallengeResponse,
+    ReviewItem,
+    ServerReviewPayload,
+    owner_control_approval_request_digest,
+    owner_control_challenge_response_digest,
+)
+from control_plane.contracts.privileged_operation import (
+    PrivilegedOperationDescriptorId,
+    PrivilegedOperationSafetyClass,
+)
+from control_plane.privileged_operation_registry import list_privileged_operation_descriptors
+from control_plane.privileged_operation_registry import read_privileged_operation_descriptor
+
+
+OWNER_CONTROL_CONTRACT_SCHEMA_VERSION = 1
+
+
+class OwnerControlContractError(ValueError):
+    pass
+
+
+def _digest_for_vector(*, descriptor_id: PrivilegedOperationDescriptorId, label: str) -> str:
+    return canonical_json_sha256(
+        {
+            "descriptor_id": descriptor_id,
+            "label": label,
+            "schema_version": OWNER_CONTROL_CONTRACT_SCHEMA_VERSION,
+        }
+    )
+
+
+def _approval_request_for_descriptor(
+    *,
+    descriptor_id: PrivilegedOperationDescriptorId,
+    safety_class: PrivilegedOperationSafetyClass,
+) -> ApprovalRequest:
+    vector_digest = _digest_for_vector(descriptor_id=descriptor_id, label="operation")
+    review = ServerReviewPayload(
+        review_id=f"review-{vector_digest[:24]}",
+        title="Owner approval required",
+        summary="Review this exact privileged operation before confirming.",
+        items=(
+            ReviewItem(
+                key="descriptor",
+                label="Operation class",
+                value=descriptor_id,
+            ),
+            ReviewItem(
+                key="safety_class",
+                label="Safety class",
+                value=safety_class,
+            ),
+        ),
+    )
+    return ApprovalRequest(
+        operation_id=f"privileged-operation-{vector_digest[:32]}",
+        descriptor_id=descriptor_id,
+        descriptor_version=1,
+        request_digest=_digest_for_vector(descriptor_id=descriptor_id, label="request"),
+        plan_digest=_digest_for_vector(descriptor_id=descriptor_id, label="plan"),
+        evidence_digest=_digest_for_vector(descriptor_id=descriptor_id, label="evidence"),
+        pre_state_digest=_digest_for_vector(descriptor_id=descriptor_id, label="pre-state"),
+        policy_record_id=f"owner-policy-{vector_digest[:20]}",
+        policy_revision=1,
+        policy_sha256=_digest_for_vector(descriptor_id=descriptor_id, label="policy"),
+        owner_github_id=100000 + int(vector_digest[:8], 16),
+        server_review=review,
+        nonce=f"owner-control-{_digest_for_vector(descriptor_id=descriptor_id, label='nonce')[:32]}",
+        issued_at="2030-01-02T03:00:05+00:00",
+        expires_at="2030-01-02T03:09:05+00:00",
+    )
+
+
+def _golden_vector(
+    *,
+    descriptor_id: PrivilegedOperationDescriptorId,
+    descriptor_version: int,
+    safety_class: PrivilegedOperationSafetyClass,
+) -> dict[str, Any]:
+    if descriptor_version != 1:
+        raise OwnerControlContractError(
+            f"Unsupported owner-control descriptor version: {descriptor_version}"
+        )
+    request = _approval_request_for_descriptor(
+        descriptor_id=descriptor_id,
+        safety_class=safety_class,
+    )
+    response = ChallengeResponse(
+        approval_request=request,
+        approval_request_digest=owner_control_approval_request_digest(request),
+        decision="approved",
+        channel_binding_sha256=_digest_for_vector(
+            descriptor_id=descriptor_id,
+            label="channel-binding",
+        ),
+        confirmed_at="2030-01-02T03:04:05+00:00",
+    )
+    request_payload = request.model_dump(mode="json")
+    response_payload = response.model_dump(mode="json")
+    return {
+        "descriptor_id": descriptor_id,
+        "descriptor_version": descriptor_version,
+        "approval_request": {
+            "canonical_json": canonical_json_bytes(request_payload).decode("utf-8"),
+            "payload": request_payload,
+            "sha256": owner_control_approval_request_digest(request),
+        },
+        "challenge_response": {
+            "canonical_json": canonical_json_bytes(response_payload).decode("utf-8"),
+            "payload": response_payload,
+            "sha256": owner_control_challenge_response_digest(response),
+        },
+    }
+
+
+def _canonicalization_vectors() -> list[dict[str, Any]]:
+    payloads: tuple[tuple[str, object], ...] = (
+        (
+            "primitive-types",
+            {
+                "array": [True, False, None, 7],
+                "integer_max": 2**63 - 1,
+                "integer_min": -(2**63),
+            },
+        ),
+        (
+            "unicode-and-escapes",
+            {
+                "controls": 'null\x00unit\x1fdelete\x7fline\n\ttab\\quote"',
+                "text": "μ😀",
+            },
+        ),
+        ("unicode-key-order", {"😀": 3, "Ｚ": 2, "a": 1}),
+        ("empty-and-nested", {"empty_array": [], "empty_object": {}, "nested": [{"x": []}]}),
+    )
+    return [
+        {
+            "name": name,
+            "payload": payload,
+            "canonical_json": canonical_json_bytes(payload).decode("utf-8"),
+            "sha256": canonical_json_sha256(payload),
+        }
+        for name, payload in payloads
+    ]
+
+
+def _negative_vectors() -> list[dict[str, Any]]:
+    descriptor = read_privileged_operation_descriptor("managed-authz-policy-set").descriptor
+    request = _approval_request_for_descriptor(
+        descriptor_id=descriptor.descriptor_id,
+        safety_class=descriptor.safety_class,
+    )
+    request_payload = request.model_dump(mode="json")
+    valid_response = ChallengeResponse(
+        approval_request=request,
+        approval_request_digest=owner_control_approval_request_digest(request),
+        decision="approved",
+        channel_binding_sha256=_digest_for_vector(
+            descriptor_id=descriptor.descriptor_id,
+            label="channel-binding",
+        ),
+        confirmed_at="2030-01-02T03:04:05+00:00",
+    ).model_dump(mode="json")
+    return [
+        {
+            "model": "approval_request",
+            "rule": "schema-version-is-one",
+            "error_location": ["schema_version"],
+            "payload": {**request_payload, "schema_version": 2},
+        },
+        {
+            "model": "approval_request",
+            "rule": "descriptor-version-is-one",
+            "error_location": ["descriptor_version"],
+            "payload": {**request_payload, "descriptor_version": 2},
+        },
+        {
+            "model": "approval_request",
+            "rule": "digests-are-lowercase-sha256",
+            "error_location": ["request_digest"],
+            "payload": {**request_payload, "request_digest": "A" * 64},
+        },
+        {
+            "model": "approval_request",
+            "rule": "timestamps-use-canonical-utc-form",
+            "error_location": ["expires_at"],
+            "payload": {**request_payload, "expires_at": "2030-01-02T03:09:05Z"},
+        },
+        {
+            "model": "approval_request",
+            "rule": "timestamps-are-calendar-valid",
+            "error_location": [],
+            "payload": {**request_payload, "expires_at": "2030-02-30T03:09:05+00:00"},
+        },
+        {
+            "model": "approval_request",
+            "rule": "nonce-is-canonical",
+            "error_location": ["nonce"],
+            "payload": {**request_payload, "nonce": "short"},
+        },
+        {
+            "model": "approval_request",
+            "rule": "expiry-follows-issuance",
+            "error_location": [],
+            "payload": {**request_payload, "expires_at": request_payload["issued_at"]},
+        },
+        {
+            "model": "challenge_response",
+            "rule": "request-digest-binds-exact-request",
+            "error_location": [],
+            "payload": {**valid_response, "approval_request_digest": "0" * 64},
+        },
+        {
+            "model": "challenge_response",
+            "rule": "confirmation-is-not-before-issuance",
+            "error_location": [],
+            "payload": {**valid_response, "confirmed_at": "2030-01-02T02:59:05+00:00"},
+        },
+        {
+            "model": "challenge_response",
+            "rule": "confirmation-is-not-after-expiry",
+            "error_location": [],
+            "payload": {**valid_response, "confirmed_at": "2030-01-02T03:10:05+00:00"},
+        },
+        {
+            "model": "server_review_payload",
+            "rule": "review-item-keys-are-unique",
+            "error_location": [],
+            "payload": {
+                **request_payload["server_review"],
+                "items": [
+                    request_payload["server_review"]["items"][0],
+                    request_payload["server_review"]["items"][0],
+                ],
+            },
+        },
+        {
+            "model": "server_review_payload",
+            "rule": "review-text-has-no-surrounding-whitespace",
+            "error_location": [],
+            "payload": {**request_payload["server_review"], "title": " Owner approval required"},
+        },
+        {
+            "model": "server_review_payload",
+            "rule": "review-item-text-has-no-surrounding-whitespace",
+            "error_location": ["items", 0],
+            "payload": {
+                **request_payload["server_review"],
+                "items": [
+                    {**request_payload["server_review"]["items"][0], "label": " Operation class"},
+                    *request_payload["server_review"]["items"][1:],
+                ],
+            },
+        },
+    ]
+
+
+def _build_owner_control_contract() -> dict[str, Any]:
+    descriptors = list_privileged_operation_descriptors()
+    return {
+        "schema_version": OWNER_CONTROL_CONTRACT_SCHEMA_VERSION,
+        "canonical_json": {
+            "encoding": "utf-8",
+            "ensure_ascii": True,
+            "integer_max": 2**63 - 1,
+            "integer_min": -(2**63),
+            "non_finite_numbers": "rejected",
+            "number_domain": "signed-64-bit-integers-only",
+            "object_key_order": "unicode-code-point",
+            "object_keys": "strings-only",
+            "separators": [",", ":"],
+            "trailing_newline": False,
+        },
+        "canonicalization_vectors": _canonicalization_vectors(),
+        "schemas": {
+            "approval_request": ApprovalRequest.model_json_schema(),
+            "challenge_response": ChallengeResponse.model_json_schema(),
+            "server_review_payload": ServerReviewPayload.model_json_schema(),
+        },
+        "golden_vectors": [
+            _golden_vector(
+                descriptor_id=descriptor.descriptor_id,
+                descriptor_version=descriptor.descriptor_version,
+                safety_class=descriptor.safety_class,
+            )
+            for descriptor in descriptors
+        ],
+        "negative_vectors": _negative_vectors(),
+    }
+
+
+def build_owner_control_contract() -> dict[str, Any]:
+    """Build the deterministic, public owner-control conformance artifact."""
+
+    return _build_owner_control_contract()
+
+
+def _require_exact_keys(value: Mapping[str, Any], expected: set[str], location: str) -> None:
+    actual = set(value)
+    if actual != expected:
+        raise OwnerControlContractError(
+            f"Unexpected owner-control contract keys at {location}: {sorted(actual)!r}"
+        )
+
+
+def validate_owner_control_contract(artifact: Mapping[str, Any]) -> None:
+    """Fail closed when an owner-control artifact drifts from its registered contract."""
+
+    _require_exact_keys(
+        artifact,
+        {
+            "schema_version",
+            "canonical_json",
+            "canonicalization_vectors",
+            "schemas",
+            "golden_vectors",
+            "negative_vectors",
+        },
+        "root",
+    )
+    if artifact["schema_version"] != OWNER_CONTROL_CONTRACT_SCHEMA_VERSION:
+        raise OwnerControlContractError("Unsupported owner-control contract schema version")
+    expected = _build_owner_control_contract()
+    if artifact["canonical_json"] != expected["canonical_json"]:
+        raise OwnerControlContractError("Owner-control canonical JSON declaration drifted")
+    if artifact["canonicalization_vectors"] != expected["canonicalization_vectors"]:
+        raise OwnerControlContractError("Owner-control canonicalization vectors drifted")
+    if artifact["schemas"] != expected["schemas"]:
+        raise OwnerControlContractError("Owner-control JSON schemas drifted")
+    vectors = artifact["golden_vectors"]
+    if not isinstance(vectors, list):
+        raise OwnerControlContractError("Owner-control golden vectors must be a list")
+    if vectors != expected["golden_vectors"]:
+        raise OwnerControlContractError("Owner-control golden vectors drifted from the registry")
+    if artifact["negative_vectors"] != expected["negative_vectors"]:
+        raise OwnerControlContractError("Owner-control negative vectors drifted")
+
+
+def write_owner_control_contract(output_path: Path) -> Path:
+    artifact = build_owner_control_contract()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(
+        json.dumps(artifact, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return output_path

--- a/docs/README.md
+++ b/docs/README.md
@@ -60,6 +60,8 @@ Use these docs as the source of truth for `launchplane`.
   product/system Owner membership, requirement, routing, and evaluation contract.
 - [owner-acceptance.md](owner-acceptance.md) — authoritative exact-change Owner
   acceptance binding, event ledger, and human-only API boundary.
+- [owner-control-channel.md](owner-control-channel.md) — public canonical owner
+  challenge payloads, cross-host conformance artifact, and deferred runtime boundary.
 - [privileged-operations.md](privileged-operations.md) — typed human-governed
   planning, managed-rule authorization, redaction, and future execution boundary.
 - [change-impact-policy.md](change-impact-policy.md) — authoritative

--- a/docs/owner-control-channel.md
+++ b/docs/owner-control-channel.md
@@ -1,0 +1,83 @@
+---
+title: Owner-Control Channel Contract
+---
+
+# Owner-Control Channel Contract
+
+Launchplane publishes a public, versioned owner-control serialization for a
+future trusted host confirmation channel. It lets a host render the exact
+server-authored review and return a challenge response without exposing owner
+authority to model tools, browser automation, shells, Code Bridge, MCP, or
+agent-controlled IPC.
+
+## Canonical Contract
+
+`control_plane.contracts.canonical_json` defines the shared UTF-8 JSON bytes:
+object keys sorted by ascending Unicode code point, compact `,` and `:` separators, JSON
+ASCII escaping, signed-64-bit integer-only numbers, string-only object keys,
+rejection of floating-point and non-finite numbers, no trailing newline, and
+lowercase SHA-256 digests. Timestamps use whole-second canonical UTC form. The
+checked artifact includes
+canonicalization edge vectors for primitive values, escapes, Unicode text, and
+Unicode key ordering. The
+existing privileged-operation digest helper delegates to that same function, so
+its existing digest bytes remain unchanged.
+
+`control_plane.contracts.owner_control` defines strict schema-version-1
+Pydantic contracts for:
+
+- `ServerReviewPayload`, the server-authored, display-ready review content;
+- `ApprovalRequest`, which binds operation and descriptor identity, request,
+  plan, evidence, pre-state, policy, immutable GitHub owner ID, review, nonce,
+  issuance time, and expiry; and
+- `ChallengeResponse`, which embeds and digests the exact request, records an
+  approved decision, channel binding digest, and bounded confirmation time.
+
+Version, digest casing, canonical UTC timestamps and ordering, nonce form, and
+duplicate review fields fail closed. Single-field constraints are present in
+the exported JSON Schemas; cross-field constraints are also represented by
+negative conformance vectors. Single-use nonce tracking, challenge issuance,
+channel/session binding verification, and expiry enforcement at request time
+require later storage and service work; this contract slice adds none of them.
+
+## Conformance Artifact
+
+`contracts/owner-control-contract.json` is deterministic and public-safe. It
+contains the JSON schemas, canonicalization declaration, and byte/digest golden
+vectors for every descriptor currently registered in
+`control_plane.privileged_operation_registry`.
+
+Descriptor vectors derive all synthetic identity values from the descriptor ID,
+so registering another descriptor does not churn existing vectors. Negative
+vectors use one explicitly named public descriptor rather than registry order
+and cover version, digest, timestamp, nonce, issuance/expiry ordering, exact
+request binding, confirmation-time rejection, review-key uniqueness, and review
+text normalization. Timestamp vectors cover both lexical UTC form and calendar
+validity.
+
+Regenerate and verify the checked artifact with:
+
+```bash
+uv run launchplane service export-owner-control-contract --output contracts/owner-control-contract.json
+uv run --extra dev python -m unittest tests.test_owner_control_contract
+```
+
+The vectors contain only synthetic identifiers, digests, nonces, timestamps,
+and generic review strings. They carry no tenant, product, repository, domain,
+operator, policy authority, session credential, or live endpoint data.
+
+## Deferred Runtime Work
+
+This is a behavior-neutral contract seam. It adds no HTTP route, storage record,
+migration, frontend, worker action, authorization grant, source-kind change,
+policy change, credential, channel implementation, or live runtime mutation.
+Existing browser approval behavior remains unchanged until a separately reviewed
+runtime adoption change proves the trusted owner-control path.
+
+`ChallengeResponse` represents successful confirmation only. Owner rejection,
+challenge expiry, and replay rejection are future audit events rather than
+alternate signed response decisions. `channel_binding_sha256` is reserved for
+the digest of the later channel-protocol binding record; its preimage and proof
+mechanism remain deliberately undefined until that separately reviewed runtime
+protocol exists. The current vectors use a synthetic placeholder digest and do
+not claim to prove a live channel.

--- a/docs/privileged-operations.md
+++ b/docs/privileged-operations.md
@@ -32,6 +32,14 @@ route, execute action, static execution credential, or agent execution path.
 The registry is not an arbitrary route, command, SQL, or payload proxy. New
 descriptors require code, schemas, tests, documentation, and review.
 
+## Owner-Control Contract Seam
+
+`contracts/owner-control-contract.json` publishes canonical owner-control
+request and response bytes plus generic golden vectors for every registered
+descriptor. It is a cross-host conformance artifact only: it does not issue a
+challenge, consume an owner confirmation, alter browser approval, add a route,
+or authorize execution. See `docs/owner-control-channel.md`.
+
 ## Authorization
 
 Privileged-operation routes do not use bare `LaunchplaneAuthzPolicy.allows`.

--- a/docs/records.md
+++ b/docs/records.md
@@ -2656,5 +2656,11 @@ review plus bounded diff and CAS/read-back evidence. See
 `docs/privileged-operations.md` for the full evidence and authorization
 boundary.
 
+The checked `contracts/owner-control-contract.json` artifact is not a record,
+nonce store, audit event, or runtime authority. It supplies deterministic
+cross-host serialization and synthetic golden vectors only; future owner-control
+issuance, confirmation, replay rejection, and expiry records require a separate
+storage contract.
+
 **Preserved history:** references to Phase 1 planning records describe the
 pre-worker lifecycle and do not constrain the current Phase 2 statuses.

--- a/tests/test_docs_contracts.py
+++ b/tests/test_docs_contracts.py
@@ -141,6 +141,7 @@ class DocsContractsTests(TestCase):
         agent_operator_contract = Path("docs/agent-operator-contract.md").read_text(
             encoding="utf-8"
         )
+        owner_control_channel = Path("docs/owner-control-channel.md").read_text(encoding="utf-8")
         docs_index = Path("docs/README.md").read_text(encoding="utf-8")
         canonical_openapi = json.loads(
             Path("frontend/generated/openapi-canonical.json").read_text(encoding="utf-8")
@@ -183,6 +184,22 @@ class DocsContractsTests(TestCase):
             "pnpm --dir frontend check:openapi-drift",
             metadata["qualityGate"]["agentContract"]["drift"],
         )
+        self.assertEqual(
+            "docs/owner-control-channel.md",
+            metadata["docs"]["ownerControlChannel"],
+        )
+        self.assertEqual(
+            "contracts/owner-control-contract.json",
+            metadata["qualityGate"]["ownerControlContract"]["artifact"],
+        )
+        self.assertEqual(
+            "uv run launchplane service export-owner-control-contract --output contracts/owner-control-contract.json",
+            metadata["qualityGate"]["ownerControlContract"]["export"],
+        )
+        self.assertEqual(
+            "uv run --extra dev python -m unittest tests.test_owner_control_contract.OwnerControlArtifactTests.test_checked_artifact_matches_generated_contract",
+            metadata["qualityGate"]["ownerControlContract"]["drift"],
+        )
         self.assertIn(
             "`uv run launchplane service export-openapi --output frontend/generated/openapi-canonical.json`",
             service_boundary,
@@ -193,7 +210,10 @@ class DocsContractsTests(TestCase):
             service_boundary,
         )
         self.assertIn("agent-operator-contract.md", docs_index)
+        self.assertIn("owner-control-channel.md", docs_index)
         self.assertIn("contracts/agent-operator-contract.json", agent_context_boundary)
+        self.assertIn("contracts/owner-control-contract.json", owner_control_channel)
+        self.assertIn("export-owner-control-contract", owner_control_channel)
         self.assertIn("`semantic_digest_sha256`", agent_operator_contract)
         self.assertIn("`normalization_version`", agent_operator_contract)
         self.assertEqual(

--- a/tests/test_owner_control_contract.py
+++ b/tests/test_owner_control_contract.py
@@ -1,0 +1,269 @@
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+from tempfile import TemporaryDirectory
+import unittest
+
+from pydantic import BaseModel, ValidationError
+
+from control_plane.contracts.canonical_json import canonical_json_bytes, canonical_json_sha256
+from control_plane.contracts.owner_control import (
+    ApprovalRequest,
+    ChallengeResponse,
+    ReviewItem,
+    ServerReviewPayload,
+    owner_control_approval_request_digest,
+    owner_control_challenge_response_digest,
+)
+from control_plane.contracts.privileged_operation import (
+    ManagedSecretReencryptionPlanInput,
+    privileged_operation_request_digest,
+)
+from control_plane.owner_control_contract import (
+    OwnerControlContractError,
+    build_owner_control_contract,
+    validate_owner_control_contract,
+    write_owner_control_contract,
+)
+from control_plane.privileged_operation_registry import list_privileged_operation_descriptors
+
+
+def _approval_request() -> ApprovalRequest:
+    review = ServerReviewPayload(
+        review_id="review-generic",
+        title="Owner approval required",
+        summary="Review this exact privileged operation before confirming.",
+        items=(
+            ReviewItem(
+                key="descriptor",
+                label="Operation class",
+                value="managed-secret-reencryption",
+            ),
+        ),
+    )
+    return ApprovalRequest(
+        operation_id="privileged-operation-0123456789abcdef0123456789abcdef",
+        descriptor_id="managed-secret-reencryption",
+        descriptor_version=1,
+        request_digest="1" * 64,
+        plan_digest="2" * 64,
+        evidence_digest="3" * 64,
+        pre_state_digest="4" * 64,
+        policy_record_id="owner-policy-generic",
+        policy_revision=1,
+        policy_sha256="5" * 64,
+        owner_github_id=100001,
+        server_review=review,
+        nonce="owner-control-nonce-0000000000000001",
+        issued_at="2030-01-02T03:00:05+00:00",
+        expires_at="2030-01-02T03:09:05+00:00",
+    )
+
+
+class CanonicalJsonTests(unittest.TestCase):
+    def test_canonical_json_bytes_and_sha256_are_stable(self) -> None:
+        payload = {"b": 2, "a": [True, None, "μ"]}
+
+        self.assertEqual(
+            canonical_json_bytes(payload),
+            b'{"a":[true,null,"\\u03bc"],"b":2}',
+        )
+        self.assertEqual(
+            canonical_json_sha256(payload),
+            "47c7f639fc01073ea65bbd5ee2207801ffa734723151617d7de493ef8c80b7c9",
+        )
+
+    def test_canonical_json_rejects_floats_non_finite_numbers_and_oversized_integers(self) -> None:
+        invalid_payloads = (
+            {"value": 1.0},
+            {"value": float("nan")},
+            {"value": float("inf")},
+            {"value": 2**63},
+            {"value": -(2**63) - 1},
+        )
+
+        for invalid_payload in invalid_payloads:
+            with self.subTest(payload=invalid_payload):
+                with self.assertRaises(ValueError):
+                    canonical_json_bytes(invalid_payload)
+
+    def test_privileged_operation_digest_bytes_remain_compatible(self) -> None:
+        request = ManagedSecretReencryptionPlanInput(
+            reason="Review canonical root migration",
+            source_label="test-plan",
+        )
+
+        self.assertEqual(
+            privileged_operation_request_digest(request),
+            "4e6864697fe5f5eb851f76b93865dc28b7897c3e8a84c68b1104912dd0b7d816",
+        )
+        self.assertEqual(
+            privileged_operation_request_digest(request),
+            canonical_json_sha256(request.model_dump(mode="json")),
+        )
+
+
+class OwnerControlContractModelTests(unittest.TestCase):
+    def test_request_and_response_digests_bind_canonical_models(self) -> None:
+        request = _approval_request()
+        response = ChallengeResponse(
+            approval_request=request,
+            approval_request_digest=owner_control_approval_request_digest(request),
+            decision="approved",
+            channel_binding_sha256="6" * 64,
+            confirmed_at="2030-01-02T03:04:05+00:00",
+        )
+
+        self.assertEqual(
+            owner_control_approval_request_digest(request),
+            canonical_json_sha256(request.model_dump(mode="json")),
+        )
+        self.assertEqual(
+            owner_control_challenge_response_digest(response),
+            canonical_json_sha256(response.model_dump(mode="json")),
+        )
+
+    def test_contracts_reject_invalid_versions_digests_timestamps_and_nonces(self) -> None:
+        payload = _approval_request().model_dump(mode="json")
+        invalid_payloads = (
+            {**payload, "schema_version": 2},
+            {**payload, "request_digest": "A" * 64},
+            {**payload, "expires_at": "2030-01-02T03:09:05Z"},
+            {**payload, "expires_at": "2030-01-02T03:09:05.000000+00:00"},
+            {**payload, "nonce": "short"},
+        )
+
+        for invalid_payload in invalid_payloads:
+            with self.subTest(invalid_payload=invalid_payload):
+                with self.assertRaises(ValidationError):
+                    ApprovalRequest.model_validate_json(json.dumps(invalid_payload))
+
+    def test_challenge_response_rejects_mismatched_request_digest_and_expiry(self) -> None:
+        request = _approval_request()
+
+        with self.assertRaises(ValidationError):
+            ChallengeResponse(
+                approval_request=request,
+                approval_request_digest="0" * 64,
+                decision="approved",
+                channel_binding_sha256="6" * 64,
+                confirmed_at="2030-01-02T03:04:05+00:00",
+            )
+        with self.assertRaises(ValidationError):
+            ChallengeResponse(
+                approval_request=request,
+                approval_request_digest=owner_control_approval_request_digest(request),
+                decision="approved",
+                channel_binding_sha256="6" * 64,
+                confirmed_at="2030-01-02T03:10:05+00:00",
+            )
+        with self.assertRaises(ValidationError):
+            ChallengeResponse(
+                approval_request=request,
+                approval_request_digest=owner_control_approval_request_digest(request),
+                decision="approved",
+                channel_binding_sha256="6" * 64,
+                confirmed_at="2030-01-02T02:59:05+00:00",
+            )
+
+    def test_exported_schema_exposes_single_field_constraints(self) -> None:
+        artifact = build_owner_control_contract()
+        approval_schema = artifact["schemas"]["approval_request"]
+        response_schema = artifact["schemas"]["challenge_response"]
+
+        self.assertEqual(approval_schema["properties"]["schema_version"]["const"], 1)
+        self.assertEqual(approval_schema["properties"]["descriptor_version"]["const"], 1)
+        self.assertEqual(
+            approval_schema["properties"]["request_digest"]["pattern"],
+            "^[0-9a-f]{64}$",
+        )
+        self.assertEqual(
+            approval_schema["properties"]["nonce"]["pattern"],
+            "^[A-Za-z0-9_-]{16,128}$",
+        )
+        self.assertIn("pattern", response_schema["properties"]["confirmed_at"])
+
+
+class OwnerControlArtifactTests(unittest.TestCase):
+    def test_golden_vectors_cover_every_registered_descriptor(self) -> None:
+        artifact = build_owner_control_contract()
+        expected_descriptors = {
+            (descriptor.descriptor_id, descriptor.descriptor_version)
+            for descriptor in list_privileged_operation_descriptors()
+        }
+        actual_descriptors = {
+            (vector["descriptor_id"], vector["descriptor_version"])
+            for vector in artifact["golden_vectors"]
+        }
+
+        self.assertEqual(actual_descriptors, expected_descriptors)
+        for vector in artifact["golden_vectors"]:
+            request = ApprovalRequest.model_validate_json(
+                json.dumps(vector["approval_request"]["payload"])
+            )
+            response = ChallengeResponse.model_validate_json(
+                json.dumps(vector["challenge_response"]["payload"])
+            )
+            self.assertEqual(
+                vector["approval_request"]["canonical_json"],
+                canonical_json_bytes(request.model_dump(mode="json")).decode("utf-8"),
+            )
+            self.assertEqual(
+                vector["approval_request"]["sha256"],
+                owner_control_approval_request_digest(request),
+            )
+            self.assertEqual(
+                vector["challenge_response"]["canonical_json"],
+                canonical_json_bytes(response.model_dump(mode="json")).decode("utf-8"),
+            )
+            self.assertEqual(
+                vector["challenge_response"]["sha256"],
+                owner_control_challenge_response_digest(response),
+            )
+
+    def test_validator_rejects_contract_drift(self) -> None:
+        artifact = build_owner_control_contract()
+        changed = copy.deepcopy(artifact)
+        changed["golden_vectors"][0]["approval_request"]["sha256"] = "0" * 64
+
+        with self.assertRaises(OwnerControlContractError):
+            validate_owner_control_contract(changed)
+
+    def test_negative_vectors_are_rejected_by_the_named_models(self) -> None:
+        artifact = build_owner_control_contract()
+        models: dict[str, type[BaseModel]] = {
+            "approval_request": ApprovalRequest,
+            "challenge_response": ChallengeResponse,
+            "server_review_payload": ServerReviewPayload,
+        }
+
+        for vector in artifact["negative_vectors"]:
+            with self.subTest(rule=vector["rule"]):
+                with self.assertRaises(ValidationError) as raised:
+                    models[vector["model"]].model_validate_json(json.dumps(vector["payload"]))
+                errors = raised.exception.errors()
+                self.assertEqual(len(errors), 1)
+                self.assertEqual(list(errors[0]["loc"]), vector["error_location"])
+
+    def test_checked_artifact_matches_generated_contract(self) -> None:
+        checked = json.loads(
+            Path("contracts/owner-control-contract.json").read_text(encoding="utf-8")
+        )
+
+        self.assertEqual(checked, build_owner_control_contract())
+
+    def test_writer_is_deterministic(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            output_path = Path(temporary_directory) / "owner-control-contract.json"
+            write_owner_control_contract(output_path)
+            first = output_path.read_bytes()
+            write_owner_control_contract(output_path)
+            second = output_path.read_bytes()
+
+        self.assertEqual(first, second)
+        self.assertEqual(
+            first,
+            json.dumps(build_owner_control_contract(), indent=2, sort_keys=True).encode() + b"\n",
+        )

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -2699,6 +2699,27 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(payload["provenance"]["source_commit_sha"], "a" * 40)
         self.assertEqual(len(payload["contract"]["operations"]), 12)
 
+    def test_service_export_owner_control_contract_writes_conformance_artifact(self) -> None:
+        runner = CliRunner()
+        with TemporaryDirectory() as temporary_directory_name:
+            output_path = Path(temporary_directory_name) / "owner-control-contract.json"
+
+            result = runner.invoke(
+                CLI_MAIN,
+                [
+                    "service",
+                    "export-owner-control-contract",
+                    "--output",
+                    str(output_path),
+                ],
+            )
+            payload = json.loads(output_path.read_text(encoding="utf-8"))
+
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+        self.assertEqual(result.output.strip(), str(output_path))
+        self.assertEqual(payload["schema_version"], 1)
+        self.assertTrue(payload["golden_vectors"])
+
     def test_product_onboarding_endpoint_writes_full_launchplane_owned_bundle(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)


### PR DESCRIPTION
## Summary

- publish strict version-1 owner-control approval, review, and confirmation schemas
- define deterministic signed-64-bit canonical JSON with positive and negative cross-host conformance vectors
- cover every registered privileged-operation descriptor with stable synthetic golden vectors
- add the checked artifact export command, drift gate, tests, and ownership-boundary documentation

## Behavior Boundary

This is intentionally behavior-neutral. It adds no HTTP route, storage record, migration, worker action, authorization grant, frontend, session credential, signing key, channel implementation, or live runtime mutation. Existing browser approval remains unchanged.

## Validation

- `uv run --extra dev launchplane ci unittest-shard local` — 3,137 targets across 12 shards passed
- `uv run --extra dev python -m unittest tests.test_owner_control_contract tests.test_privileged_operation tests.test_service tests.test_docs_contracts` — 169 passed
- `uv run --extra dev mypy control_plane tests` — 775 source files clean
- changed-file `ruff check` and `ruff format --check` — clean
- checked artifact export/drift comparison — clean
- JetBrains changed-file inspection — GREEN, zero findings
- Claude Opus 5 final review — LOVE
- Gemini 3.1 Pro High final review — LOVE

Refs #2257
