### PR TITLE
Define signed owner-control envelope contract

### DIFF
--- a/contracts/owner-control-contract.json
+++ b/contracts/owner-control-contract.json
@@ -64,6 +64,356 @@
       "sha256": "07db6c156108fd238db2691d759e6fe5d8f8649fb5e9c8130dc3f98342ba5ae2"
     }
   ],
+  "confirmation_golden_vectors": [
+    {
+      "challenge_response": {
+        "canonical_json": "{\"approval_request\":{\"descriptor_id\":\"managed-authz-policy-set\",\"descriptor_version\":1,\"evidence_digest\":\"df6da961581b149a28639add56e3b08401b3bed6afb07ad0c7b5ca3d51632be9\",\"expires_at\":\"2030-01-02T03:09:05+00:00\",\"issued_at\":\"2030-01-02T03:00:05+00:00\",\"nonce\":\"owner-control-b565a7b3115d408e250eeffe65af9513\",\"operation_id\":\"privileged-operation-1d762a6ac3895594ed85ba7aa9c39330\",\"owner_github_id\":494383370,\"plan_digest\":\"edf23f94b33d1188e34e143e7aff91075ec941053b3b95d367a45de67b1fe1d7\",\"policy_record_id\":\"owner-policy-1d762a6ac3895594ed85\",\"policy_revision\":1,\"policy_sha256\":\"b379db2fe113e77eef0b3bb05aec804189d9f0b359e67d941d837c7de59e6f8e\",\"pre_state_digest\":\"46df3876ade6b39b0edfbd3b8ea1a408173bbe5d8cc7154cea4d63e5d057239f\",\"request_digest\":\"e0e31f55312d2562bf610587d7a21b5badeed50224284b08d1662924379b4539\",\"schema_version\":1,\"server_review\":{\"items\":[{\"key\":\"descriptor\",\"label\":\"Operation class\",\"value\":\"managed-authz-policy-set\"},{\"key\":\"safety_class\",\"label\":\"Safety class\",\"value\":\"policy_admin\"}],\"review_id\":\"review-1d762a6ac3895594ed85ba7a\",\"schema_version\":1,\"summary\":\"Review this exact privileged operation before confirming.\",\"title\":\"Owner approval required\"}},\"approval_request_digest\":\"a60572025b121241d44c3f28ce22715841e348765dd50cfa514861e89334d9eb\",\"channel_binding_sha256\":\"1b8a26cd423937c1b5edcb5f7162c67978055213231bc4e85c3c46dc9a9738aa\",\"confirmed_at\":\"2030-01-02T03:04:05+00:00\",\"decision\":\"approved\",\"schema_version\":1}",
+        "payload": {
+          "approval_request": {
+            "descriptor_id": "managed-authz-policy-set",
+            "descriptor_version": 1,
+            "evidence_digest": "df6da961581b149a28639add56e3b08401b3bed6afb07ad0c7b5ca3d51632be9",
+            "expires_at": "2030-01-02T03:09:05+00:00",
+            "issued_at": "2030-01-02T03:00:05+00:00",
+            "nonce": "owner-control-b565a7b3115d408e250eeffe65af9513",
+            "operation_id": "privileged-operation-1d762a6ac3895594ed85ba7aa9c39330",
+            "owner_github_id": 494383370,
+            "plan_digest": "edf23f94b33d1188e34e143e7aff91075ec941053b3b95d367a45de67b1fe1d7",
+            "policy_record_id": "owner-policy-1d762a6ac3895594ed85",
+            "policy_revision": 1,
+            "policy_sha256": "b379db2fe113e77eef0b3bb05aec804189d9f0b359e67d941d837c7de59e6f8e",
+            "pre_state_digest": "46df3876ade6b39b0edfbd3b8ea1a408173bbe5d8cc7154cea4d63e5d057239f",
+            "request_digest": "e0e31f55312d2562bf610587d7a21b5badeed50224284b08d1662924379b4539",
+            "schema_version": 1,
+            "server_review": {
+              "items": [
+                {
+                  "key": "descriptor",
+                  "label": "Operation class",
+                  "value": "managed-authz-policy-set"
+                },
+                {
+                  "key": "safety_class",
+                  "label": "Safety class",
+                  "value": "policy_admin"
+                }
+              ],
+              "review_id": "review-1d762a6ac3895594ed85ba7a",
+              "schema_version": 1,
+              "summary": "Review this exact privileged operation before confirming.",
+              "title": "Owner approval required"
+            }
+          },
+          "approval_request_digest": "a60572025b121241d44c3f28ce22715841e348765dd50cfa514861e89334d9eb",
+          "channel_binding_sha256": "1b8a26cd423937c1b5edcb5f7162c67978055213231bc4e85c3c46dc9a9738aa",
+          "confirmed_at": "2030-01-02T03:04:05+00:00",
+          "decision": "approved",
+          "schema_version": 1
+        },
+        "sha256": "cd4d72f6fca70cd0e62dbdb5db25f1c8b200fffb71c2e62edc85aa4a1f955539"
+      },
+      "channel_binding": {
+        "canonical_json": "{\"channel_session_id\":\"channel-session-5138ce25ddfcf0b39d4d178ef80612d0\",\"owner_github_id\":494383370,\"owner_public_key\":\"A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg\",\"schema_version\":1,\"session_expires_at\":\"2030-01-02T03:09:05+00:00\",\"session_issued_at\":\"2030-01-02T03:00:05+00:00\",\"signature_algorithm\":\"ed25519\"}",
+        "payload": {
+          "channel_session_id": "channel-session-5138ce25ddfcf0b39d4d178ef80612d0",
+          "owner_github_id": 494383370,
+          "owner_public_key": "A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg",
+          "schema_version": 1,
+          "session_expires_at": "2030-01-02T03:09:05+00:00",
+          "session_issued_at": "2030-01-02T03:00:05+00:00",
+          "signature_algorithm": "ed25519"
+        },
+        "sha256": "1b8a26cd423937c1b5edcb5f7162c67978055213231bc4e85c3c46dc9a9738aa"
+      },
+      "confirmation_envelope": {
+        "canonical_json": "{\"challenge_response\":{\"approval_request\":{\"descriptor_id\":\"managed-authz-policy-set\",\"descriptor_version\":1,\"evidence_digest\":\"df6da961581b149a28639add56e3b08401b3bed6afb07ad0c7b5ca3d51632be9\",\"expires_at\":\"2030-01-02T03:09:05+00:00\",\"issued_at\":\"2030-01-02T03:00:05+00:00\",\"nonce\":\"owner-control-b565a7b3115d408e250eeffe65af9513\",\"operation_id\":\"privileged-operation-1d762a6ac3895594ed85ba7aa9c39330\",\"owner_github_id\":494383370,\"plan_digest\":\"edf23f94b33d1188e34e143e7aff91075ec941053b3b95d367a45de67b1fe1d7\",\"policy_record_id\":\"owner-policy-1d762a6ac3895594ed85\",\"policy_revision\":1,\"policy_sha256\":\"b379db2fe113e77eef0b3bb05aec804189d9f0b359e67d941d837c7de59e6f8e\",\"pre_state_digest\":\"46df3876ade6b39b0edfbd3b8ea1a408173bbe5d8cc7154cea4d63e5d057239f\",\"request_digest\":\"e0e31f55312d2562bf610587d7a21b5badeed50224284b08d1662924379b4539\",\"schema_version\":1,\"server_review\":{\"items\":[{\"key\":\"descriptor\",\"label\":\"Operation class\",\"value\":\"managed-authz-policy-set\"},{\"key\":\"safety_class\",\"label\":\"Safety class\",\"value\":\"policy_admin\"}],\"review_id\":\"review-1d762a6ac3895594ed85ba7a\",\"schema_version\":1,\"summary\":\"Review this exact privileged operation before confirming.\",\"title\":\"Owner approval required\"}},\"approval_request_digest\":\"a60572025b121241d44c3f28ce22715841e348765dd50cfa514861e89334d9eb\",\"channel_binding_sha256\":\"1b8a26cd423937c1b5edcb5f7162c67978055213231bc4e85c3c46dc9a9738aa\",\"confirmed_at\":\"2030-01-02T03:04:05+00:00\",\"decision\":\"approved\",\"schema_version\":1},\"channel_binding\":{\"channel_session_id\":\"channel-session-5138ce25ddfcf0b39d4d178ef80612d0\",\"owner_github_id\":494383370,\"owner_public_key\":\"A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg\",\"schema_version\":1,\"session_expires_at\":\"2030-01-02T03:09:05+00:00\",\"session_issued_at\":\"2030-01-02T03:00:05+00:00\",\"signature_algorithm\":\"ed25519\"},\"schema_version\":1,\"signature\":\"tglT-SQl-k0_FmKKynVn6iop-CRZnBmAVLLgCSX6Ak1FN5NcQRSrFYiGLmTtoqOKvYb9FCc0GRGnGWVKaXaDAQ\",\"signature_algorithm\":\"ed25519\"}",
+        "payload": {
+          "challenge_response": {
+            "approval_request": {
+              "descriptor_id": "managed-authz-policy-set",
+              "descriptor_version": 1,
+              "evidence_digest": "df6da961581b149a28639add56e3b08401b3bed6afb07ad0c7b5ca3d51632be9",
+              "expires_at": "2030-01-02T03:09:05+00:00",
+              "issued_at": "2030-01-02T03:00:05+00:00",
+              "nonce": "owner-control-b565a7b3115d408e250eeffe65af9513",
+              "operation_id": "privileged-operation-1d762a6ac3895594ed85ba7aa9c39330",
+              "owner_github_id": 494383370,
+              "plan_digest": "edf23f94b33d1188e34e143e7aff91075ec941053b3b95d367a45de67b1fe1d7",
+              "policy_record_id": "owner-policy-1d762a6ac3895594ed85",
+              "policy_revision": 1,
+              "policy_sha256": "b379db2fe113e77eef0b3bb05aec804189d9f0b359e67d941d837c7de59e6f8e",
+              "pre_state_digest": "46df3876ade6b39b0edfbd3b8ea1a408173bbe5d8cc7154cea4d63e5d057239f",
+              "request_digest": "e0e31f55312d2562bf610587d7a21b5badeed50224284b08d1662924379b4539",
+              "schema_version": 1,
+              "server_review": {
+                "items": [
+                  {
+                    "key": "descriptor",
+                    "label": "Operation class",
+                    "value": "managed-authz-policy-set"
+                  },
+                  {
+                    "key": "safety_class",
+                    "label": "Safety class",
+                    "value": "policy_admin"
+                  }
+                ],
+                "review_id": "review-1d762a6ac3895594ed85ba7a",
+                "schema_version": 1,
+                "summary": "Review this exact privileged operation before confirming.",
+                "title": "Owner approval required"
+              }
+            },
+            "approval_request_digest": "a60572025b121241d44c3f28ce22715841e348765dd50cfa514861e89334d9eb",
+            "channel_binding_sha256": "1b8a26cd423937c1b5edcb5f7162c67978055213231bc4e85c3c46dc9a9738aa",
+            "confirmed_at": "2030-01-02T03:04:05+00:00",
+            "decision": "approved",
+            "schema_version": 1
+          },
+          "channel_binding": {
+            "channel_session_id": "channel-session-5138ce25ddfcf0b39d4d178ef80612d0",
+            "owner_github_id": 494383370,
+            "owner_public_key": "A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg",
+            "schema_version": 1,
+            "session_expires_at": "2030-01-02T03:09:05+00:00",
+            "session_issued_at": "2030-01-02T03:00:05+00:00",
+            "signature_algorithm": "ed25519"
+          },
+          "schema_version": 1,
+          "signature": "tglT-SQl-k0_FmKKynVn6iop-CRZnBmAVLLgCSX6Ak1FN5NcQRSrFYiGLmTtoqOKvYb9FCc0GRGnGWVKaXaDAQ",
+          "signature_algorithm": "ed25519"
+        },
+        "sha256": "38fb345517a01931f91ab8f0ba81cf99c082103f50da24dc4b2e284ccbf864cc"
+      },
+      "descriptor_id": "managed-authz-policy-set",
+      "descriptor_version": 1,
+      "signature_payload": {
+        "canonical_json": "{\"challenge_response\":{\"approval_request\":{\"descriptor_id\":\"managed-authz-policy-set\",\"descriptor_version\":1,\"evidence_digest\":\"df6da961581b149a28639add56e3b08401b3bed6afb07ad0c7b5ca3d51632be9\",\"expires_at\":\"2030-01-02T03:09:05+00:00\",\"issued_at\":\"2030-01-02T03:00:05+00:00\",\"nonce\":\"owner-control-b565a7b3115d408e250eeffe65af9513\",\"operation_id\":\"privileged-operation-1d762a6ac3895594ed85ba7aa9c39330\",\"owner_github_id\":494383370,\"plan_digest\":\"edf23f94b33d1188e34e143e7aff91075ec941053b3b95d367a45de67b1fe1d7\",\"policy_record_id\":\"owner-policy-1d762a6ac3895594ed85\",\"policy_revision\":1,\"policy_sha256\":\"b379db2fe113e77eef0b3bb05aec804189d9f0b359e67d941d837c7de59e6f8e\",\"pre_state_digest\":\"46df3876ade6b39b0edfbd3b8ea1a408173bbe5d8cc7154cea4d63e5d057239f\",\"request_digest\":\"e0e31f55312d2562bf610587d7a21b5badeed50224284b08d1662924379b4539\",\"schema_version\":1,\"server_review\":{\"items\":[{\"key\":\"descriptor\",\"label\":\"Operation class\",\"value\":\"managed-authz-policy-set\"},{\"key\":\"safety_class\",\"label\":\"Safety class\",\"value\":\"policy_admin\"}],\"review_id\":\"review-1d762a6ac3895594ed85ba7a\",\"schema_version\":1,\"summary\":\"Review this exact privileged operation before confirming.\",\"title\":\"Owner approval required\"}},\"approval_request_digest\":\"a60572025b121241d44c3f28ce22715841e348765dd50cfa514861e89334d9eb\",\"channel_binding_sha256\":\"1b8a26cd423937c1b5edcb5f7162c67978055213231bc4e85c3c46dc9a9738aa\",\"confirmed_at\":\"2030-01-02T03:04:05+00:00\",\"decision\":\"approved\",\"schema_version\":1},\"domain\":\"launchplane-owner-control-confirmation-v1\",\"schema_version\":1}",
+        "payload": {
+          "challenge_response": {
+            "approval_request": {
+              "descriptor_id": "managed-authz-policy-set",
+              "descriptor_version": 1,
+              "evidence_digest": "df6da961581b149a28639add56e3b08401b3bed6afb07ad0c7b5ca3d51632be9",
+              "expires_at": "2030-01-02T03:09:05+00:00",
+              "issued_at": "2030-01-02T03:00:05+00:00",
+              "nonce": "owner-control-b565a7b3115d408e250eeffe65af9513",
+              "operation_id": "privileged-operation-1d762a6ac3895594ed85ba7aa9c39330",
+              "owner_github_id": 494383370,
+              "plan_digest": "edf23f94b33d1188e34e143e7aff91075ec941053b3b95d367a45de67b1fe1d7",
+              "policy_record_id": "owner-policy-1d762a6ac3895594ed85",
+              "policy_revision": 1,
+              "policy_sha256": "b379db2fe113e77eef0b3bb05aec804189d9f0b359e67d941d837c7de59e6f8e",
+              "pre_state_digest": "46df3876ade6b39b0edfbd3b8ea1a408173bbe5d8cc7154cea4d63e5d057239f",
+              "request_digest": "e0e31f55312d2562bf610587d7a21b5badeed50224284b08d1662924379b4539",
+              "schema_version": 1,
+              "server_review": {
+                "items": [
+                  {
+                    "key": "descriptor",
+                    "label": "Operation class",
+                    "value": "managed-authz-policy-set"
+                  },
+                  {
+                    "key": "safety_class",
+                    "label": "Safety class",
+                    "value": "policy_admin"
+                  }
+                ],
+                "review_id": "review-1d762a6ac3895594ed85ba7a",
+                "schema_version": 1,
+                "summary": "Review this exact privileged operation before confirming.",
+                "title": "Owner approval required"
+              }
+            },
+            "approval_request_digest": "a60572025b121241d44c3f28ce22715841e348765dd50cfa514861e89334d9eb",
+            "channel_binding_sha256": "1b8a26cd423937c1b5edcb5f7162c67978055213231bc4e85c3c46dc9a9738aa",
+            "confirmed_at": "2030-01-02T03:04:05+00:00",
+            "decision": "approved",
+            "schema_version": 1
+          },
+          "domain": "launchplane-owner-control-confirmation-v1",
+          "schema_version": 1
+        },
+        "sha256": "d4e381e653d1de2252a06c4e0e150318d938e27a6da8b0791a3820431652f56e"
+      },
+      "verification": "valid"
+    },
+    {
+      "challenge_response": {
+        "canonical_json": "{\"approval_request\":{\"descriptor_id\":\"managed-secret-reencryption\",\"descriptor_version\":1,\"evidence_digest\":\"9823b32b0823bd4004bacdbe08391b3e0120e8f24c36f91474115ef9fa01155d\",\"expires_at\":\"2030-01-02T03:09:05+00:00\",\"issued_at\":\"2030-01-02T03:00:05+00:00\",\"nonce\":\"owner-control-1bb1a85cd3cf848e5c7a0ee17410addb\",\"operation_id\":\"privileged-operation-9a9d1838b14102ef23bc2528687abda0\",\"owner_github_id\":2594086616,\"plan_digest\":\"f87d15dd32b95865b4fe98cc67c5c418757a0559488488355bb0cf52a06cdf95\",\"policy_record_id\":\"owner-policy-9a9d1838b14102ef23bc\",\"policy_revision\":1,\"policy_sha256\":\"158ffbbe76bc73789a3e644e339411d8569ed880328b1e7728e7db3a25f1be8f\",\"pre_state_digest\":\"96cb3e8e7bc9a596d31b699bd6ea1681651eda477f9b7a6c482f9378e6798d58\",\"request_digest\":\"4a9624ebacf973b34eeb4762279d052e3c637d8090cb79ecbb217fa320a58d68\",\"schema_version\":1,\"server_review\":{\"items\":[{\"key\":\"descriptor\",\"label\":\"Operation class\",\"value\":\"managed-secret-reencryption\"},{\"key\":\"safety_class\",\"label\":\"Safety class\",\"value\":\"secret_backed\"}],\"review_id\":\"review-9a9d1838b14102ef23bc2528\",\"schema_version\":1,\"summary\":\"Review this exact privileged operation before confirming.\",\"title\":\"Owner approval required\"}},\"approval_request_digest\":\"a158dabb09e35c75932985b8682c34f7f598a2b1404ac80a9e4fa0d4a19313c4\",\"channel_binding_sha256\":\"f700fe53f99c7817cb6451964b9bc50c66fd1628ae842c5c496a0a7fc6be1c93\",\"confirmed_at\":\"2030-01-02T03:04:05+00:00\",\"decision\":\"approved\",\"schema_version\":1}",
+        "payload": {
+          "approval_request": {
+            "descriptor_id": "managed-secret-reencryption",
+            "descriptor_version": 1,
+            "evidence_digest": "9823b32b0823bd4004bacdbe08391b3e0120e8f24c36f91474115ef9fa01155d",
+            "expires_at": "2030-01-02T03:09:05+00:00",
+            "issued_at": "2030-01-02T03:00:05+00:00",
+            "nonce": "owner-control-1bb1a85cd3cf848e5c7a0ee17410addb",
+            "operation_id": "privileged-operation-9a9d1838b14102ef23bc2528687abda0",
+            "owner_github_id": 2594086616,
+            "plan_digest": "f87d15dd32b95865b4fe98cc67c5c418757a0559488488355bb0cf52a06cdf95",
+            "policy_record_id": "owner-policy-9a9d1838b14102ef23bc",
+            "policy_revision": 1,
+            "policy_sha256": "158ffbbe76bc73789a3e644e339411d8569ed880328b1e7728e7db3a25f1be8f",
+            "pre_state_digest": "96cb3e8e7bc9a596d31b699bd6ea1681651eda477f9b7a6c482f9378e6798d58",
+            "request_digest": "4a9624ebacf973b34eeb4762279d052e3c637d8090cb79ecbb217fa320a58d68",
+            "schema_version": 1,
+            "server_review": {
+              "items": [
+                {
+                  "key": "descriptor",
+                  "label": "Operation class",
+                  "value": "managed-secret-reencryption"
+                },
+                {
+                  "key": "safety_class",
+                  "label": "Safety class",
+                  "value": "secret_backed"
+                }
+              ],
+              "review_id": "review-9a9d1838b14102ef23bc2528",
+              "schema_version": 1,
+              "summary": "Review this exact privileged operation before confirming.",
+              "title": "Owner approval required"
+            }
+          },
+          "approval_request_digest": "a158dabb09e35c75932985b8682c34f7f598a2b1404ac80a9e4fa0d4a19313c4",
+          "channel_binding_sha256": "f700fe53f99c7817cb6451964b9bc50c66fd1628ae842c5c496a0a7fc6be1c93",
+          "confirmed_at": "2030-01-02T03:04:05+00:00",
+          "decision": "approved",
+          "schema_version": 1
+        },
+        "sha256": "9b817797377a5895e81a3c741372c1bfedc79dba42b280e51e14bd175a098081"
+      },
+      "channel_binding": {
+        "canonical_json": "{\"channel_session_id\":\"channel-session-0f7a58f81d1b3945ee77723d618048a3\",\"owner_github_id\":2594086616,\"owner_public_key\":\"A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg\",\"schema_version\":1,\"session_expires_at\":\"2030-01-02T03:09:05+00:00\",\"session_issued_at\":\"2030-01-02T03:00:05+00:00\",\"signature_algorithm\":\"ed25519\"}",
+        "payload": {
+          "channel_session_id": "channel-session-0f7a58f81d1b3945ee77723d618048a3",
+          "owner_github_id": 2594086616,
+          "owner_public_key": "A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg",
+          "schema_version": 1,
+          "session_expires_at": "2030-01-02T03:09:05+00:00",
+          "session_issued_at": "2030-01-02T03:00:05+00:00",
+          "signature_algorithm": "ed25519"
+        },
+        "sha256": "f700fe53f99c7817cb6451964b9bc50c66fd1628ae842c5c496a0a7fc6be1c93"
+      },
+      "confirmation_envelope": {
+        "canonical_json": "{\"challenge_response\":{\"approval_request\":{\"descriptor_id\":\"managed-secret-reencryption\",\"descriptor_version\":1,\"evidence_digest\":\"9823b32b0823bd4004bacdbe08391b3e0120e8f24c36f91474115ef9fa01155d\",\"expires_at\":\"2030-01-02T03:09:05+00:00\",\"issued_at\":\"2030-01-02T03:00:05+00:00\",\"nonce\":\"owner-control-1bb1a85cd3cf848e5c7a0ee17410addb\",\"operation_id\":\"privileged-operation-9a9d1838b14102ef23bc2528687abda0\",\"owner_github_id\":2594086616,\"plan_digest\":\"f87d15dd32b95865b4fe98cc67c5c418757a0559488488355bb0cf52a06cdf95\",\"policy_record_id\":\"owner-policy-9a9d1838b14102ef23bc\",\"policy_revision\":1,\"policy_sha256\":\"158ffbbe76bc73789a3e644e339411d8569ed880328b1e7728e7db3a25f1be8f\",\"pre_state_digest\":\"96cb3e8e7bc9a596d31b699bd6ea1681651eda477f9b7a6c482f9378e6798d58\",\"request_digest\":\"4a9624ebacf973b34eeb4762279d052e3c637d8090cb79ecbb217fa320a58d68\",\"schema_version\":1,\"server_review\":{\"items\":[{\"key\":\"descriptor\",\"label\":\"Operation class\",\"value\":\"managed-secret-reencryption\"},{\"key\":\"safety_class\",\"label\":\"Safety class\",\"value\":\"secret_backed\"}],\"review_id\":\"review-9a9d1838b14102ef23bc2528\",\"schema_version\":1,\"summary\":\"Review this exact privileged operation before confirming.\",\"title\":\"Owner approval required\"}},\"approval_request_digest\":\"a158dabb09e35c75932985b8682c34f7f598a2b1404ac80a9e4fa0d4a19313c4\",\"channel_binding_sha256\":\"f700fe53f99c7817cb6451964b9bc50c66fd1628ae842c5c496a0a7fc6be1c93\",\"confirmed_at\":\"2030-01-02T03:04:05+00:00\",\"decision\":\"approved\",\"schema_version\":1},\"channel_binding\":{\"channel_session_id\":\"channel-session-0f7a58f81d1b3945ee77723d618048a3\",\"owner_github_id\":2594086616,\"owner_public_key\":\"A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg\",\"schema_version\":1,\"session_expires_at\":\"2030-01-02T03:09:05+00:00\",\"session_issued_at\":\"2030-01-02T03:00:05+00:00\",\"signature_algorithm\":\"ed25519\"},\"schema_version\":1,\"signature\":\"x8JWwd2jpFDAtEnjO1HJWuck3kwxVq_c2MXWcElZlk-2orXreHObpdIqioPGq4R5Uyu-VeKVlU1CnBLvD_YdBA\",\"signature_algorithm\":\"ed25519\"}",
+        "payload": {
+          "challenge_response": {
+            "approval_request": {
+              "descriptor_id": "managed-secret-reencryption",
+              "descriptor_version": 1,
+              "evidence_digest": "9823b32b0823bd4004bacdbe08391b3e0120e8f24c36f91474115ef9fa01155d",
+              "expires_at": "2030-01-02T03:09:05+00:00",
+              "issued_at": "2030-01-02T03:00:05+00:00",
+              "nonce": "owner-control-1bb1a85cd3cf848e5c7a0ee17410addb",
+              "operation_id": "privileged-operation-9a9d1838b14102ef23bc2528687abda0",
+              "owner_github_id": 2594086616,
+              "plan_digest": "f87d15dd32b95865b4fe98cc67c5c418757a0559488488355bb0cf52a06cdf95",
+              "policy_record_id": "owner-policy-9a9d1838b14102ef23bc",
+              "policy_revision": 1,
+              "policy_sha256": "158ffbbe76bc73789a3e644e339411d8569ed880328b1e7728e7db3a25f1be8f",
+              "pre_state_digest": "96cb3e8e7bc9a596d31b699bd6ea1681651eda477f9b7a6c482f9378e6798d58",
+              "request_digest": "4a9624ebacf973b34eeb4762279d052e3c637d8090cb79ecbb217fa320a58d68",
+              "schema_version": 1,
+              "server_review": {
+                "items": [
+                  {
+                    "key": "descriptor",
+                    "label": "Operation class",
+                    "value": "managed-secret-reencryption"
+                  },
+                  {
+                    "key": "safety_class",
+                    "label": "Safety class",
+                    "value": "secret_backed"
+                  }
+                ],
+                "review_id": "review-9a9d1838b14102ef23bc2528",
+                "schema_version": 1,
+                "summary": "Review this exact privileged operation before confirming.",
+                "title": "Owner approval required"
+              }
+            },
+            "approval_request_digest": "a158dabb09e35c75932985b8682c34f7f598a2b1404ac80a9e4fa0d4a19313c4",
+            "channel_binding_sha256": "f700fe53f99c7817cb6451964b9bc50c66fd1628ae842c5c496a0a7fc6be1c93",
+            "confirmed_at": "2030-01-02T03:04:05+00:00",
+            "decision": "approved",
+            "schema_version": 1
+          },
+          "channel_binding": {
+            "channel_session_id": "channel-session-0f7a58f81d1b3945ee77723d618048a3",
+            "owner_github_id": 2594086616,
+            "owner_public_key": "A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg",
+            "schema_version": 1,
+            "session_expires_at": "2030-01-02T03:09:05+00:00",
+            "session_issued_at": "2030-01-02T03:00:05+00:00",
+            "signature_algorithm": "ed25519"
+          },
+          "schema_version": 1,
+          "signature": "x8JWwd2jpFDAtEnjO1HJWuck3kwxVq_c2MXWcElZlk-2orXreHObpdIqioPGq4R5Uyu-VeKVlU1CnBLvD_YdBA",
+          "signature_algorithm": "ed25519"
+        },
+        "sha256": "a7eef23e056ba68142aa18c05f636a8c18cf2f71f813c4bd21b195ac9f18dbde"
+      },
+      "descriptor_id": "managed-secret-reencryption",
+      "descriptor_version": 1,
+      "signature_payload": {
+        "canonical_json": "{\"challenge_response\":{\"approval_request\":{\"descriptor_id\":\"managed-secret-reencryption\",\"descriptor_version\":1,\"evidence_digest\":\"9823b32b0823bd4004bacdbe08391b3e0120e8f24c36f91474115ef9fa01155d\",\"expires_at\":\"2030-01-02T03:09:05+00:00\",\"issued_at\":\"2030-01-02T03:00:05+00:00\",\"nonce\":\"owner-control-1bb1a85cd3cf848e5c7a0ee17410addb\",\"operation_id\":\"privileged-operation-9a9d1838b14102ef23bc2528687abda0\",\"owner_github_id\":2594086616,\"plan_digest\":\"f87d15dd32b95865b4fe98cc67c5c418757a0559488488355bb0cf52a06cdf95\",\"policy_record_id\":\"owner-policy-9a9d1838b14102ef23bc\",\"policy_revision\":1,\"policy_sha256\":\"158ffbbe76bc73789a3e644e339411d8569ed880328b1e7728e7db3a25f1be8f\",\"pre_state_digest\":\"96cb3e8e7bc9a596d31b699bd6ea1681651eda477f9b7a6c482f9378e6798d58\",\"request_digest\":\"4a9624ebacf973b34eeb4762279d052e3c637d8090cb79ecbb217fa320a58d68\",\"schema_version\":1,\"server_review\":{\"items\":[{\"key\":\"descriptor\",\"label\":\"Operation class\",\"value\":\"managed-secret-reencryption\"},{\"key\":\"safety_class\",\"label\":\"Safety class\",\"value\":\"secret_backed\"}],\"review_id\":\"review-9a9d1838b14102ef23bc2528\",\"schema_version\":1,\"summary\":\"Review this exact privileged operation before confirming.\",\"title\":\"Owner approval required\"}},\"approval_request_digest\":\"a158dabb09e35c75932985b8682c34f7f598a2b1404ac80a9e4fa0d4a19313c4\",\"channel_binding_sha256\":\"f700fe53f99c7817cb6451964b9bc50c66fd1628ae842c5c496a0a7fc6be1c93\",\"confirmed_at\":\"2030-01-02T03:04:05+00:00\",\"decision\":\"approved\",\"schema_version\":1},\"domain\":\"launchplane-owner-control-confirmation-v1\",\"schema_version\":1}",
+        "payload": {
+          "challenge_response": {
+            "approval_request": {
+              "descriptor_id": "managed-secret-reencryption",
+              "descriptor_version": 1,
+              "evidence_digest": "9823b32b0823bd4004bacdbe08391b3e0120e8f24c36f91474115ef9fa01155d",
+              "expires_at": "2030-01-02T03:09:05+00:00",
+              "issued_at": "2030-01-02T03:00:05+00:00",
+              "nonce": "owner-control-1bb1a85cd3cf848e5c7a0ee17410addb",
+              "operation_id": "privileged-operation-9a9d1838b14102ef23bc2528687abda0",
+              "owner_github_id": 2594086616,
+              "plan_digest": "f87d15dd32b95865b4fe98cc67c5c418757a0559488488355bb0cf52a06cdf95",
+              "policy_record_id": "owner-policy-9a9d1838b14102ef23bc",
+              "policy_revision": 1,
+              "policy_sha256": "158ffbbe76bc73789a3e644e339411d8569ed880328b1e7728e7db3a25f1be8f",
+              "pre_state_digest": "96cb3e8e7bc9a596d31b699bd6ea1681651eda477f9b7a6c482f9378e6798d58",
+              "request_digest": "4a9624ebacf973b34eeb4762279d052e3c637d8090cb79ecbb217fa320a58d68",
+              "schema_version": 1,
+              "server_review": {
+                "items": [
+                  {
+                    "key": "descriptor",
+                    "label": "Operation class",
+                    "value": "managed-secret-reencryption"
+                  },
+                  {
+                    "key": "safety_class",
+                    "label": "Safety class",
+                    "value": "secret_backed"
+                  }
+                ],
+                "review_id": "review-9a9d1838b14102ef23bc2528",
+                "schema_version": 1,
+                "summary": "Review this exact privileged operation before confirming.",
+                "title": "Owner approval required"
+              }
+            },
+            "approval_request_digest": "a158dabb09e35c75932985b8682c34f7f598a2b1404ac80a9e4fa0d4a19313c4",
+            "channel_binding_sha256": "f700fe53f99c7817cb6451964b9bc50c66fd1628ae842c5c496a0a7fc6be1c93",
+            "confirmed_at": "2030-01-02T03:04:05+00:00",
+            "decision": "approved",
+            "schema_version": 1
+          },
+          "domain": "launchplane-owner-control-confirmation-v1",
+          "schema_version": 1
+        },
+        "sha256": "db44c6648567a3a88e48cff26cf6c1efe11c9d6345d2ee457477292a335fa7d6"
+      },
+      "verification": "valid"
+    }
+  ],
   "golden_vectors": [
     {
       "approval_request": {
@@ -242,6 +592,823 @@
       },
       "descriptor_id": "managed-secret-reencryption",
       "descriptor_version": 1
+    }
+  ],
+  "negative_confirmation_vectors": [
+    {
+      "error_location": [
+        "schema_version"
+      ],
+      "model": "owner_control_confirmation_envelope",
+      "payload": {
+        "challenge_response": {
+          "approval_request": {
+            "descriptor_id": "managed-authz-policy-set",
+            "descriptor_version": 1,
+            "evidence_digest": "df6da961581b149a28639add56e3b08401b3bed6afb07ad0c7b5ca3d51632be9",
+            "expires_at": "2030-01-02T03:09:05+00:00",
+            "issued_at": "2030-01-02T03:00:05+00:00",
+            "nonce": "owner-control-b565a7b3115d408e250eeffe65af9513",
+            "operation_id": "privileged-operation-1d762a6ac3895594ed85ba7aa9c39330",
+            "owner_github_id": 494383370,
+            "plan_digest": "edf23f94b33d1188e34e143e7aff91075ec941053b3b95d367a45de67b1fe1d7",
+            "policy_record_id": "owner-policy-1d762a6ac3895594ed85",
+            "policy_revision": 1,
+            "policy_sha256": "b379db2fe113e77eef0b3bb05aec804189d9f0b359e67d941d837c7de59e6f8e",
+            "pre_state_digest": "46df3876ade6b39b0edfbd3b8ea1a408173bbe5d8cc7154cea4d63e5d057239f",
+            "request_digest": "e0e31f55312d2562bf610587d7a21b5badeed50224284b08d1662924379b4539",
+            "schema_version": 1,
+            "server_review": {
+              "items": [
+                {
+                  "key": "descriptor",
+                  "label": "Operation class",
+                  "value": "managed-authz-policy-set"
+                },
+                {
+                  "key": "safety_class",
+                  "label": "Safety class",
+                  "value": "policy_admin"
+                }
+              ],
+              "review_id": "review-1d762a6ac3895594ed85ba7a",
+              "schema_version": 1,
+              "summary": "Review this exact privileged operation before confirming.",
+              "title": "Owner approval required"
+            }
+          },
+          "approval_request_digest": "a60572025b121241d44c3f28ce22715841e348765dd50cfa514861e89334d9eb",
+          "channel_binding_sha256": "1b8a26cd423937c1b5edcb5f7162c67978055213231bc4e85c3c46dc9a9738aa",
+          "confirmed_at": "2030-01-02T03:04:05+00:00",
+          "decision": "approved",
+          "schema_version": 1
+        },
+        "channel_binding": {
+          "channel_session_id": "channel-session-5138ce25ddfcf0b39d4d178ef80612d0",
+          "owner_github_id": 494383370,
+          "owner_public_key": "A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg",
+          "schema_version": 1,
+          "session_expires_at": "2030-01-02T03:09:05+00:00",
+          "session_issued_at": "2030-01-02T03:00:05+00:00",
+          "signature_algorithm": "ed25519"
+        },
+        "schema_version": 2,
+        "signature": "tglT-SQl-k0_FmKKynVn6iop-CRZnBmAVLLgCSX6Ak1FN5NcQRSrFYiGLmTtoqOKvYb9FCc0GRGnGWVKaXaDAQ",
+        "signature_algorithm": "ed25519"
+      },
+      "rule": "schema-version-is-one"
+    },
+    {
+      "error_location": [
+        "signature_algorithm"
+      ],
+      "model": "owner_control_confirmation_envelope",
+      "payload": {
+        "challenge_response": {
+          "approval_request": {
+            "descriptor_id": "managed-authz-policy-set",
+            "descriptor_version": 1,
+            "evidence_digest": "df6da961581b149a28639add56e3b08401b3bed6afb07ad0c7b5ca3d51632be9",
+            "expires_at": "2030-01-02T03:09:05+00:00",
+            "issued_at": "2030-01-02T03:00:05+00:00",
+            "nonce": "owner-control-b565a7b3115d408e250eeffe65af9513",
+            "operation_id": "privileged-operation-1d762a6ac3895594ed85ba7aa9c39330",
+            "owner_github_id": 494383370,
+            "plan_digest": "edf23f94b33d1188e34e143e7aff91075ec941053b3b95d367a45de67b1fe1d7",
+            "policy_record_id": "owner-policy-1d762a6ac3895594ed85",
+            "policy_revision": 1,
+            "policy_sha256": "b379db2fe113e77eef0b3bb05aec804189d9f0b359e67d941d837c7de59e6f8e",
+            "pre_state_digest": "46df3876ade6b39b0edfbd3b8ea1a408173bbe5d8cc7154cea4d63e5d057239f",
+            "request_digest": "e0e31f55312d2562bf610587d7a21b5badeed50224284b08d1662924379b4539",
+            "schema_version": 1,
+            "server_review": {
+              "items": [
+                {
+                  "key": "descriptor",
+                  "label": "Operation class",
+                  "value": "managed-authz-policy-set"
+                },
+                {
+                  "key": "safety_class",
+                  "label": "Safety class",
+                  "value": "policy_admin"
+                }
+              ],
+              "review_id": "review-1d762a6ac3895594ed85ba7a",
+              "schema_version": 1,
+              "summary": "Review this exact privileged operation before confirming.",
+              "title": "Owner approval required"
+            }
+          },
+          "approval_request_digest": "a60572025b121241d44c3f28ce22715841e348765dd50cfa514861e89334d9eb",
+          "channel_binding_sha256": "1b8a26cd423937c1b5edcb5f7162c67978055213231bc4e85c3c46dc9a9738aa",
+          "confirmed_at": "2030-01-02T03:04:05+00:00",
+          "decision": "approved",
+          "schema_version": 1
+        },
+        "channel_binding": {
+          "channel_session_id": "channel-session-5138ce25ddfcf0b39d4d178ef80612d0",
+          "owner_github_id": 494383370,
+          "owner_public_key": "A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg",
+          "schema_version": 1,
+          "session_expires_at": "2030-01-02T03:09:05+00:00",
+          "session_issued_at": "2030-01-02T03:00:05+00:00",
+          "signature_algorithm": "ed25519"
+        },
+        "schema_version": 1,
+        "signature": "tglT-SQl-k0_FmKKynVn6iop-CRZnBmAVLLgCSX6Ak1FN5NcQRSrFYiGLmTtoqOKvYb9FCc0GRGnGWVKaXaDAQ",
+        "signature_algorithm": "rsa"
+      },
+      "rule": "signature-algorithm-is-ed25519"
+    },
+    {
+      "error_location": [
+        "channel_binding",
+        "owner_public_key"
+      ],
+      "model": "owner_control_confirmation_envelope",
+      "payload": {
+        "challenge_response": {
+          "approval_request": {
+            "descriptor_id": "managed-authz-policy-set",
+            "descriptor_version": 1,
+            "evidence_digest": "df6da961581b149a28639add56e3b08401b3bed6afb07ad0c7b5ca3d51632be9",
+            "expires_at": "2030-01-02T03:09:05+00:00",
+            "issued_at": "2030-01-02T03:00:05+00:00",
+            "nonce": "owner-control-b565a7b3115d408e250eeffe65af9513",
+            "operation_id": "privileged-operation-1d762a6ac3895594ed85ba7aa9c39330",
+            "owner_github_id": 494383370,
+            "plan_digest": "edf23f94b33d1188e34e143e7aff91075ec941053b3b95d367a45de67b1fe1d7",
+            "policy_record_id": "owner-policy-1d762a6ac3895594ed85",
+            "policy_revision": 1,
+            "policy_sha256": "b379db2fe113e77eef0b3bb05aec804189d9f0b359e67d941d837c7de59e6f8e",
+            "pre_state_digest": "46df3876ade6b39b0edfbd3b8ea1a408173bbe5d8cc7154cea4d63e5d057239f",
+            "request_digest": "e0e31f55312d2562bf610587d7a21b5badeed50224284b08d1662924379b4539",
+            "schema_version": 1,
+            "server_review": {
+              "items": [
+                {
+                  "key": "descriptor",
+                  "label": "Operation class",
+                  "value": "managed-authz-policy-set"
+                },
+                {
+                  "key": "safety_class",
+                  "label": "Safety class",
+                  "value": "policy_admin"
+                }
+              ],
+              "review_id": "review-1d762a6ac3895594ed85ba7a",
+              "schema_version": 1,
+              "summary": "Review this exact privileged operation before confirming.",
+              "title": "Owner approval required"
+            }
+          },
+          "approval_request_digest": "a60572025b121241d44c3f28ce22715841e348765dd50cfa514861e89334d9eb",
+          "channel_binding_sha256": "1b8a26cd423937c1b5edcb5f7162c67978055213231bc4e85c3c46dc9a9738aa",
+          "confirmed_at": "2030-01-02T03:04:05+00:00",
+          "decision": "approved",
+          "schema_version": 1
+        },
+        "channel_binding": {
+          "channel_session_id": "channel-session-5138ce25ddfcf0b39d4d178ef80612d0",
+          "owner_github_id": 494383370,
+          "owner_public_key": "bad!",
+          "schema_version": 1,
+          "session_expires_at": "2030-01-02T03:09:05+00:00",
+          "session_issued_at": "2030-01-02T03:00:05+00:00",
+          "signature_algorithm": "ed25519"
+        },
+        "schema_version": 1,
+        "signature": "tglT-SQl-k0_FmKKynVn6iop-CRZnBmAVLLgCSX6Ak1FN5NcQRSrFYiGLmTtoqOKvYb9FCc0GRGnGWVKaXaDAQ",
+        "signature_algorithm": "ed25519"
+      },
+      "rule": "public-key-is-raw-32-byte-unpadded-base64url"
+    },
+    {
+      "error_location": [
+        "signature"
+      ],
+      "model": "owner_control_confirmation_envelope",
+      "payload": {
+        "challenge_response": {
+          "approval_request": {
+            "descriptor_id": "managed-authz-policy-set",
+            "descriptor_version": 1,
+            "evidence_digest": "df6da961581b149a28639add56e3b08401b3bed6afb07ad0c7b5ca3d51632be9",
+            "expires_at": "2030-01-02T03:09:05+00:00",
+            "issued_at": "2030-01-02T03:00:05+00:00",
+            "nonce": "owner-control-b565a7b3115d408e250eeffe65af9513",
+            "operation_id": "privileged-operation-1d762a6ac3895594ed85ba7aa9c39330",
+            "owner_github_id": 494383370,
+            "plan_digest": "edf23f94b33d1188e34e143e7aff91075ec941053b3b95d367a45de67b1fe1d7",
+            "policy_record_id": "owner-policy-1d762a6ac3895594ed85",
+            "policy_revision": 1,
+            "policy_sha256": "b379db2fe113e77eef0b3bb05aec804189d9f0b359e67d941d837c7de59e6f8e",
+            "pre_state_digest": "46df3876ade6b39b0edfbd3b8ea1a408173bbe5d8cc7154cea4d63e5d057239f",
+            "request_digest": "e0e31f55312d2562bf610587d7a21b5badeed50224284b08d1662924379b4539",
+            "schema_version": 1,
+            "server_review": {
+              "items": [
+                {
+                  "key": "descriptor",
+                  "label": "Operation class",
+                  "value": "managed-authz-policy-set"
+                },
+                {
+                  "key": "safety_class",
+                  "label": "Safety class",
+                  "value": "policy_admin"
+                }
+              ],
+              "review_id": "review-1d762a6ac3895594ed85ba7a",
+              "schema_version": 1,
+              "summary": "Review this exact privileged operation before confirming.",
+              "title": "Owner approval required"
+            }
+          },
+          "approval_request_digest": "a60572025b121241d44c3f28ce22715841e348765dd50cfa514861e89334d9eb",
+          "channel_binding_sha256": "1b8a26cd423937c1b5edcb5f7162c67978055213231bc4e85c3c46dc9a9738aa",
+          "confirmed_at": "2030-01-02T03:04:05+00:00",
+          "decision": "approved",
+          "schema_version": 1
+        },
+        "channel_binding": {
+          "channel_session_id": "channel-session-5138ce25ddfcf0b39d4d178ef80612d0",
+          "owner_github_id": 494383370,
+          "owner_public_key": "A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg",
+          "schema_version": 1,
+          "session_expires_at": "2030-01-02T03:09:05+00:00",
+          "session_issued_at": "2030-01-02T03:00:05+00:00",
+          "signature_algorithm": "ed25519"
+        },
+        "schema_version": 1,
+        "signature": "bad!",
+        "signature_algorithm": "ed25519"
+      },
+      "rule": "signature-is-raw-64-byte-unpadded-base64url"
+    },
+    {
+      "error_location": [
+        "channel_binding"
+      ],
+      "error_message_contains": "owner_public_key must use canonical unpadded base64url",
+      "model": "owner_control_confirmation_envelope",
+      "payload": {
+        "challenge_response": {
+          "approval_request": {
+            "descriptor_id": "managed-authz-policy-set",
+            "descriptor_version": 1,
+            "evidence_digest": "df6da961581b149a28639add56e3b08401b3bed6afb07ad0c7b5ca3d51632be9",
+            "expires_at": "2030-01-02T03:09:05+00:00",
+            "issued_at": "2030-01-02T03:00:05+00:00",
+            "nonce": "owner-control-b565a7b3115d408e250eeffe65af9513",
+            "operation_id": "privileged-operation-1d762a6ac3895594ed85ba7aa9c39330",
+            "owner_github_id": 494383370,
+            "plan_digest": "edf23f94b33d1188e34e143e7aff91075ec941053b3b95d367a45de67b1fe1d7",
+            "policy_record_id": "owner-policy-1d762a6ac3895594ed85",
+            "policy_revision": 1,
+            "policy_sha256": "b379db2fe113e77eef0b3bb05aec804189d9f0b359e67d941d837c7de59e6f8e",
+            "pre_state_digest": "46df3876ade6b39b0edfbd3b8ea1a408173bbe5d8cc7154cea4d63e5d057239f",
+            "request_digest": "e0e31f55312d2562bf610587d7a21b5badeed50224284b08d1662924379b4539",
+            "schema_version": 1,
+            "server_review": {
+              "items": [
+                {
+                  "key": "descriptor",
+                  "label": "Operation class",
+                  "value": "managed-authz-policy-set"
+                },
+                {
+                  "key": "safety_class",
+                  "label": "Safety class",
+                  "value": "policy_admin"
+                }
+              ],
+              "review_id": "review-1d762a6ac3895594ed85ba7a",
+              "schema_version": 1,
+              "summary": "Review this exact privileged operation before confirming.",
+              "title": "Owner approval required"
+            }
+          },
+          "approval_request_digest": "a60572025b121241d44c3f28ce22715841e348765dd50cfa514861e89334d9eb",
+          "channel_binding_sha256": "1b8a26cd423937c1b5edcb5f7162c67978055213231bc4e85c3c46dc9a9738aa",
+          "confirmed_at": "2030-01-02T03:04:05+00:00",
+          "decision": "approved",
+          "schema_version": 1
+        },
+        "channel_binding": {
+          "channel_session_id": "channel-session-5138ce25ddfcf0b39d4d178ef80612d0",
+          "owner_github_id": 494383370,
+          "owner_public_key": "A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbh",
+          "schema_version": 1,
+          "session_expires_at": "2030-01-02T03:09:05+00:00",
+          "session_issued_at": "2030-01-02T03:00:05+00:00",
+          "signature_algorithm": "ed25519"
+        },
+        "schema_version": 1,
+        "signature": "tglT-SQl-k0_FmKKynVn6iop-CRZnBmAVLLgCSX6Ak1FN5NcQRSrFYiGLmTtoqOKvYb9FCc0GRGnGWVKaXaDAQ",
+        "signature_algorithm": "ed25519"
+      },
+      "rule": "public-key-base64url-has-canonical-trailing-bits"
+    },
+    {
+      "error_location": [],
+      "error_message_contains": "signature must use canonical unpadded base64url",
+      "model": "owner_control_confirmation_envelope",
+      "payload": {
+        "challenge_response": {
+          "approval_request": {
+            "descriptor_id": "managed-authz-policy-set",
+            "descriptor_version": 1,
+            "evidence_digest": "df6da961581b149a28639add56e3b08401b3bed6afb07ad0c7b5ca3d51632be9",
+            "expires_at": "2030-01-02T03:09:05+00:00",
+            "issued_at": "2030-01-02T03:00:05+00:00",
+            "nonce": "owner-control-b565a7b3115d408e250eeffe65af9513",
+            "operation_id": "privileged-operation-1d762a6ac3895594ed85ba7aa9c39330",
+            "owner_github_id": 494383370,
+            "plan_digest": "edf23f94b33d1188e34e143e7aff91075ec941053b3b95d367a45de67b1fe1d7",
+            "policy_record_id": "owner-policy-1d762a6ac3895594ed85",
+            "policy_revision": 1,
+            "policy_sha256": "b379db2fe113e77eef0b3bb05aec804189d9f0b359e67d941d837c7de59e6f8e",
+            "pre_state_digest": "46df3876ade6b39b0edfbd3b8ea1a408173bbe5d8cc7154cea4d63e5d057239f",
+            "request_digest": "e0e31f55312d2562bf610587d7a21b5badeed50224284b08d1662924379b4539",
+            "schema_version": 1,
+            "server_review": {
+              "items": [
+                {
+                  "key": "descriptor",
+                  "label": "Operation class",
+                  "value": "managed-authz-policy-set"
+                },
+                {
+                  "key": "safety_class",
+                  "label": "Safety class",
+                  "value": "policy_admin"
+                }
+              ],
+              "review_id": "review-1d762a6ac3895594ed85ba7a",
+              "schema_version": 1,
+              "summary": "Review this exact privileged operation before confirming.",
+              "title": "Owner approval required"
+            }
+          },
+          "approval_request_digest": "a60572025b121241d44c3f28ce22715841e348765dd50cfa514861e89334d9eb",
+          "channel_binding_sha256": "1b8a26cd423937c1b5edcb5f7162c67978055213231bc4e85c3c46dc9a9738aa",
+          "confirmed_at": "2030-01-02T03:04:05+00:00",
+          "decision": "approved",
+          "schema_version": 1
+        },
+        "channel_binding": {
+          "channel_session_id": "channel-session-5138ce25ddfcf0b39d4d178ef80612d0",
+          "owner_github_id": 494383370,
+          "owner_public_key": "A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg",
+          "schema_version": 1,
+          "session_expires_at": "2030-01-02T03:09:05+00:00",
+          "session_issued_at": "2030-01-02T03:00:05+00:00",
+          "signature_algorithm": "ed25519"
+        },
+        "schema_version": 1,
+        "signature": "tglT-SQl-k0_FmKKynVn6iop-CRZnBmAVLLgCSX6Ak1FN5NcQRSrFYiGLmTtoqOKvYb9FCc0GRGnGWVKaXaDAR",
+        "signature_algorithm": "ed25519"
+      },
+      "rule": "signature-base64url-has-canonical-trailing-bits"
+    },
+    {
+      "error_location": [],
+      "error_message_contains": "channel binding owner identity does not match",
+      "model": "owner_control_confirmation_envelope",
+      "payload": {
+        "challenge_response": {
+          "approval_request": {
+            "descriptor_id": "managed-authz-policy-set",
+            "descriptor_version": 1,
+            "evidence_digest": "df6da961581b149a28639add56e3b08401b3bed6afb07ad0c7b5ca3d51632be9",
+            "expires_at": "2030-01-02T03:09:05+00:00",
+            "issued_at": "2030-01-02T03:00:05+00:00",
+            "nonce": "owner-control-b565a7b3115d408e250eeffe65af9513",
+            "operation_id": "privileged-operation-1d762a6ac3895594ed85ba7aa9c39330",
+            "owner_github_id": 494383370,
+            "plan_digest": "edf23f94b33d1188e34e143e7aff91075ec941053b3b95d367a45de67b1fe1d7",
+            "policy_record_id": "owner-policy-1d762a6ac3895594ed85",
+            "policy_revision": 1,
+            "policy_sha256": "b379db2fe113e77eef0b3bb05aec804189d9f0b359e67d941d837c7de59e6f8e",
+            "pre_state_digest": "46df3876ade6b39b0edfbd3b8ea1a408173bbe5d8cc7154cea4d63e5d057239f",
+            "request_digest": "e0e31f55312d2562bf610587d7a21b5badeed50224284b08d1662924379b4539",
+            "schema_version": 1,
+            "server_review": {
+              "items": [
+                {
+                  "key": "descriptor",
+                  "label": "Operation class",
+                  "value": "managed-authz-policy-set"
+                },
+                {
+                  "key": "safety_class",
+                  "label": "Safety class",
+                  "value": "policy_admin"
+                }
+              ],
+              "review_id": "review-1d762a6ac3895594ed85ba7a",
+              "schema_version": 1,
+              "summary": "Review this exact privileged operation before confirming.",
+              "title": "Owner approval required"
+            }
+          },
+          "approval_request_digest": "a60572025b121241d44c3f28ce22715841e348765dd50cfa514861e89334d9eb",
+          "channel_binding_sha256": "2ee116ed52d29d898b7e557f5091a2ca3a60b95aa27f1cc476d5f0a89be4235b",
+          "confirmed_at": "2030-01-02T03:04:05+00:00",
+          "decision": "approved",
+          "schema_version": 1
+        },
+        "channel_binding": {
+          "channel_session_id": "channel-session-5138ce25ddfcf0b39d4d178ef80612d0",
+          "owner_github_id": 494383371,
+          "owner_public_key": "A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg",
+          "schema_version": 1,
+          "session_expires_at": "2030-01-02T03:09:05+00:00",
+          "session_issued_at": "2030-01-02T03:00:05+00:00",
+          "signature_algorithm": "ed25519"
+        },
+        "schema_version": 1,
+        "signature": "tglT-SQl-k0_FmKKynVn6iop-CRZnBmAVLLgCSX6Ak1FN5NcQRSrFYiGLmTtoqOKvYb9FCc0GRGnGWVKaXaDAQ",
+        "signature_algorithm": "ed25519"
+      },
+      "rule": "owner-identity-matches"
+    },
+    {
+      "error_location": [],
+      "error_message_contains": "channel binding digest does not match",
+      "model": "owner_control_confirmation_envelope",
+      "payload": {
+        "challenge_response": {
+          "approval_request": {
+            "descriptor_id": "managed-authz-policy-set",
+            "descriptor_version": 1,
+            "evidence_digest": "df6da961581b149a28639add56e3b08401b3bed6afb07ad0c7b5ca3d51632be9",
+            "expires_at": "2030-01-02T03:09:05+00:00",
+            "issued_at": "2030-01-02T03:00:05+00:00",
+            "nonce": "owner-control-b565a7b3115d408e250eeffe65af9513",
+            "operation_id": "privileged-operation-1d762a6ac3895594ed85ba7aa9c39330",
+            "owner_github_id": 494383370,
+            "plan_digest": "edf23f94b33d1188e34e143e7aff91075ec941053b3b95d367a45de67b1fe1d7",
+            "policy_record_id": "owner-policy-1d762a6ac3895594ed85",
+            "policy_revision": 1,
+            "policy_sha256": "b379db2fe113e77eef0b3bb05aec804189d9f0b359e67d941d837c7de59e6f8e",
+            "pre_state_digest": "46df3876ade6b39b0edfbd3b8ea1a408173bbe5d8cc7154cea4d63e5d057239f",
+            "request_digest": "e0e31f55312d2562bf610587d7a21b5badeed50224284b08d1662924379b4539",
+            "schema_version": 1,
+            "server_review": {
+              "items": [
+                {
+                  "key": "descriptor",
+                  "label": "Operation class",
+                  "value": "managed-authz-policy-set"
+                },
+                {
+                  "key": "safety_class",
+                  "label": "Safety class",
+                  "value": "policy_admin"
+                }
+              ],
+              "review_id": "review-1d762a6ac3895594ed85ba7a",
+              "schema_version": 1,
+              "summary": "Review this exact privileged operation before confirming.",
+              "title": "Owner approval required"
+            }
+          },
+          "approval_request_digest": "a60572025b121241d44c3f28ce22715841e348765dd50cfa514861e89334d9eb",
+          "channel_binding_sha256": "1b8a26cd423937c1b5edcb5f7162c67978055213231bc4e85c3c46dc9a9738aa",
+          "confirmed_at": "2030-01-02T03:04:05+00:00",
+          "decision": "approved",
+          "schema_version": 1
+        },
+        "channel_binding": {
+          "channel_session_id": "channel-session-substituted",
+          "owner_github_id": 494383370,
+          "owner_public_key": "A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg",
+          "schema_version": 1,
+          "session_expires_at": "2030-01-02T03:09:05+00:00",
+          "session_issued_at": "2030-01-02T03:00:05+00:00",
+          "signature_algorithm": "ed25519"
+        },
+        "schema_version": 1,
+        "signature": "tglT-SQl-k0_FmKKynVn6iop-CRZnBmAVLLgCSX6Ak1FN5NcQRSrFYiGLmTtoqOKvYb9FCc0GRGnGWVKaXaDAQ",
+        "signature_algorithm": "ed25519"
+      },
+      "rule": "binding-digest-matches"
+    },
+    {
+      "error_location": [
+        "channel_binding"
+      ],
+      "error_message_contains": "session_expires_at must be later than session_issued_at",
+      "model": "owner_control_confirmation_envelope",
+      "payload": {
+        "challenge_response": {
+          "approval_request": {
+            "descriptor_id": "managed-authz-policy-set",
+            "descriptor_version": 1,
+            "evidence_digest": "df6da961581b149a28639add56e3b08401b3bed6afb07ad0c7b5ca3d51632be9",
+            "expires_at": "2030-01-02T03:09:05+00:00",
+            "issued_at": "2030-01-02T03:00:05+00:00",
+            "nonce": "owner-control-b565a7b3115d408e250eeffe65af9513",
+            "operation_id": "privileged-operation-1d762a6ac3895594ed85ba7aa9c39330",
+            "owner_github_id": 494383370,
+            "plan_digest": "edf23f94b33d1188e34e143e7aff91075ec941053b3b95d367a45de67b1fe1d7",
+            "policy_record_id": "owner-policy-1d762a6ac3895594ed85",
+            "policy_revision": 1,
+            "policy_sha256": "b379db2fe113e77eef0b3bb05aec804189d9f0b359e67d941d837c7de59e6f8e",
+            "pre_state_digest": "46df3876ade6b39b0edfbd3b8ea1a408173bbe5d8cc7154cea4d63e5d057239f",
+            "request_digest": "e0e31f55312d2562bf610587d7a21b5badeed50224284b08d1662924379b4539",
+            "schema_version": 1,
+            "server_review": {
+              "items": [
+                {
+                  "key": "descriptor",
+                  "label": "Operation class",
+                  "value": "managed-authz-policy-set"
+                },
+                {
+                  "key": "safety_class",
+                  "label": "Safety class",
+                  "value": "policy_admin"
+                }
+              ],
+              "review_id": "review-1d762a6ac3895594ed85ba7a",
+              "schema_version": 1,
+              "summary": "Review this exact privileged operation before confirming.",
+              "title": "Owner approval required"
+            }
+          },
+          "approval_request_digest": "a60572025b121241d44c3f28ce22715841e348765dd50cfa514861e89334d9eb",
+          "channel_binding_sha256": "1b8a26cd423937c1b5edcb5f7162c67978055213231bc4e85c3c46dc9a9738aa",
+          "confirmed_at": "2030-01-02T03:04:05+00:00",
+          "decision": "approved",
+          "schema_version": 1
+        },
+        "channel_binding": {
+          "channel_session_id": "channel-session-5138ce25ddfcf0b39d4d178ef80612d0",
+          "owner_github_id": 494383370,
+          "owner_public_key": "A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg",
+          "schema_version": 1,
+          "session_expires_at": "2030-01-02T03:00:05+00:00",
+          "session_issued_at": "2030-01-02T03:00:05+00:00",
+          "signature_algorithm": "ed25519"
+        },
+        "schema_version": 1,
+        "signature": "tglT-SQl-k0_FmKKynVn6iop-CRZnBmAVLLgCSX6Ak1FN5NcQRSrFYiGLmTtoqOKvYb9FCc0GRGnGWVKaXaDAQ",
+        "signature_algorithm": "ed25519"
+      },
+      "rule": "session-expires-after-issuance"
+    },
+    {
+      "error_location": [],
+      "error_message_contains": "approval request bounds must be inside",
+      "model": "owner_control_confirmation_envelope",
+      "payload": {
+        "challenge_response": {
+          "approval_request": {
+            "descriptor_id": "managed-authz-policy-set",
+            "descriptor_version": 1,
+            "evidence_digest": "df6da961581b149a28639add56e3b08401b3bed6afb07ad0c7b5ca3d51632be9",
+            "expires_at": "2030-01-02T03:09:05+00:00",
+            "issued_at": "2030-01-02T03:00:05+00:00",
+            "nonce": "owner-control-b565a7b3115d408e250eeffe65af9513",
+            "operation_id": "privileged-operation-1d762a6ac3895594ed85ba7aa9c39330",
+            "owner_github_id": 494383370,
+            "plan_digest": "edf23f94b33d1188e34e143e7aff91075ec941053b3b95d367a45de67b1fe1d7",
+            "policy_record_id": "owner-policy-1d762a6ac3895594ed85",
+            "policy_revision": 1,
+            "policy_sha256": "b379db2fe113e77eef0b3bb05aec804189d9f0b359e67d941d837c7de59e6f8e",
+            "pre_state_digest": "46df3876ade6b39b0edfbd3b8ea1a408173bbe5d8cc7154cea4d63e5d057239f",
+            "request_digest": "e0e31f55312d2562bf610587d7a21b5badeed50224284b08d1662924379b4539",
+            "schema_version": 1,
+            "server_review": {
+              "items": [
+                {
+                  "key": "descriptor",
+                  "label": "Operation class",
+                  "value": "managed-authz-policy-set"
+                },
+                {
+                  "key": "safety_class",
+                  "label": "Safety class",
+                  "value": "policy_admin"
+                }
+              ],
+              "review_id": "review-1d762a6ac3895594ed85ba7a",
+              "schema_version": 1,
+              "summary": "Review this exact privileged operation before confirming.",
+              "title": "Owner approval required"
+            }
+          },
+          "approval_request_digest": "a60572025b121241d44c3f28ce22715841e348765dd50cfa514861e89334d9eb",
+          "channel_binding_sha256": "e927ba5607063982c2a4919447c1d52b6ef860a05875823ee6fe53cef2684d34",
+          "confirmed_at": "2030-01-02T03:04:05+00:00",
+          "decision": "approved",
+          "schema_version": 1
+        },
+        "channel_binding": {
+          "channel_session_id": "channel-session-5138ce25ddfcf0b39d4d178ef80612d0",
+          "owner_github_id": 494383370,
+          "owner_public_key": "A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg",
+          "schema_version": 1,
+          "session_expires_at": "2030-01-02T03:09:05+00:00",
+          "session_issued_at": "2030-01-02T03:01:05+00:00",
+          "signature_algorithm": "ed25519"
+        },
+        "schema_version": 1,
+        "signature": "tglT-SQl-k0_FmKKynVn6iop-CRZnBmAVLLgCSX6Ak1FN5NcQRSrFYiGLmTtoqOKvYb9FCc0GRGnGWVKaXaDAQ",
+        "signature_algorithm": "ed25519"
+      },
+      "rule": "request-and-confirmation-stay-inside-session"
+    },
+    {
+      "error_location": [],
+      "model": "owner_control_confirmation_envelope",
+      "payload": {
+        "challenge_response": {
+          "approval_request": {
+            "descriptor_id": "managed-authz-policy-set",
+            "descriptor_version": 1,
+            "evidence_digest": "df6da961581b149a28639add56e3b08401b3bed6afb07ad0c7b5ca3d51632be9",
+            "expires_at": "2030-01-02T03:09:05+00:00",
+            "issued_at": "2030-01-02T03:00:05+00:00",
+            "nonce": "owner-control-b565a7b3115d408e250eeffe65af9513",
+            "operation_id": "privileged-operation-1d762a6ac3895594ed85ba7aa9c39330",
+            "owner_github_id": 494383370,
+            "plan_digest": "edf23f94b33d1188e34e143e7aff91075ec941053b3b95d367a45de67b1fe1d7",
+            "policy_record_id": "owner-policy-1d762a6ac3895594ed85",
+            "policy_revision": 1,
+            "policy_sha256": "b379db2fe113e77eef0b3bb05aec804189d9f0b359e67d941d837c7de59e6f8e",
+            "pre_state_digest": "46df3876ade6b39b0edfbd3b8ea1a408173bbe5d8cc7154cea4d63e5d057239f",
+            "request_digest": "e0e31f55312d2562bf610587d7a21b5badeed50224284b08d1662924379b4539",
+            "schema_version": 1,
+            "server_review": {
+              "items": [
+                {
+                  "key": "descriptor",
+                  "label": "Operation class",
+                  "value": "managed-authz-policy-set"
+                },
+                {
+                  "key": "safety_class",
+                  "label": "Safety class",
+                  "value": "policy_admin"
+                }
+              ],
+              "review_id": "review-1d762a6ac3895594ed85ba7a",
+              "schema_version": 1,
+              "summary": "Review this exact privileged operation before confirming.",
+              "title": "Owner approval required"
+            }
+          },
+          "approval_request_digest": "a60572025b121241d44c3f28ce22715841e348765dd50cfa514861e89334d9eb",
+          "channel_binding_sha256": "1b8a26cd423937c1b5edcb5f7162c67978055213231bc4e85c3c46dc9a9738aa",
+          "confirmed_at": "2030-01-02T03:05:05+00:00",
+          "decision": "approved",
+          "schema_version": 1
+        },
+        "channel_binding": {
+          "channel_session_id": "channel-session-5138ce25ddfcf0b39d4d178ef80612d0",
+          "owner_github_id": 494383370,
+          "owner_public_key": "A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg",
+          "schema_version": 1,
+          "session_expires_at": "2030-01-02T03:09:05+00:00",
+          "session_issued_at": "2030-01-02T03:00:05+00:00",
+          "signature_algorithm": "ed25519"
+        },
+        "schema_version": 1,
+        "signature": "tglT-SQl-k0_FmKKynVn6iop-CRZnBmAVLLgCSX6Ak1FN5NcQRSrFYiGLmTtoqOKvYb9FCc0GRGnGWVKaXaDAQ",
+        "signature_algorithm": "ed25519"
+      },
+      "rule": "tampered-signed-payload-is-rejected",
+      "verification": "invalid"
+    },
+    {
+      "error_location": [],
+      "model": "owner_control_confirmation_envelope",
+      "payload": {
+        "challenge_response": {
+          "approval_request": {
+            "descriptor_id": "managed-authz-policy-set",
+            "descriptor_version": 1,
+            "evidence_digest": "df6da961581b149a28639add56e3b08401b3bed6afb07ad0c7b5ca3d51632be9",
+            "expires_at": "2030-01-02T03:09:05+00:00",
+            "issued_at": "2030-01-02T03:00:05+00:00",
+            "nonce": "owner-control-b565a7b3115d408e250eeffe65af9513",
+            "operation_id": "privileged-operation-1d762a6ac3895594ed85ba7aa9c39330",
+            "owner_github_id": 494383370,
+            "plan_digest": "edf23f94b33d1188e34e143e7aff91075ec941053b3b95d367a45de67b1fe1d7",
+            "policy_record_id": "owner-policy-1d762a6ac3895594ed85",
+            "policy_revision": 1,
+            "policy_sha256": "b379db2fe113e77eef0b3bb05aec804189d9f0b359e67d941d837c7de59e6f8e",
+            "pre_state_digest": "46df3876ade6b39b0edfbd3b8ea1a408173bbe5d8cc7154cea4d63e5d057239f",
+            "request_digest": "e0e31f55312d2562bf610587d7a21b5badeed50224284b08d1662924379b4539",
+            "schema_version": 1,
+            "server_review": {
+              "items": [
+                {
+                  "key": "descriptor",
+                  "label": "Operation class",
+                  "value": "managed-authz-policy-set"
+                },
+                {
+                  "key": "safety_class",
+                  "label": "Safety class",
+                  "value": "policy_admin"
+                }
+              ],
+              "review_id": "review-1d762a6ac3895594ed85ba7a",
+              "schema_version": 1,
+              "summary": "Review this exact privileged operation before confirming.",
+              "title": "Owner approval required"
+            }
+          },
+          "approval_request_digest": "a60572025b121241d44c3f28ce22715841e348765dd50cfa514861e89334d9eb",
+          "channel_binding_sha256": "1b8a26cd423937c1b5edcb5f7162c67978055213231bc4e85c3c46dc9a9738aa",
+          "confirmed_at": "2030-01-02T03:04:05+00:00",
+          "decision": "approved",
+          "schema_version": 1
+        },
+        "channel_binding": {
+          "channel_session_id": "channel-session-5138ce25ddfcf0b39d4d178ef80612d0",
+          "owner_github_id": 494383370,
+          "owner_public_key": "A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg",
+          "schema_version": 1,
+          "session_expires_at": "2030-01-02T03:09:05+00:00",
+          "session_issued_at": "2030-01-02T03:00:05+00:00",
+          "signature_algorithm": "ed25519"
+        },
+        "schema_version": 1,
+        "signature": "02J6oR7ilFnTUXL4_Qex6UOK199sdgOJ7nfIvBDMwLgD5-RheWhxWqpfBG_ctz8wrZ16j2WsSPCXznrKAuLVAg",
+        "signature_algorithm": "ed25519"
+      },
+      "rule": "signature-from-wrong-private-key-is-rejected",
+      "verification": "invalid"
+    },
+    {
+      "error_location": [],
+      "model": "owner_control_confirmation_envelope",
+      "payload": {
+        "challenge_response": {
+          "approval_request": {
+            "descriptor_id": "managed-authz-policy-set",
+            "descriptor_version": 1,
+            "evidence_digest": "df6da961581b149a28639add56e3b08401b3bed6afb07ad0c7b5ca3d51632be9",
+            "expires_at": "2030-01-02T03:09:05+00:00",
+            "issued_at": "2030-01-02T03:00:05+00:00",
+            "nonce": "owner-control-b565a7b3115d408e250eeffe65af9513",
+            "operation_id": "privileged-operation-1d762a6ac3895594ed85ba7aa9c39330",
+            "owner_github_id": 494383370,
+            "plan_digest": "edf23f94b33d1188e34e143e7aff91075ec941053b3b95d367a45de67b1fe1d7",
+            "policy_record_id": "owner-policy-1d762a6ac3895594ed85",
+            "policy_revision": 1,
+            "policy_sha256": "b379db2fe113e77eef0b3bb05aec804189d9f0b359e67d941d837c7de59e6f8e",
+            "pre_state_digest": "46df3876ade6b39b0edfbd3b8ea1a408173bbe5d8cc7154cea4d63e5d057239f",
+            "request_digest": "e0e31f55312d2562bf610587d7a21b5badeed50224284b08d1662924379b4539",
+            "schema_version": 1,
+            "server_review": {
+              "items": [
+                {
+                  "key": "descriptor",
+                  "label": "Operation class",
+                  "value": "managed-authz-policy-set"
+                },
+                {
+                  "key": "safety_class",
+                  "label": "Safety class",
+                  "value": "policy_admin"
+                }
+              ],
+              "review_id": "review-1d762a6ac3895594ed85ba7a",
+              "schema_version": 1,
+              "summary": "Review this exact privileged operation before confirming.",
+              "title": "Owner approval required"
+            }
+          },
+          "approval_request_digest": "a60572025b121241d44c3f28ce22715841e348765dd50cfa514861e89334d9eb",
+          "channel_binding_sha256": "ad99324cd7ba27f2730bad0fdcaf32d4184e189823a83ea67ae8a5ab3216df38",
+          "confirmed_at": "2030-01-02T03:04:05+00:00",
+          "decision": "approved",
+          "schema_version": 1
+        },
+        "channel_binding": {
+          "channel_session_id": "channel-session-substituted",
+          "owner_github_id": 494383370,
+          "owner_public_key": "A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg",
+          "schema_version": 1,
+          "session_expires_at": "2030-01-02T03:09:05+00:00",
+          "session_issued_at": "2030-01-02T03:00:05+00:00",
+          "signature_algorithm": "ed25519"
+        },
+        "schema_version": 1,
+        "signature": "tglT-SQl-k0_FmKKynVn6iop-CRZnBmAVLLgCSX6Ak1FN5NcQRSrFYiGLmTtoqOKvYb9FCc0GRGnGWVKaXaDAQ",
+        "signature_algorithm": "ed25519"
+      },
+      "rule": "cross-session-substitution-is-rejected",
+      "verification": "invalid"
     }
   ],
   "negative_vectors": [
@@ -749,7 +1916,7 @@
       "rule": "review-item-text-has-no-surrounding-whitespace"
     }
   ],
-  "schema_version": 1,
+  "schema_version": 2,
   "schemas": {
     "approval_request": {
       "$defs": {
@@ -1169,6 +2336,642 @@
       "title": "ChallengeResponse",
       "type": "object"
     },
+    "channel_binding_record": {
+      "additionalProperties": false,
+      "description": "Immutable versioned binding between an owner key and one channel session.",
+      "properties": {
+        "channel_session_id": {
+          "pattern": "^[a-z][a-z0-9_-]{0,127}$",
+          "title": "Channel Session Id",
+          "type": "string"
+        },
+        "owner_github_id": {
+          "maximum": 9223372036854775807,
+          "minimum": 1,
+          "title": "Owner Github Id",
+          "type": "integer"
+        },
+        "owner_public_key": {
+          "maxLength": 43,
+          "minLength": 43,
+          "pattern": "^[A-Za-z0-9_-]+$",
+          "title": "Owner Public Key",
+          "type": "string"
+        },
+        "schema_version": {
+          "const": 1,
+          "default": 1,
+          "title": "Schema Version",
+          "type": "integer"
+        },
+        "session_expires_at": {
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\+00:00$",
+          "title": "Session Expires At",
+          "type": "string"
+        },
+        "session_issued_at": {
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\+00:00$",
+          "title": "Session Issued At",
+          "type": "string"
+        },
+        "signature_algorithm": {
+          "const": "ed25519",
+          "default": "ed25519",
+          "title": "Signature Algorithm",
+          "type": "string"
+        }
+      },
+      "required": [
+        "channel_session_id",
+        "owner_github_id",
+        "owner_public_key",
+        "session_issued_at",
+        "session_expires_at"
+      ],
+      "title": "ChannelBindingRecord",
+      "type": "object"
+    },
+    "owner_control_confirmation_envelope": {
+      "$defs": {
+        "ApprovalRequest": {
+          "additionalProperties": false,
+          "description": "Exact, versioned owner-control challenge input issued by Launchplane.",
+          "properties": {
+            "descriptor_id": {
+              "enum": [
+                "managed-secret-reencryption",
+                "managed-authz-policy-set"
+              ],
+              "title": "Descriptor Id",
+              "type": "string"
+            },
+            "descriptor_version": {
+              "const": 1,
+              "title": "Descriptor Version",
+              "type": "integer"
+            },
+            "evidence_digest": {
+              "pattern": "^[0-9a-f]{64}$",
+              "title": "Evidence Digest",
+              "type": "string"
+            },
+            "expires_at": {
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\+00:00$",
+              "title": "Expires At",
+              "type": "string"
+            },
+            "issued_at": {
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\+00:00$",
+              "title": "Issued At",
+              "type": "string"
+            },
+            "nonce": {
+              "pattern": "^[A-Za-z0-9_-]{16,128}$",
+              "title": "Nonce",
+              "type": "string"
+            },
+            "operation_id": {
+              "pattern": "^privileged-operation-[0-9a-f]{32}$",
+              "title": "Operation Id",
+              "type": "string"
+            },
+            "owner_github_id": {
+              "maximum": 9223372036854775807,
+              "minimum": 1,
+              "title": "Owner Github Id",
+              "type": "integer"
+            },
+            "plan_digest": {
+              "pattern": "^[0-9a-f]{64}$",
+              "title": "Plan Digest",
+              "type": "string"
+            },
+            "policy_record_id": {
+              "pattern": "^[a-z][a-z0-9_-]{0,127}$",
+              "title": "Policy Record Id",
+              "type": "string"
+            },
+            "policy_revision": {
+              "maximum": 9223372036854775807,
+              "minimum": 1,
+              "title": "Policy Revision",
+              "type": "integer"
+            },
+            "policy_sha256": {
+              "pattern": "^[0-9a-f]{64}$",
+              "title": "Policy Sha256",
+              "type": "string"
+            },
+            "pre_state_digest": {
+              "pattern": "^[0-9a-f]{64}$",
+              "title": "Pre State Digest",
+              "type": "string"
+            },
+            "request_digest": {
+              "pattern": "^[0-9a-f]{64}$",
+              "title": "Request Digest",
+              "type": "string"
+            },
+            "schema_version": {
+              "const": 1,
+              "default": 1,
+              "title": "Schema Version",
+              "type": "integer"
+            },
+            "server_review": {
+              "$ref": "#/$defs/ServerReviewPayload"
+            }
+          },
+          "required": [
+            "operation_id",
+            "descriptor_id",
+            "descriptor_version",
+            "request_digest",
+            "plan_digest",
+            "evidence_digest",
+            "pre_state_digest",
+            "policy_record_id",
+            "policy_revision",
+            "policy_sha256",
+            "owner_github_id",
+            "server_review",
+            "nonce",
+            "issued_at",
+            "expires_at"
+          ],
+          "title": "ApprovalRequest",
+          "type": "object"
+        },
+        "ChallengeResponse": {
+          "additionalProperties": false,
+          "description": "Owner-channel confirmation bound to one exact approval request.",
+          "properties": {
+            "approval_request": {
+              "$ref": "#/$defs/ApprovalRequest"
+            },
+            "approval_request_digest": {
+              "pattern": "^[0-9a-f]{64}$",
+              "title": "Approval Request Digest",
+              "type": "string"
+            },
+            "channel_binding_sha256": {
+              "pattern": "^[0-9a-f]{64}$",
+              "title": "Channel Binding Sha256",
+              "type": "string"
+            },
+            "confirmed_at": {
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\+00:00$",
+              "title": "Confirmed At",
+              "type": "string"
+            },
+            "decision": {
+              "const": "approved",
+              "title": "Decision",
+              "type": "string"
+            },
+            "schema_version": {
+              "const": 1,
+              "default": 1,
+              "title": "Schema Version",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "approval_request",
+            "approval_request_digest",
+            "decision",
+            "channel_binding_sha256",
+            "confirmed_at"
+          ],
+          "title": "ChallengeResponse",
+          "type": "object"
+        },
+        "ChannelBindingRecord": {
+          "additionalProperties": false,
+          "description": "Immutable versioned binding between an owner key and one channel session.",
+          "properties": {
+            "channel_session_id": {
+              "pattern": "^[a-z][a-z0-9_-]{0,127}$",
+              "title": "Channel Session Id",
+              "type": "string"
+            },
+            "owner_github_id": {
+              "maximum": 9223372036854775807,
+              "minimum": 1,
+              "title": "Owner Github Id",
+              "type": "integer"
+            },
+            "owner_public_key": {
+              "maxLength": 43,
+              "minLength": 43,
+              "pattern": "^[A-Za-z0-9_-]+$",
+              "title": "Owner Public Key",
+              "type": "string"
+            },
+            "schema_version": {
+              "const": 1,
+              "default": 1,
+              "title": "Schema Version",
+              "type": "integer"
+            },
+            "session_expires_at": {
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\+00:00$",
+              "title": "Session Expires At",
+              "type": "string"
+            },
+            "session_issued_at": {
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\+00:00$",
+              "title": "Session Issued At",
+              "type": "string"
+            },
+            "signature_algorithm": {
+              "const": "ed25519",
+              "default": "ed25519",
+              "title": "Signature Algorithm",
+              "type": "string"
+            }
+          },
+          "required": [
+            "channel_session_id",
+            "owner_github_id",
+            "owner_public_key",
+            "session_issued_at",
+            "session_expires_at"
+          ],
+          "title": "ChannelBindingRecord",
+          "type": "object"
+        },
+        "ReviewItem": {
+          "additionalProperties": false,
+          "description": "One server-authored, display-ready field in an owner review payload.",
+          "properties": {
+            "key": {
+              "pattern": "^[a-z][a-z0-9_]{0,63}$",
+              "title": "Key",
+              "type": "string"
+            },
+            "label": {
+              "maxLength": 120,
+              "minLength": 1,
+              "title": "Label",
+              "type": "string"
+            },
+            "value": {
+              "maxLength": 4000,
+              "minLength": 1,
+              "title": "Value",
+              "type": "string"
+            }
+          },
+          "required": [
+            "key",
+            "label",
+            "value"
+          ],
+          "title": "ReviewItem",
+          "type": "object"
+        },
+        "ServerReviewPayload": {
+          "additionalProperties": false,
+          "description": "Canonical server-authored review content rendered for one owner decision.",
+          "properties": {
+            "items": {
+              "items": {
+                "$ref": "#/$defs/ReviewItem"
+              },
+              "maxItems": 32,
+              "minItems": 1,
+              "title": "Items",
+              "type": "array"
+            },
+            "review_id": {
+              "pattern": "^[a-z][a-z0-9_-]{0,127}$",
+              "title": "Review Id",
+              "type": "string"
+            },
+            "schema_version": {
+              "const": 1,
+              "default": 1,
+              "title": "Schema Version",
+              "type": "integer"
+            },
+            "summary": {
+              "maxLength": 4000,
+              "minLength": 1,
+              "title": "Summary",
+              "type": "string"
+            },
+            "title": {
+              "maxLength": 200,
+              "minLength": 1,
+              "title": "Title",
+              "type": "string"
+            }
+          },
+          "required": [
+            "review_id",
+            "title",
+            "summary",
+            "items"
+          ],
+          "title": "ServerReviewPayload",
+          "type": "object"
+        }
+      },
+      "additionalProperties": false,
+      "description": "Signed owner confirmation bound to one channel session and challenge.",
+      "properties": {
+        "challenge_response": {
+          "$ref": "#/$defs/ChallengeResponse"
+        },
+        "channel_binding": {
+          "$ref": "#/$defs/ChannelBindingRecord"
+        },
+        "schema_version": {
+          "const": 1,
+          "default": 1,
+          "title": "Schema Version",
+          "type": "integer"
+        },
+        "signature": {
+          "maxLength": 86,
+          "minLength": 86,
+          "pattern": "^[A-Za-z0-9_-]+$",
+          "title": "Signature",
+          "type": "string"
+        },
+        "signature_algorithm": {
+          "const": "ed25519",
+          "default": "ed25519",
+          "title": "Signature Algorithm",
+          "type": "string"
+        }
+      },
+      "required": [
+        "channel_binding",
+        "challenge_response",
+        "signature"
+      ],
+      "title": "OwnerControlConfirmationEnvelope",
+      "type": "object"
+    },
+    "owner_control_signature_payload": {
+      "$defs": {
+        "ApprovalRequest": {
+          "additionalProperties": false,
+          "description": "Exact, versioned owner-control challenge input issued by Launchplane.",
+          "properties": {
+            "descriptor_id": {
+              "enum": [
+                "managed-secret-reencryption",
+                "managed-authz-policy-set"
+              ],
+              "title": "Descriptor Id",
+              "type": "string"
+            },
+            "descriptor_version": {
+              "const": 1,
+              "title": "Descriptor Version",
+              "type": "integer"
+            },
+            "evidence_digest": {
+              "pattern": "^[0-9a-f]{64}$",
+              "title": "Evidence Digest",
+              "type": "string"
+            },
+            "expires_at": {
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\+00:00$",
+              "title": "Expires At",
+              "type": "string"
+            },
+            "issued_at": {
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\+00:00$",
+              "title": "Issued At",
+              "type": "string"
+            },
+            "nonce": {
+              "pattern": "^[A-Za-z0-9_-]{16,128}$",
+              "title": "Nonce",
+              "type": "string"
+            },
+            "operation_id": {
+              "pattern": "^privileged-operation-[0-9a-f]{32}$",
+              "title": "Operation Id",
+              "type": "string"
+            },
+            "owner_github_id": {
+              "maximum": 9223372036854775807,
+              "minimum": 1,
+              "title": "Owner Github Id",
+              "type": "integer"
+            },
+            "plan_digest": {
+              "pattern": "^[0-9a-f]{64}$",
+              "title": "Plan Digest",
+              "type": "string"
+            },
+            "policy_record_id": {
+              "pattern": "^[a-z][a-z0-9_-]{0,127}$",
+              "title": "Policy Record Id",
+              "type": "string"
+            },
+            "policy_revision": {
+              "maximum": 9223372036854775807,
+              "minimum": 1,
+              "title": "Policy Revision",
+              "type": "integer"
+            },
+            "policy_sha256": {
+              "pattern": "^[0-9a-f]{64}$",
+              "title": "Policy Sha256",
+              "type": "string"
+            },
+            "pre_state_digest": {
+              "pattern": "^[0-9a-f]{64}$",
+              "title": "Pre State Digest",
+              "type": "string"
+            },
+            "request_digest": {
+              "pattern": "^[0-9a-f]{64}$",
+              "title": "Request Digest",
+              "type": "string"
+            },
+            "schema_version": {
+              "const": 1,
+              "default": 1,
+              "title": "Schema Version",
+              "type": "integer"
+            },
+            "server_review": {
+              "$ref": "#/$defs/ServerReviewPayload"
+            }
+          },
+          "required": [
+            "operation_id",
+            "descriptor_id",
+            "descriptor_version",
+            "request_digest",
+            "plan_digest",
+            "evidence_digest",
+            "pre_state_digest",
+            "policy_record_id",
+            "policy_revision",
+            "policy_sha256",
+            "owner_github_id",
+            "server_review",
+            "nonce",
+            "issued_at",
+            "expires_at"
+          ],
+          "title": "ApprovalRequest",
+          "type": "object"
+        },
+        "ChallengeResponse": {
+          "additionalProperties": false,
+          "description": "Owner-channel confirmation bound to one exact approval request.",
+          "properties": {
+            "approval_request": {
+              "$ref": "#/$defs/ApprovalRequest"
+            },
+            "approval_request_digest": {
+              "pattern": "^[0-9a-f]{64}$",
+              "title": "Approval Request Digest",
+              "type": "string"
+            },
+            "channel_binding_sha256": {
+              "pattern": "^[0-9a-f]{64}$",
+              "title": "Channel Binding Sha256",
+              "type": "string"
+            },
+            "confirmed_at": {
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\+00:00$",
+              "title": "Confirmed At",
+              "type": "string"
+            },
+            "decision": {
+              "const": "approved",
+              "title": "Decision",
+              "type": "string"
+            },
+            "schema_version": {
+              "const": 1,
+              "default": 1,
+              "title": "Schema Version",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "approval_request",
+            "approval_request_digest",
+            "decision",
+            "channel_binding_sha256",
+            "confirmed_at"
+          ],
+          "title": "ChallengeResponse",
+          "type": "object"
+        },
+        "ReviewItem": {
+          "additionalProperties": false,
+          "description": "One server-authored, display-ready field in an owner review payload.",
+          "properties": {
+            "key": {
+              "pattern": "^[a-z][a-z0-9_]{0,63}$",
+              "title": "Key",
+              "type": "string"
+            },
+            "label": {
+              "maxLength": 120,
+              "minLength": 1,
+              "title": "Label",
+              "type": "string"
+            },
+            "value": {
+              "maxLength": 4000,
+              "minLength": 1,
+              "title": "Value",
+              "type": "string"
+            }
+          },
+          "required": [
+            "key",
+            "label",
+            "value"
+          ],
+          "title": "ReviewItem",
+          "type": "object"
+        },
+        "ServerReviewPayload": {
+          "additionalProperties": false,
+          "description": "Canonical server-authored review content rendered for one owner decision.",
+          "properties": {
+            "items": {
+              "items": {
+                "$ref": "#/$defs/ReviewItem"
+              },
+              "maxItems": 32,
+              "minItems": 1,
+              "title": "Items",
+              "type": "array"
+            },
+            "review_id": {
+              "pattern": "^[a-z][a-z0-9_-]{0,127}$",
+              "title": "Review Id",
+              "type": "string"
+            },
+            "schema_version": {
+              "const": 1,
+              "default": 1,
+              "title": "Schema Version",
+              "type": "integer"
+            },
+            "summary": {
+              "maxLength": 4000,
+              "minLength": 1,
+              "title": "Summary",
+              "type": "string"
+            },
+            "title": {
+              "maxLength": 200,
+              "minLength": 1,
+              "title": "Title",
+              "type": "string"
+            }
+          },
+          "required": [
+            "review_id",
+            "title",
+            "summary",
+            "items"
+          ],
+          "title": "ServerReviewPayload",
+          "type": "object"
+        }
+      },
+      "additionalProperties": false,
+      "description": "Exact domain-separated payload authenticated by an owner signature.",
+      "properties": {
+        "challenge_response": {
+          "$ref": "#/$defs/ChallengeResponse"
+        },
+        "domain": {
+          "const": "launchplane-owner-control-confirmation-v1",
+          "default": "launchplane-owner-control-confirmation-v1",
+          "title": "Domain",
+          "type": "string"
+        },
+        "schema_version": {
+          "const": 1,
+          "default": 1,
+          "title": "Schema Version",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "challenge_response"
+      ],
+      "title": "OwnerControlSignaturePayload",
+      "type": "object"
+    },
     "server_review_payload": {
       "$defs": {
         "ReviewItem": {
@@ -1247,5 +3050,17 @@
       "title": "ServerReviewPayload",
       "type": "object"
     }
+  },
+  "signature_declaration": {
+    "algorithm": "ed25519",
+    "contract_schema_version": 2,
+    "domain": "launchplane-owner-control-confirmation-v1",
+    "legacy_golden_channel_binding": "synthetic-placeholder-not-channel-binding-record",
+    "payload": "OwnerControlSignaturePayload",
+    "payload_encoding": "canonical-json-utf8",
+    "public_key_bytes": 32,
+    "public_key_encoding": "base64url-unpadded",
+    "signature_bytes": 64,
+    "signature_encoding": "base64url-unpadded"
   }
 }

--- a/control_plane/contracts/owner_control.py
+++ b/control_plane/contracts/owner_control.py
@@ -1,16 +1,24 @@
 from __future__ import annotations
 
+import base64
+import binascii
 from datetime import datetime, timezone
 import re
 from typing import Final, Literal
 
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
-from control_plane.contracts.canonical_json import canonical_json_sha256
+from control_plane.contracts.canonical_json import canonical_json_bytes, canonical_json_sha256
 from control_plane.contracts.privileged_operation import PrivilegedOperationDescriptorId
 
 
 OWNER_CONTROL_SCHEMA_VERSION: Final[Literal[1]] = 1
+OWNER_CONTROL_SIGNATURE_DOMAIN: Final[Literal["launchplane-owner-control-confirmation-v1"]] = (
+    "launchplane-owner-control-confirmation-v1"
+)
+OWNER_CONTROL_SIGNATURE_ALGORITHM: Final[Literal["ed25519"]] = "ed25519"
 
 _SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
 _OPERATION_ID_PATTERN = re.compile(r"^privileged-operation-[0-9a-f]{32}$")
@@ -18,6 +26,7 @@ _NONCE_PATTERN = re.compile(r"^[A-Za-z0-9_-]{16,128}$")
 _IDENTIFIER_PATTERN = re.compile(r"^[a-z][a-z0-9_-]{0,127}$")
 _REVIEW_KEY_PATTERN = re.compile(r"^[a-z][a-z0-9_]{0,63}$")
 _CANONICAL_TIMESTAMP_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\+00:00$")
+_BASE64URL_PATTERN = re.compile(r"^[A-Za-z0-9_-]+$")
 
 
 def _canonical_sha256(value: str, field_name: str) -> str:
@@ -43,6 +52,25 @@ def _canonical_timestamp(value: str, field_name: str) -> str:
     if value != canonical:
         raise ValueError(f"{field_name} must use canonical UTC ISO-8601 form")
     return value
+
+
+def _canonical_base64url(value: str, field_name: str, expected_length: int) -> str:
+    if _BASE64URL_PATTERN.fullmatch(value) is None or len(value) % 4 == 1:
+        raise ValueError(f"{field_name} must be unpadded base64url")
+    try:
+        decoded = base64.urlsafe_b64decode(value + "=" * (-len(value) % 4))
+    except (binascii.Error, ValueError) as error:
+        raise ValueError(f"{field_name} must be unpadded base64url") from error
+    if len(decoded) != expected_length:
+        raise ValueError(f"{field_name} must encode exactly {expected_length} bytes")
+    if base64.urlsafe_b64encode(decoded).decode("ascii").rstrip("=") != value:
+        raise ValueError(f"{field_name} must use canonical unpadded base64url")
+    return value
+
+
+def _decode_canonical_base64url(value: str, field_name: str, expected_length: int) -> bytes:
+    _canonical_base64url(value, field_name, expected_length)
+    return base64.urlsafe_b64decode(value + "=" * (-len(value) % 4))
 
 
 class ReviewItem(BaseModel):
@@ -169,6 +197,109 @@ class ChallengeResponse(BaseModel):
         return self
 
 
+class ChannelBindingRecord(BaseModel):
+    """Immutable versioned binding between an owner key and one channel session."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    schema_version: Literal[1] = OWNER_CONTROL_SCHEMA_VERSION
+    channel_session_id: str = Field(pattern=_IDENTIFIER_PATTERN.pattern)
+    owner_github_id: int = Field(ge=1, le=2**63 - 1)
+    signature_algorithm: Literal["ed25519"] = OWNER_CONTROL_SIGNATURE_ALGORITHM
+    owner_public_key: str = Field(
+        min_length=43,
+        max_length=43,
+        pattern=_BASE64URL_PATTERN.pattern,
+    )
+    session_issued_at: str = Field(pattern=_CANONICAL_TIMESTAMP_PATTERN.pattern)
+    session_expires_at: str = Field(pattern=_CANONICAL_TIMESTAMP_PATTERN.pattern)
+
+    @model_validator(mode="after")
+    def _validate_channel_binding_record(self) -> "ChannelBindingRecord":
+        if self.schema_version != OWNER_CONTROL_SCHEMA_VERSION:
+            raise ValueError("Unsupported owner-control channel binding schema version.")
+        _canonical_identifier(self.channel_session_id, "channel_session_id")
+        if self.signature_algorithm != OWNER_CONTROL_SIGNATURE_ALGORITHM:
+            raise ValueError("Unsupported owner-control signature algorithm.")
+        _canonical_base64url(self.owner_public_key, "owner_public_key", 32)
+        _canonical_timestamp(self.session_issued_at, "session_issued_at")
+        _canonical_timestamp(self.session_expires_at, "session_expires_at")
+        session_issued_at = datetime.fromisoformat(self.session_issued_at)
+        session_expires_at = datetime.fromisoformat(self.session_expires_at)
+        if session_expires_at <= session_issued_at:
+            raise ValueError("session_expires_at must be later than session_issued_at")
+        return self
+
+
+class OwnerControlSignaturePayload(BaseModel):
+    """Exact domain-separated payload authenticated by an owner signature."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    schema_version: Literal[1] = OWNER_CONTROL_SCHEMA_VERSION
+    domain: Literal["launchplane-owner-control-confirmation-v1"] = OWNER_CONTROL_SIGNATURE_DOMAIN
+    challenge_response: ChallengeResponse
+
+    @model_validator(mode="after")
+    def _validate_signature_payload(self) -> "OwnerControlSignaturePayload":
+        if self.schema_version != OWNER_CONTROL_SCHEMA_VERSION:
+            raise ValueError("Unsupported owner-control signature payload schema version.")
+        if self.domain != OWNER_CONTROL_SIGNATURE_DOMAIN:
+            raise ValueError("Unsupported owner-control signature payload domain.")
+        return self
+
+
+class OwnerControlConfirmationEnvelope(BaseModel):
+    """Signed owner confirmation bound to one channel session and challenge."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    schema_version: Literal[1] = OWNER_CONTROL_SCHEMA_VERSION
+    channel_binding: ChannelBindingRecord
+    challenge_response: ChallengeResponse
+    signature_algorithm: Literal["ed25519"] = OWNER_CONTROL_SIGNATURE_ALGORITHM
+    signature: str = Field(
+        min_length=86,
+        max_length=86,
+        pattern=_BASE64URL_PATTERN.pattern,
+    )
+
+    @model_validator(mode="after")
+    def _validate_confirmation_envelope(self) -> "OwnerControlConfirmationEnvelope":
+        if self.schema_version != OWNER_CONTROL_SCHEMA_VERSION:
+            raise ValueError("Unsupported owner-control confirmation envelope schema version.")
+        if self.signature_algorithm != OWNER_CONTROL_SIGNATURE_ALGORITHM:
+            raise ValueError("Unsupported owner-control signature algorithm.")
+        _canonical_base64url(self.signature, "signature", 64)
+        if self.challenge_response.channel_binding_sha256 != owner_control_channel_binding_sha256(
+            self.channel_binding
+        ):
+            raise ValueError(
+                "challenge_response channel binding digest does not match the binding record"
+            )
+        if (
+            self.challenge_response.approval_request.owner_github_id
+            != self.channel_binding.owner_github_id
+        ):
+            raise ValueError(
+                "channel binding owner identity does not match the approval request owner"
+            )
+        session_issued_at = datetime.fromisoformat(self.channel_binding.session_issued_at)
+        session_expires_at = datetime.fromisoformat(self.channel_binding.session_expires_at)
+        request_issued_at = datetime.fromisoformat(
+            self.challenge_response.approval_request.issued_at
+        )
+        request_expires_at = datetime.fromisoformat(
+            self.challenge_response.approval_request.expires_at
+        )
+        confirmed_at = datetime.fromisoformat(self.challenge_response.confirmed_at)
+        if request_issued_at < session_issued_at or request_expires_at > session_expires_at:
+            raise ValueError("approval request bounds must be inside the channel session interval")
+        if confirmed_at < session_issued_at or confirmed_at > session_expires_at:
+            raise ValueError("confirmation time must be inside the channel session interval")
+        return self
+
+
 def owner_control_approval_request_digest(request: ApprovalRequest) -> str:
     """Return the canonical digest shared by Launchplane and the owner-control host."""
 
@@ -179,3 +310,45 @@ def owner_control_challenge_response_digest(response: ChallengeResponse) -> str:
     """Return the canonical digest of an owner-control challenge response."""
 
     return canonical_json_sha256(response.model_dump(mode="json"))
+
+
+def owner_control_channel_binding_sha256(binding: ChannelBindingRecord) -> str:
+    """Return the digest of the exact canonical channel binding record payload."""
+
+    return canonical_json_sha256(binding.model_dump(mode="json"))
+
+
+def owner_control_signature_payload(response: ChallengeResponse) -> OwnerControlSignaturePayload:
+    """Build the exact domain-separated payload covered by an owner signature."""
+
+    return OwnerControlSignaturePayload(challenge_response=response)
+
+
+def owner_control_signature_payload_bytes(response: ChallengeResponse) -> bytes:
+    """Return canonical JSON bytes for the exact owner signature preimage."""
+
+    return canonical_json_bytes(owner_control_signature_payload(response).model_dump(mode="json"))
+
+
+def verify_owner_control_confirmation_signature(
+    envelope: OwnerControlConfirmationEnvelope,
+) -> bool:
+    """Verify only the envelope's internal Ed25519 proof, not server authorization state."""
+
+    try:
+        validated_envelope = OwnerControlConfirmationEnvelope.model_validate_json(
+            canonical_json_bytes(envelope.model_dump(mode="json"))
+        )
+        public_key = Ed25519PublicKey.from_public_bytes(
+            _decode_canonical_base64url(
+                validated_envelope.channel_binding.owner_public_key, "owner_public_key", 32
+            )
+        )
+        signature = _decode_canonical_base64url(validated_envelope.signature, "signature", 64)
+        public_key.verify(
+            signature,
+            owner_control_signature_payload_bytes(validated_envelope.challenge_response),
+        )
+    except (AttributeError, InvalidSignature, TypeError, ValueError):
+        return False
+    return True

--- a/control_plane/owner_control_contract.py
+++ b/control_plane/owner_control_contract.py
@@ -1,18 +1,27 @@
 from __future__ import annotations
 
+import base64
 import json
 from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 from control_plane.contracts.canonical_json import canonical_json_bytes, canonical_json_sha256
 from control_plane.contracts.owner_control import (
     ApprovalRequest,
+    ChannelBindingRecord,
     ChallengeResponse,
+    OwnerControlConfirmationEnvelope,
+    OwnerControlSignaturePayload,
     ReviewItem,
     ServerReviewPayload,
     owner_control_approval_request_digest,
+    owner_control_channel_binding_sha256,
     owner_control_challenge_response_digest,
+    owner_control_signature_payload,
+    owner_control_signature_payload_bytes,
 )
 from control_plane.contracts.privileged_operation import (
     PrivilegedOperationDescriptorId,
@@ -22,7 +31,10 @@ from control_plane.privileged_operation_registry import list_privileged_operatio
 from control_plane.privileged_operation_registry import read_privileged_operation_descriptor
 
 
-OWNER_CONTROL_CONTRACT_SCHEMA_VERSION = 1
+OWNER_CONTROL_CONTRACT_SCHEMA_VERSION = 2
+_OWNER_CONTROL_VECTOR_SCHEMA_VERSION = 1
+_ARTIFACT_SYNTHETIC_PRIVATE_KEY_SEED = bytes(range(32))
+_ARTIFACT_SYNTHETIC_WRONG_PRIVATE_KEY_SEED = bytes(range(31, -1, -1))
 
 
 class OwnerControlContractError(ValueError):
@@ -34,7 +46,7 @@ def _digest_for_vector(*, descriptor_id: PrivilegedOperationDescriptorId, label:
         {
             "descriptor_id": descriptor_id,
             "label": label,
-            "schema_version": OWNER_CONTROL_CONTRACT_SCHEMA_VERSION,
+            "schema_version": _OWNER_CONTROL_VECTOR_SCHEMA_VERSION,
         }
     )
 
@@ -111,16 +123,126 @@ def _golden_vector(
         "descriptor_id": descriptor_id,
         "descriptor_version": descriptor_version,
         "approval_request": {
-            "canonical_json": canonical_json_bytes(request_payload).decode("utf-8"),
+            "canonical_json": canonical_json_bytes(request_payload).decode(),
             "payload": request_payload,
             "sha256": owner_control_approval_request_digest(request),
         },
         "challenge_response": {
-            "canonical_json": canonical_json_bytes(response_payload).decode("utf-8"),
+            "canonical_json": canonical_json_bytes(response_payload).decode(),
             "payload": response_payload,
             "sha256": owner_control_challenge_response_digest(response),
         },
     }
+
+
+def _artifact_synthetic_private_key() -> Ed25519PrivateKey:
+    return Ed25519PrivateKey.from_private_bytes(_ARTIFACT_SYNTHETIC_PRIVATE_KEY_SEED)
+
+
+def _artifact_synthetic_wrong_private_key() -> Ed25519PrivateKey:
+    return Ed25519PrivateKey.from_private_bytes(_ARTIFACT_SYNTHETIC_WRONG_PRIVATE_KEY_SEED)
+
+
+def _base64url(value: bytes) -> str:
+    return base64.urlsafe_b64encode(value).decode("ascii").rstrip("=")
+
+
+def _synthetic_owner_public_key(private_key: Ed25519PrivateKey) -> str:
+    return _base64url(
+        private_key.public_key().public_bytes(
+            encoding=serialization.Encoding.Raw,
+            format=serialization.PublicFormat.Raw,
+        )
+    )
+
+
+def _channel_binding_for_request(
+    *,
+    descriptor_id: PrivilegedOperationDescriptorId,
+    request: ApprovalRequest,
+) -> ChannelBindingRecord:
+    return ChannelBindingRecord(
+        channel_session_id=f"channel-session-{_digest_for_vector(descriptor_id=descriptor_id, label='channel-session')[:32]}",
+        owner_github_id=request.owner_github_id,
+        signature_algorithm="ed25519",
+        owner_public_key=_synthetic_owner_public_key(_artifact_synthetic_private_key()),
+        session_issued_at=request.issued_at,
+        session_expires_at=request.expires_at,
+    )
+
+
+def _confirmation_golden_vector(
+    *,
+    descriptor_id: PrivilegedOperationDescriptorId,
+    descriptor_version: int,
+    safety_class: PrivilegedOperationSafetyClass,
+) -> dict[str, Any]:
+    if descriptor_version != 1:
+        raise OwnerControlContractError(
+            f"Unsupported owner-control descriptor version: {descriptor_version}"
+        )
+    binding, response, envelope = _confirmation_models_for_descriptor(
+        descriptor_id=descriptor_id,
+        safety_class=safety_class,
+    )
+    signature_payload = owner_control_signature_payload(response)
+    binding_payload = binding.model_dump(mode="json")
+    response_payload = response.model_dump(mode="json")
+    signature_payload_data = signature_payload.model_dump(mode="json")
+    envelope_payload = envelope.model_dump(mode="json")
+    return {
+        "descriptor_id": descriptor_id,
+        "descriptor_version": descriptor_version,
+        "channel_binding": {
+            "canonical_json": canonical_json_bytes(binding_payload).decode(),
+            "payload": binding_payload,
+            "sha256": owner_control_channel_binding_sha256(binding),
+        },
+        "challenge_response": {
+            "canonical_json": canonical_json_bytes(response_payload).decode(),
+            "payload": response_payload,
+            "sha256": owner_control_challenge_response_digest(response),
+        },
+        "signature_payload": {
+            "canonical_json": canonical_json_bytes(signature_payload_data).decode(),
+            "payload": signature_payload_data,
+            "sha256": canonical_json_sha256(signature_payload_data),
+        },
+        "confirmation_envelope": {
+            "canonical_json": canonical_json_bytes(envelope_payload).decode(),
+            "payload": envelope_payload,
+            "sha256": canonical_json_sha256(envelope_payload),
+        },
+        "verification": "valid",
+    }
+
+
+def _confirmation_models_for_descriptor(
+    *,
+    descriptor_id: PrivilegedOperationDescriptorId,
+    safety_class: PrivilegedOperationSafetyClass,
+) -> tuple[ChannelBindingRecord, ChallengeResponse, OwnerControlConfirmationEnvelope]:
+    request = _approval_request_for_descriptor(
+        descriptor_id=descriptor_id,
+        safety_class=safety_class,
+    )
+    binding = _channel_binding_for_request(descriptor_id=descriptor_id, request=request)
+    response = ChallengeResponse(
+        approval_request=request,
+        approval_request_digest=owner_control_approval_request_digest(request),
+        decision="approved",
+        channel_binding_sha256=owner_control_channel_binding_sha256(binding),
+        confirmed_at="2030-01-02T03:04:05+00:00",
+    )
+    envelope = OwnerControlConfirmationEnvelope(
+        channel_binding=binding,
+        challenge_response=response,
+        signature_algorithm="ed25519",
+        signature=_base64url(
+            _artifact_synthetic_private_key().sign(owner_control_signature_payload_bytes(response))
+        ),
+    )
+    return binding, response, envelope
 
 
 def _canonicalization_vectors() -> list[dict[str, Any]]:
@@ -147,7 +269,7 @@ def _canonicalization_vectors() -> list[dict[str, Any]]:
         {
             "name": name,
             "payload": payload,
-            "canonical_json": canonical_json_bytes(payload).decode("utf-8"),
+            "canonical_json": canonical_json_bytes(payload).decode(),
             "sha256": canonical_json_sha256(payload),
         }
         for name, payload in payloads
@@ -265,6 +387,187 @@ def _negative_vectors() -> list[dict[str, Any]]:
     ]
 
 
+def _negative_confirmation_vectors() -> list[dict[str, Any]]:
+    descriptor = read_privileged_operation_descriptor("managed-authz-policy-set").descriptor
+    binding, response, envelope = _confirmation_models_for_descriptor(
+        descriptor_id=descriptor.descriptor_id,
+        safety_class=descriptor.safety_class,
+    )
+    valid_payload = envelope.model_dump(mode="json")
+    changed_binding = binding.model_copy(update={"owner_github_id": binding.owner_github_id + 1})
+    changed_binding_payload = changed_binding.model_dump(mode="json")
+    response_for_changed_binding = response.model_copy(
+        update={"channel_binding_sha256": owner_control_channel_binding_sha256(changed_binding)}
+    )
+    changed_session_binding = binding.model_copy(
+        update={"session_issued_at": "2030-01-02T03:01:05+00:00"}
+    )
+    response_for_changed_session = response.model_copy(
+        update={
+            "channel_binding_sha256": owner_control_channel_binding_sha256(changed_session_binding)
+        }
+    )
+    cross_session_binding = binding.model_copy(
+        update={"channel_session_id": "channel-session-substituted"}
+    )
+    response_for_cross_session = response.model_copy(
+        update={
+            "channel_binding_sha256": owner_control_channel_binding_sha256(cross_session_binding)
+        }
+    )
+    wrong_key_signature = _base64url(
+        _artifact_synthetic_wrong_private_key().sign(
+            owner_control_signature_payload_bytes(response)
+        )
+    )
+
+    return [
+        {
+            "model": "owner_control_confirmation_envelope",
+            "rule": "schema-version-is-one",
+            "error_location": ["schema_version"],
+            "payload": {**valid_payload, "schema_version": 2},
+        },
+        {
+            "model": "owner_control_confirmation_envelope",
+            "rule": "signature-algorithm-is-ed25519",
+            "error_location": ["signature_algorithm"],
+            "payload": {**valid_payload, "signature_algorithm": "rsa"},
+        },
+        {
+            "model": "owner_control_confirmation_envelope",
+            "rule": "public-key-is-raw-32-byte-unpadded-base64url",
+            "error_location": ["channel_binding", "owner_public_key"],
+            "payload": {
+                **valid_payload,
+                "channel_binding": {**valid_payload["channel_binding"], "owner_public_key": "bad!"},
+            },
+        },
+        {
+            "model": "owner_control_confirmation_envelope",
+            "rule": "signature-is-raw-64-byte-unpadded-base64url",
+            "error_location": ["signature"],
+            "payload": {**valid_payload, "signature": "bad!"},
+        },
+        {
+            "model": "owner_control_confirmation_envelope",
+            "rule": "public-key-base64url-has-canonical-trailing-bits",
+            "error_location": ["channel_binding"],
+            "error_message_contains": "owner_public_key must use canonical unpadded base64url",
+            "payload": {
+                **valid_payload,
+                "channel_binding": {
+                    **valid_payload["channel_binding"],
+                    "owner_public_key": (
+                        valid_payload["channel_binding"]["owner_public_key"][:-1] + "h"
+                    ),
+                },
+            },
+        },
+        {
+            "model": "owner_control_confirmation_envelope",
+            "rule": "signature-base64url-has-canonical-trailing-bits",
+            "error_location": [],
+            "error_message_contains": "signature must use canonical unpadded base64url",
+            "payload": {**valid_payload, "signature": valid_payload["signature"][:-1] + "R"},
+        },
+        {
+            "model": "owner_control_confirmation_envelope",
+            "rule": "owner-identity-matches",
+            "error_location": [],
+            "error_message_contains": "channel binding owner identity does not match",
+            "payload": {
+                **valid_payload,
+                "channel_binding": changed_binding_payload,
+                "challenge_response": response_for_changed_binding.model_dump(mode="json"),
+            },
+        },
+        {
+            "model": "owner_control_confirmation_envelope",
+            "rule": "binding-digest-matches",
+            "error_location": [],
+            "error_message_contains": "channel binding digest does not match",
+            "payload": {
+                **valid_payload,
+                "channel_binding": {
+                    **valid_payload["channel_binding"],
+                    "channel_session_id": "channel-session-substituted",
+                },
+            },
+        },
+        {
+            "model": "owner_control_confirmation_envelope",
+            "rule": "session-expires-after-issuance",
+            "error_location": ["channel_binding"],
+            "error_message_contains": "session_expires_at must be later than session_issued_at",
+            "payload": {
+                **valid_payload,
+                "channel_binding": {
+                    **valid_payload["channel_binding"],
+                    "session_expires_at": valid_payload["channel_binding"]["session_issued_at"],
+                },
+            },
+        },
+        {
+            "model": "owner_control_confirmation_envelope",
+            "rule": "request-and-confirmation-stay-inside-session",
+            "error_location": [],
+            "error_message_contains": "approval request bounds must be inside",
+            "payload": {
+                **valid_payload,
+                "channel_binding": changed_session_binding.model_dump(mode="json"),
+                "challenge_response": response_for_changed_session.model_dump(mode="json"),
+            },
+        },
+        {
+            "model": "owner_control_confirmation_envelope",
+            "rule": "tampered-signed-payload-is-rejected",
+            "error_location": [],
+            "payload": {
+                **valid_payload,
+                "challenge_response": {
+                    **valid_payload["challenge_response"],
+                    "confirmed_at": "2030-01-02T03:05:05+00:00",
+                },
+            },
+            "verification": "invalid",
+        },
+        {
+            "model": "owner_control_confirmation_envelope",
+            "rule": "signature-from-wrong-private-key-is-rejected",
+            "error_location": [],
+            "payload": {**valid_payload, "signature": wrong_key_signature},
+            "verification": "invalid",
+        },
+        {
+            "model": "owner_control_confirmation_envelope",
+            "rule": "cross-session-substitution-is-rejected",
+            "error_location": [],
+            "payload": {
+                **valid_payload,
+                "channel_binding": cross_session_binding.model_dump(mode="json"),
+                "challenge_response": response_for_cross_session.model_dump(mode="json"),
+            },
+            "verification": "invalid",
+        },
+    ]
+
+
+def _signature_declaration() -> dict[str, Any]:
+    return {
+        "algorithm": "ed25519",
+        "domain": "launchplane-owner-control-confirmation-v1",
+        "payload": "OwnerControlSignaturePayload",
+        "payload_encoding": "canonical-json-utf8",
+        "public_key_bytes": 32,
+        "public_key_encoding": "base64url-unpadded",
+        "signature_bytes": 64,
+        "signature_encoding": "base64url-unpadded",
+        "legacy_golden_channel_binding": "synthetic-placeholder-not-channel-binding-record",
+        "contract_schema_version": OWNER_CONTROL_CONTRACT_SCHEMA_VERSION,
+    }
+
+
 def _build_owner_control_contract() -> dict[str, Any]:
     descriptors = list_privileged_operation_descriptors()
     return {
@@ -281,10 +584,14 @@ def _build_owner_control_contract() -> dict[str, Any]:
             "separators": [",", ":"],
             "trailing_newline": False,
         },
+        "signature_declaration": _signature_declaration(),
         "canonicalization_vectors": _canonicalization_vectors(),
         "schemas": {
             "approval_request": ApprovalRequest.model_json_schema(),
+            "channel_binding_record": ChannelBindingRecord.model_json_schema(),
             "challenge_response": ChallengeResponse.model_json_schema(),
+            "owner_control_confirmation_envelope": OwnerControlConfirmationEnvelope.model_json_schema(),
+            "owner_control_signature_payload": OwnerControlSignaturePayload.model_json_schema(),
             "server_review_payload": ServerReviewPayload.model_json_schema(),
         },
         "golden_vectors": [
@@ -295,7 +602,16 @@ def _build_owner_control_contract() -> dict[str, Any]:
             )
             for descriptor in descriptors
         ],
+        "confirmation_golden_vectors": [
+            _confirmation_golden_vector(
+                descriptor_id=descriptor.descriptor_id,
+                descriptor_version=descriptor.descriptor_version,
+                safety_class=descriptor.safety_class,
+            )
+            for descriptor in descriptors
+        ],
         "negative_vectors": _negative_vectors(),
+        "negative_confirmation_vectors": _negative_confirmation_vectors(),
     }
 
 
@@ -321,10 +637,13 @@ def validate_owner_control_contract(artifact: Mapping[str, Any]) -> None:
         {
             "schema_version",
             "canonical_json",
+            "signature_declaration",
             "canonicalization_vectors",
             "schemas",
             "golden_vectors",
+            "confirmation_golden_vectors",
             "negative_vectors",
+            "negative_confirmation_vectors",
         },
         "root",
     )
@@ -333,6 +652,8 @@ def validate_owner_control_contract(artifact: Mapping[str, Any]) -> None:
     expected = _build_owner_control_contract()
     if artifact["canonical_json"] != expected["canonical_json"]:
         raise OwnerControlContractError("Owner-control canonical JSON declaration drifted")
+    if artifact["signature_declaration"] != expected["signature_declaration"]:
+        raise OwnerControlContractError("Owner-control signature declaration drifted")
     if artifact["canonicalization_vectors"] != expected["canonicalization_vectors"]:
         raise OwnerControlContractError("Owner-control canonicalization vectors drifted")
     if artifact["schemas"] != expected["schemas"]:
@@ -342,8 +663,12 @@ def validate_owner_control_contract(artifact: Mapping[str, Any]) -> None:
         raise OwnerControlContractError("Owner-control golden vectors must be a list")
     if vectors != expected["golden_vectors"]:
         raise OwnerControlContractError("Owner-control golden vectors drifted from the registry")
+    if artifact["confirmation_golden_vectors"] != expected["confirmation_golden_vectors"]:
+        raise OwnerControlContractError("Owner-control confirmation golden vectors drifted")
     if artifact["negative_vectors"] != expected["negative_vectors"]:
         raise OwnerControlContractError("Owner-control negative vectors drifted")
+    if artifact["negative_confirmation_vectors"] != expected["negative_confirmation_vectors"]:
+        raise OwnerControlContractError("Owner-control negative confirmation vectors drifted")
 
 
 def write_owner_control_contract(output_path: Path) -> Path:

--- a/docs/owner-control-channel.md
+++ b/docs/owner-control-channel.md
@@ -31,14 +31,53 @@ Pydantic contracts for:
   plan, evidence, pre-state, policy, immutable GitHub owner ID, review, nonce,
   issuance time, and expiry; and
 - `ChallengeResponse`, which embeds and digests the exact request, records an
-  approved decision, channel binding digest, and bounded confirmation time.
+  approved decision, channel binding digest, and bounded confirmation time;
+- `ChannelBindingRecord`, which binds one canonical channel-session interval,
+  immutable owner ID, and raw Ed25519 public key; and
+- `OwnerControlConfirmationEnvelope`, which carries the exact challenge,
+  binding record, and an Ed25519 proof over the domain-separated signature
+  payload.
 
 Version, digest casing, canonical UTC timestamps and ordering, nonce form, and
 duplicate review fields fail closed. Single-field constraints are present in
 the exported JSON Schemas; cross-field constraints are also represented by
 negative conformance vectors. Single-use nonce tracking, challenge issuance,
-channel/session binding verification, and expiry enforcement at request time
-require later storage and service work; this contract slice adds none of them.
+and expiry enforcement at request time require later storage and service work;
+this contract slice adds none of them.
+
+## Binding and Signature Proof
+
+`channel_binding_sha256` is the lowercase SHA-256 digest of the exact canonical
+JSON bytes of the `ChannelBindingRecord` payload. The payload is not wrapped,
+prefixed, or newline-terminated. The record uses schema version `1`, a
+canonical `channel_session_id`, an `owner_github_id` in the signed 64-bit
+positive range, `signature_algorithm: "ed25519"`, an Ed25519 public key as raw
+32-byte unpadded base64url, and canonical whole-second UTC
+`session_issued_at`/`session_expires_at` values with expiry later than issuance.
+
+`OwnerControlSignaturePayload` is the exact schema-version-1 object
+`{"schema_version":1,"domain":"launchplane-owner-control-confirmation-v1","challenge_response":<exact ChallengeResponse>}`.
+The signature is Ed25519 over its canonical UTF-8 JSON bytes. Signatures are
+raw 64-byte values encoded as unpadded base64url. The envelope repeats the
+algorithm, binds the response digest to the exact binding record, requires the
+owner ID to match, and requires request issuance, request expiry, and
+confirmation time to remain inside the channel-session interval. Verification
+fails closed for malformed encodings, wrong keys, tampered payloads, and
+cross-session substitution.
+
+The retained `golden_vectors` are legacy v1 byte-compatibility fixtures; their
+`channel_binding_sha256` values remain explicit synthetic placeholders and do
+not have a `ChannelBindingRecord` preimage. Signed-channel consumers must use
+`confirmation_golden_vectors`, whose binding digests follow the definition
+above. The artifact's signature declaration marks this compatibility boundary
+explicitly.
+
+Signature verification proves only that the private key corresponding to the
+public key inside the envelope signed the exact challenge response. A future
+runtime verifier must also compare the exact binding record and digest against
+the server-enrolled channel-session record and the binding selected when the
+challenge was issued. A self-asserted binding or otherwise valid self-signed
+envelope is never authorization evidence by itself.
 
 ## Conformance Artifact
 
@@ -46,6 +85,12 @@ require later storage and service work; this contract slice adds none of them.
 contains the JSON schemas, canonicalization declaration, and byte/digest golden
 vectors for every descriptor currently registered in
 `control_plane.privileged_operation_registry`.
+
+The artifact container is schema version `2`; the embedded approval, response,
+binding, signature-payload, and envelope models remain schema version `1`.
+Version `2` adds the signed-channel declarations and vectors while preserving
+the legacy version-1 canonicalization, approval, response, and negative-vector
+bytes.
 
 Descriptor vectors derive all synthetic identity values from the descriptor ID,
 so registering another descriptor does not churn existing vectors. Negative
@@ -76,8 +121,6 @@ runtime adoption change proves the trusted owner-control path.
 
 `ChallengeResponse` represents successful confirmation only. Owner rejection,
 challenge expiry, and replay rejection are future audit events rather than
-alternate signed response decisions. `channel_binding_sha256` is reserved for
-the digest of the later channel-protocol binding record; its preimage and proof
-mechanism remain deliberately undefined until that separately reviewed runtime
-protocol exists. The current vectors use a synthetic placeholder digest and do
-not claim to prove a live channel.
+alternate signed response decisions. The checked artifact uses one explicitly
+synthetic deterministic Ed25519 key only to make public conformance vectors
+reproducible; it is not runtime authority, a credential, or a deployed key.

--- a/tests/test_owner_control_contract.py
+++ b/tests/test_owner_control_contract.py
@@ -11,11 +11,16 @@ from pydantic import BaseModel, ValidationError
 from control_plane.contracts.canonical_json import canonical_json_bytes, canonical_json_sha256
 from control_plane.contracts.owner_control import (
     ApprovalRequest,
+    ChannelBindingRecord,
     ChallengeResponse,
+    OwnerControlConfirmationEnvelope,
     ReviewItem,
     ServerReviewPayload,
     owner_control_approval_request_digest,
+    owner_control_channel_binding_sha256,
     owner_control_challenge_response_digest,
+    owner_control_signature_payload_bytes,
+    verify_owner_control_confirmation_signature,
 )
 from control_plane.contracts.privileged_operation import (
     ManagedSecretReencryptionPlanInput,
@@ -172,6 +177,9 @@ class OwnerControlContractModelTests(unittest.TestCase):
         artifact = build_owner_control_contract()
         approval_schema = artifact["schemas"]["approval_request"]
         response_schema = artifact["schemas"]["challenge_response"]
+        binding_schema = artifact["schemas"]["channel_binding_record"]
+        envelope_schema = artifact["schemas"]["owner_control_confirmation_envelope"]
+        signature_payload_schema = artifact["schemas"]["owner_control_signature_payload"]
 
         self.assertEqual(approval_schema["properties"]["schema_version"]["const"], 1)
         self.assertEqual(approval_schema["properties"]["descriptor_version"]["const"], 1)
@@ -184,9 +192,74 @@ class OwnerControlContractModelTests(unittest.TestCase):
             "^[A-Za-z0-9_-]{16,128}$",
         )
         self.assertIn("pattern", response_schema["properties"]["confirmed_at"])
+        self.assertEqual(binding_schema["properties"]["signature_algorithm"]["const"], "ed25519")
+        self.assertEqual(
+            signature_payload_schema["properties"]["domain"]["const"],
+            "launchplane-owner-control-confirmation-v1",
+        )
+        self.assertEqual(envelope_schema["properties"]["signature_algorithm"]["const"], "ed25519")
+
+    def test_confirmation_verifies_only_for_the_exact_signed_payload(self) -> None:
+        vector = build_owner_control_contract()["confirmation_golden_vectors"][0]
+        binding = ChannelBindingRecord.model_validate_json(
+            json.dumps(vector["channel_binding"]["payload"])
+        )
+        response = ChallengeResponse.model_validate_json(
+            json.dumps(vector["challenge_response"]["payload"])
+        )
+        envelope = OwnerControlConfirmationEnvelope.model_validate_json(
+            json.dumps(vector["confirmation_envelope"]["payload"])
+        )
+
+        self.assertEqual(
+            vector["channel_binding"]["canonical_json"],
+            canonical_json_bytes(binding.model_dump(mode="json")).decode(),
+        )
+        self.assertEqual(
+            vector["channel_binding"]["sha256"],
+            owner_control_channel_binding_sha256(binding),
+        )
+        self.assertEqual(
+            vector["signature_payload"]["canonical_json"],
+            owner_control_signature_payload_bytes(response).decode(),
+        )
+        self.assertTrue(verify_owner_control_confirmation_signature(envelope))
+
+        tampered = envelope.model_copy(
+            update={
+                "challenge_response": response.model_copy(
+                    update={"confirmed_at": "2030-01-02T03:05:05+00:00"}
+                )
+            }
+        )
+        self.assertFalse(verify_owner_control_confirmation_signature(tampered))
 
 
 class OwnerControlArtifactTests(unittest.TestCase):
+    def test_existing_approval_and_challenge_vectors_remain_byte_compatible(self) -> None:
+        vector = next(
+            vector
+            for vector in build_owner_control_contract()["golden_vectors"]
+            if vector["descriptor_id"] == "managed-secret-reencryption"
+        )
+
+        self.assertEqual(
+            vector["approval_request"]["canonical_json"],
+            '{"descriptor_id":"managed-secret-reencryption","descriptor_version":1,"evidence_digest":"9823b32b0823bd4004bacdbe08391b3e0120e8f24c36f91474115ef9fa01155d","expires_at":"2030-01-02T03:09:05+00:00","issued_at":"2030-01-02T03:00:05+00:00","nonce":"owner-control-1bb1a85cd3cf848e5c7a0ee17410addb","operation_id":"privileged-operation-9a9d1838b14102ef23bc2528687abda0","owner_github_id":2594086616,"plan_digest":"f87d15dd32b95865b4fe98cc67c5c418757a0559488488355bb0cf52a06cdf95","policy_record_id":"owner-policy-9a9d1838b14102ef23bc","policy_revision":1,"policy_sha256":"158ffbbe76bc73789a3e644e339411d8569ed880328b1e7728e7db3a25f1be8f","pre_state_digest":"96cb3e8e7bc9a596d31b699bd6ea1681651eda477f9b7a6c482f9378e6798d58","request_digest":"4a9624ebacf973b34eeb4762279d052e3c637d8090cb79ecbb217fa320a58d68","schema_version":1,"server_review":{"items":[{"key":"descriptor","label":"Operation class","value":"managed-secret-reencryption"},{"key":"safety_class","label":"Safety class","value":"secret_backed"}],"review_id":"review-9a9d1838b14102ef23bc2528","schema_version":1,"summary":"Review this exact privileged operation before confirming.","title":"Owner approval required"}}',
+        )
+        self.assertEqual(
+            vector["approval_request"]["sha256"],
+            "a158dabb09e35c75932985b8682c34f7f598a2b1404ac80a9e4fa0d4a19313c4",
+        )
+        self.assertEqual(
+            vector["challenge_response"]["canonical_json"],
+            '{"approval_request":{"descriptor_id":"managed-secret-reencryption","descriptor_version":1,"evidence_digest":"9823b32b0823bd4004bacdbe08391b3e0120e8f24c36f91474115ef9fa01155d","expires_at":"2030-01-02T03:09:05+00:00","issued_at":"2030-01-02T03:00:05+00:00","nonce":"owner-control-1bb1a85cd3cf848e5c7a0ee17410addb","operation_id":"privileged-operation-9a9d1838b14102ef23bc2528687abda0","owner_github_id":2594086616,"plan_digest":"f87d15dd32b95865b4fe98cc67c5c418757a0559488488355bb0cf52a06cdf95","policy_record_id":"owner-policy-9a9d1838b14102ef23bc","policy_revision":1,"policy_sha256":"158ffbbe76bc73789a3e644e339411d8569ed880328b1e7728e7db3a25f1be8f","pre_state_digest":"96cb3e8e7bc9a596d31b699bd6ea1681651eda477f9b7a6c482f9378e6798d58","request_digest":"4a9624ebacf973b34eeb4762279d052e3c637d8090cb79ecbb217fa320a58d68","schema_version":1,"server_review":{"items":[{"key":"descriptor","label":"Operation class","value":"managed-secret-reencryption"},{"key":"safety_class","label":"Safety class","value":"secret_backed"}],"review_id":"review-9a9d1838b14102ef23bc2528","schema_version":1,"summary":"Review this exact privileged operation before confirming.","title":"Owner approval required"}},"approval_request_digest":"a158dabb09e35c75932985b8682c34f7f598a2b1404ac80a9e4fa0d4a19313c4","channel_binding_sha256":"4a000cc8036cc97f077bc431ad78ce27f5a940d5766377ef2de3d964229b8a9c","confirmed_at":"2030-01-02T03:04:05+00:00","decision":"approved","schema_version":1}',
+        )
+        self.assertEqual(
+            vector["challenge_response"]["sha256"],
+            "76b409c883d422aef5378d03dfe1527c16f2f1ac41b8b81202a71c2375641a28",
+        )
+
     def test_golden_vectors_cover_every_registered_descriptor(self) -> None:
         artifact = build_owner_control_contract()
         expected_descriptors = {
@@ -208,7 +281,7 @@ class OwnerControlArtifactTests(unittest.TestCase):
             )
             self.assertEqual(
                 vector["approval_request"]["canonical_json"],
-                canonical_json_bytes(request.model_dump(mode="json")).decode("utf-8"),
+                canonical_json_bytes(request.model_dump(mode="json")).decode(),
             )
             self.assertEqual(
                 vector["approval_request"]["sha256"],
@@ -216,12 +289,45 @@ class OwnerControlArtifactTests(unittest.TestCase):
             )
             self.assertEqual(
                 vector["challenge_response"]["canonical_json"],
-                canonical_json_bytes(response.model_dump(mode="json")).decode("utf-8"),
+                canonical_json_bytes(response.model_dump(mode="json")).decode(),
             )
             self.assertEqual(
                 vector["challenge_response"]["sha256"],
                 owner_control_challenge_response_digest(response),
             )
+
+    def test_confirmation_vectors_cover_every_descriptor_and_verify(self) -> None:
+        artifact = build_owner_control_contract()
+        expected_descriptors = {
+            (descriptor.descriptor_id, descriptor.descriptor_version)
+            for descriptor in list_privileged_operation_descriptors()
+        }
+        actual_descriptors = {
+            (vector["descriptor_id"], vector["descriptor_version"])
+            for vector in artifact["confirmation_golden_vectors"]
+        }
+
+        self.assertEqual(actual_descriptors, expected_descriptors)
+        for vector in artifact["confirmation_golden_vectors"]:
+            with self.subTest(descriptor_id=vector["descriptor_id"]):
+                binding = ChannelBindingRecord.model_validate_json(
+                    json.dumps(vector["channel_binding"]["payload"])
+                )
+                response = ChallengeResponse.model_validate_json(
+                    json.dumps(vector["challenge_response"]["payload"])
+                )
+                envelope = OwnerControlConfirmationEnvelope.model_validate_json(
+                    json.dumps(vector["confirmation_envelope"]["payload"])
+                )
+                self.assertEqual(
+                    vector["channel_binding"]["sha256"],
+                    owner_control_channel_binding_sha256(binding),
+                )
+                self.assertEqual(
+                    vector["signature_payload"]["canonical_json"],
+                    owner_control_signature_payload_bytes(response).decode(),
+                )
+                self.assertTrue(verify_owner_control_confirmation_signature(envelope))
 
     def test_validator_rejects_contract_drift(self) -> None:
         artifact = build_owner_control_contract()
@@ -246,6 +352,28 @@ class OwnerControlArtifactTests(unittest.TestCase):
                 errors = raised.exception.errors()
                 self.assertEqual(len(errors), 1)
                 self.assertEqual(list(errors[0]["loc"]), vector["error_location"])
+                if expected_message := vector.get("error_message_contains"):
+                    self.assertIn(expected_message, errors[0]["msg"])
+
+    def test_negative_confirmation_vectors_fail_closed(self) -> None:
+        artifact = build_owner_control_contract()
+        for vector in artifact["negative_confirmation_vectors"]:
+            with self.subTest(rule=vector["rule"]):
+                if vector.get("verification") == "invalid":
+                    envelope = OwnerControlConfirmationEnvelope.model_validate_json(
+                        json.dumps(vector["payload"])
+                    )
+                    self.assertFalse(verify_owner_control_confirmation_signature(envelope))
+                    continue
+                with self.assertRaises(ValidationError) as raised:
+                    OwnerControlConfirmationEnvelope.model_validate_json(
+                        json.dumps(vector["payload"])
+                    )
+                errors = raised.exception.errors()
+                self.assertEqual(len(errors), 1)
+                self.assertEqual(list(errors[0]["loc"]), vector["error_location"])
+                if expected_message := vector.get("error_message_contains"):
+                    self.assertIn(expected_message, errors[0]["msg"])
 
     def test_checked_artifact_matches_generated_contract(self) -> None:
         checked = json.loads(

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -2717,7 +2717,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
 
         self.assertEqual(result.exit_code, 0, msg=result.output)
         self.assertEqual(result.output.strip(), str(output_path))
-        self.assertEqual(payload["schema_version"], 1)
+        self.assertEqual(payload["schema_version"], 2)
         self.assertTrue(payload["golden_vectors"])
 
     def test_product_onboarding_endpoint_writes_full_launchplane_owned_bundle(self) -> None:


### PR DESCRIPTION
## Summary

- define the exact `ChannelBindingRecord` preimage for `channel_binding_sha256`
- add a domain-separated Ed25519 `OwnerControlSignaturePayload` and signed confirmation envelope
- publish deterministic per-descriptor confirmation vectors plus fail-closed validation/verification vectors
- advance the artifact container to schema version 2 while preserving every legacy v1 canonicalization/request/response/negative vector byte
- document that signature verification is internal proof only; runtime authorization must match server-enrolled session and issued challenge records

## Behavior Boundary

This is intentionally behavior-neutral. It adds no HTTP route, storage record, migration, worker action, authorization grant, frontend, credential, runtime key, channel implementation, or live mutation. Browser approval remains unchanged and authoritative.

## Validation

- `uv run --extra dev launchplane ci unittest-shard local` — 3,137 targets across 12 shards passed
- focused owner-control/docs/privileged-operation/export suite — 40 passed
- `uv run --extra dev mypy control_plane tests` — 775 source files clean
- changed-file Ruff dry-run/lint/format — clean
- checked artifact export/drift — clean
- legacy artifact sections byte-identical to `main`; container schema intentionally advances to 2
- Claude Opus 5 final review — LOVE
- Gemini 3.1 Pro High final review — LOVE
- JetBrains agent inspection was GREEN before the final vector refinements; final closeout returned `UNKNOWN/stale_results` with zero cached findings and explicitly prohibited another retry, so no IDE finding is attributed to this change

## Cryptographic Contract

- Ed25519 public keys: raw 32-byte, unpadded base64url
- signatures: raw 64-byte, unpadded base64url
- signature preimage: canonical UTF-8 JSON of the versioned domain-separated signature payload
- a self-asserted binding or self-signed envelope is never authorization by itself

Refs #2257
