### PR TITLE
Add bounded authz administration reads

### DIFF
--- a/control_plane/contracts/authz_access_read.py
+++ b/control_plane/contracts/authz_access_read.py
@@ -21,8 +21,10 @@ AUTHZ_DENIAL_EXPLANATION_READ_ACTION = "authz_denial_explanation.read"
 AUTHZ_POLICY_HEALTH_READ_ACTION = "authz_policy_health.read"
 AUTHZ_POLICY_CANDIDATE_PREVIEW_READ_ACTION = "authz_policy_candidate_preview.read"
 AUTHZ_REPOSITORY_SCOPE_READ_ACTION = "authz_repository_scope.read"
+AUTHZ_POLICY_ADMINISTRATION_READ_ACTION = "authz_policy_administration.read"
 AUTHZ_POLICY_CANDIDATE_PREVIEW_MAX_PROBES = 25
 AUTHZ_POLICY_CANDIDATE_PREVIEW_MAX_RULES = 500
+AUTHZ_POLICY_ADMINISTRATION_HISTORY_LIMIT = 50
 AUTHZ_REPOSITORY_SCOPE_MAX_CANDIDATES = 100
 AUTHZ_REPOSITORY_SCOPE_MAX_SOURCE_RECORDS = 1000
 AuthzPolicyPrincipalType: TypeAlias = Literal[
@@ -418,6 +420,78 @@ class AuthzPolicyHealthSnapshot(BaseModel):
 class AuthzPolicyHealthResponse(AuthzPolicyHealthSnapshot):
     status: Literal["ok"] = "ok"
     trace_id: str
+
+
+class AuthzPolicyAdministrationProvenance(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    record_id: str
+    revision: int = Field(ge=1)
+    status: Literal["active", "superseded"]
+    source: str
+    updated_at: str
+    policy_sha256: str
+    schema_version: Literal[1, 2]
+
+
+class AuthzPolicyAdministrationResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    status: Literal["ok"] = "ok"
+    trace_id: str
+    policy: AuthzPolicyAdministrationProvenance
+    principal_rule_counts: AuthzPrincipalRuleCounts
+    health: AuthzPolicyHealthSummary
+    managed_sets: AuthzManagedSetCollectionSummary
+    reachable_administrators: AuthzReachableAdministratorSummary
+
+
+AuthzPolicyRevisionAuditOperation: TypeAlias = Literal[
+    "managed_rule_set_reconcile",
+    "unknown",
+]
+AuthzPolicyRevisionAuditMode: TypeAlias = Literal["apply", "dry_run", "unknown"]
+
+
+class AuthzPolicyRevisionDiffCounts(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    added_rule_count: int | None = Field(default=None, ge=0)
+    adopted_rule_count: int | None = Field(default=None, ge=0)
+    updated_rule_count: int | None = Field(default=None, ge=0)
+    removed_rule_count: int | None = Field(default=None, ge=0)
+    unchanged_rule_count: int | None = Field(default=None, ge=0)
+    policy_safety_blocker_count: int | None = Field(default=None, ge=0)
+    operational_readiness_blocked_rule_count: int | None = Field(default=None, ge=0)
+
+
+class AuthzPolicyRevisionAuditSummary(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    audit_present: bool
+    audit_sha256: str = ""
+    operation: AuthzPolicyRevisionAuditOperation = "unknown"
+    mode: AuthzPolicyRevisionAuditMode = "unknown"
+    diff_counts: AuthzPolicyRevisionDiffCounts = Field(
+        default_factory=AuthzPolicyRevisionDiffCounts
+    )
+
+
+class AuthzPolicyRevisionHistoryEntry(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    policy: AuthzPolicyAdministrationProvenance
+    audit: AuthzPolicyRevisionAuditSummary
+
+
+class AuthzPolicyRevisionHistoryResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    status: Literal["ok"] = "ok"
+    trace_id: str
+    returned_count: int = Field(ge=0)
+    truncated: bool
+    revisions: tuple[AuthzPolicyRevisionHistoryEntry, ...]
 
 
 class AuthzPolicyCandidateSummary(BaseModel):

--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -78,15 +78,24 @@ from control_plane.contracts.generic_web_deploy_recovery import (
 )
 from control_plane.contracts.authz_access_read import (
     AUTHZ_DENIAL_EXPLANATION_READ_ACTION,
+    AUTHZ_POLICY_ADMINISTRATION_HISTORY_LIMIT,
+    AUTHZ_POLICY_ADMINISTRATION_READ_ACTION,
     AUTHZ_POLICY_CANDIDATE_PREVIEW_READ_ACTION,
     AUTHZ_POLICY_HEALTH_READ_ACTION,
     AuthzActivationPreflightSelfResponse,
     AUTHZ_REPOSITORY_SCOPE_READ_ACTION,
     EFFECTIVE_ACCESS_READ_ACTION,
     AuthzDenialExplanationResponse,
+    AuthzPolicyAdministrationProvenance,
+    AuthzPolicyAdministrationResponse,
     AuthzPolicyCandidatePreviewRequest,
     AuthzPolicyCandidatePreviewResponse,
     AuthzPolicyHealthResponse,
+    AuthzPolicyRevisionAuditSummary,
+    AuthzPolicyRevisionDiffCounts,
+    AuthzPolicyRevisionHistoryEntry,
+    AuthzPolicyRevisionHistoryResponse,
+    AuthzPrincipalRuleCounts,
     AuthzRepositoryScopeReadRequest,
     AuthzRepositoryScopeResponse,
     EffectiveAccessDecision,
@@ -1051,6 +1060,8 @@ _DETACHED_APPLICATION_RETIREMENT_ROUTE = "/v1/detached-application-retirement"
 _PRODUCT_ONBOARDING_APPLY_ROUTE = "/v1/product-onboarding/apply"
 _MERGE_TRAIN_POLICY_IMPORT_ROUTE = "/v1/merge-train/policies/import"
 _AUTHZ_POLICY_ACTIVE_ROUTE = "/v1/authz-policies/active"
+_AUTHZ_POLICY_ADMINISTRATION_ROUTE = "/v1/authz-policies/administration"
+_AUTHZ_POLICY_REVISION_HISTORY_ROUTE = "/v1/authz-policies/revisions"
 _AUTHZ_DIAGNOSTIC_EVALUATE_ROUTE = "/v1/authz-diagnostics/github-actions/evaluate"
 _AUTHZ_EFFECTIVE_ACCESS_EVALUATE_ROUTE = "/v1/authz-diagnostics/effective-access/evaluate"
 _AUTHZ_POLICY_HEALTH_ROUTE = "/v1/authz-diagnostics/active-policy/health"
@@ -1059,6 +1070,12 @@ _AUTHZ_POLICY_CANDIDATE_PREVIEW_ROUTE = "/v1/authz-diagnostics/candidate-policy/
 _AUTHZ_REPOSITORY_SCOPE_READ_ROUTE = "/v1/authz-diagnostics/repository-scope/read"
 _AUTHZ_DENIAL_EXPLANATION_ROUTE = "/v1/authz-diagnostics/denials/{trace_id}"
 _AUTHZ_POLICY_MANAGED_RECONCILE_ROUTE = "/v1/authz-policies/managed-rule-sets/reconcile"
+_AUTHZ_NONPERSISTING_SENSITIVE_READ_ROUTES = frozenset(
+    {
+        _AUTHZ_POLICY_ADMINISTRATION_ROUTE,
+        _AUTHZ_POLICY_REVISION_HISTORY_ROUTE,
+    }
+)
 _GENERIC_WEB_PREVIEW_AUTHZ_PLAN_ROUTE = (
     "/v1/authz-policies/managed-rule-sets/generic-web-preview/plan"
 )
@@ -3998,7 +4015,9 @@ def create_launchplane_fastapi_app(
         clear_authz_evaluation()
         try:
             response = cast(Response, await call_next(request))
-            if request.url.path == _AUTHZ_ACTIVATION_PREFLIGHT_ROUTE:
+            if request.url.path == _AUTHZ_ACTIVATION_PREFLIGHT_ROUTE or (
+                request.url.path in _AUTHZ_NONPERSISTING_SENSITIVE_READ_ROUTES
+            ):
                 response.headers["Cache-Control"] = "no-store"
             return response
         finally:
@@ -4743,7 +4762,7 @@ def create_launchplane_fastapi_app(
         common=read_route_dependencies,
         read_bearer_identity=read_bearer_identity,
         read_github_human_identity=read_github_human_identity,
-        read_github_human_mutation_identity=(read_github_human_browser_mutation_identity),
+        read_github_human_mutation_identity=read_github_human_browser_mutation_identity,
         policy_reader=lambda: resolved_authz_policy_runtime.policy,
         policy_record_reader=lambda: read_active_authz_policy_record(get_record_store()),
     )
@@ -13792,8 +13811,8 @@ def create_launchplane_fastapi_app(
     async def reencrypt_managed_secrets(
         request: Request,
         identity: Annotated[LaunchplaneIdentity, Depends(read_bearer_identity)],
-        record_store: Annotated[object, Depends(get_record_store)],
-        idempotency_key: Annotated[str, Header(alias="Idempotency-Key")] = "",
+        _record_store: Annotated[object, Depends(get_record_store)],
+        _idempotency_key: Annotated[str, Header(alias="Idempotency-Key")] = "",
     ) -> AcceptedEvidenceResponse:
         trace_id = next_trace_id()
         if isinstance(identity, TerminalAgentIdentity):
@@ -14593,6 +14612,169 @@ def create_launchplane_fastapi_app(
                 message="Multiple active Launchplane authz policy records were found.",
             )
         return active_records[0]
+
+    def authz_policy_administration_provenance(
+        record: LaunchplaneAuthzPolicyRecord,
+    ) -> AuthzPolicyAdministrationProvenance:
+        return AuthzPolicyAdministrationProvenance(
+            record_id=record.record_id,
+            revision=record.revision,
+            status=record.status,
+            source=record.source,
+            updated_at=record.updated_at,
+            policy_sha256=record.policy_sha256,
+            schema_version=record.policy.schema_version,
+        )
+
+    def require_authz_policy_administration_read(
+        *,
+        identity: LaunchplaneIdentity,
+        record_store: object,
+        trace_id: str,
+    ) -> tuple[PostgresRecordStore, LaunchplaneAuthzPolicyRecord]:
+        is_administrator = isinstance(identity, LocalAdminIdentity) or (
+            isinstance(identity, GitHubHumanIdentity) and identity.role == "admin"
+        )
+        preflight_authorized = resolved_authz_policy_runtime.policy.allows(
+            identity=identity,
+            action=AUTHZ_POLICY_ADMINISTRATION_READ_ACTION,
+            product="launchplane",
+            context=_LAUNCHPLANE_SERVICE_CONTEXT,
+        )
+        if not is_administrator or not preflight_authorized:
+            raise _launchplane_http_error(
+                status_code=403,
+                trace_id=trace_id,
+                code="authorization_denied",
+                message="Identity cannot read Launchplane authz policy administration.",
+            )
+        database_store = require_authz_policy_database_store(
+            record_store=record_store,
+            trace_id=trace_id,
+            message="Authz policy administration reads require Launchplane database storage.",
+        )
+        active_record = read_single_active_authz_policy_record(
+            database_store=database_store,
+            trace_id=trace_id,
+        )
+        if not active_record.policy.allows(
+            identity=identity,
+            action=AUTHZ_POLICY_ADMINISTRATION_READ_ACTION,
+            product="launchplane",
+            context=_LAUNCHPLANE_SERVICE_CONTEXT,
+        ):
+            raise _launchplane_http_error(
+                status_code=403,
+                trace_id=trace_id,
+                code="authorization_denied",
+                message="Identity cannot read Launchplane authz policy administration.",
+                authz_policy_provenance=AuthzPolicyProvenance.from_record(active_record),
+            )
+        return database_store, active_record
+
+    def authz_policy_principal_rule_counts(
+        policy: LaunchplaneAuthzPolicy,
+    ) -> AuthzPrincipalRuleCounts:
+        return AuthzPrincipalRuleCounts(
+            github_actions=len(policy.github_actions),
+            github_humans=len(policy.github_humans),
+            terminal_agents=len(policy.terminal_agents),
+            local_operators=len(policy.local_operators),
+            local_admins=len(policy.local_admins),
+        )
+
+    def authz_policy_revision_audit_summary(
+        audit: dict[str, object],
+    ) -> AuthzPolicyRevisionAuditSummary:
+        if not audit:
+            return AuthzPolicyRevisionAuditSummary(audit_present=False)
+        serialized = json.dumps(audit, sort_keys=True, separators=(",", ":"), default=str)
+        raw_diff = audit.get("diff")
+        allowed_count_names = (
+            "added_rule_count",
+            "adopted_rule_count",
+            "updated_rule_count",
+            "removed_rule_count",
+            "unchanged_rule_count",
+            "policy_safety_blocker_count",
+            "operational_readiness_blocked_rule_count",
+        )
+        diff_counts: dict[str, int] = {}
+        if isinstance(raw_diff, dict):
+            for name in allowed_count_names:
+                value = raw_diff.get(name)
+                if type(value) is int and value >= 0:
+                    diff_counts[name] = value
+        operation: Literal["managed_rule_set_reconcile", "unknown"] = (
+            "managed_rule_set_reconcile"
+            if audit.get("operation") == "managed_rule_set_reconcile"
+            else "unknown"
+        )
+        raw_mode = audit.get("mode")
+        mode: Literal["apply", "dry_run", "unknown"] = (
+            raw_mode if raw_mode in {"apply", "dry_run"} else "unknown"
+        )
+        return AuthzPolicyRevisionAuditSummary(
+            audit_present=True,
+            audit_sha256=hashlib.sha256(serialized.encode()).hexdigest(),
+            operation=operation,
+            mode=mode,
+            diff_counts=AuthzPolicyRevisionDiffCounts(**diff_counts),
+        )
+
+    async def read_authz_policy_administration(
+        response: Response,
+        identity: Annotated[LaunchplaneIdentity, Depends(read_nonpersisting_sensitive_identity)],
+        record_store: Annotated[object, Depends(get_record_store)],
+    ) -> AuthzPolicyAdministrationResponse:
+        trace_id = next_trace_id()
+        response.headers["Cache-Control"] = "no-store"
+        _, active_record = require_authz_policy_administration_read(
+            identity=identity,
+            record_store=record_store,
+            trace_id=trace_id,
+        )
+        snapshot = control_plane_authz_grant_service.summarize_active_authz_policy_health_record(
+            record=active_record,
+            caller_identity=identity,
+        )
+        return AuthzPolicyAdministrationResponse(
+            trace_id=trace_id,
+            policy=authz_policy_administration_provenance(active_record),
+            principal_rule_counts=authz_policy_principal_rule_counts(active_record.policy),
+            health=snapshot.health,
+            managed_sets=snapshot.managed_sets,
+            reachable_administrators=snapshot.reachable_administrators,
+        )
+
+    async def read_authz_policy_revision_history(
+        response: Response,
+        identity: Annotated[LaunchplaneIdentity, Depends(read_nonpersisting_sensitive_identity)],
+        record_store: Annotated[object, Depends(get_record_store)],
+    ) -> AuthzPolicyRevisionHistoryResponse:
+        trace_id = next_trace_id()
+        response.headers["Cache-Control"] = "no-store"
+        database_store, _ = require_authz_policy_administration_read(
+            identity=identity,
+            record_store=record_store,
+            trace_id=trace_id,
+        )
+        records = database_store.list_authz_policy_records(
+            limit=AUTHZ_POLICY_ADMINISTRATION_HISTORY_LIMIT + 1
+        )
+        bounded_records = records[:AUTHZ_POLICY_ADMINISTRATION_HISTORY_LIMIT]
+        return AuthzPolicyRevisionHistoryResponse(
+            trace_id=trace_id,
+            returned_count=len(bounded_records),
+            truncated=len(records) > len(bounded_records),
+            revisions=tuple(
+                AuthzPolicyRevisionHistoryEntry(
+                    policy=authz_policy_administration_provenance(record),
+                    audit=authz_policy_revision_audit_summary(record.audit),
+                )
+                for record in bounded_records
+            ),
+        )
 
     async def read_authz_policy_health(
         identity: Annotated[LaunchplaneIdentity, Depends(read_identity)],
@@ -22699,6 +22881,28 @@ def create_launchplane_fastapi_app(
     )
 
     app.add_api_route(
+        _AUTHZ_POLICY_ADMINISTRATION_ROUTE,
+        read_authz_policy_administration,
+        methods=["GET"],
+        response_model=AuthzPolicyAdministrationResponse,
+        response_model_exclude_none=True,
+        operation_id="read_authz_policy_administration",
+        summary="Read redacted authorization policy administration",
+        responses=authz_policy_route_responses,
+    )
+
+    app.add_api_route(
+        _AUTHZ_POLICY_REVISION_HISTORY_ROUTE,
+        read_authz_policy_revision_history,
+        methods=["GET"],
+        response_model=AuthzPolicyRevisionHistoryResponse,
+        response_model_exclude_none=True,
+        operation_id="read_authz_policy_revision_history",
+        summary="Read redacted authorization policy revision history",
+        responses=authz_policy_route_responses,
+    )
+
+    app.add_api_route(
         _AUTHZ_POLICY_HEALTH_ROUTE,
         read_authz_policy_health,
         methods=["GET"],
@@ -23084,7 +23288,11 @@ def create_launchplane_fastapi_app(
             authz = None
             authz_evaluation = None
             authz_policy_provenance = None
-        if http_error.status_code == 403 and code == "authorization_denied":
+        if (
+            http_error.status_code == 403
+            and code == "authorization_denied"
+            and request.url.path not in _AUTHZ_NONPERSISTING_SENSITIVE_READ_ROUTES
+        ):
             if authz_policy_provenance is None:
                 request_provenance = getattr(
                     request.state,
@@ -23113,6 +23321,7 @@ def create_launchplane_fastapi_app(
                 **(
                     {"Cache-Control": "no-store"}
                     if request.url.path == _AUTHZ_ACTIVATION_PREFLIGHT_ROUTE
+                    or request.url.path in _AUTHZ_NONPERSISTING_SENSITIVE_READ_ROUTES
                     else {}
                 ),
             },
@@ -23155,6 +23364,7 @@ def create_launchplane_fastapi_app(
                 **(
                     {"Cache-Control": "no-store"}
                     if request.url.path == _AUTHZ_ACTIVATION_PREFLIGHT_ROUTE
+                    or request.url.path in _AUTHZ_NONPERSISTING_SENSITIVE_READ_ROUTES
                     else {}
                 ),
             },
@@ -23180,7 +23390,11 @@ def create_launchplane_fastapi_app(
             headers=(
                 {"Cache-Control": "no-store"}
                 if request.url.path
-                in {_AUTHZ_REPOSITORY_SCOPE_READ_ROUTE, _AUTHZ_ACTIVATION_PREFLIGHT_ROUTE}
+                in {
+                    _AUTHZ_REPOSITORY_SCOPE_READ_ROUTE,
+                    _AUTHZ_ACTIVATION_PREFLIGHT_ROUTE,
+                    *_AUTHZ_NONPERSISTING_SENSITIVE_READ_ROUTES,
+                }
                 else None
             ),
         )

--- a/docs/authorization-authority.md
+++ b/docs/authorization-authority.md
@@ -131,6 +131,33 @@ and fails closed when active policy state is missing or ambiguous. It performs
 no policy, provider, runtime, bootstrap, secret, or deployment mutation. Landing
 the action and route does not grant production access to them.
 
+The bounded policy-administration read slice adds the independently grantable
+`authz_policy_administration.read` action and two backend-only routes:
+`GET /v1/authz-policies/administration` and `GET
+/v1/authz-policies/revisions`. Both routes are restricted to authenticated
+GitHub administrators or local administrators, require the action in both the
+current runtime policy and the freshly loaded single active DB policy record,
+and fail closed for missing, ambiguous, or non-database policy authority. The
+action is defined but deliberately ungranted; landing these routes gives no real
+caller access.
+
+The administration response contains only policy-record provenance, principal
+rule counts, and the existing bounded health, managed-set, and reachable-
+administrator summaries. The revision response is newest-first, returns at most
+50 records, and reports truncation from one additional bounded read. Revision
+audit data is reduced to presence, a canonical SHA-256 digest, normalized
+operation and mode enums, and allowlisted nonnegative numeric counts. Neither
+route returns raw policy or audit payloads, principal identifiers, selectors,
+managed rule IDs or hashes, reasons, key IDs, tokens, or free text.
+
+Browser administrators must provide the existing strict same-origin,
+`Sec-Fetch-*`, and CSRF proof. Validation neither renews the session nor rotates
+the CSRF token. Successes and every error class are `Cache-Control: no-store`,
+and the routes do not write denial, session, policy, idempotency, audit, outbox,
+provider, runtime, deployment, secret, or other persistent state. This slice
+adds no proposal, export, rollback, mutation, workflow, UI, or authorization
+grant and does not weaken the issue `#2058` freeze.
+
 The activation preflight is a separate, read-only self-check at
 `GET /v1/authz-diagnostics/activation-preflight/self`. It accepts only the
 signed Launchplane browser-session cookie and rejects every Authorization

--- a/docs/records.md
+++ b/docs/records.md
@@ -526,6 +526,14 @@ an ORM column/table or remains only in the evidence payload.
   caller/worker rule identities. Their workflow artifacts are scoped by run and
   attempt so retries preserve distinct evidence without turning observation or
   payload churn into new runtime authority.
+  The bounded authorization-administration read model projects only record
+  provenance, principal counts, existing health summaries, and at most 50
+  newest-first revision summaries. Historical audit payloads remain stored as
+  authority evidence but are returned only as presence, canonical digest,
+  normalized operation/mode, and allowlisted numeric diff counts. Read access
+  never exposes raw policy, raw audit, principal identifiers, selectors,
+  managed rule IDs or hashes, reasons, or key material and never creates a new
+  policy, denial, session, audit, or idempotency record.
   During a future OpenFGA migration, these DB-backed policy records remain the
   source evidence for dry-run tuple proposals and parity checks.
   After a proven cutover, records should store import/audit/model-version

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -313,6 +313,10 @@ cleanup scope so the store is always closed.
     and optional `Idempotency-Key` replay/conflict handling)
 - authz policy administration routes:
   - `GET /v1/authz-policies/active`
+  - `GET /v1/authz-policies/administration` (backend-only bounded policy
+    provenance, principal counts, and existing health summaries)
+  - `GET /v1/authz-policies/revisions` (newest-first bounded redacted revision
+    provenance and digest/count-only audit summaries)
   - `GET /v1/authz-diagnostics/active-policy/health`
   - `POST /v1/authz-diagnostics/candidate-policy/preview`
   - `POST /v1/authz-policies/managed-rule-sets/reconcile`
@@ -322,6 +326,13 @@ cleanup scope so the store is always closed.
     `Idempotency-Key` completion. Managed reconciliation is the sole policy
     write contract and requires immutable numeric `repository_id` and
     `repository_owner_id` selectors for GitHub Actions rules.)
+  - The two bounded administration GET routes require an eligible GitHub or
+    local administrator, runtime and fresh active-DB authorization for the
+    ungranted `authz_policy_administration.read` action, strict same-origin/CSRF
+    proof for browser sessions, PostgreSQL record storage, and exactly one active
+    policy. They are `no-store`, nonrenewing, nonpersisting reads and expose no
+    raw policy, raw audit, principal identity, selector, managed-rule identity,
+    proposal, export, rollback, or mutation surface.
 
 - Every Code local automation work-request routes:
   - `GET /v1/every-code/summary` (native FastAPI for bearer-token,

--- a/frontend/generated/openapi-canonical.json
+++ b/frontend/generated/openapi-canonical.json
@@ -1799,6 +1799,99 @@
         "title": "AuthzManagedSetSummary",
         "type": "object"
       },
+      "AuthzPolicyAdministrationProvenance": {
+        "additionalProperties": false,
+        "properties": {
+          "policy_sha256": {
+            "title": "Policy Sha256",
+            "type": "string"
+          },
+          "record_id": {
+            "title": "Record Id",
+            "type": "string"
+          },
+          "revision": {
+            "minimum": 1.0,
+            "title": "Revision",
+            "type": "integer"
+          },
+          "schema_version": {
+            "enum": [
+              1,
+              2
+            ],
+            "title": "Schema Version",
+            "type": "integer"
+          },
+          "source": {
+            "title": "Source",
+            "type": "string"
+          },
+          "status": {
+            "enum": [
+              "active",
+              "superseded"
+            ],
+            "title": "Status",
+            "type": "string"
+          },
+          "updated_at": {
+            "title": "Updated At",
+            "type": "string"
+          }
+        },
+        "required": [
+          "record_id",
+          "revision",
+          "status",
+          "source",
+          "updated_at",
+          "policy_sha256",
+          "schema_version"
+        ],
+        "title": "AuthzPolicyAdministrationProvenance",
+        "type": "object"
+      },
+      "AuthzPolicyAdministrationResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "health": {
+            "$ref": "#/components/schemas/AuthzPolicyHealthSummary"
+          },
+          "managed_sets": {
+            "$ref": "#/components/schemas/AuthzManagedSetCollectionSummary"
+          },
+          "policy": {
+            "$ref": "#/components/schemas/AuthzPolicyAdministrationProvenance"
+          },
+          "principal_rule_counts": {
+            "$ref": "#/components/schemas/AuthzPrincipalRuleCounts"
+          },
+          "reachable_administrators": {
+            "$ref": "#/components/schemas/AuthzReachableAdministratorSummary"
+          },
+          "status": {
+            "const": "ok",
+            "default": "ok",
+            "title": "Status",
+            "type": "string"
+          },
+          "trace_id": {
+            "title": "Trace Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "trace_id",
+          "policy",
+          "principal_rule_counts",
+          "health",
+          "managed_sets",
+          "reachable_administrators"
+        ],
+        "title": "AuthzPolicyAdministrationResponse",
+        "type": "object"
+      },
       "AuthzPolicyCandidatePreviewRequest": {
         "additionalProperties": false,
         "properties": {
@@ -2239,6 +2332,194 @@
           "schema_version"
         ],
         "title": "AuthzPolicyRecordSummary",
+        "type": "object"
+      },
+      "AuthzPolicyRevisionAuditSummary": {
+        "additionalProperties": false,
+        "properties": {
+          "audit_present": {
+            "title": "Audit Present",
+            "type": "boolean"
+          },
+          "audit_sha256": {
+            "default": "",
+            "title": "Audit Sha256",
+            "type": "string"
+          },
+          "diff_counts": {
+            "$ref": "#/components/schemas/AuthzPolicyRevisionDiffCounts"
+          },
+          "mode": {
+            "default": "unknown",
+            "enum": [
+              "apply",
+              "dry_run",
+              "unknown"
+            ],
+            "title": "Mode",
+            "type": "string"
+          },
+          "operation": {
+            "default": "unknown",
+            "enum": [
+              "managed_rule_set_reconcile",
+              "unknown"
+            ],
+            "title": "Operation",
+            "type": "string"
+          }
+        },
+        "required": [
+          "audit_present"
+        ],
+        "title": "AuthzPolicyRevisionAuditSummary",
+        "type": "object"
+      },
+      "AuthzPolicyRevisionDiffCounts": {
+        "additionalProperties": false,
+        "properties": {
+          "added_rule_count": {
+            "anyOf": [
+              {
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Added Rule Count"
+          },
+          "adopted_rule_count": {
+            "anyOf": [
+              {
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Adopted Rule Count"
+          },
+          "operational_readiness_blocked_rule_count": {
+            "anyOf": [
+              {
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Operational Readiness Blocked Rule Count"
+          },
+          "policy_safety_blocker_count": {
+            "anyOf": [
+              {
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Policy Safety Blocker Count"
+          },
+          "removed_rule_count": {
+            "anyOf": [
+              {
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Removed Rule Count"
+          },
+          "unchanged_rule_count": {
+            "anyOf": [
+              {
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Unchanged Rule Count"
+          },
+          "updated_rule_count": {
+            "anyOf": [
+              {
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated Rule Count"
+          }
+        },
+        "title": "AuthzPolicyRevisionDiffCounts",
+        "type": "object"
+      },
+      "AuthzPolicyRevisionHistoryEntry": {
+        "additionalProperties": false,
+        "properties": {
+          "audit": {
+            "$ref": "#/components/schemas/AuthzPolicyRevisionAuditSummary"
+          },
+          "policy": {
+            "$ref": "#/components/schemas/AuthzPolicyAdministrationProvenance"
+          }
+        },
+        "required": [
+          "policy",
+          "audit"
+        ],
+        "title": "AuthzPolicyRevisionHistoryEntry",
+        "type": "object"
+      },
+      "AuthzPolicyRevisionHistoryResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "returned_count": {
+            "minimum": 0.0,
+            "title": "Returned Count",
+            "type": "integer"
+          },
+          "revisions": {
+            "items": {
+              "$ref": "#/components/schemas/AuthzPolicyRevisionHistoryEntry"
+            },
+            "title": "Revisions",
+            "type": "array"
+          },
+          "status": {
+            "const": "ok",
+            "default": "ok",
+            "title": "Status",
+            "type": "string"
+          },
+          "trace_id": {
+            "title": "Trace Id",
+            "type": "string"
+          },
+          "truncated": {
+            "title": "Truncated",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "trace_id",
+          "returned_count",
+          "truncated",
+          "revisions"
+        ],
+        "title": "AuthzPolicyRevisionHistoryResponse",
         "type": "object"
       },
       "AuthzPrincipalRuleCounts": {
@@ -39607,6 +39888,96 @@
         "summary": "Read redacted active authz policy administration state"
       }
     },
+    "/v1/authz-policies/administration": {
+      "get": {
+        "operationId": "read_authz_policy_administration",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Authorization",
+            "required": false,
+            "schema": {
+              "default": "",
+              "title": "Authorization",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "Cookie",
+            "required": false,
+            "schema": {
+              "default": "",
+              "title": "Cookie",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthzPolicyAdministrationResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "summary": "Read redacted authorization policy administration"
+      }
+    },
     "/v1/authz-policies/managed-rule-sets/generic-web-preview/plan": {
       "post": {
         "operationId": "plan_generic_web_preview_authz",
@@ -40375,6 +40746,96 @@
           }
         },
         "summary": "Reconcile managed authz policy rules"
+      }
+    },
+    "/v1/authz-policies/revisions": {
+      "get": {
+        "operationId": "read_authz_policy_revision_history",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Authorization",
+            "required": false,
+            "schema": {
+              "default": "",
+              "title": "Authorization",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "Cookie",
+            "required": false,
+            "schema": {
+              "default": "",
+              "title": "Cookie",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthzPolicyRevisionHistoryResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "summary": "Read redacted authorization policy revision history"
       }
     },
     "/v1/change-impact/evaluation": {

--- a/tests/test_authz_administration_read.py
+++ b/tests/test_authz_administration_read.py
@@ -1,0 +1,610 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+import json
+from pathlib import Path
+from tempfile import TemporaryDirectory
+import unittest
+from unittest.mock import patch
+
+from fastapi import FastAPI
+
+from control_plane.contracts.authz_access_read import (
+    AUTHZ_POLICY_ADMINISTRATION_HISTORY_LIMIT,
+    AUTHZ_POLICY_ADMINISTRATION_READ_ACTION,
+)
+from control_plane.contracts.authz_policy_record import (
+    AuthzPolicyStatus,
+    LaunchplaneAuthzPolicyRecord,
+    authz_policy_sha256,
+    build_authz_policy_record_id,
+)
+from control_plane.http_app import LaunchplaneAuthzPolicyRuntime, create_launchplane_fastapi_app
+from control_plane.service_auth import (
+    BearerIdentityConfig,
+    GitHubActionsIdentity,
+    GitHubHumanIdentity,
+    LaunchplaneAuthzPolicy,
+)
+from control_plane.service_human_auth import (
+    GitHubOAuthConfig,
+    HumanSessionManager,
+    InMemoryHumanSessionStore,
+    build_browser_mutation_request_headers,
+)
+from control_plane.storage.filesystem import FilesystemRecordStore
+from control_plane.storage.postgres import PostgresRecordStore
+from tests.support.http import lifespan_client
+
+
+class _RejectingVerifier:
+    def verify(self, token: str) -> GitHubActionsIdentity:
+        raise ValueError(f"Unexpected GitHub token: {token}")
+
+
+def _database_url(path: Path) -> str:
+    return f"sqlite+pysqlite:///{path}"
+
+
+def _record(
+    *,
+    policy: LaunchplaneAuthzPolicy,
+    revision: int = 1,
+    status: AuthzPolicyStatus = "active",
+    audit: dict[str, object] | None = None,
+) -> LaunchplaneAuthzPolicyRecord:
+    digest = authz_policy_sha256(policy)
+    return LaunchplaneAuthzPolicyRecord(
+        record_id=build_authz_policy_record_id(revision=revision, policy_sha256=digest),
+        revision=revision,
+        status=status,
+        source="test:bounded-read",
+        updated_at=f"2026-08-28T12:{revision % 60:02d}:00+00:00",
+        policy_sha256=digest,
+        policy=policy,
+        audit=audit or {},
+    )
+
+
+def _local_admin_policy(
+    *,
+    administration_action: str = AUTHZ_POLICY_ADMINISTRATION_READ_ACTION,
+    extra_action: str = "",
+) -> LaunchplaneAuthzPolicy:
+    actions = tuple(action for action in (administration_action, extra_action) if action)
+    return LaunchplaneAuthzPolicy.model_validate(
+        {
+            "schema_version": 2,
+            "local_admins": [
+                {
+                    "managed_set_id": "operator.administration",
+                    "managed_rule_id": "local-reader",
+                    "subjects": ["authz-admin"],
+                    "token_labels": ["authz-admin-label"],
+                    "products": ["launchplane"],
+                    "contexts": ["launchplane"],
+                    "actions": actions,
+                }
+            ],
+            "github_humans": [
+                {
+                    "managed_set_id": "operator.recovery",
+                    "managed_rule_id": "independent-admin",
+                    "github_ids": [9001],
+                    "roles": ["admin"],
+                    "products": ["launchplane"],
+                    "contexts": ["launchplane"],
+                    "actions": ["authz_policy_grant.write"],
+                }
+            ],
+        }
+    )
+
+
+def _github_human_policy(
+    *,
+    role: str = "admin",
+    include_administration_action: bool = True,
+) -> LaunchplaneAuthzPolicy:
+    caller_actions = ["authz_policy_grant.write"]
+    if include_administration_action:
+        caller_actions.append(AUTHZ_POLICY_ADMINISTRATION_READ_ACTION)
+    return LaunchplaneAuthzPolicy.model_validate(
+        {
+            "schema_version": 2,
+            "github_humans": [
+                {
+                    "managed_set_id": "operator.browser-administration",
+                    "managed_rule_id": "browser-reader",
+                    "github_ids": [101],
+                    "roles": [role],
+                    "products": ["launchplane"],
+                    "contexts": ["launchplane"],
+                    "actions": caller_actions,
+                },
+                {
+                    "managed_set_id": "operator.recovery",
+                    "managed_rule_id": "independent-admin",
+                    "github_ids": [202],
+                    "roles": ["admin"],
+                    "products": ["launchplane"],
+                    "contexts": ["launchplane"],
+                    "actions": ["authz_policy_grant.write"],
+                },
+            ],
+        }
+    )
+
+
+def _app(
+    *,
+    root: Path,
+    store: object,
+    runtime_record: LaunchplaneAuthzPolicyRecord,
+    human_session_manager: HumanSessionManager | None = None,
+) -> FastAPI:
+    return create_launchplane_fastapi_app(
+        verifier=_RejectingVerifier(),
+        authz_policy=runtime_record.policy,
+        authz_policy_runtime=LaunchplaneAuthzPolicyRuntime(
+            runtime_record.policy,
+            policy_sha256=runtime_record.policy_sha256,
+            source="db",
+            record_id=runtime_record.record_id,
+            revision=runtime_record.revision,
+        ),
+        record_store_factory=lambda: store,
+        human_session_manager=human_session_manager,
+        bearer_identity_config=BearerIdentityConfig(
+            local_admin_token="admin-token",
+            local_admin_subject="authz-admin",
+            local_admin_token_label="authz-admin-label",
+        ),
+        control_plane_root_path=root,
+        state_dir=root / "state",
+    )
+
+
+@contextmanager
+def _database_app(
+    database_policy: LaunchplaneAuthzPolicy,
+    *,
+    runtime_policy: LaunchplaneAuthzPolicy | None = None,
+    human_session_manager: HumanSessionManager | None = None,
+) -> Iterator[tuple[PostgresRecordStore, LaunchplaneAuthzPolicyRecord, FastAPI]]:
+    with TemporaryDirectory() as directory:
+        root = Path(directory)
+        store = PostgresRecordStore(database_url=_database_url(root / "launchplane.sqlite3"))
+        store.ensure_schema()
+        database_record = store.seed_authz_policy_if_absent(_record(policy=database_policy))
+        runtime_record = _record(policy=runtime_policy or database_policy)
+        app = _app(
+            root=root,
+            store=store,
+            runtime_record=runtime_record,
+            human_session_manager=human_session_manager,
+        )
+        try:
+            yield store, database_record, app
+        finally:
+            store.close()
+
+
+def _human_session_manager() -> tuple[HumanSessionManager, InMemoryHumanSessionStore]:
+    session_store = InMemoryHumanSessionStore()
+    manager = HumanSessionManager(
+        config=GitHubOAuthConfig(
+            client_id="client-id",
+            client_secret="client-secret",
+            public_url="https://launchplane.example",
+            session_secret="session-secret",
+            cookie_secure=False,
+        ),
+        session_store=session_store,
+    )
+    return manager, session_store
+
+
+def _browser_headers(
+    manager: HumanSessionManager,
+    identity: GitHubHumanIdentity,
+) -> tuple[dict[str, str], str, str]:
+    session = manager.issue(identity)
+    csrf_token = manager.csrf_token(session)
+    headers = build_browser_mutation_request_headers(
+        origin="https://launchplane.example",
+        csrf_token=csrf_token,
+    )
+    headers["Cookie"] = manager.session_cookie_header(session).split(";", 1)[0]
+    return headers, session.session_id, csrf_token
+
+
+class AuthzAdministrationReadHttpTests(unittest.IsolatedAsyncioTestCase):
+    async def test_local_admin_reads_redacted_administration_and_history_without_writes(
+        self,
+    ) -> None:
+        policy = _local_admin_policy(extra_action="sensitive.runtime.action")
+        audit: dict[str, object] = {
+            "operation": "managed_rule_set_reconcile",
+            "mode": "apply",
+            "reason": "private rollback reason",
+            "related_issue": "private/repository#123",
+            "managed_set_id": "private.managed-set",
+            "operator": {"subject": "private-operator", "token_label": "private-token"},
+            "diff": {
+                "added_rule_count": 2,
+                "removed_rule_count": 1,
+                "private_count": 99,
+            },
+        }
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            store = PostgresRecordStore(database_url=_database_url(root / "launchplane.sqlite3"))
+            store.ensure_schema()
+            record = store.seed_authz_policy_if_absent(_record(policy=policy, audit=audit))
+            app = _app(root=root, store=store, runtime_record=record)
+            before = store.list_authz_policy_records()
+            try:
+                async with lifespan_client(app) as client:
+                    with patch.object(
+                        store,
+                        "write_authz_denial_record",
+                        side_effect=AssertionError("administration reads must not write"),
+                    ):
+                        administration = await client.get(
+                            "/v1/authz-policies/administration",
+                            headers={"Authorization": "Bearer admin-token"},
+                        )
+                        history = await client.get(
+                            "/v1/authz-policies/revisions",
+                            headers={"Authorization": "Bearer admin-token"},
+                        )
+                after = store.list_authz_policy_records()
+            finally:
+                store.close()
+
+        self.assertEqual(administration.status_code, 200, administration.text)
+        self.assertEqual(history.status_code, 200, history.text)
+        self.assertEqual(administration.headers["cache-control"], "no-store")
+        self.assertEqual(history.headers["cache-control"], "no-store")
+        self.assertEqual(before, after)
+        administration_payload = administration.json()
+        history_payload = history.json()
+        self.assertEqual(administration_payload["policy"]["record_id"], record.record_id)
+        self.assertEqual(administration_payload["principal_rule_counts"]["local_admins"], 1)
+        self.assertNotIn("managed_rules", administration_payload)
+        self.assertEqual(history_payload["returned_count"], 1)
+        audit_payload = history_payload["revisions"][0]["audit"]
+        self.assertTrue(audit_payload["audit_present"])
+        self.assertEqual(audit_payload["operation"], "managed_rule_set_reconcile")
+        self.assertEqual(audit_payload["mode"], "apply")
+        self.assertEqual(
+            audit_payload["diff_counts"],
+            {"added_rule_count": 2, "removed_rule_count": 1},
+        )
+        self.assertEqual(len(audit_payload["audit_sha256"]), 64)
+        serialized = json.dumps(
+            {"administration": administration_payload, "history": history_payload},
+            sort_keys=True,
+        )
+        for private_value in (
+            "authz-admin",
+            "authz-admin-label",
+            "9001",
+            "independent-admin",
+            "sensitive.runtime.action",
+            "private rollback reason",
+            "private/repository#123",
+            "private.managed-set",
+            "private-operator",
+            "private-token",
+            "private_count",
+        ):
+            self.assertNotIn(private_value, serialized)
+
+    async def test_browser_admin_read_validates_same_origin_csrf_without_session_mutation(
+        self,
+    ) -> None:
+        manager, session_store = _human_session_manager()
+        identity = GitHubHumanIdentity(
+            login="browser-admin",
+            github_id=101,
+            name="Browser Admin",
+            email="browser-admin@example.test",
+            organizations=frozenset(),
+            teams=frozenset(),
+            role="admin",
+        )
+        headers, session_id, csrf_token = _browser_headers(manager, identity)
+        policy = _github_human_policy()
+        with _database_app(policy, human_session_manager=manager) as (
+            _store,
+            _active_record,
+            app,
+        ):
+            session_before = session_store.read_session(session_id)
+            async with lifespan_client(app) as client:
+                response = await client.get(
+                    "/v1/authz-policies/administration",
+                    headers=headers,
+                )
+                missing_csrf_headers = dict(headers)
+                missing_csrf_headers.pop("X-CSRF-Token")
+                missing_csrf = await client.get(
+                    "/v1/authz-policies/administration",
+                    headers=missing_csrf_headers,
+                )
+                cross_site_headers = dict(headers)
+                cross_site_headers["Origin"] = "https://attacker.example"
+                cross_site = await client.get(
+                    "/v1/authz-policies/revisions",
+                    headers=cross_site_headers,
+                )
+            session_after = session_store.read_session(session_id)
+
+        self.assertEqual(response.status_code, 200, response.text)
+        self.assertEqual(response.headers["cache-control"], "no-store")
+        self.assertNotIn("set-cookie", response.headers)
+        self.assertEqual(session_after, session_before)
+        self.assertIsNotNone(session_before)
+        assert session_before is not None
+        self.assertTrue(manager.csrf_token_is_valid(session_before, csrf_token))
+        for rejected in (missing_csrf, cross_site):
+            self.assertEqual(rejected.status_code, 403, rejected.text)
+            self.assertEqual(rejected.headers["cache-control"], "no-store")
+            self.assertEqual(rejected.json()["error"]["code"], "browser_mutation_denied")
+            self.assertNotIn("set-cookie", rejected.headers)
+
+    async def test_administration_read_requires_both_runtime_and_fresh_database_grants(
+        self,
+    ) -> None:
+        allowed_policy = _local_admin_policy()
+        denied_policy = _local_admin_policy(administration_action="unrelated.read")
+        cases = (
+            (denied_policy, allowed_policy),
+            (allowed_policy, denied_policy),
+        )
+        for runtime_policy, database_policy in cases:
+            with self.subTest(runtime_allows=runtime_policy is allowed_policy):
+                with _database_app(
+                    database_policy,
+                    runtime_policy=runtime_policy,
+                ) as (store, _active_record, app):
+                    async with lifespan_client(app) as client:
+                        with patch.object(
+                            store,
+                            "write_authz_denial_record",
+                            create=True,
+                            side_effect=AssertionError("administration denial must not write"),
+                        ):
+                            response = await client.get(
+                                "/v1/authz-policies/administration",
+                                headers={"Authorization": "Bearer admin-token"},
+                            )
+
+                self.assertEqual(response.status_code, 403, response.text)
+                self.assertEqual(response.headers["cache-control"], "no-store")
+                self.assertEqual(response.json()["error"]["code"], "authorization_denied")
+
+    async def test_ungranted_action_denies_before_route_database_reads_or_writes(self) -> None:
+        policy = _local_admin_policy(administration_action="unrelated.read")
+        with _database_app(policy) as (store, _active_record, app):
+            async with lifespan_client(app) as client:
+                with (
+                    patch.object(
+                        store,
+                        "list_authz_policy_records",
+                        create=True,
+                        side_effect=AssertionError("runtime denial must precede route DB reads"),
+                    ),
+                    patch.object(
+                        store,
+                        "write_authz_denial_record",
+                        create=True,
+                        side_effect=AssertionError("administration denial must not write"),
+                    ),
+                ):
+                    response = await client.get(
+                        "/v1/authz-policies/revisions",
+                        headers={"Authorization": "Bearer admin-token"},
+                    )
+
+        self.assertEqual(response.status_code, 403, response.text)
+        self.assertEqual(response.headers["cache-control"], "no-store")
+
+    async def test_nonadministrator_human_is_denied_even_when_action_is_granted(self) -> None:
+        manager, _session_store = _human_session_manager()
+        identity = GitHubHumanIdentity(
+            login="browser-reader",
+            github_id=101,
+            name="Browser Reader",
+            email="browser-reader@example.test",
+            organizations=frozenset(),
+            teams=frozenset(),
+            role="read_only",
+        )
+        headers, _session_id, _csrf_token = _browser_headers(manager, identity)
+        policy = _github_human_policy(role="read_only")
+        with _database_app(policy, human_session_manager=manager) as (
+            store,
+            _active_record,
+            app,
+        ):
+            async with lifespan_client(app) as client:
+                with patch.object(
+                    store,
+                    "write_authz_denial_record",
+                    create=True,
+                    side_effect=AssertionError("administration denial must not write"),
+                ):
+                    response = await client.get(
+                        "/v1/authz-policies/administration",
+                        headers=headers,
+                    )
+
+        self.assertEqual(response.status_code, 403, response.text)
+        self.assertEqual(response.headers["cache-control"], "no-store")
+
+    async def test_administration_reads_fail_closed_for_storage_and_active_record_gaps(
+        self,
+    ) -> None:
+        policy = _local_admin_policy()
+        runtime_record = _record(policy=policy)
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            filesystem_app = _app(
+                root=root,
+                store=FilesystemRecordStore(root / "filesystem-state"),
+                runtime_record=runtime_record,
+            )
+            missing_store = PostgresRecordStore(
+                database_url=_database_url(root / "missing.sqlite3")
+            )
+            missing_store.ensure_schema()
+            missing_app = _app(
+                root=root,
+                store=missing_store,
+                runtime_record=runtime_record,
+            )
+            ambiguous_store = PostgresRecordStore(
+                database_url=_database_url(root / "ambiguous.sqlite3")
+            )
+            ambiguous_store.ensure_schema()
+            active_record = ambiguous_store.seed_authz_policy_if_absent(runtime_record)
+            ambiguous_app = _app(
+                root=root,
+                store=ambiguous_store,
+                runtime_record=runtime_record,
+            )
+            try:
+                async with lifespan_client(filesystem_app) as client:
+                    storage_response = await client.get(
+                        "/v1/authz-policies/administration",
+                        headers={"Authorization": "Bearer admin-token"},
+                    )
+                async with lifespan_client(missing_app) as client:
+                    missing_response = await client.get(
+                        "/v1/authz-policies/revisions",
+                        headers={"Authorization": "Bearer admin-token"},
+                    )
+                with patch.object(
+                    ambiguous_store,
+                    "list_authz_policy_records",
+                    return_value=(active_record, active_record.model_copy()),
+                ):
+                    async with lifespan_client(ambiguous_app) as client:
+                        ambiguous_response = await client.get(
+                            "/v1/authz-policies/administration",
+                            headers={"Authorization": "Bearer admin-token"},
+                        )
+            finally:
+                missing_store.close()
+                ambiguous_store.close()
+
+        expectations = (
+            (storage_response, 503, "database_required"),
+            (missing_response, 503, "authz_policy_unavailable"),
+            (ambiguous_response, 409, "active_authz_policy_ambiguous"),
+        )
+        for response, status_code, error_code in expectations:
+            self.assertEqual(response.status_code, status_code, response.text)
+            self.assertEqual(response.headers["cache-control"], "no-store")
+            self.assertEqual(response.json()["error"]["code"], error_code)
+
+    async def test_revision_history_is_newest_first_and_bounded_to_fifty(self) -> None:
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            store = PostgresRecordStore(database_url=_database_url(root / "launchplane.sqlite3"))
+            store.ensure_schema()
+            current_policy = _local_admin_policy(extra_action="revision.1")
+            current_record = store.seed_authz_policy_if_absent(_record(policy=current_policy))
+            for revision in range(2, AUTHZ_POLICY_ADMINISTRATION_HISTORY_LIMIT + 2):
+                replacement_policy = _local_admin_policy(extra_action=f"revision.{revision}")
+                replacement_record = _record(
+                    policy=replacement_policy,
+                    revision=revision,
+                    audit={
+                        "operation": "unexpected_operation",
+                        "mode": "unexpected_mode",
+                        "reason": f"private reason {revision}",
+                        "diff": {
+                            "updated_rule_count": revision,
+                            "invalid_negative_count": -1,
+                        },
+                    },
+                )
+                result = store.compare_and_write_authz_policy_record(
+                    expected_record=current_record,
+                    replacement_record=replacement_record,
+                )
+                self.assertEqual(result.status, "written")
+                current_record = replacement_record
+            app = _app(root=root, store=store, runtime_record=current_record)
+            try:
+                async with lifespan_client(app) as client:
+                    response = await client.get(
+                        "/v1/authz-policies/revisions",
+                        headers={"Authorization": "Bearer admin-token"},
+                    )
+            finally:
+                store.close()
+
+        self.assertEqual(response.status_code, 200, response.text)
+        payload = response.json()
+        self.assertEqual(payload["returned_count"], AUTHZ_POLICY_ADMINISTRATION_HISTORY_LIMIT)
+        self.assertTrue(payload["truncated"])
+        revisions = [entry["policy"]["revision"] for entry in payload["revisions"]]
+        self.assertEqual(
+            revisions,
+            list(range(AUTHZ_POLICY_ADMINISTRATION_HISTORY_LIMIT + 1, 1, -1)),
+        )
+        newest_audit = payload["revisions"][0]["audit"]
+        self.assertEqual(newest_audit["operation"], "unknown")
+        self.assertEqual(newest_audit["mode"], "unknown")
+        self.assertEqual(
+            newest_audit["diff_counts"],
+            {"updated_rule_count": AUTHZ_POLICY_ADMINISTRATION_HISTORY_LIMIT + 1},
+        )
+        self.assertNotIn("private reason", response.text)
+
+    async def test_administration_routes_publish_bounded_openapi_contracts(self) -> None:
+        with _database_app(_local_admin_policy()) as (_store, _active_record, app):
+            paths = app.openapi()["paths"]
+
+        administration = paths["/v1/authz-policies/administration"]["get"]
+        revisions = paths["/v1/authz-policies/revisions"]["get"]
+        self.assertEqual(
+            administration["operationId"],
+            "read_authz_policy_administration",
+        )
+        self.assertEqual(
+            revisions["operationId"],
+            "read_authz_policy_revision_history",
+        )
+        self.assertEqual(
+            administration["responses"]["200"]["content"]["application/json"]["schema"]["$ref"],
+            "#/components/schemas/AuthzPolicyAdministrationResponse",
+        )
+        self.assertEqual(
+            revisions["responses"]["200"]["content"]["application/json"]["schema"]["$ref"],
+            "#/components/schemas/AuthzPolicyRevisionHistoryResponse",
+        )
+
+    async def test_sensitive_route_errors_are_no_store(self) -> None:
+        with _database_app(_local_admin_policy()) as (_store, _active_record, app):
+            async with lifespan_client(app) as client:
+                unauthenticated = await client.get("/v1/authz-policies/administration")
+                method_not_allowed = await client.post(
+                    "/v1/authz-policies/revisions",
+                    headers={"Authorization": "Bearer admin-token"},
+                )
+
+        self.assertEqual(unauthenticated.status_code, 401, unauthenticated.text)
+        self.assertEqual(method_not_allowed.status_code, 405, method_not_allowed.text)
+        self.assertEqual(unauthenticated.headers["cache-control"], "no-store")
+        self.assertEqual(method_not_allowed.headers["cache-control"], "no-store")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_owner_control_shadow_verifier.py
+++ b/tests/test_owner_control_shadow_verifier.py
@@ -769,11 +769,10 @@ class OwnerControlShadowVerifierStorageTests(unittest.TestCase):
 
 
 class OwnerControlShadowVerifierFreezeBoundaryTests(unittest.TestCase):
-    def test_published_wire_contract_and_transport_boundaries_remain_frozen(self) -> None:
+    def test_published_wire_contract_remains_frozen(self) -> None:
         frozen_paths = (
             "contracts/owner-control-contract.json",
             "control_plane/contracts/owner_control.py",
-            "control_plane/http_app.py",
         )
 
         for path in frozen_paths:
@@ -783,6 +782,19 @@ class OwnerControlShadowVerifierFreezeBoundaryTests(unittest.TestCase):
                     cwd=REPOSITORY_ROOT,
                 )
                 self.assertEqual(result.returncode, 0, f"Frozen boundary changed: {path}")
+
+    def test_http_transport_remains_decoupled_from_shadow_verifier(self) -> None:
+        source = (REPOSITORY_ROOT / "control_plane/http_app.py").read_text(encoding="utf-8")
+
+        for forbidden_reference in (
+            "owner_control_shadow_verifier",
+            "owner_control_challenge",
+            "OwnerControlChallengeIssueRequest",
+            "evaluate_owner_control_shadow_verification",
+            "/owner-control",
+        ):
+            with self.subTest(forbidden_reference=forbidden_reference):
+                self.assertNotIn(forbidden_reference, source)
 
     def test_shadow_verifier_contract_has_no_transport_or_execution_coupling(self) -> None:
         for path in (


### PR DESCRIPTION
## Summary

- add backend-only `GET /v1/authz-policies/administration` and `GET /v1/authz-policies/revisions`
- define `authz_policy_administration.read` without granting it to any checked-in caller
- return bounded policy provenance, counts, health summaries, and redacted 50-record revision history
- preserve strict browser Origin/Sec-Fetch/CSRF validation without session renewal or token rotation
- keep all success and error responses `no-store` and suppress denial/session/policy writes for these reads

## Authority Boundary

- requires an eligible local administrator or admin GitHub human
- requires both runtime authorization and fresh authorization from exactly one active DB policy record
- fails closed for missing, ambiguous, or non-database policy authority
- adds no write, proposal, export, rollback, workflow, UI, secret, migration, or production grant
- leaves the issue #2058 authorization freeze unchanged
- preserves owner-control contract freezing while replacing an overbroad whole-`http_app.py` diff check with explicit transport-decoupling assertions

## Validation

- `uv run --extra dev launchplane ci unittest-shard local` — 3,143 targets passed
- `uv run --extra dev mypy control_plane tests` — passed
- `uv run --extra dev ruff check .` — passed
- changed-file Ruff format check — passed
- `pnpm --dir frontend check:openapi-drift` — passed
- JetBrains changed-file inspection — GREEN, 0 findings
- Claude Opus 5 exact-head review — LOVE
- Gemini 3.1 Pro High exact-head review — LOVE

Part of #2180.
