### PR TITLE
Allow browser-safe sensitive authorization GETs

### DIFF
--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -737,6 +737,7 @@ from control_plane.service_human_auth import (
     build_pkce_verifier,
     safe_oauth_return_to,
     validate_browser_mutation_request_headers,
+    validate_browser_sensitive_read_request_headers,
 )
 from control_plane.storage.factory import build_shared_record_store
 from control_plane.storage.factory import storage_backend_name
@@ -4454,7 +4455,7 @@ def create_launchplane_fastapi_app(
         if session is None or human_session_manager is None:
             raise _authentication_required_error("Authorization header is required.")
         try:
-            csrf_token = validate_browser_mutation_request_headers(
+            csrf_token = validate_browser_sensitive_read_request_headers(
                 expected_origin=human_session_manager.public_origin,
                 origin_values=tuple(request.headers.getlist("Origin")),
                 sec_fetch_site_values=tuple(request.headers.getlist("Sec-Fetch-Site")),

--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -4455,7 +4455,12 @@ def create_launchplane_fastapi_app(
         if session is None or human_session_manager is None:
             raise _authentication_required_error("Authorization header is required.")
         try:
-            csrf_token = validate_browser_sensitive_read_request_headers(
+            validate_browser_request_headers = (
+                validate_browser_sensitive_read_request_headers
+                if request.method == "GET"
+                else validate_browser_mutation_request_headers
+            )
+            csrf_token = validate_browser_request_headers(
                 expected_origin=human_session_manager.public_origin,
                 origin_values=tuple(request.headers.getlist("Origin")),
                 sec_fetch_site_values=tuple(request.headers.getlist("Sec-Fetch-Site")),

--- a/control_plane/service_human_auth.py
+++ b/control_plane/service_human_auth.py
@@ -649,6 +649,48 @@ def validate_browser_mutation_request_headers(
     return csrf_token
 
 
+def validate_browser_sensitive_read_request_headers(
+    *,
+    expected_origin: str,
+    origin_values: tuple[str, ...],
+    sec_fetch_site_values: tuple[str, ...],
+    sec_fetch_mode_values: tuple[str, ...],
+    sec_fetch_dest_values: tuple[str, ...],
+    csrf_token_values: tuple[str, ...],
+) -> str:
+    if len(origin_values) > 1 or not all(
+        len(values) == 1
+        for values in (
+            sec_fetch_site_values,
+            sec_fetch_mode_values,
+            sec_fetch_dest_values,
+            csrf_token_values,
+        )
+    ):
+        raise PermissionError("Browser sensitive read request metadata is invalid.")
+    if origin_values:
+        origin = origin_values[0].strip()
+        parsed_origin = urlsplit(origin)
+        if parsed_origin.path not in {"", "/"} or parsed_origin.query or parsed_origin.fragment:
+            raise PermissionError("Browser sensitive read request metadata is invalid.")
+        try:
+            normalized_origin = browser_origin_from_url(origin)
+        except ValueError as error:
+            raise PermissionError("Browser sensitive read request metadata is invalid.") from error
+        if normalized_origin != expected_origin:
+            raise PermissionError("Browser sensitive read request metadata is invalid.")
+    if sec_fetch_site_values[0].strip().lower() != "same-origin":
+        raise PermissionError("Browser sensitive read request metadata is invalid.")
+    if sec_fetch_mode_values[0].strip().lower() not in {"cors", "same-origin"}:
+        raise PermissionError("Browser sensitive read request metadata is invalid.")
+    if sec_fetch_dest_values[0].strip().lower() != "empty":
+        raise PermissionError("Browser sensitive read request metadata is invalid.")
+    csrf_token = csrf_token_values[0].strip()
+    if not csrf_token:
+        raise PermissionError("Browser sensitive read request metadata is invalid.")
+    return csrf_token
+
+
 def _csrf_token_generation(token: str) -> int | None:
     if len(token) > 256:
         return None

--- a/docs/authorization-authority.md
+++ b/docs/authorization-authority.md
@@ -150,9 +150,16 @@ operation and mode enums, and allowlisted nonnegative numeric counts. Neither
 route returns raw policy or audit payloads, principal identifiers, selectors,
 managed rule IDs or hashes, reasons, key IDs, tokens, or free text.
 
-Browser administrators must provide the existing strict same-origin,
-`Sec-Fetch-*`, and CSRF proof. Validation neither renews the session nor rotates
-the CSRF token. Successes and every error class are `Cache-Control: no-store`,
+Browser administrators must provide strict same-origin `Sec-Fetch-*` metadata
+and CSRF proof. Same-origin browser GET requests normally omit `Origin`, so this
+sensitive-read validator accepts zero or one `Origin` value, validates it
+against the configured public origin when present, and always rejects duplicate
+or cross-origin values. It still requires `Sec-Fetch-Site: same-origin`, a
+`cors` or `same-origin` mode, `Sec-Fetch-Dest: empty`, and one valid CSRF token.
+The stricter mutation validator continues to require exactly one matching
+`Origin` for POST requests. Sensitive-read validation neither renews the session
+nor rotates the CSRF token. Successes and every error class are
+`Cache-Control: no-store`,
 and the routes do not write denial, session, policy, idempotency, audit, outbox,
 provider, runtime, deployment, secret, or other persistent state. This slice
 adds no proposal, export, rollback, mutation, workflow, UI, or authorization

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -328,11 +328,14 @@ cleanup scope so the store is always closed.
     `repository_owner_id` selectors for GitHub Actions rules.)
   - The two bounded administration GET routes require an eligible GitHub or
     local administrator, runtime and fresh active-DB authorization for the
-    ungranted `authz_policy_administration.read` action, strict same-origin/CSRF
-    proof for browser sessions, PostgreSQL record storage, and exactly one active
-    policy. They are `no-store`, nonrenewing, nonpersisting reads and expose no
-    raw policy, raw audit, principal identity, selector, managed-rule identity,
-    proposal, export, rollback, or mutation surface.
+    ungranted `authz_policy_administration.read` action, strict same-origin Fetch
+    Metadata and CSRF proof for browser sessions, PostgreSQL record storage, and
+    exactly one active policy. Same-origin GETs may omit `Origin`; the service
+    validates it when present and rejects duplicates or mismatches, while POST
+    mutation validation still requires exactly one matching `Origin`. The GETs
+    are `no-store`, nonrenewing, nonpersisting reads and expose no raw policy,
+    raw audit, principal identity, selector, managed-rule identity, proposal,
+    export, rollback, or mutation surface.
 
 - Every Code local automation work-request routes:
   - `GET /v1/every-code/summary` (native FastAPI for bearer-token,

--- a/tests/test_authz_access_read.py
+++ b/tests/test_authz_access_read.py
@@ -310,6 +310,68 @@ class AuthzAccessReadHttpTests(unittest.IsolatedAsyncioTestCase):
         ):
             self.assertNotIn(private_value, serialized)
 
+    async def test_browser_repository_scope_post_requires_origin(self) -> None:
+        policy = LaunchplaneAuthzPolicy.model_validate(
+            {
+                "schema_version": 2,
+                "github_humans": [
+                    {
+                        "github_ids": [12345],
+                        "roles": ["admin"],
+                        "products": ["launchplane"],
+                        "contexts": ["launchplane"],
+                        "actions": [AUTHZ_REPOSITORY_SCOPE_READ_ACTION],
+                    }
+                ],
+            }
+        )
+        session_store = InMemoryHumanSessionStore()
+        session_manager = HumanSessionManager(
+            config=GitHubOAuthConfig(
+                client_id="client-id",
+                client_secret="client-secret",
+                public_url="https://launchplane.example",
+                session_secret="session-secret",
+                cookie_secure=False,
+            ),
+            session_store=session_store,
+        )
+        session = session_manager.issue(
+            GitHubHumanIdentity(
+                login="browser-admin",
+                github_id=12345,
+                name="Browser Admin",
+                email="browser-admin@example.test",
+                organizations=frozenset(),
+                teams=frozenset(),
+                role="admin",
+            )
+        )
+        headers = build_browser_mutation_request_headers(
+            origin="https://launchplane.example",
+            csrf_token=session_manager.csrf_token(session),
+        )
+        headers["Cookie"] = session_manager.session_cookie_header(session).split(";", 1)[0]
+        headers.pop("Origin")
+        with _database_app(policy, human_session_manager=session_manager) as (
+            _store,
+            _record,
+            app,
+        ):
+            session_before = session_store.read_session(session.session_id)
+            async with lifespan_client(app) as client:
+                response = await client.post(
+                    "/v1/authz-diagnostics/repository-scope/read",
+                    headers=headers,
+                    json={"candidates": []},
+                )
+            session_after = session_store.read_session(session.session_id)
+
+        self.assertEqual(response.status_code, 403, response.text)
+        self.assertEqual(response.json()["error"]["code"], "browser_mutation_denied")
+        self.assertNotIn("set-cookie", response.headers)
+        self.assertEqual(session_after, session_before)
+
     async def test_repository_scope_authorization_precedes_route_database_reads(self) -> None:
         policy = LaunchplaneAuthzPolicy.model_validate(
             {
@@ -754,6 +816,13 @@ class AuthzAccessReadHttpTests(unittest.IsolatedAsyncioTestCase):
                         headers=rejected_headers,
                         json={"candidate_policy": policy.model_dump(mode="json")},
                     )
+                    absent_origin_headers = dict(headers)
+                    absent_origin_headers.pop("Origin")
+                    absent_origin_response = await client.post(
+                        "/v1/authz-diagnostics/candidate-policy/preview",
+                        headers=absent_origin_headers,
+                        json={"candidate_policy": policy.model_dump(mode="json")},
+                    )
                 session_after_preview = session_store.read_session(session.session_id)
             finally:
                 store.close()
@@ -765,6 +834,11 @@ class AuthzAccessReadHttpTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(rejected_response.status_code, 403, rejected_response.text)
         self.assertEqual(
             rejected_response.json()["error"]["code"],
+            "browser_mutation_denied",
+        )
+        self.assertEqual(absent_origin_response.status_code, 403, absent_origin_response.text)
+        self.assertEqual(
+            absent_origin_response.json()["error"]["code"],
             "browser_mutation_denied",
         )
 

--- a/tests/test_authz_administration_read.py
+++ b/tests/test_authz_administration_read.py
@@ -325,6 +325,12 @@ class AuthzAdministrationReadHttpTests(unittest.IsolatedAsyncioTestCase):
         ):
             session_before = session_store.read_session(session_id)
             async with lifespan_client(app) as client:
+                absent_origin_headers = dict(headers)
+                absent_origin_headers.pop("Origin")
+                absent_origin_response = await client.get(
+                    "/v1/authz-policies/administration",
+                    headers=absent_origin_headers,
+                )
                 response = await client.get(
                     "/v1/authz-policies/administration",
                     headers=headers,
@@ -343,6 +349,9 @@ class AuthzAdministrationReadHttpTests(unittest.IsolatedAsyncioTestCase):
                 )
             session_after = session_store.read_session(session_id)
 
+        self.assertEqual(absent_origin_response.status_code, 200, absent_origin_response.text)
+        self.assertEqual(absent_origin_response.headers["cache-control"], "no-store")
+        self.assertNotIn("set-cookie", absent_origin_response.headers)
         self.assertEqual(response.status_code, 200, response.text)
         self.assertEqual(response.headers["cache-control"], "no-store")
         self.assertNotIn("set-cookie", response.headers)
@@ -355,6 +364,50 @@ class AuthzAdministrationReadHttpTests(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(rejected.headers["cache-control"], "no-store")
             self.assertEqual(rejected.json()["error"]["code"], "browser_mutation_denied")
             self.assertNotIn("set-cookie", rejected.headers)
+
+    async def test_browser_without_origin_reaches_authorization_denial_without_writes(
+        self,
+    ) -> None:
+        manager, session_store = _human_session_manager()
+        identity = GitHubHumanIdentity(
+            login="browser-admin",
+            github_id=101,
+            name="Browser Admin",
+            email="browser-admin@example.test",
+            organizations=frozenset(),
+            teams=frozenset(),
+            role="admin",
+        )
+        headers, session_id, csrf_token = _browser_headers(manager, identity)
+        headers.pop("Origin")
+        policy = _github_human_policy(include_administration_action=False)
+        with _database_app(policy, human_session_manager=manager) as (
+            store,
+            _active_record,
+            app,
+        ):
+            session_before = session_store.read_session(session_id)
+            async with lifespan_client(app) as client:
+                with patch.object(
+                    store,
+                    "write_authz_denial_record",
+                    create=True,
+                    side_effect=AssertionError("administration denial must not write"),
+                ):
+                    response = await client.get(
+                        "/v1/authz-policies/administration",
+                        headers=headers,
+                    )
+            session_after = session_store.read_session(session_id)
+
+        self.assertEqual(response.status_code, 403, response.text)
+        self.assertEqual(response.headers["cache-control"], "no-store")
+        self.assertEqual(response.json()["error"]["code"], "authorization_denied")
+        self.assertNotIn("set-cookie", response.headers)
+        self.assertEqual(session_after, session_before)
+        self.assertIsNotNone(session_before)
+        assert session_before is not None
+        self.assertTrue(manager.csrf_token_is_valid(session_before, csrf_token))
 
     async def test_administration_read_requires_both_runtime_and_fresh_database_grants(
         self,

--- a/tests/test_service_human_auth.py
+++ b/tests/test_service_human_auth.py
@@ -21,6 +21,7 @@ from control_plane.service_human_auth import (
     LaunchplaneHumanSession,
     build_browser_mutation_request_headers,
     validate_browser_mutation_request_headers,
+    validate_browser_sensitive_read_request_headers,
 )
 
 
@@ -459,6 +460,49 @@ class HumanSessionManagerTests(unittest.TestCase):
             values.update(overrides)
             with self.subTest(overrides=overrides), self.assertRaises(PermissionError):
                 validate_browser_mutation_request_headers(
+                    expected_origin=manager.public_origin,
+                    **values,
+                )
+
+    def test_browser_sensitive_read_headers_allow_absent_same_origin_get_origin(self) -> None:
+        manager = HumanSessionManager(config=_config(), session_store=InMemoryHumanSessionStore())
+        headers = build_browser_mutation_request_headers(
+            origin="https://launchplane.example/operator",
+            csrf_token="csrf-token",
+        )
+        common_values: dict[str, tuple[str, ...]] = {
+            "sec_fetch_site_values": (headers["Sec-Fetch-Site"],),
+            "sec_fetch_mode_values": (headers["Sec-Fetch-Mode"],),
+            "sec_fetch_dest_values": (headers["Sec-Fetch-Dest"],),
+            "csrf_token_values": (headers["X-CSRF-Token"],),
+        }
+
+        absent_origin_token = validate_browser_sensitive_read_request_headers(
+            expected_origin=manager.public_origin,
+            origin_values=(),
+            **common_values,
+        )
+        explicit_origin_token = validate_browser_sensitive_read_request_headers(
+            expected_origin=manager.public_origin,
+            origin_values=(headers["Origin"],),
+            **common_values,
+        )
+
+        self.assertEqual(absent_origin_token, "csrf-token")
+        self.assertEqual(explicit_origin_token, "csrf-token")
+        for overrides in (
+            {"origin_values": (headers["Origin"], headers["Origin"])},
+            {"origin_values": ("https://attacker.example",)},
+            {"sec_fetch_site_values": ("cross-site",)},
+            {"sec_fetch_mode_values": ("navigate",)},
+            {"sec_fetch_dest_values": ("document",)},
+            {"csrf_token_values": ()},
+            {"csrf_token_values": ("",)},
+        ):
+            values = {"origin_values": (), **common_values}
+            values.update(overrides)
+            with self.subTest(overrides=overrides), self.assertRaises(PermissionError):
+                validate_browser_sensitive_read_request_headers(
                     expected_origin=manager.public_origin,
                     **values,
                 )


### PR DESCRIPTION
## Summary

- add a read-specific browser header validator that accepts the real same-origin GET shape where browsers omit `Origin`
- continue requiring exact same-origin Fetch Metadata and a valid CSRF token
- restrict the relaxed validator to GET requests only
- keep both sensitive POST diagnostics on the strict mutation validator requiring exactly one matching `Origin`
- add explicit GET and POST regression coverage plus browser-session no-renewal/no-rotation assertions

## Boundary

A headed Chrome probe observed the real same-origin request as:

- `Origin`: absent
- `Sec-Fetch-Site`: `same-origin`
- `Sec-Fetch-Mode`: `cors`
- `Sec-Fetch-Dest`: `empty`

This PR fixes that transport mismatch without adding a UI, authorization grant, policy mutation, proposal, export, rollback, workflow, secret, or owner-control authority. `authz_policy_administration.read` remains deliberately ungranted under #2058.

## Validation

- `uv run --extra dev launchplane ci unittest-shard local` — 3,144 targets passed
- `uv run --extra dev mypy control_plane tests` — passed
- `uv run --extra dev ruff check .` — passed
- changed-file Ruff format check — passed
- JetBrains changed-file inspection — GREEN, 0 findings
- Claude Opus 5 exact-head review — LOVE
- Gemini 3.1 Pro High exact-head review — LOVE

Part of #2180.
