### PR TITLE
Add inert owner-control shadow verifier records

### DIFF
--- a/control_plane/contracts/owner_control_shadow_verifier.py
+++ b/control_plane/contracts/owner_control_shadow_verifier.py
@@ -1,0 +1,569 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+import hmac
+import re
+from typing import Final, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from control_plane.contracts.canonical_json import canonical_json_bytes, canonical_json_sha256
+from control_plane.contracts.owner_control import (
+    ApprovalRequest,
+    ChannelBindingRecord,
+    OwnerControlConfirmationEnvelope,
+    owner_control_approval_request_digest,
+    owner_control_channel_binding_sha256,
+    verify_owner_control_confirmation_signature,
+)
+from control_plane.contracts.privileged_operation import PrivilegedOperationDescriptorId
+
+
+OWNER_CONTROL_SHADOW_VERIFIER_SCHEMA_VERSION: Final[Literal[1]] = 1
+OWNER_CONTROL_SHADOW_VERIFIER_MODE: Final[Literal["shadow"]] = "shadow"
+OWNER_CONTROL_SHADOW_AUTHORITY_STATE: Final[Literal["inert"]] = "inert"
+OWNER_CONTROL_SHADOW_MAX_ATTEMPTS: Final = 8
+_SERVER_IDENTIFIER_PATTERN = re.compile(r"^[a-z][a-z0-9_-]{0,127}$")
+_SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+_CANONICAL_TIMESTAMP_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\+00:00$")
+
+OwnerControlChannelSessionStatus = Literal["enrolled", "revoked"]
+OwnerControlChallengeState = Literal["issued", "consumed", "expired", "rejected"]
+OwnerControlShadowVerificationStatus = Literal["verified", "rejected"]
+OwnerControlShadowVerificationReason = Literal[
+    "unknown_channel_session",
+    "unknown_challenge",
+    "channel_session_revoked",
+    "channel_session_expired",
+    "challenge_channel_session_mismatch",
+    "challenge_expired",
+    "challenge_replayed",
+    "stored_binding_mismatch",
+    "stored_approval_request_mismatch",
+    "signature_invalid",
+    "attempt_budget_exhausted",
+]
+
+
+class OwnerControlShadowVerifierConflictError(ValueError):
+    """Raised when immutable owner-control verifier state conflicts."""
+
+
+def _canonical_timestamp(value: str, field_name: str) -> datetime:
+    if _CANONICAL_TIMESTAMP_PATTERN.fullmatch(value) is None:
+        raise ValueError(f"{field_name} must use whole-second canonical UTC form")
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError as error:
+        raise ValueError(f"{field_name} must be an ISO-8601 timestamp") from error
+    if parsed.tzinfo is None:
+        raise ValueError(f"{field_name} must include a timezone")
+    if value != parsed.astimezone(timezone.utc).isoformat():
+        raise ValueError(f"{field_name} must use canonical ISO-8601 form")
+    return parsed
+
+
+def _canonical_wire_json(model: BaseModel) -> str:
+    return canonical_json_bytes(model.model_dump(mode="json")).decode()
+
+
+def _validate_canonical_wire_json(
+    value: str,
+    *,
+    model_type: type[ApprovalRequest] | type[ChannelBindingRecord],
+    field_name: str,
+) -> ApprovalRequest | ChannelBindingRecord:
+    try:
+        model = model_type.model_validate_json(value)
+    except ValueError as error:
+        raise ValueError(f"{field_name} must contain a valid owner-control payload") from error
+    if _canonical_wire_json(model) != value:
+        raise ValueError(f"{field_name} must contain exact canonical owner-control bytes")
+    return model
+
+
+def owner_control_challenge_id(approval_request_sha256: str) -> str:
+    """Return the deterministic identifier for one exact issued approval request."""
+
+    if _SHA256_PATTERN.fullmatch(approval_request_sha256) is None:
+        raise ValueError("approval_request_sha256 must be a lowercase SHA-256 digest")
+    return f"owner-control-challenge-{approval_request_sha256[:32]}"
+
+
+def owner_control_verification_event_id(
+    *,
+    challenge_id: str,
+    sequence: int,
+    envelope_sha256: str,
+    verification_status: OwnerControlShadowVerificationStatus,
+    rejection_reason: OwnerControlShadowVerificationReason | None,
+) -> str:
+    """Return a deterministic append-only verification event identifier."""
+
+    digest = canonical_json_sha256(
+        {
+            "challenge_id": challenge_id,
+            "envelope_sha256": envelope_sha256,
+            "rejection_reason": rejection_reason,
+            "sequence": sequence,
+            "verification_status": verification_status,
+        }
+    )
+    return f"owner-control-shadow-event-{digest[:32]}"
+
+
+class OwnerControlChannelSessionRecord(BaseModel):
+    """Server-enrolled owner channel session, independent of the wire envelope."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    schema_version: Literal[1] = OWNER_CONTROL_SHADOW_VERIFIER_SCHEMA_VERSION
+    channel_session_id: str = Field(pattern=_SERVER_IDENTIFIER_PATTERN.pattern)
+    owner_github_id: int = Field(ge=1, le=9_223_372_036_854_775_807)
+    status: OwnerControlChannelSessionStatus
+    binding_json: str = Field(min_length=2, max_length=20_000)
+    binding_sha256: str = Field(pattern=_SHA256_PATTERN.pattern)
+    enrolled_at: str
+    revoked_at: str | None = None
+    authority_state: Literal["inert"] = OWNER_CONTROL_SHADOW_AUTHORITY_STATE
+
+    @model_validator(mode="after")
+    def _validate_record(self) -> "OwnerControlChannelSessionRecord":
+        binding = _validate_canonical_wire_json(
+            self.binding_json,
+            model_type=ChannelBindingRecord,
+            field_name="binding_json",
+        )
+        assert isinstance(binding, ChannelBindingRecord)
+        if self.channel_session_id != binding.channel_session_id:
+            raise ValueError("channel_session_id must match the stored channel binding")
+        if self.owner_github_id != binding.owner_github_id:
+            raise ValueError("owner_github_id must match the stored channel binding")
+        if self.binding_sha256 != owner_control_channel_binding_sha256(binding):
+            raise ValueError("binding_sha256 must match the stored channel binding")
+        enrolled_at = _canonical_timestamp(self.enrolled_at, "enrolled_at")
+        revoked_at = (
+            _canonical_timestamp(self.revoked_at, "revoked_at")
+            if self.revoked_at is not None
+            else None
+        )
+        if self.status == "enrolled" and revoked_at is not None:
+            raise ValueError("enrolled channel sessions must not have revoked_at")
+        if self.status == "revoked" and revoked_at is None:
+            raise ValueError("revoked channel sessions must include revoked_at")
+        if revoked_at is not None and revoked_at < enrolled_at:
+            raise ValueError("revoked_at must not precede enrolled_at")
+        binding_issued_at = _canonical_timestamp(binding.session_issued_at, "session_issued_at")
+        binding_expires_at = _canonical_timestamp(binding.session_expires_at, "session_expires_at")
+        if enrolled_at < binding_issued_at or enrolled_at > binding_expires_at:
+            raise ValueError("enrolled_at must be inside the channel session interval")
+        return self
+
+    def channel_binding(self) -> ChannelBindingRecord:
+        binding = ChannelBindingRecord.model_validate_json(self.binding_json)
+        return binding
+
+
+class OwnerControlChallengeIssueRequest(BaseModel):
+    """Server-only challenge template whose timestamp bounds are set by the store clock."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    channel_session_id: str = Field(pattern=_SERVER_IDENTIFIER_PATTERN.pattern)
+    approval_request: ApprovalRequest
+    expires_in_seconds: int = Field(ge=1, le=3_600)
+
+
+class OwnerControlIssuedChallengeRecord(BaseModel):
+    """Server-issued, single-use owner-control challenge with exact stored bindings."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    schema_version: Literal[1] = OWNER_CONTROL_SHADOW_VERIFIER_SCHEMA_VERSION
+    challenge_id: str = Field(pattern=_SERVER_IDENTIFIER_PATTERN.pattern)
+    challenge_nonce: str = Field(min_length=16, max_length=128, pattern=r"^[A-Za-z0-9_-]+$")
+    channel_session_id: str = Field(pattern=_SERVER_IDENTIFIER_PATTERN.pattern)
+    operation_id: str
+    descriptor_id: PrivilegedOperationDescriptorId
+    owner_github_id: int = Field(ge=1, le=9_223_372_036_854_775_807)
+    issued_at: str
+    expires_at: str
+    approval_request_json: str = Field(min_length=2, max_length=20_000)
+    approval_request_sha256: str = Field(pattern=_SHA256_PATTERN.pattern)
+    binding_json: str = Field(min_length=2, max_length=20_000)
+    binding_sha256: str = Field(pattern=_SHA256_PATTERN.pattern)
+    state: OwnerControlChallengeState = "issued"
+    attempt_count: int = Field(default=0, ge=0, le=OWNER_CONTROL_SHADOW_MAX_ATTEMPTS)
+    consumed_at: str | None = None
+    terminal_event_id: str | None = Field(default=None, pattern=_SERVER_IDENTIFIER_PATTERN.pattern)
+    authority_state: Literal["inert"] = OWNER_CONTROL_SHADOW_AUTHORITY_STATE
+
+    @model_validator(mode="after")
+    def _validate_record(self) -> "OwnerControlIssuedChallengeRecord":
+        request = _validate_canonical_wire_json(
+            self.approval_request_json,
+            model_type=ApprovalRequest,
+            field_name="approval_request_json",
+        )
+        binding = _validate_canonical_wire_json(
+            self.binding_json,
+            model_type=ChannelBindingRecord,
+            field_name="binding_json",
+        )
+        assert isinstance(request, ApprovalRequest)
+        assert isinstance(binding, ChannelBindingRecord)
+        if self.challenge_nonce != request.nonce:
+            raise ValueError("challenge_nonce must match the stored approval request nonce")
+        expected_challenge_id = owner_control_challenge_id(
+            owner_control_approval_request_digest(request)
+        )
+        if self.challenge_id != expected_challenge_id:
+            raise ValueError("challenge_id must derive from the stored approval request")
+        if self.channel_session_id != binding.channel_session_id:
+            raise ValueError("channel_session_id must match the stored channel binding")
+        if self.operation_id != request.operation_id:
+            raise ValueError("operation_id must match the stored approval request")
+        if self.descriptor_id != request.descriptor_id:
+            raise ValueError("descriptor_id must match the stored approval request")
+        if (
+            self.owner_github_id != request.owner_github_id
+            or self.owner_github_id != binding.owner_github_id
+        ):
+            raise ValueError("owner_github_id must match the stored request and channel binding")
+        if self.approval_request_sha256 != owner_control_approval_request_digest(request):
+            raise ValueError("approval_request_sha256 must match the stored approval request")
+        if self.binding_sha256 != owner_control_channel_binding_sha256(binding):
+            raise ValueError("binding_sha256 must match the stored channel binding")
+        issued_at = _canonical_timestamp(self.issued_at, "issued_at")
+        expires_at = _canonical_timestamp(self.expires_at, "expires_at")
+        if request.issued_at != self.issued_at or request.expires_at != self.expires_at:
+            raise ValueError(
+                "stored approval request timestamps must match the challenge timestamps"
+            )
+        if expires_at <= issued_at:
+            raise ValueError("expires_at must be later than issued_at")
+        consumed_at = (
+            _canonical_timestamp(self.consumed_at, "consumed_at")
+            if self.consumed_at is not None
+            else None
+        )
+        if self.state == "issued":
+            if consumed_at is not None or self.terminal_event_id is not None:
+                raise ValueError("issued challenges must not have terminal fields")
+        elif self.terminal_event_id is None:
+            raise ValueError("terminal challenges must include terminal_event_id")
+        if self.state == "consumed" and consumed_at is None:
+            raise ValueError("consumed challenges must include consumed_at")
+        if self.state != "consumed" and consumed_at is not None:
+            raise ValueError("only consumed challenges may include consumed_at")
+        if consumed_at is not None and consumed_at < issued_at:
+            raise ValueError("consumed_at must not precede issued_at")
+        return self
+
+    def approval_request(self) -> ApprovalRequest:
+        request = ApprovalRequest.model_validate_json(self.approval_request_json)
+        return request
+
+    def channel_binding(self) -> ChannelBindingRecord:
+        binding = ChannelBindingRecord.model_validate_json(self.binding_json)
+        return binding
+
+
+class OwnerControlShadowVerificationEventRecord(BaseModel):
+    """Append-only result of one structurally valid owner-control envelope evaluation."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    schema_version: Literal[1] = OWNER_CONTROL_SHADOW_VERIFIER_SCHEMA_VERSION
+    event_id: str = Field(pattern=_SERVER_IDENTIFIER_PATTERN.pattern)
+    challenge_id: str = Field(pattern=_SERVER_IDENTIFIER_PATTERN.pattern)
+    sequence: int = Field(ge=1, le=OWNER_CONTROL_SHADOW_MAX_ATTEMPTS)
+    channel_session_id: str = Field(pattern=_SERVER_IDENTIFIER_PATTERN.pattern)
+    challenge_nonce: str = Field(min_length=16, max_length=128, pattern=r"^[A-Za-z0-9_-]+$")
+    envelope_sha256: str = Field(pattern=_SHA256_PATTERN.pattern)
+    approval_request_sha256: str = Field(pattern=_SHA256_PATTERN.pattern)
+    binding_sha256: str = Field(pattern=_SHA256_PATTERN.pattern)
+    verification_status: OwnerControlShadowVerificationStatus
+    rejection_reason: OwnerControlShadowVerificationReason | None = None
+    resulting_challenge_state: OwnerControlChallengeState
+    occurred_at: str
+    verifier_mode: Literal["shadow"] = OWNER_CONTROL_SHADOW_VERIFIER_MODE
+    authorizes_execution: Literal[False] = False
+    authority_state: Literal["inert"] = OWNER_CONTROL_SHADOW_AUTHORITY_STATE
+
+    @model_validator(mode="after")
+    def _validate_record(self) -> "OwnerControlShadowVerificationEventRecord":
+        _canonical_timestamp(self.occurred_at, "occurred_at")
+        if self.verification_status == "verified" and (
+            self.rejection_reason is not None or self.resulting_challenge_state != "consumed"
+        ):
+            raise ValueError("verified events must consume without a rejection_reason")
+        if self.verification_status == "rejected" and self.rejection_reason is None:
+            raise ValueError("rejected events must include a rejection_reason")
+        return self
+
+
+class OwnerControlShadowVerificationResult(BaseModel):
+    """Non-authorizing result returned only after its append-only audit event is stored."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    event_id: str = Field(pattern=_SERVER_IDENTIFIER_PATTERN.pattern)
+    challenge_id: str = Field(pattern=_SERVER_IDENTIFIER_PATTERN.pattern)
+    sequence: int = Field(ge=1, le=OWNER_CONTROL_SHADOW_MAX_ATTEMPTS)
+    verification_status: OwnerControlShadowVerificationStatus
+    rejection_reason: OwnerControlShadowVerificationReason | None = None
+    resulting_challenge_state: OwnerControlChallengeState
+    verifier_mode: Literal["shadow"] = OWNER_CONTROL_SHADOW_VERIFIER_MODE
+    authorizes_execution: Literal[False] = False
+    authority_state: Literal["inert"] = OWNER_CONTROL_SHADOW_AUTHORITY_STATE
+
+    @model_validator(mode="after")
+    def _validate_result(self) -> "OwnerControlShadowVerificationResult":
+        if self.verification_status == "verified" and (
+            self.rejection_reason is not None or self.resulting_challenge_state != "consumed"
+        ):
+            raise ValueError("verified results must consume without a rejection_reason")
+        if self.verification_status == "rejected" and self.rejection_reason is None:
+            raise ValueError("rejected results must include a rejection_reason")
+        return self
+
+
+class OwnerControlShadowVerificationEvaluation(BaseModel):
+    """Pure exact-state evaluation used inside the transactional storage operation."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    verification_status: OwnerControlShadowVerificationStatus
+    rejection_reason: OwnerControlShadowVerificationReason | None = None
+    consume_challenge: bool = False
+    resulting_challenge_state: OwnerControlChallengeState
+
+    @model_validator(mode="after")
+    def _validate_evaluation(self) -> "OwnerControlShadowVerificationEvaluation":
+        if self.verification_status == "verified":
+            if (
+                self.rejection_reason is not None
+                or not self.consume_challenge
+                or self.resulting_challenge_state != "consumed"
+            ):
+                raise ValueError(
+                    "verified evaluations must consume one challenge without a rejection"
+                )
+        elif self.rejection_reason is None or self.consume_challenge:
+            raise ValueError(
+                "rejected evaluations must include a reason and not consume a challenge"
+            )
+        return self
+
+
+def build_owner_control_channel_session_record(
+    *,
+    binding: ChannelBindingRecord,
+    enrolled_at: str,
+) -> OwnerControlChannelSessionRecord:
+    """Build an active server-enrolled record from an exact wire binding."""
+
+    binding_json = _canonical_wire_json(binding)
+    return OwnerControlChannelSessionRecord(
+        channel_session_id=binding.channel_session_id,
+        owner_github_id=binding.owner_github_id,
+        status="enrolled",
+        binding_json=binding_json,
+        binding_sha256=owner_control_channel_binding_sha256(binding),
+        enrolled_at=enrolled_at,
+    )
+
+
+def revoke_owner_control_channel_session_record(
+    record: OwnerControlChannelSessionRecord,
+    *,
+    revoked_at: str,
+) -> OwnerControlChannelSessionRecord:
+    """Return the one-way revoked successor for a stored channel session."""
+
+    if record.status == "revoked":
+        return record
+    return record.model_copy(update={"status": "revoked", "revoked_at": revoked_at})
+
+
+def issue_owner_control_challenge_record(
+    *,
+    issue_request: OwnerControlChallengeIssueRequest,
+    session: OwnerControlChannelSessionRecord,
+    challenge_nonce: str,
+    issued_at: str,
+) -> OwnerControlIssuedChallengeRecord:
+    """Materialize a challenge with DB-clock issuance and expiry timestamps."""
+
+    if session.status != "enrolled":
+        raise OwnerControlShadowVerifierConflictError("Channel session is not enrolled.")
+    if issue_request.channel_session_id != session.channel_session_id:
+        raise OwnerControlShadowVerifierConflictError(
+            "Challenge issue session does not match enrollment."
+        )
+    if issue_request.approval_request.owner_github_id != session.owner_github_id:
+        raise OwnerControlShadowVerifierConflictError("Challenge owner does not match enrollment.")
+    issued_at_value = _canonical_timestamp(issued_at, "issued_at")
+    expires_at = (issued_at_value + timedelta(seconds=issue_request.expires_in_seconds)).isoformat()
+    binding = session.channel_binding()
+    session_expires_at = _canonical_timestamp(binding.session_expires_at, "session_expires_at")
+    if issued_at_value < _canonical_timestamp(binding.session_issued_at, "session_issued_at"):
+        raise OwnerControlShadowVerifierConflictError("Channel session has not started.")
+    if datetime.fromisoformat(expires_at) > session_expires_at:
+        raise OwnerControlShadowVerifierConflictError(
+            "Challenge expiry exceeds the channel session."
+        )
+    request = issue_request.approval_request.model_copy(
+        update={
+            "nonce": challenge_nonce,
+            "issued_at": issued_at,
+            "expires_at": expires_at,
+        }
+    )
+    request_json = _canonical_wire_json(request)
+    approval_request_sha256 = owner_control_approval_request_digest(request)
+    return OwnerControlIssuedChallengeRecord(
+        challenge_id=owner_control_challenge_id(approval_request_sha256),
+        challenge_nonce=request.nonce,
+        channel_session_id=session.channel_session_id,
+        operation_id=request.operation_id,
+        descriptor_id=request.descriptor_id,
+        owner_github_id=session.owner_github_id,
+        issued_at=issued_at,
+        expires_at=expires_at,
+        approval_request_json=request_json,
+        approval_request_sha256=approval_request_sha256,
+        binding_json=session.binding_json,
+        binding_sha256=session.binding_sha256,
+    )
+
+
+def evaluate_owner_control_shadow_verification(
+    *,
+    envelope: OwnerControlConfirmationEnvelope,
+    channel_session: OwnerControlChannelSessionRecord | None,
+    issued_challenge: OwnerControlIssuedChallengeRecord | None,
+    observed_at: str,
+) -> OwnerControlShadowVerificationEvaluation:
+    """Evaluate one envelope against exact stored server state without authorizing execution."""
+
+    observed_at_value = _canonical_timestamp(observed_at, "observed_at")
+    if channel_session is None:
+        return OwnerControlShadowVerificationEvaluation(
+            verification_status="rejected",
+            rejection_reason="unknown_channel_session",
+            resulting_challenge_state="rejected",
+        )
+    if issued_challenge is None:
+        return OwnerControlShadowVerificationEvaluation(
+            verification_status="rejected",
+            rejection_reason="unknown_challenge",
+            resulting_challenge_state="rejected",
+        )
+    if (
+        issued_challenge.channel_session_id != channel_session.channel_session_id
+        or envelope.channel_binding.channel_session_id != issued_challenge.channel_session_id
+    ):
+        return OwnerControlShadowVerificationEvaluation(
+            verification_status="rejected",
+            rejection_reason="challenge_channel_session_mismatch",
+            resulting_challenge_state="rejected",
+        )
+    if channel_session.status != "enrolled":
+        return OwnerControlShadowVerificationEvaluation(
+            verification_status="rejected",
+            rejection_reason="channel_session_revoked",
+            resulting_challenge_state="rejected",
+        )
+    session_binding = channel_session.channel_binding()
+    if not (
+        _canonical_timestamp(session_binding.session_issued_at, "session_issued_at")
+        <= observed_at_value
+        <= _canonical_timestamp(session_binding.session_expires_at, "session_expires_at")
+    ):
+        return OwnerControlShadowVerificationEvaluation(
+            verification_status="rejected",
+            rejection_reason="channel_session_expired",
+            resulting_challenge_state="expired",
+        )
+    if issued_challenge.state == "consumed":
+        return OwnerControlShadowVerificationEvaluation(
+            verification_status="rejected",
+            rejection_reason="challenge_replayed",
+            resulting_challenge_state="consumed",
+        )
+    if issued_challenge.state == "expired":
+        return OwnerControlShadowVerificationEvaluation(
+            verification_status="rejected",
+            rejection_reason="challenge_expired",
+            resulting_challenge_state="expired",
+        )
+    if issued_challenge.state == "rejected":
+        return OwnerControlShadowVerificationEvaluation(
+            verification_status="rejected",
+            rejection_reason="attempt_budget_exhausted",
+            resulting_challenge_state="rejected",
+        )
+    if not (
+        _canonical_timestamp(issued_challenge.issued_at, "issued_at")
+        <= observed_at_value
+        <= _canonical_timestamp(issued_challenge.expires_at, "expires_at")
+    ):
+        return OwnerControlShadowVerificationEvaluation(
+            verification_status="rejected",
+            rejection_reason="challenge_expired",
+            resulting_challenge_state="expired",
+        )
+    envelope_binding_json = _canonical_wire_json(envelope.channel_binding)
+    if (
+        envelope_binding_json != channel_session.binding_json
+        or envelope_binding_json != issued_challenge.binding_json
+        or not hmac.compare_digest(
+            owner_control_channel_binding_sha256(envelope.channel_binding),
+            channel_session.binding_sha256,
+        )
+        or not hmac.compare_digest(
+            envelope.challenge_response.channel_binding_sha256,
+            issued_challenge.binding_sha256,
+        )
+    ):
+        return OwnerControlShadowVerificationEvaluation(
+            verification_status="rejected",
+            rejection_reason="stored_binding_mismatch",
+            resulting_challenge_state="issued",
+        )
+    envelope_request_json = _canonical_wire_json(envelope.challenge_response.approval_request)
+    if (
+        envelope_request_json != issued_challenge.approval_request_json
+        or not hmac.compare_digest(
+            owner_control_approval_request_digest(envelope.challenge_response.approval_request),
+            issued_challenge.approval_request_sha256,
+        )
+        or not hmac.compare_digest(
+            envelope.challenge_response.approval_request_digest,
+            issued_challenge.approval_request_sha256,
+        )
+    ):
+        return OwnerControlShadowVerificationEvaluation(
+            verification_status="rejected",
+            rejection_reason="stored_approval_request_mismatch",
+            resulting_challenge_state="issued",
+        )
+    if not verify_owner_control_confirmation_signature(envelope):
+        return OwnerControlShadowVerificationEvaluation(
+            verification_status="rejected",
+            rejection_reason="signature_invalid",
+            resulting_challenge_state="issued",
+        )
+    return OwnerControlShadowVerificationEvaluation(
+        verification_status="verified",
+        consume_challenge=True,
+        resulting_challenge_state="consumed",
+    )
+
+
+def owner_control_confirmation_envelope_sha256(envelope: OwnerControlConfirmationEnvelope) -> str:
+    """Return the bounded canonical digest retained by shadow-verifier audit records."""
+
+    return canonical_json_sha256(envelope.model_dump(mode="json"))

--- a/control_plane/contracts/owner_control_shadow_verifier.py
+++ b/control_plane/contracts/owner_control_shadow_verifier.py
@@ -449,16 +449,36 @@ def evaluate_owner_control_shadow_verification(
     """Evaluate one envelope against exact stored server state without authorizing execution."""
 
     observed_at_value = _canonical_timestamp(observed_at, "observed_at")
+    if issued_challenge is None:
+        return OwnerControlShadowVerificationEvaluation(
+            verification_status="rejected",
+            rejection_reason=(
+                "unknown_channel_session" if channel_session is None else "unknown_challenge"
+            ),
+            resulting_challenge_state="rejected",
+        )
+    if issued_challenge.state == "consumed":
+        return OwnerControlShadowVerificationEvaluation(
+            verification_status="rejected",
+            rejection_reason="challenge_replayed",
+            resulting_challenge_state="consumed",
+        )
+    if issued_challenge.state == "expired":
+        return OwnerControlShadowVerificationEvaluation(
+            verification_status="rejected",
+            rejection_reason="challenge_expired",
+            resulting_challenge_state="expired",
+        )
+    if issued_challenge.state == "rejected":
+        return OwnerControlShadowVerificationEvaluation(
+            verification_status="rejected",
+            rejection_reason="attempt_budget_exhausted",
+            resulting_challenge_state="rejected",
+        )
     if channel_session is None:
         return OwnerControlShadowVerificationEvaluation(
             verification_status="rejected",
             rejection_reason="unknown_channel_session",
-            resulting_challenge_state="rejected",
-        )
-    if issued_challenge is None:
-        return OwnerControlShadowVerificationEvaluation(
-            verification_status="rejected",
-            rejection_reason="unknown_challenge",
             resulting_challenge_state="rejected",
         )
     if (
@@ -486,24 +506,6 @@ def evaluate_owner_control_shadow_verification(
             verification_status="rejected",
             rejection_reason="channel_session_expired",
             resulting_challenge_state="expired",
-        )
-    if issued_challenge.state == "consumed":
-        return OwnerControlShadowVerificationEvaluation(
-            verification_status="rejected",
-            rejection_reason="challenge_replayed",
-            resulting_challenge_state="consumed",
-        )
-    if issued_challenge.state == "expired":
-        return OwnerControlShadowVerificationEvaluation(
-            verification_status="rejected",
-            rejection_reason="challenge_expired",
-            resulting_challenge_state="expired",
-        )
-    if issued_challenge.state == "rejected":
-        return OwnerControlShadowVerificationEvaluation(
-            verification_status="rejected",
-            rejection_reason="attempt_budget_exhausted",
-            resulting_challenge_state="rejected",
         )
     if not (
         _canonical_timestamp(issued_challenge.issued_at, "issued_at")

--- a/control_plane/storage/migrations/versions/e5f7a9b1c3d6_add_owner_control_shadow_verifier.py
+++ b/control_plane/storage/migrations/versions/e5f7a9b1c3d6_add_owner_control_shadow_verifier.py
@@ -1,0 +1,234 @@
+"""add owner control shadow verifier
+
+Revision ID: e5f7a9b1c3d6
+Revises: f2241a0b1c2d
+Create Date: 2026-08-28 00:00:00.000000+00:00
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision: str = "e5f7a9b1c3d6"
+down_revision: str | None = "f2241a0b1c2d"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_SESSIONS_TABLE = "launchplane_owner_control_channel_sessions"
+_CHALLENGES_TABLE = "launchplane_owner_control_issued_challenges"
+_EVENTS_TABLE = "launchplane_owner_control_shadow_verification_events"
+_SESSIONS_STATUS_INDEX = "launchplane_owner_control_session_status_idx"
+_CHALLENGES_SESSION_INDEX = "launchplane_owner_control_challenge_session_idx"
+_CHALLENGES_STATE_INDEX = "launchplane_owner_control_challenge_state_idx"
+_EVENTS_CHALLENGE_INDEX = "launchplane_owner_control_shadow_event_challenge_idx"
+_EVENTS_SESSION_INDEX = "launchplane_owner_control_shadow_event_session_idx"
+
+
+def _table_exists(table_name: str) -> bool:
+    return table_name in set(sa.inspect(op.get_bind()).get_table_names())
+
+
+def _index_exists(table_name: str, index_name: str) -> bool:
+    return _table_exists(table_name) and index_name in {
+        str(name)
+        for index in sa.inspect(op.get_bind()).get_indexes(table_name)
+        if (name := index.get("name")) is not None
+    }
+
+
+def _payload_column() -> sa.Column[object]:
+    return sa.Column(
+        "payload",
+        sa.JSON().with_variant(postgresql.JSONB(astext_type=sa.Text()), "postgresql"),
+        nullable=False,
+    )
+
+
+def upgrade() -> None:
+    if not _table_exists(_SESSIONS_TABLE):
+        op.create_table(
+            _SESSIONS_TABLE,
+            sa.Column("channel_session_id", sa.String(), nullable=False),
+            sa.Column("owner_github_id", sa.BigInteger(), nullable=False),
+            sa.Column("status", sa.String(), nullable=False),
+            sa.Column("session_issued_at", sa.String(), nullable=False),
+            sa.Column("session_expires_at", sa.String(), nullable=False),
+            sa.Column("binding_sha256", sa.String(), nullable=False),
+            sa.Column("enrolled_at", sa.String(), nullable=False),
+            sa.Column("revoked_at", sa.String(), nullable=True),
+            sa.Column("authority_state", sa.String(), nullable=False, server_default="inert"),
+            _payload_column(),
+            sa.CheckConstraint(
+                "status IN ('enrolled', 'revoked')",
+                name="launchplane_owner_control_session_status_ck",
+            ),
+            sa.CheckConstraint(
+                "(status = 'enrolled' AND revoked_at IS NULL) OR "
+                "(status = 'revoked' AND revoked_at IS NOT NULL)",
+                name="launchplane_owner_control_session_revocation_ck",
+            ),
+            sa.CheckConstraint(
+                "authority_state = 'inert'",
+                name="launchplane_owner_control_session_authority_ck",
+            ),
+            sa.PrimaryKeyConstraint("channel_session_id"),
+            sa.UniqueConstraint(
+                "owner_github_id",
+                "binding_sha256",
+                name="launchplane_owner_control_session_owner_binding_uq",
+            ),
+        )
+    if not _index_exists(_SESSIONS_TABLE, _SESSIONS_STATUS_INDEX):
+        op.create_index(
+            _SESSIONS_STATUS_INDEX,
+            _SESSIONS_TABLE,
+            ["status", "session_expires_at"],
+        )
+
+    if not _table_exists(_CHALLENGES_TABLE):
+        op.create_table(
+            _CHALLENGES_TABLE,
+            sa.Column("challenge_id", sa.String(), nullable=False),
+            sa.Column("challenge_nonce", sa.String(), nullable=False),
+            sa.Column("channel_session_id", sa.String(), nullable=False),
+            sa.Column("operation_id", sa.String(), nullable=False),
+            sa.Column("descriptor_id", sa.String(), nullable=False),
+            sa.Column("owner_github_id", sa.BigInteger(), nullable=False),
+            sa.Column("issued_at", sa.String(), nullable=False),
+            sa.Column("expires_at", sa.String(), nullable=False),
+            sa.Column("approval_request_sha256", sa.String(), nullable=False),
+            sa.Column("binding_sha256", sa.String(), nullable=False),
+            sa.Column("state", sa.String(), nullable=False),
+            sa.Column("attempt_count", sa.Integer(), nullable=False),
+            sa.Column("consumed_at", sa.String(), nullable=True),
+            sa.Column("terminal_event_id", sa.String(), nullable=True),
+            sa.Column("authority_state", sa.String(), nullable=False, server_default="inert"),
+            _payload_column(),
+            sa.CheckConstraint(
+                "expires_at > issued_at",
+                name="launchplane_owner_control_challenge_expiry_ck",
+            ),
+            sa.CheckConstraint(
+                "state IN ('issued', 'consumed', 'expired', 'rejected')",
+                name="launchplane_owner_control_challenge_state_ck",
+            ),
+            sa.CheckConstraint(
+                "attempt_count BETWEEN 0 AND 8",
+                name="launchplane_owner_control_challenge_attempt_count_ck",
+            ),
+            sa.CheckConstraint(
+                "(state = 'issued' AND consumed_at IS NULL AND terminal_event_id IS NULL) OR "
+                "(state = 'consumed' AND consumed_at IS NOT NULL AND terminal_event_id IS NOT NULL) OR "
+                "(state IN ('expired', 'rejected') AND consumed_at IS NULL AND terminal_event_id IS NOT NULL)",
+                name="launchplane_owner_control_challenge_terminal_ck",
+            ),
+            sa.CheckConstraint(
+                "authority_state = 'inert'",
+                name="launchplane_owner_control_challenge_authority_ck",
+            ),
+            sa.PrimaryKeyConstraint("challenge_id"),
+            sa.UniqueConstraint(
+                "challenge_nonce",
+                name="launchplane_owner_control_challenge_nonce_uq",
+            ),
+            sa.UniqueConstraint(
+                "approval_request_sha256",
+                name="launchplane_owner_control_challenge_request_digest_uq",
+            ),
+        )
+    if not _index_exists(_CHALLENGES_TABLE, _CHALLENGES_SESSION_INDEX):
+        op.create_index(
+            _CHALLENGES_SESSION_INDEX,
+            _CHALLENGES_TABLE,
+            ["channel_session_id", "expires_at"],
+        )
+    if not _index_exists(_CHALLENGES_TABLE, _CHALLENGES_STATE_INDEX):
+        op.create_index(
+            _CHALLENGES_STATE_INDEX,
+            _CHALLENGES_TABLE,
+            ["state", "expires_at"],
+        )
+
+    if not _table_exists(_EVENTS_TABLE):
+        op.create_table(
+            _EVENTS_TABLE,
+            sa.Column("event_id", sa.String(), nullable=False),
+            sa.Column("challenge_id", sa.String(), nullable=False),
+            sa.Column("sequence", sa.Integer(), nullable=False),
+            sa.Column("channel_session_id", sa.String(), nullable=False),
+            sa.Column("challenge_nonce", sa.String(), nullable=False),
+            sa.Column("envelope_sha256", sa.String(), nullable=False),
+            sa.Column("approval_request_sha256", sa.String(), nullable=False),
+            sa.Column("binding_sha256", sa.String(), nullable=False),
+            sa.Column("verification_status", sa.String(), nullable=False),
+            sa.Column("rejection_reason", sa.String(), nullable=True),
+            sa.Column("resulting_challenge_state", sa.String(), nullable=False),
+            sa.Column("occurred_at", sa.String(), nullable=False),
+            sa.Column("verifier_mode", sa.String(), nullable=False, server_default="shadow"),
+            sa.Column(
+                "authorizes_execution",
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.false(),
+            ),
+            sa.Column("authority_state", sa.String(), nullable=False, server_default="inert"),
+            _payload_column(),
+            sa.CheckConstraint(
+                "verification_status IN ('verified', 'rejected')",
+                name="launchplane_owner_control_shadow_event_status_ck",
+            ),
+            sa.CheckConstraint(
+                "verifier_mode = 'shadow'",
+                name="launchplane_owner_control_shadow_event_mode_ck",
+            ),
+            sa.CheckConstraint(
+                "authorizes_execution = false",
+                name="launchplane_owner_control_shadow_event_authorization_ck",
+            ),
+            sa.CheckConstraint(
+                "authority_state = 'inert'",
+                name="launchplane_owner_control_shadow_event_authority_ck",
+            ),
+            sa.CheckConstraint(
+                "sequence BETWEEN 1 AND 8",
+                name="launchplane_owner_control_shadow_event_sequence_ck",
+            ),
+            sa.PrimaryKeyConstraint("event_id"),
+            sa.UniqueConstraint(
+                "challenge_id",
+                "sequence",
+                name="launchplane_owner_control_shadow_event_sequence_uq",
+            ),
+        )
+    if not _index_exists(_EVENTS_TABLE, _EVENTS_CHALLENGE_INDEX):
+        op.create_index(
+            _EVENTS_CHALLENGE_INDEX,
+            _EVENTS_TABLE,
+            ["challenge_nonce", sa.text("occurred_at DESC")],
+        )
+    if not _index_exists(_EVENTS_TABLE, _EVENTS_SESSION_INDEX):
+        op.create_index(
+            _EVENTS_SESSION_INDEX,
+            _EVENTS_TABLE,
+            ["channel_session_id", sa.text("occurred_at DESC")],
+        )
+
+
+def downgrade() -> None:
+    for table_name, index_name in (
+        (_EVENTS_TABLE, _EVENTS_SESSION_INDEX),
+        (_EVENTS_TABLE, _EVENTS_CHALLENGE_INDEX),
+        (_CHALLENGES_TABLE, _CHALLENGES_STATE_INDEX),
+        (_CHALLENGES_TABLE, _CHALLENGES_SESSION_INDEX),
+        (_SESSIONS_TABLE, _SESSIONS_STATUS_INDEX),
+    ):
+        if _index_exists(table_name, index_name):
+            op.drop_index(index_name, table_name=table_name)
+    for table_name in (_EVENTS_TABLE, _CHALLENGES_TABLE, _SESSIONS_TABLE):
+        if _table_exists(table_name):
+            op.drop_table(table_name)

--- a/control_plane/storage/postgres.py
+++ b/control_plane/storage/postgres.py
@@ -9175,8 +9175,10 @@ class PostgresRecordStore(HumanSessionStore):
         statement = select(LaunchplaneOwnerControlChannelSessionRow).where(
             LaunchplaneOwnerControlChannelSessionRow.channel_session_id == channel_session_id
         )
-        if for_update and not self.database_url.startswith("sqlite"):
-            statement = statement.with_for_update()
+        if for_update:
+            statement = statement.execution_options(populate_existing=True)
+            if not self.database_url.startswith("sqlite"):
+                statement = statement.with_for_update()
         return cast(LaunchplaneOwnerControlChannelSessionRow | None, session.scalar(statement))
 
     def _owner_control_issued_challenge_row(
@@ -9189,8 +9191,10 @@ class PostgresRecordStore(HumanSessionStore):
         statement = select(LaunchplaneOwnerControlIssuedChallengeRow).where(
             LaunchplaneOwnerControlIssuedChallengeRow.challenge_nonce == challenge_nonce
         )
-        if for_update and not self.database_url.startswith("sqlite"):
-            statement = statement.with_for_update()
+        if for_update:
+            statement = statement.execution_options(populate_existing=True)
+            if not self.database_url.startswith("sqlite"):
+                statement = statement.with_for_update()
         return cast(LaunchplaneOwnerControlIssuedChallengeRow | None, session.scalar(statement))
 
     @staticmethod

--- a/control_plane/storage/postgres.py
+++ b/control_plane/storage/postgres.py
@@ -7,6 +7,7 @@ from datetime import datetime, timedelta, timezone
 import fcntl
 import hashlib
 from pathlib import Path
+import secrets
 from threading import Lock
 import time
 from typing import Any, Literal, NamedTuple, Protocol, TypeVar, cast, overload
@@ -20,6 +21,7 @@ from sqlalchemy import (
     Index,
     Integer,
     String,
+    UniqueConstraint,
     create_engine,
     delete,
     desc,
@@ -114,6 +116,27 @@ from control_plane.contracts.owner_acceptance import (
     owner_acceptance_event_replay_digest,
     owner_acceptance_subject_key,
     validate_owner_acceptance_event_transition,
+)
+from control_plane.contracts.owner_control import (
+    ChannelBindingRecord,
+    OwnerControlConfirmationEnvelope,
+    owner_control_channel_binding_sha256,
+)
+from control_plane.contracts.owner_control_shadow_verifier import (
+    OWNER_CONTROL_SHADOW_MAX_ATTEMPTS,
+    OwnerControlChannelSessionRecord,
+    OwnerControlChallengeIssueRequest,
+    OwnerControlIssuedChallengeRecord,
+    OwnerControlShadowVerificationEvaluation,
+    OwnerControlShadowVerificationEventRecord,
+    OwnerControlShadowVerificationResult,
+    OwnerControlShadowVerifierConflictError,
+    build_owner_control_channel_session_record,
+    evaluate_owner_control_shadow_verification,
+    issue_owner_control_challenge_record,
+    owner_control_confirmation_envelope_sha256,
+    owner_control_verification_event_id,
+    revoke_owner_control_channel_session_record,
 )
 from control_plane.contracts.merge_train_batch import (
     MergeTrainBatchCandidateRecord,
@@ -1023,6 +1046,183 @@ class LaunchplaneOwnerAcceptanceEventRow(Base):
     )
     self_review: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=false())
     occurred_at: Mapped[str] = mapped_column(String, nullable=False)
+    payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
+
+
+class LaunchplaneOwnerControlChannelSessionRow(Base):
+    __tablename__ = "launchplane_owner_control_channel_sessions"
+    __table_args__ = (
+        CheckConstraint(
+            "status IN ('enrolled', 'revoked')",
+            name="launchplane_owner_control_session_status_ck",
+        ),
+        CheckConstraint(
+            "(status = 'enrolled' AND revoked_at IS NULL) OR "
+            "(status = 'revoked' AND revoked_at IS NOT NULL)",
+            name="launchplane_owner_control_session_revocation_ck",
+        ),
+        CheckConstraint(
+            "authority_state = 'inert'",
+            name="launchplane_owner_control_session_authority_ck",
+        ),
+        UniqueConstraint(
+            "owner_github_id",
+            "binding_sha256",
+            name="launchplane_owner_control_session_owner_binding_uq",
+        ),
+        Index(
+            "launchplane_owner_control_session_status_idx",
+            "status",
+            "session_expires_at",
+        ),
+    )
+
+    channel_session_id: Mapped[str] = mapped_column(String, primary_key=True)
+    owner_github_id: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    status: Mapped[str] = mapped_column(String, nullable=False)
+    session_issued_at: Mapped[str] = mapped_column(String, nullable=False)
+    session_expires_at: Mapped[str] = mapped_column(String, nullable=False)
+    binding_sha256: Mapped[str] = mapped_column(String, nullable=False)
+    enrolled_at: Mapped[str] = mapped_column(String, nullable=False)
+    revoked_at: Mapped[str | None] = mapped_column(String, nullable=True)
+    authority_state: Mapped[str] = mapped_column(
+        String,
+        nullable=False,
+        server_default="inert",
+    )
+    payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
+
+
+class LaunchplaneOwnerControlIssuedChallengeRow(Base):
+    __tablename__ = "launchplane_owner_control_issued_challenges"
+    __table_args__ = (
+        CheckConstraint(
+            "expires_at > issued_at",
+            name="launchplane_owner_control_challenge_expiry_ck",
+        ),
+        CheckConstraint(
+            "state IN ('issued', 'consumed', 'expired', 'rejected')",
+            name="launchplane_owner_control_challenge_state_ck",
+        ),
+        CheckConstraint(
+            "attempt_count BETWEEN 0 AND 8",
+            name="launchplane_owner_control_challenge_attempt_count_ck",
+        ),
+        CheckConstraint(
+            "(state = 'issued' AND consumed_at IS NULL AND terminal_event_id IS NULL) OR "
+            "(state = 'consumed' AND consumed_at IS NOT NULL AND terminal_event_id IS NOT NULL) OR "
+            "(state IN ('expired', 'rejected') AND consumed_at IS NULL AND terminal_event_id IS NOT NULL)",
+            name="launchplane_owner_control_challenge_terminal_ck",
+        ),
+        CheckConstraint(
+            "authority_state = 'inert'",
+            name="launchplane_owner_control_challenge_authority_ck",
+        ),
+        UniqueConstraint(
+            "challenge_nonce",
+            name="launchplane_owner_control_challenge_nonce_uq",
+        ),
+        UniqueConstraint(
+            "approval_request_sha256",
+            name="launchplane_owner_control_challenge_request_digest_uq",
+        ),
+        Index(
+            "launchplane_owner_control_challenge_session_idx",
+            "channel_session_id",
+            "expires_at",
+        ),
+        Index(
+            "launchplane_owner_control_challenge_state_idx",
+            "state",
+            "expires_at",
+        ),
+    )
+
+    challenge_id: Mapped[str] = mapped_column(String, primary_key=True)
+    challenge_nonce: Mapped[str] = mapped_column(String, nullable=False)
+    channel_session_id: Mapped[str] = mapped_column(String, nullable=False)
+    operation_id: Mapped[str] = mapped_column(String, nullable=False)
+    descriptor_id: Mapped[str] = mapped_column(String, nullable=False)
+    owner_github_id: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    issued_at: Mapped[str] = mapped_column(String, nullable=False)
+    expires_at: Mapped[str] = mapped_column(String, nullable=False)
+    approval_request_sha256: Mapped[str] = mapped_column(String, nullable=False)
+    binding_sha256: Mapped[str] = mapped_column(String, nullable=False)
+    state: Mapped[str] = mapped_column(String, nullable=False)
+    attempt_count: Mapped[int] = mapped_column(Integer, nullable=False)
+    consumed_at: Mapped[str | None] = mapped_column(String, nullable=True)
+    terminal_event_id: Mapped[str | None] = mapped_column(String, nullable=True)
+    authority_state: Mapped[str] = mapped_column(
+        String,
+        nullable=False,
+        server_default="inert",
+    )
+    payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
+
+
+class LaunchplaneOwnerControlShadowVerificationEventRow(Base):
+    __tablename__ = "launchplane_owner_control_shadow_verification_events"
+    __table_args__ = (
+        CheckConstraint(
+            "verification_status IN ('verified', 'rejected')",
+            name="launchplane_owner_control_shadow_event_status_ck",
+        ),
+        CheckConstraint(
+            "verifier_mode = 'shadow'",
+            name="launchplane_owner_control_shadow_event_mode_ck",
+        ),
+        CheckConstraint(
+            "authorizes_execution = false",
+            name="launchplane_owner_control_shadow_event_authorization_ck",
+        ),
+        CheckConstraint(
+            "authority_state = 'inert'",
+            name="launchplane_owner_control_shadow_event_authority_ck",
+        ),
+        CheckConstraint(
+            "sequence BETWEEN 1 AND 8",
+            name="launchplane_owner_control_shadow_event_sequence_ck",
+        ),
+        UniqueConstraint(
+            "challenge_id",
+            "sequence",
+            name="launchplane_owner_control_shadow_event_sequence_uq",
+        ),
+        Index(
+            "launchplane_owner_control_shadow_event_challenge_idx",
+            "challenge_nonce",
+            desc("occurred_at"),
+        ),
+        Index(
+            "launchplane_owner_control_shadow_event_session_idx",
+            "channel_session_id",
+            desc("occurred_at"),
+        ),
+    )
+
+    event_id: Mapped[str] = mapped_column(String, primary_key=True)
+    challenge_id: Mapped[str] = mapped_column(String, nullable=False)
+    sequence: Mapped[int] = mapped_column(Integer, nullable=False)
+    channel_session_id: Mapped[str] = mapped_column(String, nullable=False)
+    challenge_nonce: Mapped[str] = mapped_column(String, nullable=False)
+    envelope_sha256: Mapped[str] = mapped_column(String, nullable=False)
+    approval_request_sha256: Mapped[str] = mapped_column(String, nullable=False)
+    binding_sha256: Mapped[str] = mapped_column(String, nullable=False)
+    verification_status: Mapped[str] = mapped_column(String, nullable=False)
+    rejection_reason: Mapped[str | None] = mapped_column(String, nullable=True)
+    resulting_challenge_state: Mapped[str] = mapped_column(String, nullable=False)
+    occurred_at: Mapped[str] = mapped_column(String, nullable=False)
+    verifier_mode: Mapped[str] = mapped_column(String, nullable=False, server_default="shadow")
+    authorizes_execution: Mapped[bool] = mapped_column(
+        Boolean,
+        nullable=False,
+        server_default=false(),
+    )
+    authority_state: Mapped[str] = mapped_column(
+        String,
+        nullable=False,
+        server_default="inert",
+    )
     payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
 
 
@@ -4566,6 +4766,9 @@ class PostgresRecordStore(HumanSessionStore):
             if parsed.tzinfo is None:
                 parsed = parsed.replace(tzinfo=timezone.utc)
         return format_launchplane_mutation_timestamp(parsed)
+
+    def _owner_control_shadow_timestamp(self, session: Any) -> str:
+        return self._database_mutation_timestamp(session).replace("Z", "+00:00")
 
     @staticmethod
     def _mutation_lease_expiry(*, observed_at: str, lease_seconds: int) -> str:
@@ -8961,6 +9164,403 @@ class PostgresRecordStore(HumanSessionStore):
                             )
                     return
             time.sleep(0.05)
+
+    def _owner_control_channel_session_row(
+        self,
+        session: Any,
+        *,
+        channel_session_id: str,
+        for_update: bool = False,
+    ) -> LaunchplaneOwnerControlChannelSessionRow | None:
+        statement = select(LaunchplaneOwnerControlChannelSessionRow).where(
+            LaunchplaneOwnerControlChannelSessionRow.channel_session_id == channel_session_id
+        )
+        if for_update and not self.database_url.startswith("sqlite"):
+            statement = statement.with_for_update()
+        return cast(LaunchplaneOwnerControlChannelSessionRow | None, session.scalar(statement))
+
+    def _owner_control_issued_challenge_row(
+        self,
+        session: Any,
+        *,
+        challenge_nonce: str,
+        for_update: bool = False,
+    ) -> LaunchplaneOwnerControlIssuedChallengeRow | None:
+        statement = select(LaunchplaneOwnerControlIssuedChallengeRow).where(
+            LaunchplaneOwnerControlIssuedChallengeRow.challenge_nonce == challenge_nonce
+        )
+        if for_update and not self.database_url.startswith("sqlite"):
+            statement = statement.with_for_update()
+        return cast(LaunchplaneOwnerControlIssuedChallengeRow | None, session.scalar(statement))
+
+    @staticmethod
+    def _owner_control_channel_session_record_from_row(
+        row: LaunchplaneOwnerControlChannelSessionRow,
+    ) -> OwnerControlChannelSessionRecord:
+        return OwnerControlChannelSessionRecord.model_validate(row.payload)
+
+    @staticmethod
+    def _owner_control_issued_challenge_record_from_row(
+        row: LaunchplaneOwnerControlIssuedChallengeRow,
+    ) -> OwnerControlIssuedChallengeRecord:
+        return OwnerControlIssuedChallengeRecord.model_validate(row.payload)
+
+    def _owner_control_channel_session_row_from_record(
+        self,
+        record: OwnerControlChannelSessionRecord,
+    ) -> LaunchplaneOwnerControlChannelSessionRow:
+        binding = record.channel_binding()
+        return LaunchplaneOwnerControlChannelSessionRow(
+            channel_session_id=record.channel_session_id,
+            owner_github_id=record.owner_github_id,
+            status=record.status,
+            session_issued_at=binding.session_issued_at,
+            session_expires_at=binding.session_expires_at,
+            binding_sha256=record.binding_sha256,
+            enrolled_at=record.enrolled_at,
+            revoked_at=record.revoked_at,
+            authority_state=record.authority_state,
+            payload=self._payload_dict(record),
+        )
+
+    def _sync_owner_control_channel_session_row(
+        self,
+        row: LaunchplaneOwnerControlChannelSessionRow,
+        record: OwnerControlChannelSessionRecord,
+    ) -> None:
+        binding = record.channel_binding()
+        row.owner_github_id = record.owner_github_id
+        row.status = record.status
+        row.session_issued_at = binding.session_issued_at
+        row.session_expires_at = binding.session_expires_at
+        row.binding_sha256 = record.binding_sha256
+        row.enrolled_at = record.enrolled_at
+        row.revoked_at = record.revoked_at
+        row.authority_state = record.authority_state
+        row.payload = self._payload_dict(record)
+
+    def _owner_control_issued_challenge_row_from_record(
+        self,
+        record: OwnerControlIssuedChallengeRecord,
+    ) -> LaunchplaneOwnerControlIssuedChallengeRow:
+        return LaunchplaneOwnerControlIssuedChallengeRow(
+            challenge_id=record.challenge_id,
+            challenge_nonce=record.challenge_nonce,
+            channel_session_id=record.channel_session_id,
+            operation_id=record.operation_id,
+            descriptor_id=record.descriptor_id,
+            owner_github_id=record.owner_github_id,
+            issued_at=record.issued_at,
+            expires_at=record.expires_at,
+            approval_request_sha256=record.approval_request_sha256,
+            binding_sha256=record.binding_sha256,
+            state=record.state,
+            attempt_count=record.attempt_count,
+            consumed_at=record.consumed_at,
+            terminal_event_id=record.terminal_event_id,
+            authority_state=record.authority_state,
+            payload=self._payload_dict(record),
+        )
+
+    def _sync_owner_control_issued_challenge_row(
+        self,
+        row: LaunchplaneOwnerControlIssuedChallengeRow,
+        record: OwnerControlIssuedChallengeRecord,
+    ) -> None:
+        row.channel_session_id = record.channel_session_id
+        row.operation_id = record.operation_id
+        row.descriptor_id = record.descriptor_id
+        row.owner_github_id = record.owner_github_id
+        row.issued_at = record.issued_at
+        row.expires_at = record.expires_at
+        row.approval_request_sha256 = record.approval_request_sha256
+        row.binding_sha256 = record.binding_sha256
+        row.state = record.state
+        row.attempt_count = record.attempt_count
+        row.consumed_at = record.consumed_at
+        row.terminal_event_id = record.terminal_event_id
+        row.authority_state = record.authority_state
+        row.payload = self._payload_dict(record)
+
+    def enroll_owner_control_channel_session(
+        self,
+        binding: ChannelBindingRecord,
+    ) -> OwnerControlChannelSessionRecord:
+        with self._session_factory() as session:
+            self._begin_serialized_write(session)
+            existing_row = self._owner_control_channel_session_row(
+                session,
+                channel_session_id=binding.channel_session_id,
+                for_update=True,
+            )
+            if existing_row is not None:
+                existing_record = self._owner_control_channel_session_record_from_row(existing_row)
+                if (
+                    existing_record.binding_sha256 == owner_control_channel_binding_sha256(binding)
+                    and existing_record.channel_binding() == binding
+                ):
+                    session.rollback()
+                    return existing_record
+                raise OwnerControlShadowVerifierConflictError(
+                    "Channel-session enrollment changed the stored binding."
+                )
+            record = build_owner_control_channel_session_record(
+                binding=binding,
+                enrolled_at=self._owner_control_shadow_timestamp(session),
+            )
+            session.add(self._owner_control_channel_session_row_from_record(record))
+            session.commit()
+            return record
+
+    def revoke_owner_control_channel_session(
+        self,
+        *,
+        channel_session_id: str,
+    ) -> OwnerControlChannelSessionRecord:
+        with self._session_factory() as session:
+            self._begin_serialized_write(session)
+            row = self._owner_control_channel_session_row(
+                session,
+                channel_session_id=channel_session_id,
+                for_update=True,
+            )
+            if row is None:
+                raise FileNotFoundError(
+                    f"Owner-control channel session {channel_session_id} was not found."
+                )
+            record = self._owner_control_channel_session_record_from_row(row)
+            revoked_record = revoke_owner_control_channel_session_record(
+                record,
+                revoked_at=self._owner_control_shadow_timestamp(session),
+            )
+            if revoked_record != record:
+                self._sync_owner_control_channel_session_row(row, revoked_record)
+                session.commit()
+            else:
+                session.rollback()
+            return revoked_record
+
+    def issue_owner_control_challenge(
+        self,
+        issue_request: OwnerControlChallengeIssueRequest,
+    ) -> OwnerControlIssuedChallengeRecord:
+        with self._session_factory() as session:
+            self._begin_serialized_write(session)
+            session_row = self._owner_control_channel_session_row(
+                session,
+                channel_session_id=issue_request.channel_session_id,
+                for_update=True,
+            )
+            if session_row is None:
+                raise FileNotFoundError(
+                    f"Owner-control channel session {issue_request.channel_session_id} was not found."
+                )
+            session_record = self._owner_control_channel_session_record_from_row(session_row)
+            record = issue_owner_control_challenge_record(
+                issue_request=issue_request,
+                session=session_record,
+                challenge_nonce=secrets.token_urlsafe(32),
+                issued_at=self._owner_control_shadow_timestamp(session),
+            )
+            existing_row = self._owner_control_issued_challenge_row(
+                session,
+                challenge_nonce=record.challenge_nonce,
+                for_update=True,
+            )
+            if existing_row is not None:
+                existing_record = self._owner_control_issued_challenge_record_from_row(existing_row)
+                if existing_record == record:
+                    session.rollback()
+                    return existing_record
+                raise OwnerControlShadowVerifierConflictError(
+                    "Owner-control challenge nonce was already issued."
+                )
+            session.add(self._owner_control_issued_challenge_row_from_record(record))
+            session.commit()
+            return record
+
+    def verify_owner_control_confirmation_shadow(
+        self,
+        envelope: OwnerControlConfirmationEnvelope,
+    ) -> OwnerControlShadowVerificationResult:
+        with self._session_factory() as session:
+            self._begin_serialized_write(session)
+            observed_challenge_row = self._owner_control_issued_challenge_row(
+                session,
+                challenge_nonce=envelope.challenge_response.approval_request.nonce,
+            )
+            if observed_challenge_row is None:
+                session.rollback()
+                raise FileNotFoundError("Owner-control challenge was not issued.")
+            observed_challenge = self._owner_control_issued_challenge_record_from_row(
+                observed_challenge_row
+            )
+            session_row = self._owner_control_channel_session_row(
+                session,
+                channel_session_id=observed_challenge.channel_session_id,
+                for_update=True,
+            )
+            challenge_row = self._owner_control_issued_challenge_row(
+                session,
+                challenge_nonce=observed_challenge.challenge_nonce,
+                for_update=True,
+            )
+            if challenge_row is None:
+                session.rollback()
+                raise FileNotFoundError("Owner-control challenge was not issued.")
+            challenge_record = self._owner_control_issued_challenge_record_from_row(challenge_row)
+            if challenge_record.attempt_count >= OWNER_CONTROL_SHADOW_MAX_ATTEMPTS:
+                session.rollback()
+                raise OwnerControlShadowVerifierConflictError(
+                    "Owner-control challenge verification attempt budget is exhausted."
+                )
+            observed_at = self._owner_control_shadow_timestamp(session)
+            evaluation = evaluate_owner_control_shadow_verification(
+                envelope=envelope,
+                channel_session=(
+                    self._owner_control_channel_session_record_from_row(session_row)
+                    if session_row is not None
+                    else None
+                ),
+                issued_challenge=challenge_record,
+                observed_at=observed_at,
+            )
+            sequence = challenge_record.attempt_count + 1
+            if (
+                evaluation.verification_status == "rejected"
+                and evaluation.resulting_challenge_state == "issued"
+                and sequence == OWNER_CONTROL_SHADOW_MAX_ATTEMPTS
+            ):
+                evaluation = OwnerControlShadowVerificationEvaluation(
+                    verification_status="rejected",
+                    rejection_reason="attempt_budget_exhausted",
+                    resulting_challenge_state="rejected",
+                )
+            envelope_sha256 = owner_control_confirmation_envelope_sha256(envelope)
+            event_id = owner_control_verification_event_id(
+                challenge_id=challenge_record.challenge_id,
+                sequence=sequence,
+                envelope_sha256=envelope_sha256,
+                verification_status=evaluation.verification_status,
+                rejection_reason=evaluation.rejection_reason,
+            )
+            first_terminal_transition = (
+                challenge_record.state == "issued"
+                and evaluation.resulting_challenge_state != "issued"
+            )
+            updated_challenge = challenge_record.model_copy(
+                update={
+                    "attempt_count": sequence,
+                    "state": evaluation.resulting_challenge_state,
+                    "consumed_at": (
+                        observed_at
+                        if evaluation.resulting_challenge_state == "consumed"
+                        and challenge_record.consumed_at is None
+                        else challenge_record.consumed_at
+                    ),
+                    "terminal_event_id": (
+                        event_id
+                        if first_terminal_transition
+                        else challenge_record.terminal_event_id
+                    ),
+                }
+            )
+            self._sync_owner_control_issued_challenge_row(challenge_row, updated_challenge)
+            event = OwnerControlShadowVerificationEventRecord(
+                event_id=event_id,
+                challenge_id=challenge_record.challenge_id,
+                sequence=sequence,
+                channel_session_id=challenge_record.channel_session_id,
+                challenge_nonce=challenge_record.challenge_nonce,
+                envelope_sha256=envelope_sha256,
+                approval_request_sha256=challenge_record.approval_request_sha256,
+                binding_sha256=challenge_record.binding_sha256,
+                verification_status=evaluation.verification_status,
+                rejection_reason=evaluation.rejection_reason,
+                resulting_challenge_state=evaluation.resulting_challenge_state,
+                occurred_at=observed_at,
+            )
+            session.add(
+                LaunchplaneOwnerControlShadowVerificationEventRow(
+                    event_id=event.event_id,
+                    challenge_id=event.challenge_id,
+                    sequence=event.sequence,
+                    channel_session_id=event.channel_session_id,
+                    challenge_nonce=event.challenge_nonce,
+                    envelope_sha256=event.envelope_sha256,
+                    approval_request_sha256=event.approval_request_sha256,
+                    binding_sha256=event.binding_sha256,
+                    verification_status=event.verification_status,
+                    rejection_reason=event.rejection_reason,
+                    resulting_challenge_state=event.resulting_challenge_state,
+                    occurred_at=event.occurred_at,
+                    verifier_mode=event.verifier_mode,
+                    authorizes_execution=event.authorizes_execution,
+                    authority_state=event.authority_state,
+                    payload=self._payload_dict(event),
+                )
+            )
+            session.commit()
+            return OwnerControlShadowVerificationResult(
+                event_id=event.event_id,
+                challenge_id=event.challenge_id,
+                sequence=event.sequence,
+                verification_status=event.verification_status,
+                rejection_reason=event.rejection_reason,
+                resulting_challenge_state=event.resulting_challenge_state,
+            )
+
+    def read_owner_control_channel_session(
+        self,
+        *,
+        channel_session_id: str,
+    ) -> OwnerControlChannelSessionRecord:
+        return self._read_model(
+            model_type=OwnerControlChannelSessionRecord,
+            orm_model=LaunchplaneOwnerControlChannelSessionRow,
+            filters=(
+                LaunchplaneOwnerControlChannelSessionRow.channel_session_id == channel_session_id,
+            ),
+        )
+
+    def read_owner_control_issued_challenge(
+        self,
+        *,
+        challenge_nonce: str,
+    ) -> OwnerControlIssuedChallengeRecord:
+        return self._read_model(
+            model_type=OwnerControlIssuedChallengeRecord,
+            orm_model=LaunchplaneOwnerControlIssuedChallengeRow,
+            filters=(LaunchplaneOwnerControlIssuedChallengeRow.challenge_nonce == challenge_nonce,),
+        )
+
+    def list_owner_control_shadow_verification_events(
+        self,
+        *,
+        challenge_nonce: str = "",
+        channel_session_id: str = "",
+        limit: int | None = None,
+    ) -> tuple[OwnerControlShadowVerificationEventRecord, ...]:
+        filters: list[object] = []
+        if challenge_nonce:
+            filters.append(
+                LaunchplaneOwnerControlShadowVerificationEventRow.challenge_nonce == challenge_nonce
+            )
+        if channel_session_id:
+            filters.append(
+                LaunchplaneOwnerControlShadowVerificationEventRow.channel_session_id
+                == channel_session_id
+            )
+        return self._list_models(
+            model_type=OwnerControlShadowVerificationEventRecord,
+            orm_model=LaunchplaneOwnerControlShadowVerificationEventRow,
+            filters=filters,
+            order_by=(
+                LaunchplaneOwnerControlShadowVerificationEventRow.occurred_at.desc(),
+                LaunchplaneOwnerControlShadowVerificationEventRow.event_id.desc(),
+            ),
+            limit=limit,
+        )
 
     def _sync_privileged_operation_row(
         self,

--- a/control_plane/storage/schema_invariants.py
+++ b/control_plane/storage/schema_invariants.py
@@ -10,7 +10,7 @@ from sqlalchemy.engine import Engine
 from sqlalchemy.exc import SQLAlchemyError
 
 AUTHZ_COMPATIBILITY_FLOOR_REVISION = "f3b5d7e9a1c2"
-EXPECTED_ALEMBIC_HEAD_REVISION = "f2241a0b1c2d"
+EXPECTED_ALEMBIC_HEAD_REVISION = "e5f7a9b1c3d6"
 RUNTIME_COMPATIBLE_ALEMBIC_REVISIONS = (EXPECTED_ALEMBIC_HEAD_REVISION,)
 _AUTHZ_POLICY_TABLE = "launchplane_authz_policies"
 _AUTHZ_POLICY_WRITE_FENCE_TRIGGER = "launchplane_authz_policy_write_fence"
@@ -443,6 +443,21 @@ CRITICAL_POSTGRES_COLUMN_TYPES: tuple[CriticalColumnType, ...] = (
     ),
     CriticalColumnType(
         "launchplane_change_impact_policies",
+        "payload",
+        ("jsonb",),
+    ),
+    CriticalColumnType(
+        "launchplane_owner_control_channel_sessions",
+        "payload",
+        ("jsonb",),
+    ),
+    CriticalColumnType(
+        "launchplane_owner_control_issued_challenges",
+        "payload",
+        ("jsonb",),
+    ),
+    CriticalColumnType(
+        "launchplane_owner_control_shadow_verification_events",
         "payload",
         ("jsonb",),
     ),
@@ -956,6 +971,31 @@ CRITICAL_SCHEMA_INDEXES: tuple[CriticalIndex, ...] = (
         "launchplane_change_impact_policy_current_idx",
         ("repository_id", "status", "policy_revision"),
     ),
+    CriticalIndex(
+        "launchplane_owner_control_channel_sessions",
+        "launchplane_owner_control_session_status_idx",
+        ("status", "session_expires_at"),
+    ),
+    CriticalIndex(
+        "launchplane_owner_control_issued_challenges",
+        "launchplane_owner_control_challenge_session_idx",
+        ("channel_session_id", "expires_at"),
+    ),
+    CriticalIndex(
+        "launchplane_owner_control_issued_challenges",
+        "launchplane_owner_control_challenge_state_idx",
+        ("state", "expires_at"),
+    ),
+    CriticalIndex(
+        "launchplane_owner_control_shadow_verification_events",
+        "launchplane_owner_control_shadow_event_challenge_idx",
+        ("challenge_nonce", "occurred_at"),
+    ),
+    CriticalIndex(
+        "launchplane_owner_control_shadow_verification_events",
+        "launchplane_owner_control_shadow_event_session_idx",
+        ("channel_session_id", "occurred_at"),
+    ),
 )
 
 CRITICAL_PRIMARY_KEYS: tuple[CriticalPrimaryKey, ...] = (
@@ -1053,6 +1093,18 @@ CRITICAL_PRIMARY_KEYS: tuple[CriticalPrimaryKey, ...] = (
     CriticalPrimaryKey(
         "launchplane_engineering_review_decisions",
         ("decision_id",),
+    ),
+    CriticalPrimaryKey(
+        "launchplane_owner_control_channel_sessions",
+        ("channel_session_id",),
+    ),
+    CriticalPrimaryKey(
+        "launchplane_owner_control_issued_challenges",
+        ("challenge_id",),
+    ),
+    CriticalPrimaryKey(
+        "launchplane_owner_control_shadow_verification_events",
+        ("event_id",),
     ),
 )
 

--- a/docs/authorization-authority.md
+++ b/docs/authorization-authority.md
@@ -31,6 +31,13 @@ Until that work closes:
 This freeze does not prohibit code, tests, documentation, threat-model work, or
 dry-run-only validation that cannot mutate live policy.
 
+Owner-control channel-session, issued-challenge, and shadow-verification event
+records are inert verification evidence, not authorization policy or grants.
+They define no HTTP action, route, managed set, workflow, secret, or production
+access path; every result persists `authority_state = 'inert'` and
+`authorizes_execution = false`. Adding these records does not relax issue
+`#2058` or make a self-asserted key, binding, or challenge authoritative.
+
 Repository inventory follows the same authority boundary. Its
 `repository_inventory.read` and `repository_inventory.write` actions use the
 Launchplane service scope (`product=launchplane`, `context=launchplane`), but

--- a/docs/owner-control-channel.md
+++ b/docs/owner-control-channel.md
@@ -73,11 +73,12 @@ above. The artifact's signature declaration marks this compatibility boundary
 explicitly.
 
 Signature verification proves only that the private key corresponding to the
-public key inside the envelope signed the exact challenge response. A future
-runtime verifier must also compare the exact binding record and digest against
-the server-enrolled channel-session record and the binding selected when the
-challenge was issued. A self-asserted binding or otherwise valid self-signed
-envelope is never authorization evidence by itself.
+public key inside the envelope signed the exact challenge response. The
+shadow-verifier storage slice compares the exact canonical binding and approval
+request bytes plus their server-stored digests against the enrolled
+channel-session and issued challenge records. A self-asserted binding or
+otherwise valid self-signed envelope cannot create enrolled or issued state and
+is never authorization evidence by itself.
 
 ## Conformance Artifact
 
@@ -111,16 +112,38 @@ The vectors contain only synthetic identifiers, digests, nonces, timestamps,
 and generic review strings. They carry no tenant, product, repository, domain,
 operator, policy authority, session credential, or live endpoint data.
 
-## Deferred Runtime Work
+## Shadow-Verifier Storage
 
-This is a behavior-neutral contract seam. It adds no HTTP route, storage record,
-migration, frontend, worker action, authorization grant, source-kind change,
-policy change, credential, channel implementation, or live runtime mutation.
-Existing browser approval behavior remains unchanged until a separately reviewed
-runtime adoption change proves the trusted owner-control path.
+`control_plane.contracts.owner_control_shadow_verifier` defines server-state
+records separate from the published wire contract. PostgreSQL persists enrolled
+channel sessions, issued single-use challenges, and append-only verification
+events. Enrollment and revocation are DB-backed; challenge issuance, expiry,
+verification audit timestamps, and successful-consumption timestamps use the
+database clock. Verification locks the enrolled session and issued challenge in
+one transaction, so one exact valid challenge can verify only once. Each issued
+challenge permits at most eight audited verification attempts; the eighth
+non-terminal rejection closes the challenge as rejected, and later attempts
+cannot append more events.
 
-`ChallengeResponse` represents successful confirmation only. Owner rejection,
-challenge expiry, and replay rejection are future audit events rather than
-alternate signed response decisions. The checked artifact uses one explicitly
-synthetic deterministic Ed25519 key only to make public conformance vectors
-reproducible; it is not runtime authority, a credential, or a deployed key.
+Challenge issuance accepts an exact `ApprovalRequest` only through an unrouted
+service-internal storage API. This slice does not claim that arbitrary supplied
+request fields are trusted or derive a challenge from a live privileged
+operation; the database service replaces the nonce and timestamp bounds with a
+server-generated nonce and database-clock values. The remaining
+operation-binding and transport boundary requires a separate review before any
+route exists. Unknown challenge nonces create no durable state.
+
+Every stored event and returned result has `verifier_mode: "shadow"` and
+`authorizes_execution: false`. The slice adds no HTTP route, authorization
+action or grant, browser workflow, privileged-operation approval/execution
+coupling, worker, outbox, filesystem store, signing key, or channel-host
+implementation. Existing browser approval behavior remains unchanged until a
+separately reviewed runtime adoption change proves the trusted owner-control
+path.
+
+`ChallengeResponse` represents successful confirmation only. Challenge expiry,
+replay, mismatch, and attempt-budget rejection are shadow audit outcomes rather
+than alternate signed response decisions. The checked artifact uses one
+explicitly synthetic deterministic Ed25519 key only to make public conformance
+vectors reproducible; it is not runtime authority, a credential, or a deployed
+key.

--- a/docs/privileged-operations.md
+++ b/docs/privileged-operations.md
@@ -40,6 +40,12 @@ descriptor. It is a cross-host conformance artifact only: it does not issue a
 challenge, consume an owner confirmation, alter browser approval, add a route,
 or authorize execution. See `docs/owner-control-channel.md`.
 
+The DB-backed shadow verifier remains independent from this lifecycle. No
+privileged-operation route, service, worker, transition, approval, or execution
+path imports it. Its unrouted storage API can retain test or future
+service-authored challenge state and return only `authorizes_execution: false`;
+browser approval remains the only active approval transport.
+
 ## Authorization
 
 Privileged-operation routes do not use bare `LaunchplaneAuthzPolicy.allows`.

--- a/docs/records.md
+++ b/docs/records.md
@@ -2656,11 +2656,23 @@ review plus bounded diff and CAS/read-back evidence. See
 `docs/privileged-operations.md` for the full evidence and authorization
 boundary.
 
-The checked `contracts/owner-control-contract.json` artifact is not a record,
-nonce store, audit event, or runtime authority. It supplies deterministic
-cross-host serialization and synthetic golden vectors only; future owner-control
-issuance, confirmation, replay rejection, and expiry records require a separate
-storage contract.
+The checked `contracts/owner-control-contract.json` artifact is not a record or
+runtime authority. It supplies deterministic cross-host serialization and
+synthetic golden vectors only.
+
+Owner-control shadow-verifier state is persisted only in PostgreSQL through
+`PostgresRecordStore`: `launchplane_owner_control_channel_sessions` stores one
+enrolled canonical binding, inert authority marker, and revocation state;
+`launchplane_owner_control_issued_challenges` stores one canonical approval
+request and binding plus their SHA-256 digests, issued/terminal state, and a
+bounded verification-attempt count;
+and `launchplane_owner_control_shadow_verification_events` is append-only,
+retains only bounded digest/result fields with a unique per-challenge sequence,
+and is constrained to `verifier_mode = 'shadow'`, `authority_state = 'inert'`,
+and `authorizes_execution = false`. The stored canonical binding and
+approval-request bytes, rather than an envelope's self-asserted values, govern
+only the shadow verification comparison; they grant no execution authority.
+Unknown challenge nonces create no record or event.
 
 **Preserved history:** references to Phase 1 planning records describe the
 pre-worker lifecycle and do not constrain the current Phase 2 statuses.

--- a/tests/test_owner_control_shadow_verifier.py
+++ b/tests/test_owner_control_shadow_verifier.py
@@ -1,0 +1,397 @@
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+import subprocess
+from tempfile import TemporaryDirectory
+import unittest
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from control_plane.contracts.owner_control import (
+    ApprovalRequest,
+    ChannelBindingRecord,
+    ChallengeResponse,
+    OwnerControlConfirmationEnvelope,
+    ReviewItem,
+    ServerReviewPayload,
+    owner_control_approval_request_digest,
+    owner_control_channel_binding_sha256,
+    owner_control_signature_payload_bytes,
+)
+from control_plane.contracts.owner_control_shadow_verifier import (
+    OwnerControlChallengeIssueRequest,
+    evaluate_owner_control_shadow_verification,
+)
+from control_plane.storage.postgres import PostgresRecordStore
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+OWNER_CONTROL_BASE_REVISION = "8c34cb5849edafd8db05f936afe994ac82372087"
+
+
+def _base64url(value: bytes) -> str:
+    return base64.urlsafe_b64encode(value).decode("ascii").rstrip("=")
+
+
+def _binding(
+    private_key: Ed25519PrivateKey, *, session_id: str = "owner-control-session"
+) -> ChannelBindingRecord:
+    return ChannelBindingRecord(
+        channel_session_id=session_id,
+        owner_github_id=100001,
+        signature_algorithm="ed25519",
+        owner_public_key=_base64url(
+            private_key.public_key().public_bytes_raw(),
+        ),
+        session_issued_at="2025-01-01T00:00:00+00:00",
+        session_expires_at="2035-01-01T00:00:00+00:00",
+    )
+
+
+def _request(*, nonce: str = "owner-control-nonce-0000000000000001") -> ApprovalRequest:
+    return ApprovalRequest(
+        operation_id="privileged-operation-0123456789abcdef0123456789abcdef",
+        descriptor_id="managed-secret-reencryption",
+        descriptor_version=1,
+        request_digest="1" * 64,
+        plan_digest="2" * 64,
+        evidence_digest="3" * 64,
+        pre_state_digest="4" * 64,
+        policy_record_id="owner-policy",
+        policy_revision=1,
+        policy_sha256="5" * 64,
+        owner_github_id=100001,
+        server_review=ServerReviewPayload(
+            review_id="owner-control-review",
+            title="Review operation",
+            summary="Review the exact server-authored request.",
+            items=(ReviewItem(key="operation", label="Operation", value="Re-encrypt"),),
+        ),
+        nonce=nonce,
+        issued_at="2026-01-01T00:00:00+00:00",
+        expires_at="2026-01-01T00:01:00+00:00",
+    )
+
+
+def _envelope(
+    private_key: Ed25519PrivateKey,
+    *,
+    binding: ChannelBindingRecord,
+    request: ApprovalRequest,
+) -> OwnerControlConfirmationEnvelope:
+    response = ChallengeResponse(
+        approval_request=request,
+        approval_request_digest=owner_control_approval_request_digest(request),
+        decision="approved",
+        channel_binding_sha256=owner_control_channel_binding_sha256(binding),
+        confirmed_at=request.issued_at,
+    )
+    signature = private_key.sign(owner_control_signature_payload_bytes(response))
+    return OwnerControlConfirmationEnvelope(
+        channel_binding=binding,
+        challenge_response=response,
+        signature_algorithm="ed25519",
+        signature=_base64url(signature),
+    )
+
+
+class OwnerControlShadowVerifierStorageTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary_directory = TemporaryDirectory()
+        self.store = PostgresRecordStore(
+            database_url=f"sqlite+pysqlite:///{Path(self.temporary_directory.name) / 'records.sqlite3'}"
+        )
+        self.store.ensure_schema()
+
+    def tearDown(self) -> None:
+        self.store.close()
+        self.temporary_directory.cleanup()
+
+    def test_verifies_once_with_exact_server_state_and_persists_shadow_events(self) -> None:
+        private_key = Ed25519PrivateKey.generate()
+        binding = _binding(private_key)
+        enrolled = self.store.enroll_owner_control_channel_session(binding)
+        issued = self.store.issue_owner_control_challenge(
+            OwnerControlChallengeIssueRequest(
+                channel_session_id=binding.channel_session_id,
+                approval_request=_request(),
+                expires_in_seconds=300,
+            )
+        )
+        envelope = _envelope(
+            private_key,
+            binding=binding,
+            request=issued.approval_request(),
+        )
+
+        verified = self.store.verify_owner_control_confirmation_shadow(envelope)
+        replayed = self.store.verify_owner_control_confirmation_shadow(envelope)
+        stored_challenge = self.store.read_owner_control_issued_challenge(
+            challenge_nonce=issued.challenge_nonce
+        )
+        events = self.store.list_owner_control_shadow_verification_events(
+            challenge_nonce=issued.challenge_nonce
+        )
+
+        self.assertEqual(enrolled.status, "enrolled")
+        self.assertEqual(enrolled.authority_state, "inert")
+        self.assertNotEqual(issued.challenge_nonce, _request().nonce)
+        self.assertEqual(issued.state, "issued")
+        self.assertEqual(issued.authority_state, "inert")
+        self.assertEqual(verified.verification_status, "verified")
+        self.assertEqual(verified.resulting_challenge_state, "consumed")
+        self.assertFalse(verified.authorizes_execution)
+        self.assertEqual(verified.verifier_mode, "shadow")
+        self.assertEqual(replayed.verification_status, "rejected")
+        self.assertEqual(replayed.rejection_reason, "challenge_replayed")
+        self.assertEqual(stored_challenge.state, "consumed")
+        self.assertEqual(stored_challenge.attempt_count, 2)
+        self.assertIsNotNone(stored_challenge.consumed_at)
+        self.assertIsNotNone(stored_challenge.terminal_event_id)
+        self.assertEqual(
+            sorted(event.verification_status for event in events), ["rejected", "verified"]
+        )
+        self.assertEqual(sorted(event.sequence for event in events), [1, 2])
+        self.assertTrue(all(event.verifier_mode == "shadow" for event in events))
+        self.assertTrue(all(event.authorizes_execution is False for event in events))
+        self.assertTrue(all(event.authority_state == "inert" for event in events))
+
+    def test_valid_signature_with_changed_request_never_verifies(self) -> None:
+        private_key = Ed25519PrivateKey.generate()
+        binding = _binding(private_key)
+        self.store.enroll_owner_control_channel_session(binding)
+        issued = self.store.issue_owner_control_challenge(
+            OwnerControlChallengeIssueRequest(
+                channel_session_id=binding.channel_session_id,
+                approval_request=_request(),
+                expires_in_seconds=300,
+            )
+        )
+        altered_request = issued.approval_request().model_copy(update={"plan_digest": "9" * 64})
+        envelope = _envelope(private_key, binding=binding, request=altered_request)
+
+        result = self.store.verify_owner_control_confirmation_shadow(envelope)
+        stored_challenge = self.store.read_owner_control_issued_challenge(
+            challenge_nonce=issued.challenge_nonce
+        )
+
+        self.assertEqual(result.verification_status, "rejected")
+        self.assertEqual(result.rejection_reason, "stored_approval_request_mismatch")
+        self.assertEqual(stored_challenge.state, "issued")
+        self.assertEqual(stored_challenge.attempt_count, 1)
+        self.assertIsNone(stored_challenge.consumed_at)
+
+    def test_self_signed_unknown_session_never_creates_durable_state(self) -> None:
+        private_key = Ed25519PrivateKey.generate()
+        binding = _binding(private_key, session_id="self-signed-session")
+        request = _request(nonce="owner-control-nonce-0000000000000002")
+        envelope = _envelope(private_key, binding=binding, request=request)
+
+        with self.assertRaisesRegex(FileNotFoundError, "was not issued"):
+            self.store.verify_owner_control_confirmation_shadow(envelope)
+        events = self.store.list_owner_control_shadow_verification_events(
+            challenge_nonce=request.nonce
+        )
+
+        self.assertEqual(events, ())
+
+    def test_rejection_audit_is_bounded_and_terminal(self) -> None:
+        private_key = Ed25519PrivateKey.generate()
+        binding = _binding(private_key)
+        self.store.enroll_owner_control_channel_session(binding)
+        issued = self.store.issue_owner_control_challenge(
+            OwnerControlChallengeIssueRequest(
+                channel_session_id=binding.channel_session_id,
+                approval_request=_request(),
+                expires_in_seconds=300,
+            )
+        )
+        altered_request = issued.approval_request().model_copy(update={"plan_digest": "9" * 64})
+        envelope = _envelope(private_key, binding=binding, request=altered_request)
+
+        results = tuple(
+            self.store.verify_owner_control_confirmation_shadow(envelope) for _ in range(8)
+        )
+        with self.assertRaisesRegex(ValueError, "attempt budget is exhausted"):
+            self.store.verify_owner_control_confirmation_shadow(envelope)
+        stored_challenge = self.store.read_owner_control_issued_challenge(
+            challenge_nonce=issued.challenge_nonce
+        )
+        events = self.store.list_owner_control_shadow_verification_events(
+            challenge_nonce=issued.challenge_nonce
+        )
+
+        self.assertTrue(
+            all(
+                result.rejection_reason == "stored_approval_request_mismatch"
+                for result in results[:7]
+            )
+        )
+        self.assertEqual(results[7].rejection_reason, "attempt_budget_exhausted")
+        self.assertEqual(stored_challenge.state, "rejected")
+        self.assertEqual(stored_challenge.attempt_count, 8)
+        self.assertEqual(len(events), 8)
+        self.assertEqual(sorted(event.sequence for event in events), list(range(1, 9)))
+
+    def test_pure_evaluation_rejects_unknown_sessions_before_signature_can_authorize(self) -> None:
+        private_key = Ed25519PrivateKey.generate()
+        binding = _binding(private_key, session_id="not-enrolled")
+        request = _request(nonce="owner-control-nonce-0000000000000003")
+        envelope = _envelope(private_key, binding=binding, request=request)
+
+        evaluation = evaluate_owner_control_shadow_verification(
+            envelope=envelope,
+            channel_session=None,
+            issued_challenge=None,
+            observed_at="2026-08-28T00:00:00+00:00",
+        )
+
+        self.assertEqual(evaluation.verification_status, "rejected")
+        self.assertEqual(evaluation.rejection_reason, "unknown_channel_session")
+        self.assertEqual(evaluation.resulting_challenge_state, "rejected")
+        self.assertFalse(evaluation.consume_challenge)
+
+    def test_pure_evaluation_rejects_stored_state_and_signature_mismatches(self) -> None:
+        private_key = Ed25519PrivateKey.generate()
+        binding = _binding(private_key)
+        enrolled = self.store.enroll_owner_control_channel_session(binding)
+        issued = self.store.issue_owner_control_challenge(
+            OwnerControlChallengeIssueRequest(
+                channel_session_id=binding.channel_session_id,
+                approval_request=_request(),
+                expires_in_seconds=300,
+            )
+        )
+        valid_envelope = _envelope(
+            private_key,
+            binding=binding,
+            request=issued.approval_request(),
+        )
+        wrong_signature_envelope = _envelope(
+            Ed25519PrivateKey.generate(),
+            binding=binding,
+            request=issued.approval_request(),
+        )
+        cross_session_binding = binding.model_copy(
+            update={"channel_session_id": "owner-control-other-session"}
+        )
+        cross_session_envelope = _envelope(
+            private_key,
+            binding=cross_session_binding,
+            request=issued.approval_request(),
+        )
+        revoked = enrolled.model_copy(
+            update={"status": "revoked", "revoked_at": enrolled.enrolled_at}
+        )
+
+        cases = (
+            (
+                "revoked",
+                valid_envelope,
+                revoked,
+                issued.issued_at,
+                "channel_session_revoked",
+            ),
+            (
+                "session-expired",
+                valid_envelope,
+                enrolled,
+                "2035-01-02T00:00:00+00:00",
+                "channel_session_expired",
+            ),
+            (
+                "challenge-expired",
+                valid_envelope,
+                enrolled,
+                "2027-01-01T00:00:00+00:00",
+                "challenge_expired",
+            ),
+            (
+                "cross-session",
+                cross_session_envelope,
+                enrolled,
+                issued.issued_at,
+                "challenge_channel_session_mismatch",
+            ),
+            (
+                "wrong-signature",
+                wrong_signature_envelope,
+                enrolled,
+                issued.issued_at,
+                "signature_invalid",
+            ),
+        )
+        for name, envelope, session_record, observed_at, expected_reason in cases:
+            with self.subTest(name=name):
+                evaluation = evaluate_owner_control_shadow_verification(
+                    envelope=envelope,
+                    channel_session=session_record,
+                    issued_challenge=issued,
+                    observed_at=observed_at,
+                )
+                self.assertEqual(evaluation.verification_status, "rejected")
+                self.assertEqual(evaluation.rejection_reason, expected_reason)
+                self.assertFalse(evaluation.consume_challenge)
+
+
+class OwnerControlShadowVerifierFreezeBoundaryTests(unittest.TestCase):
+    def test_published_wire_contract_and_transport_boundaries_remain_frozen(self) -> None:
+        frozen_paths = (
+            "contracts/owner-control-contract.json",
+            "control_plane/contracts/owner_control.py",
+            "control_plane/http_app.py",
+        )
+
+        for path in frozen_paths:
+            with self.subTest(path=path):
+                result = subprocess.run(
+                    ["git", "diff", "--quiet", OWNER_CONTROL_BASE_REVISION, "--", path],
+                    cwd=REPOSITORY_ROOT,
+                )
+                self.assertEqual(result.returncode, 0, f"Frozen boundary changed: {path}")
+
+    def test_shadow_verifier_contract_has_no_transport_or_execution_coupling(self) -> None:
+        source = (
+            REPOSITORY_ROOT / "control_plane/contracts/owner_control_shadow_verifier.py"
+        ).read_text(encoding="utf-8")
+
+        for forbidden_reference in (
+            "http_app",
+            "http_routes",
+            "filesystem",
+            "privileged_operation_service",
+            "privileged_operation_worker",
+            "outbox",
+            "os.environ",
+        ):
+            with self.subTest(forbidden_reference=forbidden_reference):
+                self.assertNotIn(forbidden_reference, source)
+
+    def test_privileged_operation_paths_do_not_import_shadow_verifier(self) -> None:
+        for path in (
+            "control_plane/privileged_operation_service.py",
+            "control_plane/privileged_operation_worker.py",
+            "control_plane/http_routes/privileged_operations.py",
+        ):
+            with self.subTest(path=path):
+                source = (REPOSITORY_ROOT / path).read_text(encoding="utf-8")
+                self.assertNotIn("owner_control_shadow_verifier", source)
+
+    def test_docs_keep_shadow_state_inert_and_unrouted(self) -> None:
+        owner_control_doc = (REPOSITORY_ROOT / "docs/owner-control-channel.md").read_text(
+            encoding="utf-8"
+        )
+        authorization_doc = (REPOSITORY_ROOT / "docs/authorization-authority.md").read_text(
+            encoding="utf-8"
+        )
+        privileged_operation_doc = (REPOSITORY_ROOT / "docs/privileged-operations.md").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn("at most eight audited verification attempts", owner_control_doc)
+        self.assertIn("Unknown challenge nonces create no durable", owner_control_doc)
+        self.assertIn("`authority_state = 'inert'`", authorization_doc)
+        self.assertIn(
+            "browser approval remains the only active approval transport", privileged_operation_doc
+        )

--- a/tests/test_owner_control_shadow_verifier.py
+++ b/tests/test_owner_control_shadow_verifier.py
@@ -126,6 +126,9 @@ class OwnerControlShadowVerifierStorageTests(unittest.TestCase):
         )
 
         verified = self.store.verify_owner_control_confirmation_shadow(envelope)
+        revoked = self.store.revoke_owner_control_channel_session(
+            channel_session_id=binding.channel_session_id
+        )
         replayed = self.store.verify_owner_control_confirmation_shadow(envelope)
         stored_challenge = self.store.read_owner_control_issued_challenge(
             challenge_nonce=issued.challenge_nonce
@@ -143,6 +146,7 @@ class OwnerControlShadowVerifierStorageTests(unittest.TestCase):
         self.assertEqual(verified.resulting_challenge_state, "consumed")
         self.assertFalse(verified.authorizes_execution)
         self.assertEqual(verified.verifier_mode, "shadow")
+        self.assertEqual(revoked.status, "revoked")
         self.assertEqual(replayed.verification_status, "rejected")
         self.assertEqual(replayed.rejection_reason, "challenge_replayed")
         self.assertEqual(stored_challenge.state, "consumed")
@@ -150,9 +154,12 @@ class OwnerControlShadowVerifierStorageTests(unittest.TestCase):
         self.assertIsNotNone(stored_challenge.consumed_at)
         self.assertIsNotNone(stored_challenge.terminal_event_id)
         self.assertEqual(
-            sorted(event.verification_status for event in events), ["rejected", "verified"]
+            sorted(
+                (event.sequence, event.verification_status, event.rejection_reason)
+                for event in events
+            ),
+            [(1, "verified", None), (2, "rejected", "challenge_replayed")],
         )
-        self.assertEqual(sorted(event.sequence for event in events), [1, 2])
         self.assertTrue(all(event.verifier_mode == "shadow" for event in events))
         self.assertTrue(all(event.authorizes_execution is False for event in events))
         self.assertTrue(all(event.authority_state == "inert" for event in events))

--- a/tests/test_postgres_integration.py
+++ b/tests/test_postgres_integration.py
@@ -9,6 +9,7 @@ import json
 import os
 import threading
 import time
+from typing import Any
 import unittest
 from unittest.mock import patch
 from uuid import uuid4
@@ -157,6 +158,7 @@ from control_plane.service_auth import (
 )
 from control_plane.storage.postgres import (
     DbOnlyMutationRequest,
+    LaunchplaneOwnerControlIssuedChallengeRow,
     MutationReservationResult,
     OutboxWithIdempotencyRequest,
     PostgresRecordStore,
@@ -2515,17 +2517,44 @@ class RealPostgresStorageConcurrencyTests(unittest.TestCase):
                 request=issued.approval_request(),
             )
             second_store = PostgresRecordStore(database_url=store.database_url)
-            barrier = threading.Barrier(2)
+            loser_prelock_read_complete = threading.Event()
+            allow_loser_locking_read = threading.Event()
+            original_challenge_read = second_store._owner_control_issued_challenge_row
 
-            def verify_once(active_store: PostgresRecordStore) -> str:
-                barrier.wait(timeout=10)
-                return active_store.verify_owner_control_confirmation_shadow(
-                    envelope
-                ).verification_status
+            def controlled_challenge_read(
+                session: Any,
+                *,
+                challenge_nonce: str,
+                for_update: bool = False,
+            ) -> LaunchplaneOwnerControlIssuedChallengeRow | None:
+                row = original_challenge_read(
+                    session,
+                    challenge_nonce=challenge_nonce,
+                    for_update=for_update,
+                )
+                if not for_update:
+                    loser_prelock_read_complete.set()
+                    if not allow_loser_locking_read.wait(timeout=10):
+                        raise TimeoutError("Timed out waiting to release the losing verification.")
+                return row
 
+            executor = ThreadPoolExecutor(max_workers=1)
             try:
-                with ThreadPoolExecutor(max_workers=2) as executor:
-                    statuses = tuple(executor.map(verify_once, (store, second_store)))
+                with patch.object(
+                    second_store,
+                    "_owner_control_issued_challenge_row",
+                    side_effect=controlled_challenge_read,
+                ):
+                    losing_future = executor.submit(
+                        second_store.verify_owner_control_confirmation_shadow,
+                        envelope,
+                    )
+                    self.assertTrue(loser_prelock_read_complete.wait(timeout=10))
+                    winning_status = store.verify_owner_control_confirmation_shadow(
+                        envelope
+                    ).verification_status
+                    allow_loser_locking_read.set()
+                    losing_status = losing_future.result(timeout=10).verification_status
                 stored_challenge = store.read_owner_control_issued_challenge(
                     challenge_nonce=issued.challenge_nonce
                 )
@@ -2533,9 +2562,11 @@ class RealPostgresStorageConcurrencyTests(unittest.TestCase):
                     challenge_nonce=issued.challenge_nonce
                 )
             finally:
+                allow_loser_locking_read.set()
+                executor.shutdown(wait=True)
                 second_store.close()
 
-        self.assertEqual(sorted(statuses), ["rejected", "verified"])
+        self.assertEqual([winning_status, losing_status], ["verified", "rejected"])
         self.assertEqual(stored_challenge.state, "consumed")
         self.assertEqual(stored_challenge.attempt_count, 2)
         self.assertIsNotNone(stored_challenge.consumed_at)

--- a/tests/test_postgres_integration.py
+++ b/tests/test_postgres_integration.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import base64
 from collections.abc import Iterator
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
@@ -14,6 +15,7 @@ from uuid import uuid4
 
 from alembic import command as alembic_command
 from alembic.config import Config as AlembicConfig
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 from sqlalchemy import create_engine, inspect, text
 from sqlalchemy.engine import Engine
 from sqlalchemy.engine import make_url
@@ -51,6 +53,18 @@ from control_plane.contracts.owner_acceptance import (
     OwnerAcceptanceTransitionError,
     owner_acceptance_runtime_identity_binding,
 )
+from control_plane.contracts.owner_control import (
+    ApprovalRequest,
+    ChannelBindingRecord,
+    ChallengeResponse,
+    OwnerControlConfirmationEnvelope,
+    ReviewItem,
+    ServerReviewPayload,
+    owner_control_approval_request_digest,
+    owner_control_channel_binding_sha256,
+    owner_control_signature_payload_bytes,
+)
+from control_plane.contracts.owner_control_shadow_verifier import OwnerControlChallengeIssueRequest
 from control_plane.contracts.merge_train_controller_state import (
     MergeTrainControllerAdoptionRejectedError,
     MergeTrainControllerLeaseHeldError,
@@ -2417,7 +2431,122 @@ class RealPostgresSchemaIntegrationTests(unittest.TestCase):
                 store.close()
 
 
+def _owner_control_shadow_base64url(value: bytes) -> str:
+    return base64.urlsafe_b64encode(value).decode("ascii").rstrip("=")
+
+
+def _owner_control_shadow_binding(private_key: Ed25519PrivateKey) -> ChannelBindingRecord:
+    return ChannelBindingRecord(
+        channel_session_id="owner-control-postgres-session",
+        owner_github_id=100001,
+        signature_algorithm="ed25519",
+        owner_public_key=_owner_control_shadow_base64url(
+            private_key.public_key().public_bytes_raw()
+        ),
+        session_issued_at="2025-01-01T00:00:00+00:00",
+        session_expires_at="2035-01-01T00:00:00+00:00",
+    )
+
+
+def _owner_control_shadow_request() -> ApprovalRequest:
+    return ApprovalRequest(
+        operation_id="privileged-operation-0123456789abcdef0123456789abcdef",
+        descriptor_id="managed-secret-reencryption",
+        descriptor_version=1,
+        request_digest="1" * 64,
+        plan_digest="2" * 64,
+        evidence_digest="3" * 64,
+        pre_state_digest="4" * 64,
+        policy_record_id="owner-policy",
+        policy_revision=1,
+        policy_sha256="5" * 64,
+        owner_github_id=100001,
+        server_review=ServerReviewPayload(
+            review_id="owner-control-postgres-review",
+            title="Review operation",
+            summary="Review the exact server-authored request.",
+            items=(ReviewItem(key="operation", label="Operation", value="Re-encrypt"),),
+        ),
+        nonce="owner-control-nonce-0000000000000004",
+        issued_at="2026-01-01T00:00:00+00:00",
+        expires_at="2026-01-01T00:01:00+00:00",
+    )
+
+
+def _owner_control_shadow_envelope(
+    private_key: Ed25519PrivateKey,
+    *,
+    binding: ChannelBindingRecord,
+    request: ApprovalRequest,
+) -> OwnerControlConfirmationEnvelope:
+    response = ChallengeResponse(
+        approval_request=request,
+        approval_request_digest=owner_control_approval_request_digest(request),
+        decision="approved",
+        channel_binding_sha256=owner_control_channel_binding_sha256(binding),
+        confirmed_at=request.issued_at,
+    )
+    return OwnerControlConfirmationEnvelope(
+        channel_binding=binding,
+        challenge_response=response,
+        signature_algorithm="ed25519",
+        signature=_owner_control_shadow_base64url(
+            private_key.sign(owner_control_signature_payload_bytes(response))
+        ),
+    )
+
+
 class RealPostgresStorageConcurrencyTests(unittest.TestCase):
+    def test_owner_control_shadow_verification_consumes_one_challenge_once(self) -> None:
+        with _store_for_fresh_head_database() as store:
+            private_key = Ed25519PrivateKey.generate()
+            binding = _owner_control_shadow_binding(private_key)
+            store.enroll_owner_control_channel_session(binding)
+            issued = store.issue_owner_control_challenge(
+                OwnerControlChallengeIssueRequest(
+                    channel_session_id=binding.channel_session_id,
+                    approval_request=_owner_control_shadow_request(),
+                    expires_in_seconds=300,
+                )
+            )
+            envelope = _owner_control_shadow_envelope(
+                private_key,
+                binding=binding,
+                request=issued.approval_request(),
+            )
+            second_store = PostgresRecordStore(database_url=store.database_url)
+            barrier = threading.Barrier(2)
+
+            def verify_once(active_store: PostgresRecordStore) -> str:
+                barrier.wait(timeout=10)
+                return active_store.verify_owner_control_confirmation_shadow(
+                    envelope
+                ).verification_status
+
+            try:
+                with ThreadPoolExecutor(max_workers=2) as executor:
+                    statuses = tuple(executor.map(verify_once, (store, second_store)))
+                stored_challenge = store.read_owner_control_issued_challenge(
+                    challenge_nonce=issued.challenge_nonce
+                )
+                events = store.list_owner_control_shadow_verification_events(
+                    challenge_nonce=issued.challenge_nonce
+                )
+            finally:
+                second_store.close()
+
+        self.assertEqual(sorted(statuses), ["rejected", "verified"])
+        self.assertEqual(stored_challenge.state, "consumed")
+        self.assertEqual(stored_challenge.attempt_count, 2)
+        self.assertIsNotNone(stored_challenge.consumed_at)
+        self.assertEqual(
+            sorted(event.verification_status for event in events), ["rejected", "verified"]
+        )
+        self.assertEqual(sorted(event.sequence for event in events), [1, 2])
+        self.assertTrue(all(event.verifier_mode == "shadow" for event in events))
+        self.assertTrue(all(event.authorizes_execution is False for event in events))
+        self.assertTrue(all(event.authority_state == "inert" for event in events))
+
     def test_concurrent_detached_application_retirement_plans_reuse_one_reservation(
         self,
     ) -> None:

--- a/tests/test_postgres_integration.py
+++ b/tests/test_postgres_integration.py
@@ -2571,9 +2571,12 @@ class RealPostgresStorageConcurrencyTests(unittest.TestCase):
         self.assertEqual(stored_challenge.attempt_count, 2)
         self.assertIsNotNone(stored_challenge.consumed_at)
         self.assertEqual(
-            sorted(event.verification_status for event in events), ["rejected", "verified"]
+            sorted(
+                (event.sequence, event.verification_status, event.rejection_reason)
+                for event in events
+            ),
+            [(1, "verified", None), (2, "rejected", "challenge_replayed")],
         )
-        self.assertEqual(sorted(event.sequence for event in events), [1, 2])
         self.assertTrue(all(event.verifier_mode == "shadow" for event in events))
         self.assertTrue(all(event.authorizes_execution is False for event in events))
         self.assertTrue(all(event.authority_state == "inert" for event in events))

--- a/tests/test_schema_migration.py
+++ b/tests/test_schema_migration.py
@@ -1505,7 +1505,7 @@ class SchemaMigrationTests(unittest.TestCase):
             for primary_key in CRITICAL_PRIMARY_KEYS
         }
 
-        self.assertEqual(EXPECTED_ALEMBIC_HEAD_REVISION, "f2241a0b1c2d")
+        self.assertEqual(EXPECTED_ALEMBIC_HEAD_REVISION, "e5f7a9b1c3d6")
         self.assertNotIn(
             ("launchplane_human_sessions", "launchplane_human_sessions_github_id_idx"),
             indexes,
@@ -1518,6 +1518,33 @@ class SchemaMigrationTests(unittest.TestCase):
             column_types[("launchplane_privileged_operation_events", "payload")],
             ("jsonb",),
         )
+        self.assertEqual(
+            column_types[("launchplane_owner_control_channel_sessions", "payload")],
+            ("jsonb",),
+        )
+        self.assertEqual(
+            primary_keys["launchplane_owner_control_issued_challenges"],
+            ("challenge_id",),
+        )
+        self.assertIn(
+            (
+                "launchplane_owner_control_issued_challenges",
+                "launchplane_owner_control_challenge_state_idx",
+            ),
+            indexes,
+        )
+        self.assertEqual(
+            primary_keys["launchplane_owner_control_shadow_verification_events"],
+            ("event_id",),
+        )
+        self.assertIn(
+            (
+                "launchplane_owner_control_shadow_verification_events",
+                "launchplane_owner_control_shadow_event_challenge_idx",
+            ),
+            indexes,
+        )
+
         self.assertEqual(
             primary_keys["launchplane_privileged_operations"],
             ("operation_id",),
@@ -1731,6 +1758,78 @@ class SchemaMigrationTests(unittest.TestCase):
             ].column_names,
             ("repository_id", "pull_request_number", "head_sha", "occurred_at", "event_id"),
         )
+
+    def test_owner_control_shadow_verifier_migration_upgrades_and_downgrades(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            database_url = (
+                f"sqlite+pysqlite:///{Path(temporary_directory_name) / 'records.sqlite3'}"
+            )
+            config = alembic_config(database_url)
+            command.upgrade(config, EXPECTED_ALEMBIC_HEAD_REVISION)
+            engine = create_engine(database_url)
+            try:
+                inspector = inspect(engine)
+                table_names = set(inspector.get_table_names())
+                event_indexes = {
+                    str(name): index
+                    for index in inspector.get_indexes(
+                        "launchplane_owner_control_shadow_verification_events"
+                    )
+                    if (name := index.get("name")) is not None
+                }
+                event_columns = {
+                    str(column["name"])
+                    for column in inspector.get_columns(
+                        "launchplane_owner_control_shadow_verification_events"
+                    )
+                }
+                challenge_columns = {
+                    str(column["name"])
+                    for column in inspector.get_columns(
+                        "launchplane_owner_control_issued_challenges"
+                    )
+                }
+            finally:
+                engine.dispose()
+            command.downgrade(config, "f2241a0b1c2d")
+            engine = create_engine(database_url)
+            try:
+                downgraded_tables = set(inspect(engine).get_table_names())
+            finally:
+                engine.dispose()
+
+        self.assertTrue(
+            {
+                "launchplane_owner_control_channel_sessions",
+                "launchplane_owner_control_issued_challenges",
+                "launchplane_owner_control_shadow_verification_events",
+            }.issubset(table_names)
+        )
+        self.assertTrue(
+            {
+                "verifier_mode",
+                "authorizes_execution",
+                "authority_state",
+                "challenge_id",
+                "sequence",
+                "verification_status",
+                "payload",
+            }.issubset(event_columns)
+        )
+        self.assertTrue(
+            {
+                "challenge_id",
+                "state",
+                "attempt_count",
+                "consumed_at",
+                "terminal_event_id",
+                "authority_state",
+            }.issubset(challenge_columns)
+        )
+        self.assertIn("launchplane_owner_control_shadow_event_challenge_idx", event_indexes)
+        self.assertNotIn("launchplane_owner_control_channel_sessions", downgraded_tables)
+        self.assertNotIn("launchplane_owner_control_issued_challenges", downgraded_tables)
+        self.assertNotIn("launchplane_owner_control_shadow_verification_events", downgraded_tables)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- add DB-backed owner-control channel-session, issued-challenge, and append-only shadow-verification records
- add server-generated challenge nonces, database-clock bounds, exact canonical byte/digest verification, and bounded eight-attempt auditing
- serialize session/challenge verification with refreshed `FOR UPDATE` reads and deterministic real-PostgreSQL replay coverage
- document the inert storage boundary and authorization freeze

Refs #2257

## Safety boundary

- no HTTP routes or authorization actions/grants
- no privileged-operation approval or execution coupling
- no worker, outbox, UI, CLI, filesystem store, signing key, or helper process
- every result remains `verifier_mode = "shadow"`, `authority_state = "inert"`, and `authorizes_execution = false`
- unknown challenge nonces create no durable state
- browser approval remains unchanged and is still the only active approval transport

## Validation

- `uv run --extra dev launchplane ci unittest-shard local` — 3,140 targets passed across 12 shards
- real PostgreSQL integration gate — 94 tests passed, including deterministic winner/replay sequencing across two store instances
- `uv run --extra dev mypy control_plane tests` — 778 source files clean
- changed-file Ruff format and lint — clean
- owner-control artifact drift test — clean
- Alembic — single head `e5f7a9b1c3d6`
- frozen public wire/transport boundaries — unchanged

## Independent review

Exact head `fa931a9363311daa14d8c67d4214ef403c7aae63` received **LOVE** from Claude Opus 5 and Gemini 3.1 Pro High after two concurrency/terminal-state findings were fixed and re-reviewed.

JetBrains changed-file inspection is **UNKNOWN**, not clean: the helper returned terminal `cleanup_not_clean/worktree_mutation_detected` with no retry permitted, even though its preparation receipt reported zero tracked-content, untracked, added, changed, or removed paths. The surfaced warnings were pre-existing findings elsewhere in the large changed files/docs rather than evidence against this exact head.