### PR TITLE
Terminalize expired owner-control challenges before reissuance

### DIFF
--- a/control_plane/contracts/owner_control_shadow_verifier.py
+++ b/control_plane/contracts/owner_control_shadow_verifier.py
@@ -29,6 +29,7 @@ _CANONICAL_TIMESTAMP_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}
 
 OwnerControlChannelSessionStatus = Literal["enrolled", "revoked"]
 OwnerControlChallengeState = Literal["issued", "consumed", "expired", "rejected"]
+OwnerControlChallengeLifecycleTransitionReason = Literal["expired"]
 OwnerControlShadowVerificationStatus = Literal["verified", "rejected"]
 OwnerControlShadowVerificationReason = Literal[
     "unknown_channel_session",
@@ -110,6 +111,26 @@ def owner_control_verification_event_id(
         }
     )
     return f"owner-control-shadow-event-{digest[:32]}"
+
+
+def owner_control_challenge_lifecycle_event_id(
+    *,
+    challenge_id: str,
+    from_state: Literal["issued"],
+    to_state: Literal["expired"],
+    transition_reason: OwnerControlChallengeLifecycleTransitionReason,
+) -> str:
+    """Return the deterministic identifier for one non-verification transition."""
+
+    digest = canonical_json_sha256(
+        {
+            "challenge_id": challenge_id,
+            "from_state": from_state,
+            "to_state": to_state,
+            "transition_reason": transition_reason,
+        }
+    )
+    return f"owner-control-lifecycle-event-{digest[:32]}"
 
 
 class OwnerControlChannelSessionRecord(BaseModel):
@@ -267,6 +288,43 @@ class OwnerControlIssuedChallengeRecord(BaseModel):
     def channel_binding(self) -> ChannelBindingRecord:
         binding = ChannelBindingRecord.model_validate_json(self.binding_json)
         return binding
+
+
+class OwnerControlChallengeLifecycleEventRecord(BaseModel):
+    """Append-only non-verification transition for one stored challenge."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    schema_version: Literal[1] = OWNER_CONTROL_SHADOW_VERIFIER_SCHEMA_VERSION
+    event_id: str = Field(pattern=_SERVER_IDENTIFIER_PATTERN.pattern)
+    challenge_id: str = Field(pattern=_SERVER_IDENTIFIER_PATTERN.pattern)
+    challenge_nonce: str = Field(min_length=16, max_length=128, pattern=r"^[A-Za-z0-9_-]+$")
+    channel_session_id: str = Field(pattern=_SERVER_IDENTIFIER_PATTERN.pattern)
+    operation_id: str = Field(pattern=r"^privileged-operation-[0-9a-f]{32}$")
+    approval_request_sha256: str = Field(pattern=_SHA256_PATTERN.pattern)
+    binding_sha256: str = Field(pattern=_SHA256_PATTERN.pattern)
+    from_state: Literal["issued"] = "issued"
+    to_state: Literal["expired"] = "expired"
+    transition_reason: OwnerControlChallengeLifecycleTransitionReason = "expired"
+    challenge_expires_at: str
+    occurred_at: str
+    authorizes_execution: Literal[False] = False
+    authority_state: Literal["inert"] = OWNER_CONTROL_SHADOW_AUTHORITY_STATE
+
+    @model_validator(mode="after")
+    def _validate_record(self) -> "OwnerControlChallengeLifecycleEventRecord":
+        expires_at = _canonical_timestamp(self.challenge_expires_at, "challenge_expires_at")
+        occurred_at = _canonical_timestamp(self.occurred_at, "occurred_at")
+        if occurred_at < expires_at:
+            raise ValueError("occurred_at must not precede challenge_expires_at")
+        if self.event_id != owner_control_challenge_lifecycle_event_id(
+            challenge_id=self.challenge_id,
+            from_state=self.from_state,
+            to_state=self.to_state,
+            transition_reason=self.transition_reason,
+        ):
+            raise ValueError("event_id must derive from the exact lifecycle transition")
+        return self
 
 
 class OwnerControlShadowVerificationEventRecord(BaseModel):
@@ -434,6 +492,48 @@ def issue_owner_control_challenge_record(
         binding_json=session.binding_json,
         binding_sha256=session.binding_sha256,
     )
+
+
+def terminalize_expired_owner_control_challenge_record(
+    record: OwnerControlIssuedChallengeRecord,
+    *,
+    observed_at: str,
+) -> tuple[OwnerControlIssuedChallengeRecord, OwnerControlChallengeLifecycleEventRecord]:
+    """Expire one issued challenge without consuming a verification attempt."""
+
+    observed_at_value = _canonical_timestamp(observed_at, "observed_at")
+    expires_at_value = _canonical_timestamp(record.expires_at, "expires_at")
+    if record.state != "issued":
+        raise OwnerControlShadowVerifierConflictError(
+            "Only issued owner-control challenges can be terminalized as expired."
+        )
+    if expires_at_value > observed_at_value:
+        raise OwnerControlShadowVerifierConflictError("Owner-control challenge has not expired.")
+    event_id = owner_control_challenge_lifecycle_event_id(
+        challenge_id=record.challenge_id,
+        from_state="issued",
+        to_state="expired",
+        transition_reason="expired",
+    )
+    event = OwnerControlChallengeLifecycleEventRecord(
+        event_id=event_id,
+        challenge_id=record.challenge_id,
+        challenge_nonce=record.challenge_nonce,
+        channel_session_id=record.channel_session_id,
+        operation_id=record.operation_id,
+        approval_request_sha256=record.approval_request_sha256,
+        binding_sha256=record.binding_sha256,
+        challenge_expires_at=record.expires_at,
+        occurred_at=observed_at,
+    )
+    terminalized = OwnerControlIssuedChallengeRecord.model_validate(
+        {
+            **record.model_dump(),
+            "state": "expired",
+            "terminal_event_id": event.event_id,
+        }
+    )
+    return terminalized, event
 
 
 def evaluate_owner_control_shadow_verification(

--- a/control_plane/storage/migrations/versions/a7c9e1f3b5d7_add_owner_control_challenge_lifecycle_events.py
+++ b/control_plane/storage/migrations/versions/a7c9e1f3b5d7_add_owner_control_challenge_lifecycle_events.py
@@ -1,0 +1,121 @@
+"""Add owner-control challenge lifecycle events.
+
+Revision ID: a7c9e1f3b5d7
+Revises: f6a1c3e5b7d9
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision: str = "a7c9e1f3b5d7"
+down_revision: str | None = "f6a1c3e5b7d9"
+branch_labels: tuple[str, ...] | None = None
+depends_on: tuple[str, ...] | None = None
+
+
+_TABLE = "launchplane_owner_control_challenge_lifecycle_events"
+_INDEX = "launchplane_owner_control_lifecycle_event_challenge_idx"
+
+
+def _table_exists() -> bool:
+    return _TABLE in set(sa.inspect(op.get_bind()).get_table_names())
+
+
+def _index_exists() -> bool:
+    return _table_exists() and _INDEX in {
+        str(name)
+        for index in sa.inspect(op.get_bind()).get_indexes(_TABLE)
+        if (name := index.get("name")) is not None
+    }
+
+
+def _payload_column() -> sa.Column[object]:
+    return sa.Column(
+        "payload",
+        sa.JSON().with_variant(postgresql.JSONB(astext_type=sa.Text()), "postgresql"),
+        nullable=False,
+    )
+
+
+def _table_has_rows() -> bool:
+    if not _table_exists():
+        return False
+    return bool(op.get_bind().scalar(sa.text(f"SELECT EXISTS (SELECT 1 FROM {_TABLE})")))
+
+
+def upgrade() -> None:
+    if not _table_exists():
+        op.create_table(
+            _TABLE,
+            sa.Column("event_id", sa.String(), nullable=False),
+            sa.Column("challenge_id", sa.String(), nullable=False),
+            sa.Column("challenge_nonce", sa.String(), nullable=False),
+            sa.Column("channel_session_id", sa.String(), nullable=False),
+            sa.Column("operation_id", sa.String(), nullable=False),
+            sa.Column("approval_request_sha256", sa.String(), nullable=False),
+            sa.Column("binding_sha256", sa.String(), nullable=False),
+            sa.Column("from_state", sa.String(), nullable=False),
+            sa.Column("to_state", sa.String(), nullable=False),
+            sa.Column("transition_reason", sa.String(), nullable=False),
+            sa.Column("challenge_expires_at", sa.String(), nullable=False),
+            sa.Column("occurred_at", sa.String(), nullable=False),
+            sa.Column(
+                "authorizes_execution",
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.false(),
+            ),
+            sa.Column("authority_state", sa.String(), nullable=False, server_default="inert"),
+            _payload_column(),
+            sa.CheckConstraint(
+                "from_state = 'issued'",
+                name="launchplane_owner_control_lifecycle_event_from_state_ck",
+            ),
+            sa.CheckConstraint(
+                "to_state = 'expired'",
+                name="launchplane_owner_control_lifecycle_event_to_state_ck",
+            ),
+            sa.CheckConstraint(
+                "transition_reason = 'expired'",
+                name="launchplane_owner_control_lifecycle_event_reason_ck",
+            ),
+            sa.CheckConstraint(
+                "occurred_at >= challenge_expires_at",
+                name="launchplane_owner_control_lifecycle_event_time_ck",
+            ),
+            sa.CheckConstraint(
+                "authorizes_execution = false",
+                name="launchplane_owner_control_lifecycle_event_authorization_ck",
+            ),
+            sa.CheckConstraint(
+                "authority_state = 'inert'",
+                name="launchplane_owner_control_lifecycle_event_authority_ck",
+            ),
+            sa.PrimaryKeyConstraint("event_id"),
+            sa.UniqueConstraint(
+                "challenge_id",
+                "transition_reason",
+                name="launchplane_owner_control_lifecycle_event_transition_uq",
+            ),
+        )
+    if not _index_exists():
+        op.create_index(
+            _INDEX,
+            _TABLE,
+            ["challenge_nonce", sa.text("occurred_at DESC")],
+        )
+
+
+def downgrade() -> None:
+    if _table_has_rows():
+        raise RuntimeError(
+            "Cannot downgrade owner-control lifecycle storage while audit events exist."
+        )
+    if _index_exists():
+        op.drop_index(_INDEX, table_name=_TABLE)
+    if _table_exists():
+        op.drop_table(_TABLE)

--- a/control_plane/storage/postgres.py
+++ b/control_plane/storage/postgres.py
@@ -125,6 +125,7 @@ from control_plane.contracts.owner_control import (
 from control_plane.contracts.owner_control_shadow_verifier import (
     OWNER_CONTROL_SHADOW_MAX_ATTEMPTS,
     OwnerControlChannelSessionRecord,
+    OwnerControlChallengeLifecycleEventRecord,
     OwnerControlChallengeIssueRequest,
     OwnerControlIssuedChallengeRecord,
     OwnerControlShadowVerificationEvaluation,
@@ -134,6 +135,7 @@ from control_plane.contracts.owner_control_shadow_verifier import (
     build_owner_control_channel_session_record,
     evaluate_owner_control_shadow_verification,
     issue_owner_control_challenge_record,
+    terminalize_expired_owner_control_challenge_record,
     owner_control_confirmation_envelope_sha256,
     owner_control_verification_event_id,
     revoke_owner_control_channel_session_record,
@@ -1164,6 +1166,70 @@ class LaunchplaneOwnerControlIssuedChallengeRow(Base):
     attempt_count: Mapped[int] = mapped_column(Integer, nullable=False)
     consumed_at: Mapped[str | None] = mapped_column(String, nullable=True)
     terminal_event_id: Mapped[str | None] = mapped_column(String, nullable=True)
+    authority_state: Mapped[str] = mapped_column(
+        String,
+        nullable=False,
+        server_default="inert",
+    )
+    payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
+
+
+class LaunchplaneOwnerControlChallengeLifecycleEventRow(Base):
+    __tablename__ = "launchplane_owner_control_challenge_lifecycle_events"
+    __table_args__ = (
+        CheckConstraint(
+            "from_state = 'issued'",
+            name="launchplane_owner_control_lifecycle_event_from_state_ck",
+        ),
+        CheckConstraint(
+            "to_state = 'expired'",
+            name="launchplane_owner_control_lifecycle_event_to_state_ck",
+        ),
+        CheckConstraint(
+            "transition_reason = 'expired'",
+            name="launchplane_owner_control_lifecycle_event_reason_ck",
+        ),
+        CheckConstraint(
+            "occurred_at >= challenge_expires_at",
+            name="launchplane_owner_control_lifecycle_event_time_ck",
+        ),
+        CheckConstraint(
+            "authorizes_execution = false",
+            name="launchplane_owner_control_lifecycle_event_authorization_ck",
+        ),
+        CheckConstraint(
+            "authority_state = 'inert'",
+            name="launchplane_owner_control_lifecycle_event_authority_ck",
+        ),
+        UniqueConstraint(
+            "challenge_id",
+            "transition_reason",
+            name="launchplane_owner_control_lifecycle_event_transition_uq",
+        ),
+        Index(
+            "launchplane_owner_control_lifecycle_event_challenge_idx",
+            "challenge_nonce",
+            desc("occurred_at"),
+        ),
+    )
+
+    event_id: Mapped[str] = mapped_column(String, primary_key=True)
+    challenge_id: Mapped[str] = mapped_column(String, nullable=False)
+    challenge_nonce: Mapped[str] = mapped_column(String, nullable=False)
+    channel_session_id: Mapped[str] = mapped_column(String, nullable=False)
+    operation_id: Mapped[str] = mapped_column(String, nullable=False)
+    approval_request_sha256: Mapped[str] = mapped_column(String, nullable=False)
+    binding_sha256: Mapped[str] = mapped_column(String, nullable=False)
+    from_state: Mapped[str] = mapped_column(String, nullable=False)
+    to_state: Mapped[str] = mapped_column(String, nullable=False)
+    transition_reason: Mapped[str] = mapped_column(String, nullable=False)
+    challenge_expires_at: Mapped[str] = mapped_column(String, nullable=False)
+    occurred_at: Mapped[str] = mapped_column(String, nullable=False)
+    authorizes_execution: Mapped[bool] = mapped_column(
+        Boolean,
+        nullable=False,
+        server_default=false(),
+    )
     authority_state: Mapped[str] = mapped_column(
         String,
         nullable=False,
@@ -9342,6 +9408,28 @@ class PostgresRecordStore(HumanSessionStore):
         row.authority_state = record.authority_state
         row.payload = self._payload_dict(record)
 
+    def _owner_control_challenge_lifecycle_event_row_from_record(
+        self,
+        record: OwnerControlChallengeLifecycleEventRecord,
+    ) -> LaunchplaneOwnerControlChallengeLifecycleEventRow:
+        return LaunchplaneOwnerControlChallengeLifecycleEventRow(
+            event_id=record.event_id,
+            challenge_id=record.challenge_id,
+            challenge_nonce=record.challenge_nonce,
+            channel_session_id=record.channel_session_id,
+            operation_id=record.operation_id,
+            approval_request_sha256=record.approval_request_sha256,
+            binding_sha256=record.binding_sha256,
+            from_state=record.from_state,
+            to_state=record.to_state,
+            transition_reason=record.transition_reason,
+            challenge_expires_at=record.challenge_expires_at,
+            occurred_at=record.occurred_at,
+            authorizes_execution=record.authorizes_execution,
+            authority_state=record.authority_state,
+            payload=self._payload_dict(record),
+        )
+
     def enroll_owner_control_channel_session(
         self,
         binding: ChannelBindingRecord,
@@ -9421,6 +9509,11 @@ class PostgresRecordStore(HumanSessionStore):
                 operation_id=issue_request.operation_id,
             )
             policy_record = self._locked_active_authz_policy_record(session)
+            existing_row = self._owner_control_active_challenge_row_for_operation(
+                session,
+                operation_id=operation.operation_id,
+                for_update=True,
+            )
             issued_at = self._owner_control_shadow_timestamp(session)
             issued_at_value = datetime.fromisoformat(issued_at)
             operation_expires_at = datetime.fromisoformat(operation.expires_at).astimezone(
@@ -9456,36 +9549,54 @@ class PostgresRecordStore(HumanSessionStore):
                 )
             except OwnerControlChallengeProvenanceError as error:
                 raise OwnerControlShadowVerifierConflictError(str(error)) from error
-            existing_row = self._owner_control_active_challenge_row_for_operation(
-                session,
-                operation_id=operation.operation_id,
-                for_update=True,
-            )
             if existing_row is not None:
                 existing_record = self._owner_control_issued_challenge_record_from_row(existing_row)
                 existing_expires_at = datetime.fromisoformat(existing_record.expires_at)
                 if existing_expires_at <= issued_at_value:
-                    raise OwnerControlShadowVerifierConflictError(
-                        "Expired owner-control challenges require an audited terminal transition."
+                    terminalized_record, lifecycle_event = (
+                        terminalize_expired_owner_control_challenge_record(
+                            existing_record,
+                            observed_at=issued_at,
+                        )
                     )
-                if (
-                    existing_record.channel_session_id == session_record.channel_session_id
-                    and existing_record.binding_sha256 == session_record.binding_sha256
-                    and existing_expires_at <= expires_at_value
-                    and owner_control_challenge_semantics(existing_record.approval_request())
-                    == owner_control_challenge_semantics(candidate)
-                ):
-                    session.rollback()
-                    return existing_record
-                raise OwnerControlShadowVerifierConflictError(
-                    "An active owner-control challenge already binds this operation."
-                )
+                    self._sync_owner_control_issued_challenge_row(
+                        existing_row,
+                        terminalized_record,
+                    )
+                    session.add(
+                        self._owner_control_challenge_lifecycle_event_row_from_record(
+                            lifecycle_event
+                        )
+                    )
+                    session.flush()
+                else:
+                    if (
+                        existing_record.channel_session_id == session_record.channel_session_id
+                        and existing_record.binding_sha256 == session_record.binding_sha256
+                        and existing_expires_at <= expires_at_value
+                        and owner_control_challenge_semantics(existing_record.approval_request())
+                        == owner_control_challenge_semantics(candidate)
+                    ):
+                        session.rollback()
+                        return existing_record
+                    raise OwnerControlShadowVerifierConflictError(
+                        "An active owner-control challenge already binds this operation."
+                    )
             record = issue_owner_control_challenge_record(
                 issue_request=issue_request,
                 session=session_record,
                 approval_request=candidate,
             )
             session.add(self._owner_control_issued_challenge_row_from_record(record))
+            session.flush()
+            final_observed_at = self._owner_control_shadow_timestamp(session)
+            if datetime.fromisoformat(record.expires_at) <= datetime.fromisoformat(
+                final_observed_at
+            ):
+                session.rollback()
+                raise OwnerControlShadowVerifierConflictError(
+                    "Owner-control challenge expired before issuance committed."
+                )
             session.commit()
             return record
 
@@ -9642,6 +9753,33 @@ class PostgresRecordStore(HumanSessionStore):
             model_type=OwnerControlIssuedChallengeRecord,
             orm_model=LaunchplaneOwnerControlIssuedChallengeRow,
             filters=(LaunchplaneOwnerControlIssuedChallengeRow.challenge_nonce == challenge_nonce,),
+        )
+
+    def list_owner_control_challenge_lifecycle_events(
+        self,
+        *,
+        challenge_nonce: str = "",
+        operation_id: str = "",
+        limit: int | None = None,
+    ) -> tuple[OwnerControlChallengeLifecycleEventRecord, ...]:
+        filters: list[object] = []
+        if challenge_nonce:
+            filters.append(
+                LaunchplaneOwnerControlChallengeLifecycleEventRow.challenge_nonce == challenge_nonce
+            )
+        if operation_id:
+            filters.append(
+                LaunchplaneOwnerControlChallengeLifecycleEventRow.operation_id == operation_id
+            )
+        return self._list_models(
+            model_type=OwnerControlChallengeLifecycleEventRecord,
+            orm_model=LaunchplaneOwnerControlChallengeLifecycleEventRow,
+            filters=filters,
+            order_by=(
+                LaunchplaneOwnerControlChallengeLifecycleEventRow.occurred_at.desc(),
+                LaunchplaneOwnerControlChallengeLifecycleEventRow.event_id.desc(),
+            ),
+            limit=limit,
         )
 
     def list_owner_control_shadow_verification_events(

--- a/control_plane/storage/schema_invariants.py
+++ b/control_plane/storage/schema_invariants.py
@@ -10,7 +10,7 @@ from sqlalchemy.engine import Engine
 from sqlalchemy.exc import SQLAlchemyError
 
 AUTHZ_COMPATIBILITY_FLOOR_REVISION = "f3b5d7e9a1c2"
-EXPECTED_ALEMBIC_HEAD_REVISION = "f6a1c3e5b7d9"
+EXPECTED_ALEMBIC_HEAD_REVISION = "a7c9e1f3b5d7"
 RUNTIME_COMPATIBLE_ALEMBIC_REVISIONS = (EXPECTED_ALEMBIC_HEAD_REVISION,)
 _AUTHZ_POLICY_TABLE = "launchplane_authz_policies"
 _AUTHZ_POLICY_WRITE_FENCE_TRIGGER = "launchplane_authz_policy_write_fence"
@@ -458,6 +458,11 @@ CRITICAL_POSTGRES_COLUMN_TYPES: tuple[CriticalColumnType, ...] = (
     ),
     CriticalColumnType(
         "launchplane_owner_control_shadow_verification_events",
+        "payload",
+        ("jsonb",),
+    ),
+    CriticalColumnType(
+        "launchplane_owner_control_challenge_lifecycle_events",
         "payload",
         ("jsonb",),
     ),
@@ -1003,6 +1008,11 @@ CRITICAL_SCHEMA_INDEXES: tuple[CriticalIndex, ...] = (
         "launchplane_owner_control_shadow_event_session_idx",
         ("channel_session_id", "occurred_at"),
     ),
+    CriticalIndex(
+        "launchplane_owner_control_challenge_lifecycle_events",
+        "launchplane_owner_control_lifecycle_event_challenge_idx",
+        ("challenge_nonce", "occurred_at"),
+    ),
 )
 
 CRITICAL_PRIMARY_KEYS: tuple[CriticalPrimaryKey, ...] = (
@@ -1111,6 +1121,10 @@ CRITICAL_PRIMARY_KEYS: tuple[CriticalPrimaryKey, ...] = (
     ),
     CriticalPrimaryKey(
         "launchplane_owner_control_shadow_verification_events",
+        ("event_id",),
+    ),
+    CriticalPrimaryKey(
+        "launchplane_owner_control_challenge_lifecycle_events",
         ("event_id",),
     ),
 )

--- a/docs/owner-control-channel.md
+++ b/docs/owner-control-channel.md
@@ -99,9 +99,16 @@ token labels, planner errors, or free-text request reasons.
 At most one `issued` challenge can bind an operation. An exact repeat returns
 that existing challenge only while it remains unexpired, its expiry does not
 exceed the newly requested bound, and the session binding plus all current
-derived provenance still match. An expired row must receive a separately
-audited terminal transition before re-issuance; otherwise issuance conflicts.
-Verification updates only
+derived provenance still match. When locked issuance observes
+`expires_at <=` the database clock, it atomically appends one deterministic
+challenge-lifecycle event, changes the old row from `issued` to `expired`,
+flushes that transition to release the partial one-active-operation guard, and
+inserts the newly derived challenge in the same transaction. The lifecycle
+event contains no envelope and consumes no verification attempt. At the exact
+expiry boundary, issuance and verification serialize on the enrolled-session
+and challenge locks: verification may consume first under its inclusive
+confirmation-time contract, or issuance may expire first; the loser observes
+the committed terminal state. Verification updates only
 the challenge's mutable state/attempt evidence and does not change immutable
 challenge provenance, privileged-operation state, its event ledger, browser
 approval, or execution authorization. The verifier remains `shadow`, inert, and
@@ -144,7 +151,12 @@ operator, policy authority, session credential, or live endpoint data.
 `control_plane.contracts.owner_control_shadow_verifier` defines server-state
 records separate from the published wire contract. PostgreSQL persists enrolled
 channel sessions, issued single-use challenges, and append-only verification
-events. Enrollment and revocation are DB-backed; challenge issuance, expiry,
+events. A separate append-only challenge-lifecycle ledger records reactive
+non-verification transitions such as `issued -> expired` before re-issuance;
+it carries exact challenge/session/operation identifiers, request and binding
+digests, timestamp bounds, and inert non-authorizing markers without an
+envelope digest or attempt sequence. Enrollment and revocation are DB-backed;
+challenge issuance, expiry,
 verification audit timestamps, and successful-consumption timestamps use the
 database clock. Verification locks the enrolled session and issued challenge in
 one transaction, so one exact valid challenge can verify only once. Each issued

--- a/docs/records.md
+++ b/docs/records.md
@@ -2674,6 +2674,11 @@ enrolled canonical binding, inert authority marker, and revocation state;
 `launchplane_owner_control_issued_challenges` stores one canonical approval
 request and binding plus their SHA-256 digests, issued/terminal state, and a
 bounded verification-attempt count;
+`launchplane_owner_control_challenge_lifecycle_events` is append-only and stores
+one deterministic `issued -> expired` transition per challenge with exact
+challenge/session/operation identifiers, request and binding digests, challenge
+expiry, database occurrence time, `authorizes_execution = false`, and inert
+authority state but no envelope or verification-attempt sequence;
 and `launchplane_owner_control_shadow_verification_events` is append-only,
 retains only bounded digest/result fields with a unique per-challenge sequence,
 and is constrained to `verifier_mode = 'shadow'`, `authority_state = 'inert'`,
@@ -2685,8 +2690,13 @@ Unknown challenge nonces create no record or event.
 Challenge issuance is service-only and provenance-bound: the store derives the
 canonical approval request from one locked planned operation, exactly one active
 policy, and the enrolled session owner. Its partial unique index permits at most
-one `issued` challenge per operation. Issuance never updates the privileged
-operation current projection or its append-only event ledger.
+one `issued` challenge per operation. When the active row has expired at or
+before the database clock, issuance terminalizes it and appends its lifecycle
+event before flushing and inserting the replacement in the same transaction.
+The challenge `terminal_event_id` prefix identifies whether the terminal record
+came from the lifecycle ledger or the envelope-bound shadow-verification ledger.
+Issuance never updates the privileged operation current projection or its
+append-only event ledger.
 
 **Preserved history:** references to Phase 1 planning records describe the
 pre-worker lifecycle and do not constrain the current Phase 2 statuses.

--- a/tests/test_owner_control_shadow_verifier.py
+++ b/tests/test_owner_control_shadow_verifier.py
@@ -27,6 +27,8 @@ from control_plane.contracts.owner_control import (
 from control_plane.contracts.owner_control_shadow_verifier import (
     OwnerControlChallengeIssueRequest,
     evaluate_owner_control_shadow_verification,
+    owner_control_challenge_lifecycle_event_id,
+    terminalize_expired_owner_control_challenge_record,
 )
 from control_plane.contracts.authz_policy_record import (
     LaunchplaneAuthzPolicyRecord,
@@ -431,7 +433,7 @@ class OwnerControlShadowVerifierStorageTests(unittest.TestCase):
             issued = self.store.issue_owner_control_challenge(issue_request)
         self.assertEqual(issued.expires_at, "2026-08-28T12:01:30+00:00")
 
-    def test_issuance_rejects_expired_active_replay(self) -> None:
+    def test_issuance_terminalizes_expired_active_challenge_before_reissue(self) -> None:
         private_key = Ed25519PrivateKey.generate()
         binding = _binding(private_key, session_id="owner-control-stale-session")
         self.store.enroll_owner_control_channel_session(binding)
@@ -449,16 +451,189 @@ class OwnerControlShadowVerifierStorageTests(unittest.TestCase):
             "_owner_control_shadow_timestamp",
             return_value="2026-08-28T12:00:00+00:00",
         ):
-            self.store.issue_owner_control_challenge(issue_request)
+            issued = self.store.issue_owner_control_challenge(issue_request)
+        before = self.store.read_privileged_operation_record(operation.operation_id)
+        with patch.object(
+            self.store,
+            "_owner_control_shadow_timestamp",
+            return_value="2026-08-28T12:01:01+00:00",
+        ):
+            reissued = self.store.issue_owner_control_challenge(issue_request)
+        after = self.store.read_privileged_operation_record(operation.operation_id)
+        expired = self.store.read_owner_control_issued_challenge(
+            challenge_nonce=issued.challenge_nonce
+        )
+        lifecycle_events = self.store.list_owner_control_challenge_lifecycle_events(
+            challenge_nonce=issued.challenge_nonce
+        )
+        shadow_events = self.store.list_owner_control_shadow_verification_events(
+            challenge_nonce=issued.challenge_nonce
+        )
+
+        self.assertNotEqual(reissued.challenge_nonce, issued.challenge_nonce)
+        self.assertEqual(reissued.state, "issued")
+        self.assertEqual(expired.state, "expired")
+        self.assertEqual(expired.attempt_count, 0)
+        self.assertIsNone(expired.consumed_at)
+        self.assertEqual(len(lifecycle_events), 1)
+        lifecycle_event = lifecycle_events[0]
+        self.assertEqual(lifecycle_event.event_id, expired.terminal_event_id)
+        self.assertEqual(lifecycle_event.from_state, "issued")
+        self.assertEqual(lifecycle_event.to_state, "expired")
+        self.assertEqual(lifecycle_event.transition_reason, "expired")
+        self.assertEqual(lifecycle_event.occurred_at, reissued.issued_at)
+        self.assertFalse(lifecycle_event.authorizes_execution)
+        self.assertEqual(shadow_events, ())
+        self.assertEqual(before, after)
+
+        expired_result = self.store.verify_owner_control_confirmation_shadow(
+            _envelope(
+                private_key,
+                binding=binding,
+                request=issued.approval_request(),
+            )
+        )
+        expired_after_attempt = self.store.read_owner_control_issued_challenge(
+            challenge_nonce=issued.challenge_nonce
+        )
+        self.assertEqual(expired_result.rejection_reason, "challenge_expired")
+        self.assertEqual(expired_after_attempt.attempt_count, 1)
+        self.assertEqual(expired_after_attempt.terminal_event_id, lifecycle_event.event_id)
+
+    def test_expiry_terminalization_uses_exact_boundary_and_deterministic_event(self) -> None:
+        private_key = Ed25519PrivateKey.generate()
+        binding = _binding(private_key, session_id="owner-control-boundary-session")
+        self.store.enroll_owner_control_channel_session(binding)
+        operation = _seed_issue_provenance(
+            self.store,
+            expires_at="2026-08-28T12:10:00+00:00",
+        )
+        with patch.object(
+            self.store,
+            "_owner_control_shadow_timestamp",
+            return_value="2026-08-28T12:00:00+00:00",
+        ):
+            issued = self.store.issue_owner_control_challenge(
+                OwnerControlChallengeIssueRequest(
+                    channel_session_id=binding.channel_session_id,
+                    operation_id=operation.operation_id,
+                    expires_in_seconds=60,
+                )
+            )
+
+        expired, event = terminalize_expired_owner_control_challenge_record(
+            issued,
+            observed_at=issued.expires_at,
+        )
+        self.assertEqual(expired.state, "expired")
+        self.assertEqual(expired.attempt_count, issued.attempt_count)
+        self.assertEqual(expired.terminal_event_id, event.event_id)
+        self.assertEqual(
+            event.event_id,
+            owner_control_challenge_lifecycle_event_id(
+                challenge_id=issued.challenge_id,
+                from_state="issued",
+                to_state="expired",
+                transition_reason="expired",
+            ),
+        )
+        with self.assertRaisesRegex(ValueError, "has not expired"):
+            terminalize_expired_owner_control_challenge_record(
+                issued,
+                observed_at="2026-08-28T12:00:59+00:00",
+            )
+
+    def test_reissuance_rolls_back_terminalization_when_replacement_insert_fails(self) -> None:
+        private_key = Ed25519PrivateKey.generate()
+        binding = _binding(private_key, session_id="owner-control-rollback-session")
+        self.store.enroll_owner_control_channel_session(binding)
+        operation = _seed_issue_provenance(
+            self.store,
+            expires_at="2026-08-28T12:10:00+00:00",
+        )
+        issue_request = OwnerControlChallengeIssueRequest(
+            channel_session_id=binding.channel_session_id,
+            operation_id=operation.operation_id,
+            expires_in_seconds=60,
+        )
+        with patch.object(
+            self.store,
+            "_owner_control_shadow_timestamp",
+            return_value="2026-08-28T12:00:00+00:00",
+        ):
+            issued = self.store.issue_owner_control_challenge(issue_request)
+
         with (
             patch.object(
                 self.store,
                 "_owner_control_shadow_timestamp",
                 return_value="2026-08-28T12:01:01+00:00",
             ),
-            self.assertRaisesRegex(ValueError, "audited terminal transition"),
+            patch.object(
+                self.store,
+                "_owner_control_issued_challenge_row_from_record",
+                side_effect=RuntimeError("replacement insert failed"),
+            ),
+            self.assertRaisesRegex(RuntimeError, "replacement insert failed"),
         ):
             self.store.issue_owner_control_challenge(issue_request)
+
+        unchanged = self.store.read_owner_control_issued_challenge(
+            challenge_nonce=issued.challenge_nonce
+        )
+        self.assertEqual(unchanged.state, "issued")
+        self.assertIsNone(unchanged.terminal_event_id)
+        self.assertEqual(
+            self.store.list_owner_control_challenge_lifecycle_events(
+                challenge_nonce=issued.challenge_nonce
+            ),
+            (),
+        )
+
+    def test_reissuance_rolls_back_when_replacement_expires_before_commit(self) -> None:
+        private_key = Ed25519PrivateKey.generate()
+        binding = _binding(private_key, session_id="owner-control-stale-commit-session")
+        self.store.enroll_owner_control_channel_session(binding)
+        operation = _seed_issue_provenance(
+            self.store,
+            expires_at="2026-08-28T12:10:00+00:00",
+        )
+        issue_request = OwnerControlChallengeIssueRequest(
+            channel_session_id=binding.channel_session_id,
+            operation_id=operation.operation_id,
+            expires_in_seconds=60,
+        )
+        with patch.object(
+            self.store,
+            "_owner_control_shadow_timestamp",
+            return_value="2026-08-28T12:00:00+00:00",
+        ):
+            issued = self.store.issue_owner_control_challenge(issue_request)
+
+        with (
+            patch.object(
+                self.store,
+                "_owner_control_shadow_timestamp",
+                side_effect=(
+                    "2026-08-28T12:01:01+00:00",
+                    "2026-08-28T12:02:01+00:00",
+                ),
+            ),
+            self.assertRaisesRegex(ValueError, "expired before issuance committed"),
+        ):
+            self.store.issue_owner_control_challenge(issue_request)
+
+        unchanged = self.store.read_owner_control_issued_challenge(
+            challenge_nonce=issued.challenge_nonce
+        )
+        self.assertEqual(unchanged.state, "issued")
+        self.assertIsNone(unchanged.terminal_event_id)
+        self.assertEqual(
+            self.store.list_owner_control_challenge_lifecycle_events(
+                challenge_nonce=issued.challenge_nonce
+            ),
+            (),
+        )
 
     def test_issuance_rejects_rules_with_mutable_principal_selectors(self) -> None:
         private_key = Ed25519PrivateKey.generate()

--- a/tests/test_postgres_integration.py
+++ b/tests/test_postgres_integration.py
@@ -63,7 +63,10 @@ from control_plane.contracts.owner_control import (
     owner_control_channel_binding_sha256,
     owner_control_signature_payload_bytes,
 )
-from control_plane.contracts.owner_control_shadow_verifier import OwnerControlChallengeIssueRequest
+from control_plane.contracts.owner_control_shadow_verifier import (
+    OwnerControlChallengeIssueRequest,
+    OwnerControlIssuedChallengeRecord,
+)
 from control_plane.contracts.merge_train_controller_state import (
     MergeTrainControllerAdoptionRejectedError,
     MergeTrainControllerLeaseHeldError,
@@ -2596,6 +2599,84 @@ class RealPostgresStorageConcurrencyTests(unittest.TestCase):
 
         self.assertEqual(issued_records[0], issued_records[1])
         self.assertEqual(active_count, 1)
+
+    def test_owner_control_reissuance_terminalizes_expired_challenge_once(self) -> None:
+        with _store_for_fresh_head_database() as store:
+            private_key = Ed25519PrivateKey.generate()
+            binding = _owner_control_shadow_binding(private_key)
+            store.enroll_owner_control_channel_session(binding)
+            operation = _seed_owner_control_shadow_issue_provenance(store)
+            issue_request = OwnerControlChallengeIssueRequest(
+                channel_session_id=binding.channel_session_id,
+                operation_id=operation.operation_id,
+                expires_in_seconds=1,
+            )
+            with patch.object(
+                store,
+                "_owner_control_shadow_timestamp",
+                return_value="2026-08-28T12:00:00+00:00",
+            ):
+                expired_candidate = store.issue_owner_control_challenge(issue_request)
+            second_store = PostgresRecordStore(database_url=store.database_url)
+            barrier = threading.Barrier(2)
+
+            def reissue_once(
+                active_store: PostgresRecordStore,
+            ) -> OwnerControlIssuedChallengeRecord:
+                with patch.object(
+                    active_store,
+                    "_owner_control_shadow_timestamp",
+                    return_value="2026-08-28T12:00:02+00:00",
+                ):
+                    barrier.wait(timeout=10)
+                    return active_store.issue_owner_control_challenge(issue_request)
+
+            try:
+                with ThreadPoolExecutor(max_workers=2) as executor:
+                    issued_records = tuple(executor.map(reissue_once, (store, second_store)))
+                engine = create_engine(store.database_url)
+                try:
+                    with engine.connect() as connection:
+                        active_count = connection.scalar(
+                            text(
+                                "select count(*) from "
+                                "launchplane_owner_control_issued_challenges "
+                                "where operation_id = :operation_id and state = 'issued'"
+                            ),
+                            {"operation_id": operation.operation_id},
+                        )
+                        lifecycle_count = connection.scalar(
+                            text(
+                                "select count(*) from "
+                                "launchplane_owner_control_challenge_lifecycle_events "
+                                "where challenge_id = :challenge_id"
+                            ),
+                            {"challenge_id": expired_candidate.challenge_id},
+                        )
+                        shadow_count = connection.scalar(
+                            text(
+                                "select count(*) from "
+                                "launchplane_owner_control_shadow_verification_events "
+                                "where challenge_id = :challenge_id"
+                            ),
+                            {"challenge_id": expired_candidate.challenge_id},
+                        )
+                finally:
+                    engine.dispose()
+            finally:
+                second_store.close()
+
+            expired = store.read_owner_control_issued_challenge(
+                challenge_nonce=expired_candidate.challenge_nonce
+            )
+
+        self.assertEqual(issued_records[0], issued_records[1])
+        self.assertNotEqual(issued_records[0].challenge_id, expired_candidate.challenge_id)
+        self.assertEqual(expired.state, "expired")
+        self.assertEqual(expired.attempt_count, 0)
+        self.assertEqual(active_count, 1)
+        self.assertEqual(lifecycle_count, 1)
+        self.assertEqual(shadow_count, 0)
 
     def test_owner_control_shadow_verification_consumes_one_challenge_once(self) -> None:
         with _store_for_fresh_head_database() as store:

--- a/tests/test_schema_migration.py
+++ b/tests/test_schema_migration.py
@@ -1505,7 +1505,7 @@ class SchemaMigrationTests(unittest.TestCase):
             for primary_key in CRITICAL_PRIMARY_KEYS
         }
 
-        self.assertEqual(EXPECTED_ALEMBIC_HEAD_REVISION, "f6a1c3e5b7d9")
+        self.assertEqual(EXPECTED_ALEMBIC_HEAD_REVISION, "a7c9e1f3b5d7")
         self.assertNotIn(
             ("launchplane_human_sessions", "launchplane_human_sessions_github_id_idx"),
             indexes,
@@ -1537,10 +1537,25 @@ class SchemaMigrationTests(unittest.TestCase):
             primary_keys["launchplane_owner_control_shadow_verification_events"],
             ("event_id",),
         )
+        self.assertEqual(
+            column_types[("launchplane_owner_control_challenge_lifecycle_events", "payload")],
+            ("jsonb",),
+        )
+        self.assertEqual(
+            primary_keys["launchplane_owner_control_challenge_lifecycle_events"],
+            ("event_id",),
+        )
         self.assertIn(
             (
                 "launchplane_owner_control_shadow_verification_events",
                 "launchplane_owner_control_shadow_event_challenge_idx",
+            ),
+            indexes,
+        )
+        self.assertIn(
+            (
+                "launchplane_owner_control_challenge_lifecycle_events",
+                "launchplane_owner_control_lifecycle_event_challenge_idx",
             ),
             indexes,
         )
@@ -1796,6 +1811,19 @@ class SchemaMigrationTests(unittest.TestCase):
                     )
                     if (name := index.get("name")) is not None
                 }
+                lifecycle_event_indexes = {
+                    str(name): index
+                    for index in inspector.get_indexes(
+                        "launchplane_owner_control_challenge_lifecycle_events"
+                    )
+                    if (name := index.get("name")) is not None
+                }
+                lifecycle_event_columns = {
+                    str(column["name"])
+                    for column in inspector.get_columns(
+                        "launchplane_owner_control_challenge_lifecycle_events"
+                    )
+                }
             finally:
                 engine.dispose()
             command.downgrade(config, "f2241a0b1c2d")
@@ -1810,6 +1838,7 @@ class SchemaMigrationTests(unittest.TestCase):
                 "launchplane_owner_control_channel_sessions",
                 "launchplane_owner_control_issued_challenges",
                 "launchplane_owner_control_shadow_verification_events",
+                "launchplane_owner_control_challenge_lifecycle_events",
             }.issubset(table_names)
         )
         self.assertTrue(
@@ -1834,6 +1863,26 @@ class SchemaMigrationTests(unittest.TestCase):
             }.issubset(challenge_columns)
         )
         self.assertIn("launchplane_owner_control_shadow_event_challenge_idx", event_indexes)
+        self.assertTrue(
+            {
+                "event_id",
+                "challenge_id",
+                "challenge_nonce",
+                "operation_id",
+                "from_state",
+                "to_state",
+                "transition_reason",
+                "challenge_expires_at",
+                "occurred_at",
+                "authorizes_execution",
+                "authority_state",
+                "payload",
+            }.issubset(lifecycle_event_columns)
+        )
+        self.assertIn(
+            "launchplane_owner_control_lifecycle_event_challenge_idx",
+            lifecycle_event_indexes,
+        )
         active_operation_index = challenge_indexes[
             "launchplane_owner_control_challenge_active_operation_uidx"
         ]
@@ -1842,6 +1891,50 @@ class SchemaMigrationTests(unittest.TestCase):
         self.assertNotIn("launchplane_owner_control_channel_sessions", downgraded_tables)
         self.assertNotIn("launchplane_owner_control_issued_challenges", downgraded_tables)
         self.assertNotIn("launchplane_owner_control_shadow_verification_events", downgraded_tables)
+        self.assertNotIn(
+            "launchplane_owner_control_challenge_lifecycle_events",
+            downgraded_tables,
+        )
+
+    def test_owner_control_lifecycle_migration_refuses_nonempty_downgrade(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            database_url = (
+                f"sqlite+pysqlite:///{Path(temporary_directory_name) / 'records.sqlite3'}"
+            )
+            config = alembic_config(database_url)
+            command.upgrade(config, EXPECTED_ALEMBIC_HEAD_REVISION)
+            engine = create_engine(database_url)
+            try:
+                with engine.begin() as connection:
+                    connection.execute(
+                        text(
+                            "insert into launchplane_owner_control_challenge_lifecycle_events "
+                            "(event_id, challenge_id, challenge_nonce, channel_session_id, "
+                            "operation_id, approval_request_sha256, binding_sha256, from_state, "
+                            "to_state, transition_reason, challenge_expires_at, occurred_at, "
+                            "authorizes_execution, authority_state, payload) values "
+                            "(:event_id, :challenge_id, :challenge_nonce, :channel_session_id, "
+                            ":operation_id, :approval_request_sha256, :binding_sha256, 'issued', "
+                            "'expired', 'expired', :challenge_expires_at, :occurred_at, false, "
+                            "'inert', '{}')"
+                        ),
+                        {
+                            "event_id": "owner-control-lifecycle-event-test",
+                            "challenge_id": "owner-control-challenge-test",
+                            "challenge_nonce": "owner-control-challenge-nonce-test",
+                            "channel_session_id": "owner-control-session-test",
+                            "operation_id": "privileged-operation-0123456789abcdef0123456789abcdef",
+                            "approval_request_sha256": "a" * 64,
+                            "binding_sha256": "b" * 64,
+                            "challenge_expires_at": "2026-08-28T12:00:00+00:00",
+                            "occurred_at": "2026-08-28T12:00:00+00:00",
+                        },
+                    )
+            finally:
+                engine.dispose()
+
+            with self.assertRaisesRegex(RuntimeError, "audit events exist"):
+                command.downgrade(config, "f6a1c3e5b7d9")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- terminalize an expired active owner-control challenge inside the locked issuance transaction before routing a replacement
- persist one deterministic, append-only, inert lifecycle event without consuming a verification attempt or synthesizing an envelope
- add migration/schema invariants, bounded lifecycle reads, PostgreSQL concurrency coverage, rollback regressions, and ownership docs

## Safety
- lock the active challenge before sampling DB time and recheck freshness after replacement flush
- preserve immutable challenge provenance and privileged-operation state
- refuse downgrade while lifecycle audit rows exist
- add no API, worker, sweeper, grant, custody, or execution coupling

## Validation
- `uv run --extra dev python -m unittest tests.test_owner_control_shadow_verifier tests.test_schema_migration` (46 passed)
- `uv run --extra dev launchplane ci unittest-shard local` (3,147 targets, 12/12 shards passed)
- real PostgreSQL 16 `uv run --extra dev launchplane ci postgres-integration` (96 passed)
- `uv run --extra dev ruff check .`
- `uv run --extra dev mypy control_plane tests`
- changed-file Ruff format check, owner-control artifact drift, config-authority audit
- focused security review: no findings
- exact head `9221cac676f225f375f1b73738dc00b2ad61c438`: Opus `LOVE`, Gemini `LOVE`

Refs #2270
Refs #2257