### PR TITLE
Publish owner-control server-state conformance vectors

### DIFF
--- a/contracts/owner-control-contract.json
+++ b/contracts/owner-control-contract.json
@@ -64,6 +64,91 @@
       "sha256": "07db6c156108fd238db2691d759e6fe5d8f8649fb5e9c8130dc3f98342ba5ae2"
     }
   ],
+  "challenge_lifecycle_vectors": [
+    {
+      "expected_lifecycle_event": {
+        "approval_request_sha256": "a60572025b121241d44c3f28ce22715841e348765dd50cfa514861e89334d9eb",
+        "authority_state": "inert",
+        "authorizes_execution": false,
+        "binding_sha256": "278ee07f98754104407f5d42aadf5bd47090faaddc7db14c6a125b8d3bc56e1b",
+        "challenge_expires_at": "2030-01-02T03:09:05+00:00",
+        "challenge_id": "owner-control-challenge-a60572025b121241d44c3f28ce227158",
+        "challenge_nonce": "owner-control-b565a7b3115d408e250eeffe65af9513",
+        "channel_session_id": "channel-session-c57b127e5947af58b1597cb51fa705f3",
+        "event_id": "owner-control-lifecycle-event-4d643827e23fa0678377e4bbe7aaba9e",
+        "from_state": "issued",
+        "occurred_at": "2030-01-02T03:09:05+00:00",
+        "operation_id": "privileged-operation-1d762a6ac3895594ed85ba7aa9c39330",
+        "schema_version": 1,
+        "to_state": "expired",
+        "transition_reason": "expired"
+      },
+      "expected_terminalized_challenge": {
+        "approval_request_json": "{\"descriptor_id\":\"managed-authz-policy-set\",\"descriptor_version\":1,\"evidence_digest\":\"df6da961581b149a28639add56e3b08401b3bed6afb07ad0c7b5ca3d51632be9\",\"expires_at\":\"2030-01-02T03:09:05+00:00\",\"issued_at\":\"2030-01-02T03:00:05+00:00\",\"nonce\":\"owner-control-b565a7b3115d408e250eeffe65af9513\",\"operation_id\":\"privileged-operation-1d762a6ac3895594ed85ba7aa9c39330\",\"owner_github_id\":494383370,\"plan_digest\":\"edf23f94b33d1188e34e143e7aff91075ec941053b3b95d367a45de67b1fe1d7\",\"policy_record_id\":\"owner-policy-1d762a6ac3895594ed85\",\"policy_revision\":1,\"policy_sha256\":\"b379db2fe113e77eef0b3bb05aec804189d9f0b359e67d941d837c7de59e6f8e\",\"pre_state_digest\":\"46df3876ade6b39b0edfbd3b8ea1a408173bbe5d8cc7154cea4d63e5d057239f\",\"request_digest\":\"e0e31f55312d2562bf610587d7a21b5badeed50224284b08d1662924379b4539\",\"schema_version\":1,\"server_review\":{\"items\":[{\"key\":\"descriptor\",\"label\":\"Operation class\",\"value\":\"managed-authz-policy-set\"},{\"key\":\"safety_class\",\"label\":\"Safety class\",\"value\":\"policy_admin\"}],\"review_id\":\"review-1d762a6ac3895594ed85ba7a\",\"schema_version\":1,\"summary\":\"Review this exact privileged operation before confirming.\",\"title\":\"Owner approval required\"}}",
+        "approval_request_sha256": "a60572025b121241d44c3f28ce22715841e348765dd50cfa514861e89334d9eb",
+        "attempt_count": 0,
+        "authority_state": "inert",
+        "binding_json": "{\"channel_session_id\":\"channel-session-c57b127e5947af58b1597cb51fa705f3\",\"owner_github_id\":494383370,\"owner_public_key\":\"A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg\",\"schema_version\":1,\"session_expires_at\":\"2030-01-02T03:20:05+00:00\",\"session_issued_at\":\"2030-01-02T03:00:00+00:00\",\"signature_algorithm\":\"ed25519\"}",
+        "binding_sha256": "278ee07f98754104407f5d42aadf5bd47090faaddc7db14c6a125b8d3bc56e1b",
+        "challenge_id": "owner-control-challenge-a60572025b121241d44c3f28ce227158",
+        "challenge_nonce": "owner-control-b565a7b3115d408e250eeffe65af9513",
+        "channel_session_id": "channel-session-c57b127e5947af58b1597cb51fa705f3",
+        "consumed_at": null,
+        "descriptor_id": "managed-authz-policy-set",
+        "expires_at": "2030-01-02T03:09:05+00:00",
+        "issued_at": "2030-01-02T03:00:05+00:00",
+        "operation_id": "privileged-operation-1d762a6ac3895594ed85ba7aa9c39330",
+        "owner_github_id": 494383370,
+        "schema_version": 1,
+        "state": "expired",
+        "terminal_event_id": "owner-control-lifecycle-event-4d643827e23fa0678377e4bbe7aaba9e"
+      },
+      "issued_challenge": {
+        "approval_request_json": "{\"descriptor_id\":\"managed-authz-policy-set\",\"descriptor_version\":1,\"evidence_digest\":\"df6da961581b149a28639add56e3b08401b3bed6afb07ad0c7b5ca3d51632be9\",\"expires_at\":\"2030-01-02T03:09:05+00:00\",\"issued_at\":\"2030-01-02T03:00:05+00:00\",\"nonce\":\"owner-control-b565a7b3115d408e250eeffe65af9513\",\"operation_id\":\"privileged-operation-1d762a6ac3895594ed85ba7aa9c39330\",\"owner_github_id\":494383370,\"plan_digest\":\"edf23f94b33d1188e34e143e7aff91075ec941053b3b95d367a45de67b1fe1d7\",\"policy_record_id\":\"owner-policy-1d762a6ac3895594ed85\",\"policy_revision\":1,\"policy_sha256\":\"b379db2fe113e77eef0b3bb05aec804189d9f0b359e67d941d837c7de59e6f8e\",\"pre_state_digest\":\"46df3876ade6b39b0edfbd3b8ea1a408173bbe5d8cc7154cea4d63e5d057239f\",\"request_digest\":\"e0e31f55312d2562bf610587d7a21b5badeed50224284b08d1662924379b4539\",\"schema_version\":1,\"server_review\":{\"items\":[{\"key\":\"descriptor\",\"label\":\"Operation class\",\"value\":\"managed-authz-policy-set\"},{\"key\":\"safety_class\",\"label\":\"Safety class\",\"value\":\"policy_admin\"}],\"review_id\":\"review-1d762a6ac3895594ed85ba7a\",\"schema_version\":1,\"summary\":\"Review this exact privileged operation before confirming.\",\"title\":\"Owner approval required\"}}",
+        "approval_request_sha256": "a60572025b121241d44c3f28ce22715841e348765dd50cfa514861e89334d9eb",
+        "attempt_count": 0,
+        "authority_state": "inert",
+        "binding_json": "{\"channel_session_id\":\"channel-session-c57b127e5947af58b1597cb51fa705f3\",\"owner_github_id\":494383370,\"owner_public_key\":\"A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg\",\"schema_version\":1,\"session_expires_at\":\"2030-01-02T03:20:05+00:00\",\"session_issued_at\":\"2030-01-02T03:00:00+00:00\",\"signature_algorithm\":\"ed25519\"}",
+        "binding_sha256": "278ee07f98754104407f5d42aadf5bd47090faaddc7db14c6a125b8d3bc56e1b",
+        "challenge_id": "owner-control-challenge-a60572025b121241d44c3f28ce227158",
+        "challenge_nonce": "owner-control-b565a7b3115d408e250eeffe65af9513",
+        "channel_session_id": "channel-session-c57b127e5947af58b1597cb51fa705f3",
+        "consumed_at": null,
+        "descriptor_id": "managed-authz-policy-set",
+        "expires_at": "2030-01-02T03:09:05+00:00",
+        "issued_at": "2030-01-02T03:00:05+00:00",
+        "operation_id": "privileged-operation-1d762a6ac3895594ed85ba7aa9c39330",
+        "owner_github_id": 494383370,
+        "schema_version": 1,
+        "state": "issued",
+        "terminal_event_id": null
+      },
+      "name": "issued-to-expired-at-boundary",
+      "observed_at": "2030-01-02T03:09:05+00:00"
+    }
+  ],
+  "compatibility": {
+    "change_kind": "additive-server-state-vectors",
+    "container_schema_version": 3,
+    "preserved_v2_section_sha256": {
+      "canonical_json": "0c6b6454d737943d01d4621c217ff8412552a0bf0c69a0f50a761d38ac0e7d1f",
+      "canonicalization_vectors": "ca481ff769bba537310c8568b56850f5d12ebc0c90ace9ea2dc39ff714daa6a8",
+      "confirmation_golden_vectors": "58391f364a79ab321596d30200b87c9d29be366eaa1386a9ff4c242c8b38d50a",
+      "golden_vectors": "6955c5c8bb228c21bc6a68a4ddb7cf22456cd51615ffe6e421b0fa04f15d9584",
+      "negative_confirmation_vectors": "9d529ca0f5153c8c3eb3eb4862311efc6dc3c1dc7e5df55824ebde13194eb46d",
+      "negative_vectors": "232d29bc542df455c9f54a3196a2a4d41cb0912155f92d060c850df99c835b29",
+      "schemas": "00a8524a65afd637c8cfc88ef44e780154addc759b813a831f3ddf2ce1490bd0",
+      "signature_declaration": "7d9c62d55792931383d4a02ed99d31e21c67b5ce714c01d9144dc2a3bed34f72"
+    },
+    "previous_container_schema_version": 2,
+    "shadow_verifier_schema_versions": [
+      1
+    ],
+    "unknown_container_versions": "reject",
+    "wire_model_schema_versions": [
+      1
+    ]
+  },
   "confirmation_golden_vectors": [
     {
       "challenge_response": {
@@ -1916,7 +2001,7 @@
       "rule": "review-item-text-has-no-surrounding-whitespace"
     }
   ],
-  "schema_version": 2,
+  "schema_version": 3,
   "schemas": {
     "approval_request": {
       "$defs": {
@@ -3062,5 +3147,1159 @@
     "public_key_encoding": "base64url-unpadded",
     "signature_bytes": 64,
     "signature_encoding": "base64url-unpadded"
-  }
+  },
+  "verification_state_vectors": [
+    {
+      "channel_session": {
+        "authority_state": "inert",
+        "binding_json": "{\"channel_session_id\":\"channel-session-c57b127e5947af58b1597cb51fa705f3\",\"owner_github_id\":494383370,\"owner_public_key\":\"A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg\",\"schema_version\":1,\"session_expires_at\":\"2030-01-02T03:20:05+00:00\",\"session_issued_at\":\"2030-01-02T03:00:00+00:00\",\"signature_algorithm\":\"ed25519\"}",
+        "binding_sha256": "278ee07f98754104407f5d42aadf5bd47090faaddc7db14c6a125b8d3bc56e1b",
+        "channel_session_id": "channel-session-c57b127e5947af58b1597cb51fa705f3",
+        "enrolled_at": "2030-01-02T03:00:05+00:00",
+        "owner_github_id": 494383370,
+        "revoked_at": null,
+        "schema_version": 1,
+        "status": "enrolled"
+      },
+      "confirmation_envelope": {
+        "challenge_response": {
+          "approval_request": {
+            "descriptor_id": "managed-authz-policy-set",
+            "descriptor_version": 1,
+            "evidence_digest": "df6da961581b149a28639add56e3b08401b3bed6afb07ad0c7b5ca3d51632be9",
+            "expires_at": "2030-01-02T03:09:05+00:00",
+            "issued_at": "2030-01-02T03:00:05+00:00",
+            "nonce": "owner-control-b565a7b3115d408e250eeffe65af9513",
+            "operation_id": "privileged-operation-1d762a6ac3895594ed85ba7aa9c39330",
+            "owner_github_id": 494383370,
+            "plan_digest": "edf23f94b33d1188e34e143e7aff91075ec941053b3b95d367a45de67b1fe1d7",
+            "policy_record_id": "owner-policy-1d762a6ac3895594ed85",
+            "policy_revision": 1,
+            "policy_sha256": "b379db2fe113e77eef0b3bb05aec804189d9f0b359e67d941d837c7de59e6f8e",
+            "pre_state_digest": "46df3876ade6b39b0edfbd3b8ea1a408173bbe5d8cc7154cea4d63e5d057239f",
+            "request_digest": "e0e31f55312d2562bf610587d7a21b5badeed50224284b08d1662924379b4539",
+            "schema_version": 1,
+            "server_review": {
+              "items": [
+                {
+                  "key": "descriptor",
+                  "label": "Operation class",
+                  "value": "managed-authz-policy-set"
+                },
+                {
+                  "key": "safety_class",
+                  "label": "Safety class",
+                  "value": "policy_admin"
+                }
+              ],
+              "review_id": "review-1d762a6ac3895594ed85ba7a",
+              "schema_version": 1,
+              "summary": "Review this exact privileged operation before confirming.",
+              "title": "Owner approval required"
+            }
+          },
+          "approval_request_digest": "a60572025b121241d44c3f28ce22715841e348765dd50cfa514861e89334d9eb",
+          "channel_binding_sha256": "278ee07f98754104407f5d42aadf5bd47090faaddc7db14c6a125b8d3bc56e1b",
+          "confirmed_at": "2030-01-02T03:04:05+00:00",
+          "decision": "approved",
+          "schema_version": 1
+        },
+        "channel_binding": {
+          "channel_session_id": "channel-session-c57b127e5947af58b1597cb51fa705f3",
+          "owner_github_id": 494383370,
+          "owner_public_key": "A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg",
+          "schema_version": 1,
+          "session_expires_at": "2030-01-02T03:20:05+00:00",
+          "session_issued_at": "2030-01-02T03:00:00+00:00",
+          "signature_algorithm": "ed25519"
+        },
+        "schema_version": 1,
+        "signature": "5yFpKp48lfzpkxnf92lkEyl5hnYCrMeRNUdUKkOjA15CKokgDqsRDN8bNnJI_AMxFcD93fOuZxrG1Hh7rCDfCw",
+        "signature_algorithm": "ed25519"
+      },
+      "expected": {
+        "authority_state": "inert",
+        "authorizes_execution": false,
+        "consume_challenge": true,
+        "rejection_reason": null,
+        "resulting_challenge_state": "consumed",
+        "verification_status": "verified",
+        "verifier_mode": "shadow"
+      },
+      "issued_challenge": {
+        "approval_request_json": "{\"descriptor_id\":\"managed-authz-policy-set\",\"descriptor_version\":1,\"evidence_digest\":\"df6da961581b149a28639add56e3b08401b3bed6afb07ad0c7b5ca3d51632be9\",\"expires_at\":\"2030-01-02T03:09:05+00:00\",\"issued_at\":\"2030-01-02T03:00:05+00:00\",\"nonce\":\"owner-control-b565a7b3115d408e250eeffe65af9513\",\"operation_id\":\"privileged-operation-1d762a6ac3895594ed85ba7aa9c39330\",\"owner_github_id\":494383370,\"plan_digest\":\"edf23f94b33d1188e34e143e7aff91075ec941053b3b95d367a45de67b1fe1d7\",\"policy_record_id\":\"owner-policy-1d762a6ac3895594ed85\",\"policy_revision\":1,\"policy_sha256\":\"b379db2fe113e77eef0b3bb05aec804189d9f0b359e67d941d837c7de59e6f8e\",\"pre_state_digest\":\"46df3876ade6b39b0edfbd3b8ea1a408173bbe5d8cc7154cea4d63e5d057239f\",\"request_digest\":\"e0e31f55312d2562bf610587d7a21b5badeed50224284b08d1662924379b4539\",\"schema_version\":1,\"server_review\":{\"items\":[{\"key\":\"descriptor\",\"label\":\"Operation class\",\"value\":\"managed-authz-policy-set\"},{\"key\":\"safety_class\",\"label\":\"Safety class\",\"value\":\"policy_admin\"}],\"review_id\":\"review-1d762a6ac3895594ed85ba7a\",\"schema_version\":1,\"summary\":\"Review this exact privileged operation before confirming.\",\"title\":\"Owner approval required\"}}",
+        "approval_request_sha256": "a60572025b121241d44c3f28ce22715841e348765dd50cfa514861e89334d9eb",
+        "attempt_count": 0,
+        "authority_state": "inert",
+        "binding_json": "{\"channel_session_id\":\"channel-session-c57b127e5947af58b1597cb51fa705f3\",\"owner_github_id\":494383370,\"owner_public_key\":\"A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg\",\"schema_version\":1,\"session_expires_at\":\"2030-01-02T03:20:05+00:00\",\"session_issued_at\":\"2030-01-02T03:00:00+00:00\",\"signature_algorithm\":\"ed25519\"}",
+        "binding_sha256": "278ee07f98754104407f5d42aadf5bd47090faaddc7db14c6a125b8d3bc56e1b",
+        "challenge_id": "owner-control-challenge-a60572025b121241d44c3f28ce227158",
+        "challenge_nonce": "owner-control-b565a7b3115d408e250eeffe65af9513",
+        "channel_session_id": "channel-session-c57b127e5947af58b1597cb51fa705f3",
+        "consumed_at": null,
+        "descriptor_id": "managed-authz-policy-set",
+        "expires_at": "2030-01-02T03:09:05+00:00",
+        "issued_at": "2030-01-02T03:00:05+00:00",
+        "operation_id": "privileged-operation-1d762a6ac3895594ed85ba7aa9c39330",
+        "owner_github_id": 494383370,
+        "schema_version": 1,
+        "state": "issued",
+        "terminal_event_id": null
+      },
+      "name": "verified",
+      "observed_at": "2030-01-02T03:04:05+00:00"
+    },
+    {
+      "channel_session": null,
+      "confirmation_envelope": {
+        "challenge_response": {
+          "approval_request": {
+            "descriptor_id": "managed-authz-policy-set",
+            "descriptor_version": 1,
+            "evidence_digest": "df6da961581b149a28639add56e3b08401b3bed6afb07ad0c7b5ca3d51632be9",
+            "expires_at": "2030-01-02T03:09:05+00:00",
+            "issued_at": "2030-01-02T03:00:05+00:00",
+            "nonce": "owner-control-b565a7b3115d408e250eeffe65af9513",
+            "operation_id": "privileged-operation-1d762a6ac3895594ed85ba7aa9c39330",
+            "owner_github_id": 494383370,
+            "plan_digest": "edf23f94b33d1188e34e143e7aff91075ec941053b3b95d367a45de67b1fe1d7",
+            "policy_record_id": "owner-policy-1d762a6ac3895594ed85",
+            "policy_revision": 1,
+            "policy_sha256": "b379db2fe113e77eef0b3bb05aec804189d9f0b359e67d941d837c7de59e6f8e",
+            "pre_state_digest": "46df3876ade6b39b0edfbd3b8ea1a408173bbe5d8cc7154cea4d63e5d057239f",
+            "request_digest": "e0e31f55312d2562bf610587d7a21b5badeed50224284b08d1662924379b4539",
+            "schema_version": 1,
+            "server_review": {
+              "items": [
+                {
+                  "key": "descriptor",
+                  "label": "Operation class",
+                  "value": "managed-authz-policy-set"
+                },
+                {
+                  "key": "safety_class",
+                  "label": "Safety class",
+                  "value": "policy_admin"
+                }
+              ],
+              "review_id": "review-1d762a6ac3895594ed85ba7a",
+              "schema_version": 1,
+              "summary": "Review this exact privileged operation before confirming.",
+              "title": "Owner approval required"
+            }
+          },
+          "approval_request_digest": "a60572025b121241d44c3f28ce22715841e348765dd50cfa514861e89334d9eb",
+          "channel_binding_sha256": "278ee07f98754104407f5d42aadf5bd47090faaddc7db14c6a125b8d3bc56e1b",
+          "confirmed_at": "2030-01-02T03:04:05+00:00",
+          "decision": "approved",
+          "schema_version": 1
+        },
+        "channel_binding": {
+          "channel_session_id": "channel-session-c57b127e5947af58b1597cb51fa705f3",
+          "owner_github_id": 494383370,
+          "owner_public_key": "A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg",
+          "schema_version": 1,
+          "session_expires_at": "2030-01-02T03:20:05+00:00",
+          "session_issued_at": "2030-01-02T03:00:00+00:00",
+          "signature_algorithm": "ed25519"
+        },
+        "schema_version": 1,
+        "signature": "5yFpKp48lfzpkxnf92lkEyl5hnYCrMeRNUdUKkOjA15CKokgDqsRDN8bNnJI_AMxFcD93fOuZxrG1Hh7rCDfCw",
+        "signature_algorithm": "ed25519"
+      },
+      "expected": {
+        "authority_state": "inert",
+        "authorizes_execution": false,
+        "consume_challenge": false,
+        "rejection_reason": "unknown_channel_session",
+        "resulting_challenge_state": "rejected",
+        "verification_status": "rejected",
+        "verifier_mode": "shadow"
+      },
+      "issued_challenge": null,
+      "name": "unknown-channel-session",
+      "observed_at": "2030-01-02T03:04:05+00:00"
+    },
+    {
+      "channel_session": {
+        "authority_state": "inert",
+        "binding_json": "{\"channel_session_id\":\"channel-session-c57b127e5947af58b1597cb51fa705f3\",\"owner_github_id\":494383370,\"owner_public_key\":\"A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg\",\"schema_version\":1,\"session_expires_at\":\"2030-01-02T03:20:05+00:00\",\"session_issued_at\":\"2030-01-02T03:00:00+00:00\",\"signature_algorithm\":\"ed25519\"}",
+        "binding_sha256": "278ee07f98754104407f5d42aadf5bd47090faaddc7db14c6a125b8d3bc56e1b",
+        "channel_session_id": "channel-session-c57b127e5947af58b1597cb51fa705f3",
+        "enrolled_at": "2030-01-02T03:00:05+00:00",
+        "owner_github_id": 494383370,
+        "revoked_at": null,
+        "schema_version": 1,
+        "status": "enrolled"
+      },
+      "confirmation_envelope": {
+        "challenge_response": {
+          "approval_request": {
+            "descriptor_id": "managed-authz-policy-set",
+            "descriptor_version": 1,
+            "evidence_digest": "df6da961581b149a28639add56e3b08401b3bed6afb07ad0c7b5ca3d51632be9",
+            "expires_at": "2030-01-02T03:09:05+00:00",
+            "issued_at": "2030-01-02T03:00:05+00:00",
+            "nonce": "owner-control-b565a7b3115d408e250eeffe65af9513",
+            "operation_id": "privileged-operation-1d762a6ac3895594ed85ba7aa9c39330",
+            "owner_github_id": 494383370,
+            "plan_digest": "edf23f94b33d1188e34e143e7aff91075ec941053b3b95d367a45de67b1fe1d7",
+            "policy_record_id": "owner-policy-1d762a6ac3895594ed85",
+            "policy_revision": 1,
+            "policy_sha256": "b379db2fe113e77eef0b3bb05aec804189d9f0b359e67d941d837c7de59e6f8e",
+            "pre_state_digest": "46df3876ade6b39b0edfbd3b8ea1a408173bbe5d8cc7154cea4d63e5d057239f",
+            "request_digest": "e0e31f55312d2562bf610587d7a21b5badeed50224284b08d1662924379b4539",
+            "schema_version": 1,
+            "server_review": {
+              "items": [
+                {
+                  "key": "descriptor",
+                  "label": "Operation class",
+                  "value": "managed-authz-policy-set"
+                },
+                {
+                  "key": "safety_class",
+                  "label": "Safety class",
+                  "value": "policy_admin"
+                }
+              ],
+              "review_id": "review-1d762a6ac3895594ed85ba7a",
+              "schema_version": 1,
+              "summary": "Review this exact privileged operation before confirming.",
+              "title": "Owner approval required"
+            }
+          },
+          "approval_request_digest": "a60572025b121241d44c3f28ce22715841e348765dd50cfa514861e89334d9eb",
+          "channel_binding_sha256": "278ee07f98754104407f5d42aadf5bd47090faaddc7db14c6a125b8d3bc56e1b",
+          "confirmed_at": "2030-01-02T03:04:05+00:00",
+          "decision": "approved",
+          "schema_version": 1
+        },
+        "channel_binding": {
+          "channel_session_id": "channel-session-c57b127e5947af58b1597cb51fa705f3",
+          "owner_github_id": 494383370,
+          "owner_public_key": "A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg",
+          "schema_version": 1,
+          "session_expires_at": "2030-01-02T03:20:05+00:00",
+          "session_issued_at": "2030-01-02T03:00:00+00:00",
+          "signature_algorithm": "ed25519"
+        },
+        "schema_version": 1,
+        "signature": "5yFpKp48lfzpkxnf92lkEyl5hnYCrMeRNUdUKkOjA15CKokgDqsRDN8bNnJI_AMxFcD93fOuZxrG1Hh7rCDfCw",
+        "signature_algorithm": "ed25519"
+      },
+      "expected": {
+        "authority_state": "inert",
+        "authorizes_execution": false,
+        "consume_challenge": false,
+        "rejection_reason": "unknown_challenge",
+        "resulting_challenge_state": "rejected",
+        "verification_status": "rejected",
+        "verifier_mode": "shadow"
+      },
+      "issued_challenge": null,
+      "name": "unknown-challenge",
+      "observed_at": "2030-01-02T03:04:05+00:00"
+    },
+    {
+      "channel_session": {
+        "authority_state": "inert",
+        "binding_json": "{\"channel_session_id\":\"channel-session-c57b127e5947af58b1597cb51fa705f3\",\"owner_github_id\":494383370,\"owner_public_key\":\"A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg\",\"schema_version\":1,\"session_expires_at\":\"2030-01-02T03:20:05+00:00\",\"session_issued_at\":\"2030-01-02T03:00:00+00:00\",\"signature_algorithm\":\"ed25519\"}",
+        "binding_sha256": "278ee07f98754104407f5d42aadf5bd47090faaddc7db14c6a125b8d3bc56e1b",
+        "channel_session_id": "channel-session-c57b127e5947af58b1597cb51fa705f3",
+        "enrolled_at": "2030-01-02T03:00:05+00:00",
+        "owner_github_id": 494383370,
+        "revoked_at": "2030-01-02T03:03:05+00:00",
+        "schema_version": 1,
+        "status": "revoked"
+      },
+      "confirmation_envelope": {
+        "challenge_response": {
+          "approval_request": {
+            "descriptor_id": "managed-authz-policy-set",
+            "descriptor_version": 1,
+            "evidence_digest": "df6da961581b149a28639add56e3b08401b3bed6afb07ad0c7b5ca3d51632be9",
+            "expires_at": "2030-01-02T03:09:05+00:00",
+            "issued_at": "2030-01-02T03:00:05+00:00",
+            "nonce": "owner-control-b565a7b3115d408e250eeffe65af9513",
+            "operation_id": "privileged-operation-1d762a6ac3895594ed85ba7aa9c39330",
+            "owner_github_id": 494383370,
+            "plan_digest": "edf23f94b33d1188e34e143e7aff91075ec941053b3b95d367a45de67b1fe1d7",
+            "policy_record_id": "owner-policy-1d762a6ac3895594ed85",
+            "policy_revision": 1,
+            "policy_sha256": "b379db2fe113e77eef0b3bb05aec804189d9f0b359e67d941d837c7de59e6f8e",
+            "pre_state_digest": "46df3876ade6b39b0edfbd3b8ea1a408173bbe5d8cc7154cea4d63e5d057239f",
+            "request_digest": "e0e31f55312d2562bf610587d7a21b5badeed50224284b08d1662924379b4539",
+            "schema_version": 1,
+            "server_review": {
+              "items": [
+                {
+                  "key": "descriptor",
+                  "label": "Operation class",
+                  "value": "managed-authz-policy-set"
+                },
+                {
+                  "key": "safety_class",
+                  "label": "Safety class",
+                  "value": "policy_admin"
+                }
+              ],
+              "review_id": "review-1d762a6ac3895594ed85ba7a",
+              "schema_version": 1,
+              "summary": "Review this exact privileged operation before confirming.",
+              "title": "Owner approval required"
+            }
+          },
+          "approval_request_digest": "a60572025b121241d44c3f28ce22715841e348765dd50cfa514861e89334d9eb",
+          "channel_binding_sha256": "278ee07f98754104407f5d42aadf5bd47090faaddc7db14c6a125b8d3bc56e1b",
+          "confirmed_at": "2030-01-02T03:04:05+00:00",
+          "decision": "approved",
+          "schema_version": 1
+        },
+        "channel_binding": {
+          "channel_session_id": "channel-session-c57b127e5947af58b1597cb51fa705f3",
+          "owner_github_id": 494383370,
+          "owner_public_key": "A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg",
+          "schema_version": 1,
+          "session_expires_at": "2030-01-02T03:20:05+00:00",
+          "session_issued_at": "2030-01-02T03:00:00+00:00",
+          "signature_algorithm": "ed25519"
+        },
+        "schema_version": 1,
+        "signature": "5yFpKp48lfzpkxnf92lkEyl5hnYCrMeRNUdUKkOjA15CKokgDqsRDN8bNnJI_AMxFcD93fOuZxrG1Hh7rCDfCw",
+        "signature_algorithm": "ed25519"
+      },
+      "expected": {
+        "authority_state": "inert",
+        "authorizes_execution": false,
+        "consume_challenge": false,
+        "rejection_reason": "channel_session_revoked",
+        "resulting_challenge_state": "rejected",
+        "verification_status": "rejected",
+        "verifier_mode": "shadow"
+      },
+      "issued_challenge": {
+        "approval_request_json": "{\"descriptor_id\":\"managed-authz-policy-set\",\"descriptor_version\":1,\"evidence_digest\":\"df6da961581b149a28639add56e3b08401b3bed6afb07ad0c7b5ca3d51632be9\",\"expires_at\":\"2030-01-02T03:09:05+00:00\",\"issued_at\":\"2030-01-02T03:00:05+00:00\",\"nonce\":\"owner-control-b565a7b3115d408e250eeffe65af9513\",\"operation_id\":\"privileged-operation-1d762a6ac3895594ed85ba7aa9c39330\",\"owner_github_id\":494383370,\"plan_digest\":\"edf23f94b33d1188e34e143e7aff91075ec941053b3b95d367a45de67b1fe1d7\",\"policy_record_id\":\"owner-policy-1d762a6ac3895594ed85\",\"policy_revision\":1,\"policy_sha256\":\"b379db2fe113e77eef0b3bb05aec804189d9f0b359e67d941d837c7de59e6f8e\",\"pre_state_digest\":\"46df3876ade6b39b0edfbd3b8ea1a408173bbe5d8cc7154cea4d63e5d057239f\",\"request_digest\":\"e0e31f55312d2562bf610587d7a21b5badeed50224284b08d1662924379b4539\",\"schema_version\":1,\"server_review\":{\"items\":[{\"key\":\"descriptor\",\"label\":\"Operation class\",\"value\":\"managed-authz-policy-set\"},{\"key\":\"safety_class\",\"label\":\"Safety class\",\"value\":\"policy_admin\"}],\"review_id\":\"review-1d762a6ac3895594ed85ba7a\",\"schema_version\":1,\"summary\":\"Review this exact privileged operation before confirming.\",\"title\":\"Owner approval required\"}}",
+        "approval_request_sha256": "a60572025b121241d44c3f28ce22715841e348765dd50cfa514861e89334d9eb",
+        "attempt_count": 0,
+        "authority_state": "inert",
+        "binding_json": "{\"channel_session_id\":\"channel-session-c57b127e5947af58b1597cb51fa705f3\",\"owner_github_id\":494383370,\"owner_public_key\":\"A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg\",\"schema_version\":1,\"session_expires_at\":\"2030-01-02T03:20:05+00:00\",\"session_issued_at\":\"2030-01-02T03:00:00+00:00\",\"signature_algorithm\":\"ed25519\"}",
+        "binding_sha256": "278ee07f98754104407f5d42aadf5bd47090faaddc7db14c6a125b8d3bc56e1b",
+        "challenge_id": "owner-control-challenge-a60572025b121241d44c3f28ce227158",
+        "challenge_nonce": "owner-control-b565a7b3115d408e250eeffe65af9513",
+        "channel_session_id": "channel-session-c57b127e5947af58b1597cb51fa705f3",
+        "consumed_at": null,
+        "descriptor_id": "managed-authz-policy-set",
+        "expires_at": "2030-01-02T03:09:05+00:00",
+        "issued_at": "2030-01-02T03:00:05+00:00",
+        "operation_id": "privileged-operation-1d762a6ac3895594ed85ba7aa9c39330",
+        "owner_github_id": 494383370,
+        "schema_version": 1,
+        "state": "issued",
+        "terminal_event_id": null
+      },
+      "name": "channel-session-revoked",
+      "observed_at": "2030-01-02T03:04:05+00:00"
+    },
+    {
+      "channel_session": {
+        "authority_state": "inert",
+        "binding_json": "{\"channel_session_id\":\"channel-session-c57b127e5947af58b1597cb51fa705f3\",\"owner_github_id\":494383370,\"owner_public_key\":\"A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg\",\"schema_version\":1,\"session_expires_at\":\"2030-01-02T03:20:05+00:00\",\"session_issued_at\":\"2030-01-02T03:00:00+00:00\",\"signature_algorithm\":\"ed25519\"}",
+        "binding_sha256": "278ee07f98754104407f5d42aadf5bd47090faaddc7db14c6a125b8d3bc56e1b",
+        "channel_session_id": "channel-session-c57b127e5947af58b1597cb51fa705f3",
+        "enrolled_at": "2030-01-02T03:00:05+00:00",
+        "owner_github_id": 494383370,
+        "revoked_at": null,
+        "schema_version": 1,
+        "status": "enrolled"
+      },
+      "confirmation_envelope": {
+        "challenge_response": {
+          "approval_request": {
+            "descriptor_id": "managed-authz-policy-set",
+            "descriptor_version": 1,
+            "evidence_digest": "df6da961581b149a28639add56e3b08401b3bed6afb07ad0c7b5ca3d51632be9",
+            "expires_at": "2030-01-02T03:09:05+00:00",
+            "issued_at": "2030-01-02T03:00:05+00:00",
+            "nonce": "owner-control-b565a7b3115d408e250eeffe65af9513",
+            "operation_id": "privileged-operation-1d762a6ac3895594ed85ba7aa9c39330",
+            "owner_github_id": 494383370,
+            "plan_digest": "edf23f94b33d1188e34e143e7aff91075ec941053b3b95d367a45de67b1fe1d7",
+            "policy_record_id": "owner-policy-1d762a6ac3895594ed85",
+            "policy_revision": 1,
+            "policy_sha256": "b379db2fe113e77eef0b3bb05aec804189d9f0b359e67d941d837c7de59e6f8e",
+            "pre_state_digest": "46df3876ade6b39b0edfbd3b8ea1a408173bbe5d8cc7154cea4d63e5d057239f",
+            "request_digest": "e0e31f55312d2562bf610587d7a21b5badeed50224284b08d1662924379b4539",
+            "schema_version": 1,
+            "server_review": {
+              "items": [
+                {
+                  "key": "descriptor",
+                  "label": "Operation class",
+                  "value": "managed-authz-policy-set"
+                },
+                {
+                  "key": "safety_class",
+                  "label": "Safety class",
+                  "value": "policy_admin"
+                }
+              ],
+              "review_id": "review-1d762a6ac3895594ed85ba7a",
+              "schema_version": 1,
+              "summary": "Review this exact privileged operation before confirming.",
+              "title": "Owner approval required"
+            }
+          },
+          "approval_request_digest": "a60572025b121241d44c3f28ce22715841e348765dd50cfa514861e89334d9eb",
+          "channel_binding_sha256": "278ee07f98754104407f5d42aadf5bd47090faaddc7db14c6a125b8d3bc56e1b",
+          "confirmed_at": "2030-01-02T03:04:05+00:00",
+          "decision": "approved",
+          "schema_version": 1
+        },
+        "channel_binding": {
+          "channel_session_id": "channel-session-c57b127e5947af58b1597cb51fa705f3",
+          "owner_github_id": 494383370,
+          "owner_public_key": "A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg",
+          "schema_version": 1,
+          "session_expires_at": "2030-01-02T03:20:05+00:00",
+          "session_issued_at": "2030-01-02T03:00:00+00:00",
+          "signature_algorithm": "ed25519"
+        },
+        "schema_version": 1,
+        "signature": "5yFpKp48lfzpkxnf92lkEyl5hnYCrMeRNUdUKkOjA15CKokgDqsRDN8bNnJI_AMxFcD93fOuZxrG1Hh7rCDfCw",
+        "signature_algorithm": "ed25519"
+      },
+      "expected": {
+        "authority_state": "inert",
+        "authorizes_execution": false,
+        "consume_challenge": false,
+        "rejection_reason": "channel_session_expired",
+        "resulting_challenge_state": "expired",
+        "verification_status": "rejected",
+        "verifier_mode": "shadow"
+      },
+      "issued_challenge": {
+        "approval_request_json": "{\"descriptor_id\":\"managed-authz-policy-set\",\"descriptor_version\":1,\"evidence_digest\":\"df6da961581b149a28639add56e3b08401b3bed6afb07ad0c7b5ca3d51632be9\",\"expires_at\":\"2030-01-02T03:09:05+00:00\",\"issued_at\":\"2030-01-02T03:00:05+00:00\",\"nonce\":\"owner-control-b565a7b3115d408e250eeffe65af9513\",\"operation_id\":\"privileged-operation-1d762a6ac3895594ed85ba7aa9c39330\",\"owner_github_id\":494383370,\"plan_digest\":\"edf23f94b33d1188e34e143e7aff91075ec941053b3b95d367a45de67b1fe1d7\",\"policy_record_id\":\"owner-policy-1d762a6ac3895594ed85\",\"policy_revision\":1,\"policy_sha256\":\"b379db2fe113e77eef0b3bb05aec804189d9f0b359e67d941d837c7de59e6f8e\",\"pre_state_digest\":\"46df3876ade6b39b0edfbd3b8ea1a408173bbe5d8cc7154cea4d63e5d057239f\",\"request_digest\":\"e0e31f55312d2562bf610587d7a21b5badeed50224284b08d1662924379b4539\",\"schema_version\":1,\"server_review\":{\"items\":[{\"key\":\"descriptor\",\"label\":\"Operation class\",\"value\":\"managed-authz-policy-set\"},{\"key\":\"safety_class\",\"label\":\"Safety class\",\"value\":\"policy_admin\"}],\"review_id\":\"review-1d762a6ac3895594ed85ba7a\",\"schema_version\":1,\"summary\":\"Review this exact privileged operation before confirming.\",\"title\":\"Owner approval required\"}}",
+        "approval_request_sha256": "a60572025b121241d44c3f28ce22715841e348765dd50cfa514861e89334d9eb",
+        "attempt_count": 0,
+        "authority_state": "inert",
+        "binding_json": "{\"channel_session_id\":\"channel-session-c57b127e5947af58b1597cb51fa705f3\",\"owner_github_id\":494383370,\"owner_public_key\":\"A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg\",\"schema_version\":1,\"session_expires_at\":\"2030-01-02T03:20:05+00:00\",\"session_issued_at\":\"2030-01-02T03:00:00+00:00\",\"signature_algorithm\":\"ed25519\"}",
+        "binding_sha256": "278ee07f98754104407f5d42aadf5bd47090faaddc7db14c6a125b8d3bc56e1b",
+        "challenge_id": "owner-control-challenge-a60572025b121241d44c3f28ce227158",
+        "challenge_nonce": "owner-control-b565a7b3115d408e250eeffe65af9513",
+        "channel_session_id": "channel-session-c57b127e5947af58b1597cb51fa705f3",
+        "consumed_at": null,
+        "descriptor_id": "managed-authz-policy-set",
+        "expires_at": "2030-01-02T03:09:05+00:00",
+        "issued_at": "2030-01-02T03:00:05+00:00",
+        "operation_id": "privileged-operation-1d762a6ac3895594ed85ba7aa9c39330",
+        "owner_github_id": 494383370,
+        "schema_version": 1,
+        "state": "issued",
+        "terminal_event_id": null
+      },
+      "name": "channel-session-expired",
+      "observed_at": "2030-01-02T03:20:06+00:00"
+    },
+    {
+      "channel_session": {
+        "authority_state": "inert",
+        "binding_json": "{\"channel_session_id\":\"channel-session-5802cd3ec3ad1c7ce24a9b3bb529c59a\",\"owner_github_id\":494383370,\"owner_public_key\":\"A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg\",\"schema_version\":1,\"session_expires_at\":\"2030-01-02T03:20:05+00:00\",\"session_issued_at\":\"2030-01-02T03:00:00+00:00\",\"signature_algorithm\":\"ed25519\"}",
+        "binding_sha256": "a8b5e6f5ce4700ae19ea182fe387914b8361356397622868a6254f7e771f2bd7",
+        "channel_session_id": "channel-session-5802cd3ec3ad1c7ce24a9b3bb529c59a",
+        "enrolled_at": "2030-01-02T03:00:05+00:00",
+        "owner_github_id": 494383370,
+        "revoked_at": null,
+        "schema_version": 1,
+        "status": "enrolled"
+      },
+      "confirmation_envelope": {
+        "challenge_response": {
+          "approval_request": {
+            "descriptor_id": "managed-authz-policy-set",
+            "descriptor_version": 1,
+            "evidence_digest": "df6da961581b149a28639add56e3b08401b3bed6afb07ad0c7b5ca3d51632be9",
+            "expires_at": "2030-01-02T03:09:05+00:00",
+            "issued_at": "2030-01-02T03:00:05+00:00",
+            "nonce": "owner-control-b565a7b3115d408e250eeffe65af9513",
+            "operation_id": "privileged-operation-1d762a6ac3895594ed85ba7aa9c39330",
+            "owner_github_id": 494383370,
+            "plan_digest": "edf23f94b33d1188e34e143e7aff91075ec941053b3b95d367a45de67b1fe1d7",
+            "policy_record_id": "owner-policy-1d762a6ac3895594ed85",
+            "policy_revision": 1,
+            "policy_sha256": "b379db2fe113e77eef0b3bb05aec804189d9f0b359e67d941d837c7de59e6f8e",
+            "pre_state_digest": "46df3876ade6b39b0edfbd3b8ea1a408173bbe5d8cc7154cea4d63e5d057239f",
+            "request_digest": "e0e31f55312d2562bf610587d7a21b5badeed50224284b08d1662924379b4539",
+            "schema_version": 1,
+            "server_review": {
+              "items": [
+                {
+                  "key": "descriptor",
+                  "label": "Operation class",
+                  "value": "managed-authz-policy-set"
+                },
+                {
+                  "key": "safety_class",
+                  "label": "Safety class",
+                  "value": "policy_admin"
+                }
+              ],
+              "review_id": "review-1d762a6ac3895594ed85ba7a",
+              "schema_version": 1,
+              "summary": "Review this exact privileged operation before confirming.",
+              "title": "Owner approval required"
+            }
+          },
+          "approval_request_digest": "a60572025b121241d44c3f28ce22715841e348765dd50cfa514861e89334d9eb",
+          "channel_binding_sha256": "278ee07f98754104407f5d42aadf5bd47090faaddc7db14c6a125b8d3bc56e1b",
+          "confirmed_at": "2030-01-02T03:04:05+00:00",
+          "decision": "approved",
+          "schema_version": 1
+        },
+        "channel_binding": {
+          "channel_session_id": "channel-session-c57b127e5947af58b1597cb51fa705f3",
+          "owner_github_id": 494383370,
+          "owner_public_key": "A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg",
+          "schema_version": 1,
+          "session_expires_at": "2030-01-02T03:20:05+00:00",
+          "session_issued_at": "2030-01-02T03:00:00+00:00",
+          "signature_algorithm": "ed25519"
+        },
+        "schema_version": 1,
+        "signature": "5yFpKp48lfzpkxnf92lkEyl5hnYCrMeRNUdUKkOjA15CKokgDqsRDN8bNnJI_AMxFcD93fOuZxrG1Hh7rCDfCw",
+        "signature_algorithm": "ed25519"
+      },
+      "expected": {
+        "authority_state": "inert",
+        "authorizes_execution": false,
+        "consume_challenge": false,
+        "rejection_reason": "challenge_channel_session_mismatch",
+        "resulting_challenge_state": "rejected",
+        "verification_status": "rejected",
+        "verifier_mode": "shadow"
+      },
+      "issued_challenge": {
+        "approval_request_json": "{\"descriptor_id\":\"managed-authz-policy-set\",\"descriptor_version\":1,\"evidence_digest\":\"df6da961581b149a28639add56e3b08401b3bed6afb07ad0c7b5ca3d51632be9\",\"expires_at\":\"2030-01-02T03:09:05+00:00\",\"issued_at\":\"2030-01-02T03:00:05+00:00\",\"nonce\":\"owner-control-b565a7b3115d408e250eeffe65af9513\",\"operation_id\":\"privileged-operation-1d762a6ac3895594ed85ba7aa9c39330\",\"owner_github_id\":494383370,\"plan_digest\":\"edf23f94b33d1188e34e143e7aff91075ec941053b3b95d367a45de67b1fe1d7\",\"policy_record_id\":\"owner-policy-1d762a6ac3895594ed85\",\"policy_revision\":1,\"policy_sha256\":\"b379db2fe113e77eef0b3bb05aec804189d9f0b359e67d941d837c7de59e6f8e\",\"pre_state_digest\":\"46df3876ade6b39b0edfbd3b8ea1a408173bbe5d8cc7154cea4d63e5d057239f\",\"request_digest\":\"e0e31f55312d2562bf610587d7a21b5badeed50224284b08d1662924379b4539\",\"schema_version\":1,\"server_review\":{\"items\":[{\"key\":\"descriptor\",\"label\":\"Operation class\",\"value\":\"managed-authz-policy-set\"},{\"key\":\"safety_class\",\"label\":\"Safety class\",\"value\":\"policy_admin\"}],\"review_id\":\"review-1d762a6ac3895594ed85ba7a\",\"schema_version\":1,\"summary\":\"Review this exact privileged operation before confirming.\",\"title\":\"Owner approval required\"}}",
+        "approval_request_sha256": "a60572025b121241d44c3f28ce22715841e348765dd50cfa514861e89334d9eb",
+        "attempt_count": 0,
+        "authority_state": "inert",
+        "binding_json": "{\"channel_session_id\":\"channel-session-c57b127e5947af58b1597cb51fa705f3\",\"owner_github_id\":494383370,\"owner_public_key\":\"A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg\",\"schema_version\":1,\"session_expires_at\":\"2030-01-02T03:20:05+00:00\",\"session_issued_at\":\"2030-01-02T03:00:00+00:00\",\"signature_algorithm\":\"ed25519\"}",
+        "binding_sha256": "278ee07f98754104407f5d42aadf5bd47090faaddc7db14c6a125b8d3bc56e1b",
+        "challenge_id": "owner-control-challenge-a60572025b121241d44c3f28ce227158",
+        "challenge_nonce": "owner-control-b565a7b3115d408e250eeffe65af9513",
+        "channel_session_id": "channel-session-c57b127e5947af58b1597cb51fa705f3",
+        "consumed_at": null,
+        "descriptor_id": "managed-authz-policy-set",
+        "expires_at": "2030-01-02T03:09:05+00:00",
+        "issued_at": "2030-01-02T03:00:05+00:00",
+        "operation_id": "privileged-operation-1d762a6ac3895594ed85ba7aa9c39330",
+        "owner_github_id": 494383370,
+        "schema_version": 1,
+        "state": "issued",
+        "terminal_event_id": null
+      },
+      "name": "challenge-channel-session-mismatch",
+      "observed_at": "2030-01-02T03:04:05+00:00"
+    },
+    {
+      "channel_session": {
+        "authority_state": "inert",
+        "binding_json": "{\"channel_session_id\":\"channel-session-c57b127e5947af58b1597cb51fa705f3\",\"owner_github_id\":494383370,\"owner_public_key\":\"A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg\",\"schema_version\":1,\"session_expires_at\":\"2030-01-02T03:20:05+00:00\",\"session_issued_at\":\"2030-01-02T03:00:00+00:00\",\"signature_algorithm\":\"ed25519\"}",
+        "binding_sha256": "278ee07f98754104407f5d42aadf5bd47090faaddc7db14c6a125b8d3bc56e1b",
+        "channel_session_id": "channel-session-c57b127e5947af58b1597cb51fa705f3",
+        "enrolled_at": "2030-01-02T03:00:05+00:00",
+        "owner_github_id": 494383370,
+        "revoked_at": null,
+        "schema_version": 1,
+        "status": "enrolled"
+      },
+      "confirmation_envelope": {
+        "challenge_response": {
+          "approval_request": {
+            "descriptor_id": "managed-authz-policy-set",
+            "descriptor_version": 1,
+            "evidence_digest": "df6da961581b149a28639add56e3b08401b3bed6afb07ad0c7b5ca3d51632be9",
+            "expires_at": "2030-01-02T03:09:05+00:00",
+            "issued_at": "2030-01-02T03:00:05+00:00",
+            "nonce": "owner-control-b565a7b3115d408e250eeffe65af9513",
+            "operation_id": "privileged-operation-1d762a6ac3895594ed85ba7aa9c39330",
+            "owner_github_id": 494383370,
+            "plan_digest": "edf23f94b33d1188e34e143e7aff91075ec941053b3b95d367a45de67b1fe1d7",
+            "policy_record_id": "owner-policy-1d762a6ac3895594ed85",
+            "policy_revision": 1,
+            "policy_sha256": "b379db2fe113e77eef0b3bb05aec804189d9f0b359e67d941d837c7de59e6f8e",
+            "pre_state_digest": "46df3876ade6b39b0edfbd3b8ea1a408173bbe5d8cc7154cea4d63e5d057239f",
+            "request_digest": "e0e31f55312d2562bf610587d7a21b5badeed50224284b08d1662924379b4539",
+            "schema_version": 1,
+            "server_review": {
+              "items": [
+                {
+                  "key": "descriptor",
+                  "label": "Operation class",
+                  "value": "managed-authz-policy-set"
+                },
+                {
+                  "key": "safety_class",
+                  "label": "Safety class",
+                  "value": "policy_admin"
+                }
+              ],
+              "review_id": "review-1d762a6ac3895594ed85ba7a",
+              "schema_version": 1,
+              "summary": "Review this exact privileged operation before confirming.",
+              "title": "Owner approval required"
+            }
+          },
+          "approval_request_digest": "a60572025b121241d44c3f28ce22715841e348765dd50cfa514861e89334d9eb",
+          "channel_binding_sha256": "278ee07f98754104407f5d42aadf5bd47090faaddc7db14c6a125b8d3bc56e1b",
+          "confirmed_at": "2030-01-02T03:04:05+00:00",
+          "decision": "approved",
+          "schema_version": 1
+        },
+        "channel_binding": {
+          "channel_session_id": "channel-session-c57b127e5947af58b1597cb51fa705f3",
+          "owner_github_id": 494383370,
+          "owner_public_key": "A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg",
+          "schema_version": 1,
+          "session_expires_at": "2030-01-02T03:20:05+00:00",
+          "session_issued_at": "2030-01-02T03:00:00+00:00",
+          "signature_algorithm": "ed25519"
+        },
+        "schema_version": 1,
+        "signature": "5yFpKp48lfzpkxnf92lkEyl5hnYCrMeRNUdUKkOjA15CKokgDqsRDN8bNnJI_AMxFcD93fOuZxrG1Hh7rCDfCw",
+        "signature_algorithm": "ed25519"
+      },
+      "expected": {
+        "authority_state": "inert",
+        "authorizes_execution": false,
+        "consume_challenge": false,
+        "rejection_reason": "challenge_expired",
+        "resulting_challenge_state": "expired",
+        "verification_status": "rejected",
+        "verifier_mode": "shadow"
+      },
+      "issued_challenge": {
+        "approval_request_json": "{\"descriptor_id\":\"managed-authz-policy-set\",\"descriptor_version\":1,\"evidence_digest\":\"df6da961581b149a28639add56e3b08401b3bed6afb07ad0c7b5ca3d51632be9\",\"expires_at\":\"2030-01-02T03:09:05+00:00\",\"issued_at\":\"2030-01-02T03:00:05+00:00\",\"nonce\":\"owner-control-b565a7b3115d408e250eeffe65af9513\",\"operation_id\":\"privileged-operation-1d762a6ac3895594ed85ba7aa9c39330\",\"owner_github_id\":494383370,\"plan_digest\":\"edf23f94b33d1188e34e143e7aff91075ec941053b3b95d367a45de67b1fe1d7\",\"policy_record_id\":\"owner-policy-1d762a6ac3895594ed85\",\"policy_revision\":1,\"policy_sha256\":\"b379db2fe113e77eef0b3bb05aec804189d9f0b359e67d941d837c7de59e6f8e\",\"pre_state_digest\":\"46df3876ade6b39b0edfbd3b8ea1a408173bbe5d8cc7154cea4d63e5d057239f\",\"request_digest\":\"e0e31f55312d2562bf610587d7a21b5badeed50224284b08d1662924379b4539\",\"schema_version\":1,\"server_review\":{\"items\":[{\"key\":\"descriptor\",\"label\":\"Operation class\",\"value\":\"managed-authz-policy-set\"},{\"key\":\"safety_class\",\"label\":\"Safety class\",\"value\":\"policy_admin\"}],\"review_id\":\"review-1d762a6ac3895594ed85ba7a\",\"schema_version\":1,\"summary\":\"Review this exact privileged operation before confirming.\",\"title\":\"Owner approval required\"}}",
+        "approval_request_sha256": "a60572025b121241d44c3f28ce22715841e348765dd50cfa514861e89334d9eb",
+        "attempt_count": 0,
+        "authority_state": "inert",
+        "binding_json": "{\"channel_session_id\":\"channel-session-c57b127e5947af58b1597cb51fa705f3\",\"owner_github_id\":494383370,\"owner_public_key\":\"A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg\",\"schema_version\":1,\"session_expires_at\":\"2030-01-02T03:20:05+00:00\",\"session_issued_at\":\"2030-01-02T03:00:00+00:00\",\"signature_algorithm\":\"ed25519\"}",
+        "binding_sha256": "278ee07f98754104407f5d42aadf5bd47090faaddc7db14c6a125b8d3bc56e1b",
+        "challenge_id": "owner-control-challenge-a60572025b121241d44c3f28ce227158",
+        "challenge_nonce": "owner-control-b565a7b3115d408e250eeffe65af9513",
+        "channel_session_id": "channel-session-c57b127e5947af58b1597cb51fa705f3",
+        "consumed_at": null,
+        "descriptor_id": "managed-authz-policy-set",
+        "expires_at": "2030-01-02T03:09:05+00:00",
+        "issued_at": "2030-01-02T03:00:05+00:00",
+        "operation_id": "privileged-operation-1d762a6ac3895594ed85ba7aa9c39330",
+        "owner_github_id": 494383370,
+        "schema_version": 1,
+        "state": "issued",
+        "terminal_event_id": null
+      },
+      "name": "challenge-expired",
+      "observed_at": "2030-01-02T03:09:06+00:00"
+    },
+    {
+      "channel_session": {
+        "authority_state": "inert",
+        "binding_json": "{\"channel_session_id\":\"channel-session-c57b127e5947af58b1597cb51fa705f3\",\"owner_github_id\":494383370,\"owner_public_key\":\"A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg\",\"schema_version\":1,\"session_expires_at\":\"2030-01-02T03:20:05+00:00\",\"session_issued_at\":\"2030-01-02T03:00:00+00:00\",\"signature_algorithm\":\"ed25519\"}",
+        "binding_sha256": "278ee07f98754104407f5d42aadf5bd47090faaddc7db14c6a125b8d3bc56e1b",
+        "channel_session_id": "channel-session-c57b127e5947af58b1597cb51fa705f3",
+        "enrolled_at": "2030-01-02T03:00:05+00:00",
+        "owner_github_id": 494383370,
+        "revoked_at": null,
+        "schema_version": 1,
+        "status": "enrolled"
+      },
+      "confirmation_envelope": {
+        "challenge_response": {
+          "approval_request": {
+            "descriptor_id": "managed-authz-policy-set",
+            "descriptor_version": 1,
+            "evidence_digest": "df6da961581b149a28639add56e3b08401b3bed6afb07ad0c7b5ca3d51632be9",
+            "expires_at": "2030-01-02T03:09:05+00:00",
+            "issued_at": "2030-01-02T03:00:05+00:00",
+            "nonce": "owner-control-b565a7b3115d408e250eeffe65af9513",
+            "operation_id": "privileged-operation-1d762a6ac3895594ed85ba7aa9c39330",
+            "owner_github_id": 494383370,
+            "plan_digest": "edf23f94b33d1188e34e143e7aff91075ec941053b3b95d367a45de67b1fe1d7",
+            "policy_record_id": "owner-policy-1d762a6ac3895594ed85",
+            "policy_revision": 1,
+            "policy_sha256": "b379db2fe113e77eef0b3bb05aec804189d9f0b359e67d941d837c7de59e6f8e",
+            "pre_state_digest": "46df3876ade6b39b0edfbd3b8ea1a408173bbe5d8cc7154cea4d63e5d057239f",
+            "request_digest": "e0e31f55312d2562bf610587d7a21b5badeed50224284b08d1662924379b4539",
+            "schema_version": 1,
+            "server_review": {
+              "items": [
+                {
+                  "key": "descriptor",
+                  "label": "Operation class",
+                  "value": "managed-authz-policy-set"
+                },
+                {
+                  "key": "safety_class",
+                  "label": "Safety class",
+                  "value": "policy_admin"
+                }
+              ],
+              "review_id": "review-1d762a6ac3895594ed85ba7a",
+              "schema_version": 1,
+              "summary": "Review this exact privileged operation before confirming.",
+              "title": "Owner approval required"
+            }
+          },
+          "approval_request_digest": "a60572025b121241d44c3f28ce22715841e348765dd50cfa514861e89334d9eb",
+          "channel_binding_sha256": "278ee07f98754104407f5d42aadf5bd47090faaddc7db14c6a125b8d3bc56e1b",
+          "confirmed_at": "2030-01-02T03:04:05+00:00",
+          "decision": "approved",
+          "schema_version": 1
+        },
+        "channel_binding": {
+          "channel_session_id": "channel-session-c57b127e5947af58b1597cb51fa705f3",
+          "owner_github_id": 494383370,
+          "owner_public_key": "A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg",
+          "schema_version": 1,
+          "session_expires_at": "2030-01-02T03:20:05+00:00",
+          "session_issued_at": "2030-01-02T03:00:00+00:00",
+          "signature_algorithm": "ed25519"
+        },
+        "schema_version": 1,
+        "signature": "5yFpKp48lfzpkxnf92lkEyl5hnYCrMeRNUdUKkOjA15CKokgDqsRDN8bNnJI_AMxFcD93fOuZxrG1Hh7rCDfCw",
+        "signature_algorithm": "ed25519"
+      },
+      "expected": {
+        "authority_state": "inert",
+        "authorizes_execution": false,
+        "consume_challenge": false,
+        "rejection_reason": "challenge_replayed",
+        "resulting_challenge_state": "consumed",
+        "verification_status": "rejected",
+        "verifier_mode": "shadow"
+      },
+      "issued_challenge": {
+        "approval_request_json": "{\"descriptor_id\":\"managed-authz-policy-set\",\"descriptor_version\":1,\"evidence_digest\":\"df6da961581b149a28639add56e3b08401b3bed6afb07ad0c7b5ca3d51632be9\",\"expires_at\":\"2030-01-02T03:09:05+00:00\",\"issued_at\":\"2030-01-02T03:00:05+00:00\",\"nonce\":\"owner-control-b565a7b3115d408e250eeffe65af9513\",\"operation_id\":\"privileged-operation-1d762a6ac3895594ed85ba7aa9c39330\",\"owner_github_id\":494383370,\"plan_digest\":\"edf23f94b33d1188e34e143e7aff91075ec941053b3b95d367a45de67b1fe1d7\",\"policy_record_id\":\"owner-policy-1d762a6ac3895594ed85\",\"policy_revision\":1,\"policy_sha256\":\"b379db2fe113e77eef0b3bb05aec804189d9f0b359e67d941d837c7de59e6f8e\",\"pre_state_digest\":\"46df3876ade6b39b0edfbd3b8ea1a408173bbe5d8cc7154cea4d63e5d057239f\",\"request_digest\":\"e0e31f55312d2562bf610587d7a21b5badeed50224284b08d1662924379b4539\",\"schema_version\":1,\"server_review\":{\"items\":[{\"key\":\"descriptor\",\"label\":\"Operation class\",\"value\":\"managed-authz-policy-set\"},{\"key\":\"safety_class\",\"label\":\"Safety class\",\"value\":\"policy_admin\"}],\"review_id\":\"review-1d762a6ac3895594ed85ba7a\",\"schema_version\":1,\"summary\":\"Review this exact privileged operation before confirming.\",\"title\":\"Owner approval required\"}}",
+        "approval_request_sha256": "a60572025b121241d44c3f28ce22715841e348765dd50cfa514861e89334d9eb",
+        "attempt_count": 1,
+        "authority_state": "inert",
+        "binding_json": "{\"channel_session_id\":\"channel-session-c57b127e5947af58b1597cb51fa705f3\",\"owner_github_id\":494383370,\"owner_public_key\":\"A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg\",\"schema_version\":1,\"session_expires_at\":\"2030-01-02T03:20:05+00:00\",\"session_issued_at\":\"2030-01-02T03:00:00+00:00\",\"signature_algorithm\":\"ed25519\"}",
+        "binding_sha256": "278ee07f98754104407f5d42aadf5bd47090faaddc7db14c6a125b8d3bc56e1b",
+        "challenge_id": "owner-control-challenge-a60572025b121241d44c3f28ce227158",
+        "challenge_nonce": "owner-control-b565a7b3115d408e250eeffe65af9513",
+        "channel_session_id": "channel-session-c57b127e5947af58b1597cb51fa705f3",
+        "consumed_at": "2030-01-02T03:04:05+00:00",
+        "descriptor_id": "managed-authz-policy-set",
+        "expires_at": "2030-01-02T03:09:05+00:00",
+        "issued_at": "2030-01-02T03:00:05+00:00",
+        "operation_id": "privileged-operation-1d762a6ac3895594ed85ba7aa9c39330",
+        "owner_github_id": 494383370,
+        "schema_version": 1,
+        "state": "consumed",
+        "terminal_event_id": "owner-control-shadow-event-3353c3d994b679f0482ce365c75b7a19"
+      },
+      "name": "challenge-replayed",
+      "observed_at": "2030-01-02T03:05:05+00:00"
+    },
+    {
+      "channel_session": {
+        "authority_state": "inert",
+        "binding_json": "{\"channel_session_id\":\"channel-session-c57b127e5947af58b1597cb51fa705f3\",\"owner_github_id\":494383370,\"owner_public_key\":\"A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg\",\"schema_version\":1,\"session_expires_at\":\"2030-01-02T03:20:05+00:00\",\"session_issued_at\":\"2030-01-02T03:00:00+00:00\",\"signature_algorithm\":\"ed25519\"}",
+        "binding_sha256": "278ee07f98754104407f5d42aadf5bd47090faaddc7db14c6a125b8d3bc56e1b",
+        "channel_session_id": "channel-session-c57b127e5947af58b1597cb51fa705f3",
+        "enrolled_at": "2030-01-02T03:00:05+00:00",
+        "owner_github_id": 494383370,
+        "revoked_at": null,
+        "schema_version": 1,
+        "status": "enrolled"
+      },
+      "confirmation_envelope": {
+        "challenge_response": {
+          "approval_request": {
+            "descriptor_id": "managed-authz-policy-set",
+            "descriptor_version": 1,
+            "evidence_digest": "df6da961581b149a28639add56e3b08401b3bed6afb07ad0c7b5ca3d51632be9",
+            "expires_at": "2030-01-02T03:09:05+00:00",
+            "issued_at": "2030-01-02T03:00:05+00:00",
+            "nonce": "owner-control-b565a7b3115d408e250eeffe65af9513",
+            "operation_id": "privileged-operation-1d762a6ac3895594ed85ba7aa9c39330",
+            "owner_github_id": 494383370,
+            "plan_digest": "edf23f94b33d1188e34e143e7aff91075ec941053b3b95d367a45de67b1fe1d7",
+            "policy_record_id": "owner-policy-1d762a6ac3895594ed85",
+            "policy_revision": 1,
+            "policy_sha256": "b379db2fe113e77eef0b3bb05aec804189d9f0b359e67d941d837c7de59e6f8e",
+            "pre_state_digest": "46df3876ade6b39b0edfbd3b8ea1a408173bbe5d8cc7154cea4d63e5d057239f",
+            "request_digest": "e0e31f55312d2562bf610587d7a21b5badeed50224284b08d1662924379b4539",
+            "schema_version": 1,
+            "server_review": {
+              "items": [
+                {
+                  "key": "descriptor",
+                  "label": "Operation class",
+                  "value": "managed-authz-policy-set"
+                },
+                {
+                  "key": "safety_class",
+                  "label": "Safety class",
+                  "value": "policy_admin"
+                }
+              ],
+              "review_id": "review-1d762a6ac3895594ed85ba7a",
+              "schema_version": 1,
+              "summary": "Review this exact privileged operation before confirming.",
+              "title": "Owner approval required"
+            }
+          },
+          "approval_request_digest": "a60572025b121241d44c3f28ce22715841e348765dd50cfa514861e89334d9eb",
+          "channel_binding_sha256": "8216068b33dced4a9d9add414eb022fa0a93f65ad350dac964d21cbf7c5a2d2e",
+          "confirmed_at": "2030-01-02T03:04:05+00:00",
+          "decision": "approved",
+          "schema_version": 1
+        },
+        "channel_binding": {
+          "channel_session_id": "channel-session-c57b127e5947af58b1597cb51fa705f3",
+          "owner_github_id": 494383370,
+          "owner_public_key": "A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg",
+          "schema_version": 1,
+          "session_expires_at": "2030-01-02T03:19:05+00:00",
+          "session_issued_at": "2030-01-02T03:00:00+00:00",
+          "signature_algorithm": "ed25519"
+        },
+        "schema_version": 1,
+        "signature": "PNSAZXRskxNeDOqCNGys08Lh1UF4y2iPUg_H8NF-ckoy03VY2qBaHWF0cK-pz6yXJooraEU7eeXvztjjj9x0AA",
+        "signature_algorithm": "ed25519"
+      },
+      "expected": {
+        "authority_state": "inert",
+        "authorizes_execution": false,
+        "consume_challenge": false,
+        "rejection_reason": "stored_binding_mismatch",
+        "resulting_challenge_state": "issued",
+        "verification_status": "rejected",
+        "verifier_mode": "shadow"
+      },
+      "issued_challenge": {
+        "approval_request_json": "{\"descriptor_id\":\"managed-authz-policy-set\",\"descriptor_version\":1,\"evidence_digest\":\"df6da961581b149a28639add56e3b08401b3bed6afb07ad0c7b5ca3d51632be9\",\"expires_at\":\"2030-01-02T03:09:05+00:00\",\"issued_at\":\"2030-01-02T03:00:05+00:00\",\"nonce\":\"owner-control-b565a7b3115d408e250eeffe65af9513\",\"operation_id\":\"privileged-operation-1d762a6ac3895594ed85ba7aa9c39330\",\"owner_github_id\":494383370,\"plan_digest\":\"edf23f94b33d1188e34e143e7aff91075ec941053b3b95d367a45de67b1fe1d7\",\"policy_record_id\":\"owner-policy-1d762a6ac3895594ed85\",\"policy_revision\":1,\"policy_sha256\":\"b379db2fe113e77eef0b3bb05aec804189d9f0b359e67d941d837c7de59e6f8e\",\"pre_state_digest\":\"46df3876ade6b39b0edfbd3b8ea1a408173bbe5d8cc7154cea4d63e5d057239f\",\"request_digest\":\"e0e31f55312d2562bf610587d7a21b5badeed50224284b08d1662924379b4539\",\"schema_version\":1,\"server_review\":{\"items\":[{\"key\":\"descriptor\",\"label\":\"Operation class\",\"value\":\"managed-authz-policy-set\"},{\"key\":\"safety_class\",\"label\":\"Safety class\",\"value\":\"policy_admin\"}],\"review_id\":\"review-1d762a6ac3895594ed85ba7a\",\"schema_version\":1,\"summary\":\"Review this exact privileged operation before confirming.\",\"title\":\"Owner approval required\"}}",
+        "approval_request_sha256": "a60572025b121241d44c3f28ce22715841e348765dd50cfa514861e89334d9eb",
+        "attempt_count": 0,
+        "authority_state": "inert",
+        "binding_json": "{\"channel_session_id\":\"channel-session-c57b127e5947af58b1597cb51fa705f3\",\"owner_github_id\":494383370,\"owner_public_key\":\"A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg\",\"schema_version\":1,\"session_expires_at\":\"2030-01-02T03:20:05+00:00\",\"session_issued_at\":\"2030-01-02T03:00:00+00:00\",\"signature_algorithm\":\"ed25519\"}",
+        "binding_sha256": "278ee07f98754104407f5d42aadf5bd47090faaddc7db14c6a125b8d3bc56e1b",
+        "challenge_id": "owner-control-challenge-a60572025b121241d44c3f28ce227158",
+        "challenge_nonce": "owner-control-b565a7b3115d408e250eeffe65af9513",
+        "channel_session_id": "channel-session-c57b127e5947af58b1597cb51fa705f3",
+        "consumed_at": null,
+        "descriptor_id": "managed-authz-policy-set",
+        "expires_at": "2030-01-02T03:09:05+00:00",
+        "issued_at": "2030-01-02T03:00:05+00:00",
+        "operation_id": "privileged-operation-1d762a6ac3895594ed85ba7aa9c39330",
+        "owner_github_id": 494383370,
+        "schema_version": 1,
+        "state": "issued",
+        "terminal_event_id": null
+      },
+      "name": "stored-binding-mismatch",
+      "observed_at": "2030-01-02T03:04:05+00:00"
+    },
+    {
+      "channel_session": {
+        "authority_state": "inert",
+        "binding_json": "{\"channel_session_id\":\"channel-session-c57b127e5947af58b1597cb51fa705f3\",\"owner_github_id\":494383370,\"owner_public_key\":\"A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg\",\"schema_version\":1,\"session_expires_at\":\"2030-01-02T03:20:05+00:00\",\"session_issued_at\":\"2030-01-02T03:00:00+00:00\",\"signature_algorithm\":\"ed25519\"}",
+        "binding_sha256": "278ee07f98754104407f5d42aadf5bd47090faaddc7db14c6a125b8d3bc56e1b",
+        "channel_session_id": "channel-session-c57b127e5947af58b1597cb51fa705f3",
+        "enrolled_at": "2030-01-02T03:00:05+00:00",
+        "owner_github_id": 494383370,
+        "revoked_at": null,
+        "schema_version": 1,
+        "status": "enrolled"
+      },
+      "confirmation_envelope": {
+        "challenge_response": {
+          "approval_request": {
+            "descriptor_id": "managed-authz-policy-set",
+            "descriptor_version": 1,
+            "evidence_digest": "df6da961581b149a28639add56e3b08401b3bed6afb07ad0c7b5ca3d51632be9",
+            "expires_at": "2030-01-02T03:09:05+00:00",
+            "issued_at": "2030-01-02T03:00:05+00:00",
+            "nonce": "owner-control-b565a7b3115d408e250eeffe65af9513",
+            "operation_id": "privileged-operation-1d762a6ac3895594ed85ba7aa9c39330",
+            "owner_github_id": 494383370,
+            "plan_digest": "edf23f94b33d1188e34e143e7aff91075ec941053b3b95d367a45de67b1fe1d7",
+            "policy_record_id": "owner-policy-1d762a6ac3895594ed85",
+            "policy_revision": 2,
+            "policy_sha256": "b379db2fe113e77eef0b3bb05aec804189d9f0b359e67d941d837c7de59e6f8e",
+            "pre_state_digest": "46df3876ade6b39b0edfbd3b8ea1a408173bbe5d8cc7154cea4d63e5d057239f",
+            "request_digest": "e0e31f55312d2562bf610587d7a21b5badeed50224284b08d1662924379b4539",
+            "schema_version": 1,
+            "server_review": {
+              "items": [
+                {
+                  "key": "descriptor",
+                  "label": "Operation class",
+                  "value": "managed-authz-policy-set"
+                },
+                {
+                  "key": "safety_class",
+                  "label": "Safety class",
+                  "value": "policy_admin"
+                }
+              ],
+              "review_id": "review-1d762a6ac3895594ed85ba7a",
+              "schema_version": 1,
+              "summary": "Review this exact privileged operation before confirming.",
+              "title": "Owner approval required"
+            }
+          },
+          "approval_request_digest": "5b58aec46c4a7c90aea53bc89d537d2a317c4f3fde8e09f310b2d724ce7f2784",
+          "channel_binding_sha256": "278ee07f98754104407f5d42aadf5bd47090faaddc7db14c6a125b8d3bc56e1b",
+          "confirmed_at": "2030-01-02T03:04:05+00:00",
+          "decision": "approved",
+          "schema_version": 1
+        },
+        "channel_binding": {
+          "channel_session_id": "channel-session-c57b127e5947af58b1597cb51fa705f3",
+          "owner_github_id": 494383370,
+          "owner_public_key": "A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg",
+          "schema_version": 1,
+          "session_expires_at": "2030-01-02T03:20:05+00:00",
+          "session_issued_at": "2030-01-02T03:00:00+00:00",
+          "signature_algorithm": "ed25519"
+        },
+        "schema_version": 1,
+        "signature": "An7lEaGVJEJj28I6_qTwGOMtRqupS8YnlzSv5z-9digIpm5mAxmyFeAwmIdaWBiKoe80LS5t3GdI00OmbTQcCA",
+        "signature_algorithm": "ed25519"
+      },
+      "expected": {
+        "authority_state": "inert",
+        "authorizes_execution": false,
+        "consume_challenge": false,
+        "rejection_reason": "stored_approval_request_mismatch",
+        "resulting_challenge_state": "issued",
+        "verification_status": "rejected",
+        "verifier_mode": "shadow"
+      },
+      "issued_challenge": {
+        "approval_request_json": "{\"descriptor_id\":\"managed-authz-policy-set\",\"descriptor_version\":1,\"evidence_digest\":\"df6da961581b149a28639add56e3b08401b3bed6afb07ad0c7b5ca3d51632be9\",\"expires_at\":\"2030-01-02T03:09:05+00:00\",\"issued_at\":\"2030-01-02T03:00:05+00:00\",\"nonce\":\"owner-control-b565a7b3115d408e250eeffe65af9513\",\"operation_id\":\"privileged-operation-1d762a6ac3895594ed85ba7aa9c39330\",\"owner_github_id\":494383370,\"plan_digest\":\"edf23f94b33d1188e34e143e7aff91075ec941053b3b95d367a45de67b1fe1d7\",\"policy_record_id\":\"owner-policy-1d762a6ac3895594ed85\",\"policy_revision\":1,\"policy_sha256\":\"b379db2fe113e77eef0b3bb05aec804189d9f0b359e67d941d837c7de59e6f8e\",\"pre_state_digest\":\"46df3876ade6b39b0edfbd3b8ea1a408173bbe5d8cc7154cea4d63e5d057239f\",\"request_digest\":\"e0e31f55312d2562bf610587d7a21b5badeed50224284b08d1662924379b4539\",\"schema_version\":1,\"server_review\":{\"items\":[{\"key\":\"descriptor\",\"label\":\"Operation class\",\"value\":\"managed-authz-policy-set\"},{\"key\":\"safety_class\",\"label\":\"Safety class\",\"value\":\"policy_admin\"}],\"review_id\":\"review-1d762a6ac3895594ed85ba7a\",\"schema_version\":1,\"summary\":\"Review this exact privileged operation before confirming.\",\"title\":\"Owner approval required\"}}",
+        "approval_request_sha256": "a60572025b121241d44c3f28ce22715841e348765dd50cfa514861e89334d9eb",
+        "attempt_count": 0,
+        "authority_state": "inert",
+        "binding_json": "{\"channel_session_id\":\"channel-session-c57b127e5947af58b1597cb51fa705f3\",\"owner_github_id\":494383370,\"owner_public_key\":\"A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg\",\"schema_version\":1,\"session_expires_at\":\"2030-01-02T03:20:05+00:00\",\"session_issued_at\":\"2030-01-02T03:00:00+00:00\",\"signature_algorithm\":\"ed25519\"}",
+        "binding_sha256": "278ee07f98754104407f5d42aadf5bd47090faaddc7db14c6a125b8d3bc56e1b",
+        "challenge_id": "owner-control-challenge-a60572025b121241d44c3f28ce227158",
+        "challenge_nonce": "owner-control-b565a7b3115d408e250eeffe65af9513",
+        "channel_session_id": "channel-session-c57b127e5947af58b1597cb51fa705f3",
+        "consumed_at": null,
+        "descriptor_id": "managed-authz-policy-set",
+        "expires_at": "2030-01-02T03:09:05+00:00",
+        "issued_at": "2030-01-02T03:00:05+00:00",
+        "operation_id": "privileged-operation-1d762a6ac3895594ed85ba7aa9c39330",
+        "owner_github_id": 494383370,
+        "schema_version": 1,
+        "state": "issued",
+        "terminal_event_id": null
+      },
+      "name": "stored-approval-request-mismatch",
+      "observed_at": "2030-01-02T03:04:05+00:00"
+    },
+    {
+      "channel_session": {
+        "authority_state": "inert",
+        "binding_json": "{\"channel_session_id\":\"channel-session-c57b127e5947af58b1597cb51fa705f3\",\"owner_github_id\":494383370,\"owner_public_key\":\"A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg\",\"schema_version\":1,\"session_expires_at\":\"2030-01-02T03:20:05+00:00\",\"session_issued_at\":\"2030-01-02T03:00:00+00:00\",\"signature_algorithm\":\"ed25519\"}",
+        "binding_sha256": "278ee07f98754104407f5d42aadf5bd47090faaddc7db14c6a125b8d3bc56e1b",
+        "channel_session_id": "channel-session-c57b127e5947af58b1597cb51fa705f3",
+        "enrolled_at": "2030-01-02T03:00:05+00:00",
+        "owner_github_id": 494383370,
+        "revoked_at": null,
+        "schema_version": 1,
+        "status": "enrolled"
+      },
+      "confirmation_envelope": {
+        "challenge_response": {
+          "approval_request": {
+            "descriptor_id": "managed-authz-policy-set",
+            "descriptor_version": 1,
+            "evidence_digest": "df6da961581b149a28639add56e3b08401b3bed6afb07ad0c7b5ca3d51632be9",
+            "expires_at": "2030-01-02T03:09:05+00:00",
+            "issued_at": "2030-01-02T03:00:05+00:00",
+            "nonce": "owner-control-b565a7b3115d408e250eeffe65af9513",
+            "operation_id": "privileged-operation-1d762a6ac3895594ed85ba7aa9c39330",
+            "owner_github_id": 494383370,
+            "plan_digest": "edf23f94b33d1188e34e143e7aff91075ec941053b3b95d367a45de67b1fe1d7",
+            "policy_record_id": "owner-policy-1d762a6ac3895594ed85",
+            "policy_revision": 1,
+            "policy_sha256": "b379db2fe113e77eef0b3bb05aec804189d9f0b359e67d941d837c7de59e6f8e",
+            "pre_state_digest": "46df3876ade6b39b0edfbd3b8ea1a408173bbe5d8cc7154cea4d63e5d057239f",
+            "request_digest": "e0e31f55312d2562bf610587d7a21b5badeed50224284b08d1662924379b4539",
+            "schema_version": 1,
+            "server_review": {
+              "items": [
+                {
+                  "key": "descriptor",
+                  "label": "Operation class",
+                  "value": "managed-authz-policy-set"
+                },
+                {
+                  "key": "safety_class",
+                  "label": "Safety class",
+                  "value": "policy_admin"
+                }
+              ],
+              "review_id": "review-1d762a6ac3895594ed85ba7a",
+              "schema_version": 1,
+              "summary": "Review this exact privileged operation before confirming.",
+              "title": "Owner approval required"
+            }
+          },
+          "approval_request_digest": "a60572025b121241d44c3f28ce22715841e348765dd50cfa514861e89334d9eb",
+          "channel_binding_sha256": "278ee07f98754104407f5d42aadf5bd47090faaddc7db14c6a125b8d3bc56e1b",
+          "confirmed_at": "2030-01-02T03:04:05+00:00",
+          "decision": "approved",
+          "schema_version": 1
+        },
+        "channel_binding": {
+          "channel_session_id": "channel-session-c57b127e5947af58b1597cb51fa705f3",
+          "owner_github_id": 494383370,
+          "owner_public_key": "A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg",
+          "schema_version": 1,
+          "session_expires_at": "2030-01-02T03:20:05+00:00",
+          "session_issued_at": "2030-01-02T03:00:00+00:00",
+          "signature_algorithm": "ed25519"
+        },
+        "schema_version": 1,
+        "signature": "0xp7R16BOOuqxNxoz66e6PvuGGszeRq4HDkASdJOvTIFaKpnj-j3dtiGHANF6hcY1DuGdKRHTXKhw-EoLjqvAA",
+        "signature_algorithm": "ed25519"
+      },
+      "expected": {
+        "authority_state": "inert",
+        "authorizes_execution": false,
+        "consume_challenge": false,
+        "rejection_reason": "signature_invalid",
+        "resulting_challenge_state": "issued",
+        "verification_status": "rejected",
+        "verifier_mode": "shadow"
+      },
+      "issued_challenge": {
+        "approval_request_json": "{\"descriptor_id\":\"managed-authz-policy-set\",\"descriptor_version\":1,\"evidence_digest\":\"df6da961581b149a28639add56e3b08401b3bed6afb07ad0c7b5ca3d51632be9\",\"expires_at\":\"2030-01-02T03:09:05+00:00\",\"issued_at\":\"2030-01-02T03:00:05+00:00\",\"nonce\":\"owner-control-b565a7b3115d408e250eeffe65af9513\",\"operation_id\":\"privileged-operation-1d762a6ac3895594ed85ba7aa9c39330\",\"owner_github_id\":494383370,\"plan_digest\":\"edf23f94b33d1188e34e143e7aff91075ec941053b3b95d367a45de67b1fe1d7\",\"policy_record_id\":\"owner-policy-1d762a6ac3895594ed85\",\"policy_revision\":1,\"policy_sha256\":\"b379db2fe113e77eef0b3bb05aec804189d9f0b359e67d941d837c7de59e6f8e\",\"pre_state_digest\":\"46df3876ade6b39b0edfbd3b8ea1a408173bbe5d8cc7154cea4d63e5d057239f\",\"request_digest\":\"e0e31f55312d2562bf610587d7a21b5badeed50224284b08d1662924379b4539\",\"schema_version\":1,\"server_review\":{\"items\":[{\"key\":\"descriptor\",\"label\":\"Operation class\",\"value\":\"managed-authz-policy-set\"},{\"key\":\"safety_class\",\"label\":\"Safety class\",\"value\":\"policy_admin\"}],\"review_id\":\"review-1d762a6ac3895594ed85ba7a\",\"schema_version\":1,\"summary\":\"Review this exact privileged operation before confirming.\",\"title\":\"Owner approval required\"}}",
+        "approval_request_sha256": "a60572025b121241d44c3f28ce22715841e348765dd50cfa514861e89334d9eb",
+        "attempt_count": 0,
+        "authority_state": "inert",
+        "binding_json": "{\"channel_session_id\":\"channel-session-c57b127e5947af58b1597cb51fa705f3\",\"owner_github_id\":494383370,\"owner_public_key\":\"A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg\",\"schema_version\":1,\"session_expires_at\":\"2030-01-02T03:20:05+00:00\",\"session_issued_at\":\"2030-01-02T03:00:00+00:00\",\"signature_algorithm\":\"ed25519\"}",
+        "binding_sha256": "278ee07f98754104407f5d42aadf5bd47090faaddc7db14c6a125b8d3bc56e1b",
+        "challenge_id": "owner-control-challenge-a60572025b121241d44c3f28ce227158",
+        "challenge_nonce": "owner-control-b565a7b3115d408e250eeffe65af9513",
+        "channel_session_id": "channel-session-c57b127e5947af58b1597cb51fa705f3",
+        "consumed_at": null,
+        "descriptor_id": "managed-authz-policy-set",
+        "expires_at": "2030-01-02T03:09:05+00:00",
+        "issued_at": "2030-01-02T03:00:05+00:00",
+        "operation_id": "privileged-operation-1d762a6ac3895594ed85ba7aa9c39330",
+        "owner_github_id": 494383370,
+        "schema_version": 1,
+        "state": "issued",
+        "terminal_event_id": null
+      },
+      "name": "signature-invalid",
+      "observed_at": "2030-01-02T03:04:05+00:00"
+    },
+    {
+      "channel_session": {
+        "authority_state": "inert",
+        "binding_json": "{\"channel_session_id\":\"channel-session-c57b127e5947af58b1597cb51fa705f3\",\"owner_github_id\":494383370,\"owner_public_key\":\"A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg\",\"schema_version\":1,\"session_expires_at\":\"2030-01-02T03:20:05+00:00\",\"session_issued_at\":\"2030-01-02T03:00:00+00:00\",\"signature_algorithm\":\"ed25519\"}",
+        "binding_sha256": "278ee07f98754104407f5d42aadf5bd47090faaddc7db14c6a125b8d3bc56e1b",
+        "channel_session_id": "channel-session-c57b127e5947af58b1597cb51fa705f3",
+        "enrolled_at": "2030-01-02T03:00:05+00:00",
+        "owner_github_id": 494383370,
+        "revoked_at": null,
+        "schema_version": 1,
+        "status": "enrolled"
+      },
+      "confirmation_envelope": {
+        "challenge_response": {
+          "approval_request": {
+            "descriptor_id": "managed-authz-policy-set",
+            "descriptor_version": 1,
+            "evidence_digest": "df6da961581b149a28639add56e3b08401b3bed6afb07ad0c7b5ca3d51632be9",
+            "expires_at": "2030-01-02T03:09:05+00:00",
+            "issued_at": "2030-01-02T03:00:05+00:00",
+            "nonce": "owner-control-b565a7b3115d408e250eeffe65af9513",
+            "operation_id": "privileged-operation-1d762a6ac3895594ed85ba7aa9c39330",
+            "owner_github_id": 494383370,
+            "plan_digest": "edf23f94b33d1188e34e143e7aff91075ec941053b3b95d367a45de67b1fe1d7",
+            "policy_record_id": "owner-policy-1d762a6ac3895594ed85",
+            "policy_revision": 1,
+            "policy_sha256": "b379db2fe113e77eef0b3bb05aec804189d9f0b359e67d941d837c7de59e6f8e",
+            "pre_state_digest": "46df3876ade6b39b0edfbd3b8ea1a408173bbe5d8cc7154cea4d63e5d057239f",
+            "request_digest": "e0e31f55312d2562bf610587d7a21b5badeed50224284b08d1662924379b4539",
+            "schema_version": 1,
+            "server_review": {
+              "items": [
+                {
+                  "key": "descriptor",
+                  "label": "Operation class",
+                  "value": "managed-authz-policy-set"
+                },
+                {
+                  "key": "safety_class",
+                  "label": "Safety class",
+                  "value": "policy_admin"
+                }
+              ],
+              "review_id": "review-1d762a6ac3895594ed85ba7a",
+              "schema_version": 1,
+              "summary": "Review this exact privileged operation before confirming.",
+              "title": "Owner approval required"
+            }
+          },
+          "approval_request_digest": "a60572025b121241d44c3f28ce22715841e348765dd50cfa514861e89334d9eb",
+          "channel_binding_sha256": "278ee07f98754104407f5d42aadf5bd47090faaddc7db14c6a125b8d3bc56e1b",
+          "confirmed_at": "2030-01-02T03:04:05+00:00",
+          "decision": "approved",
+          "schema_version": 1
+        },
+        "channel_binding": {
+          "channel_session_id": "channel-session-c57b127e5947af58b1597cb51fa705f3",
+          "owner_github_id": 494383370,
+          "owner_public_key": "A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg",
+          "schema_version": 1,
+          "session_expires_at": "2030-01-02T03:20:05+00:00",
+          "session_issued_at": "2030-01-02T03:00:00+00:00",
+          "signature_algorithm": "ed25519"
+        },
+        "schema_version": 1,
+        "signature": "5yFpKp48lfzpkxnf92lkEyl5hnYCrMeRNUdUKkOjA15CKokgDqsRDN8bNnJI_AMxFcD93fOuZxrG1Hh7rCDfCw",
+        "signature_algorithm": "ed25519"
+      },
+      "expected": {
+        "authority_state": "inert",
+        "authorizes_execution": false,
+        "consume_challenge": false,
+        "rejection_reason": "attempt_budget_exhausted",
+        "resulting_challenge_state": "rejected",
+        "verification_status": "rejected",
+        "verifier_mode": "shadow"
+      },
+      "issued_challenge": {
+        "approval_request_json": "{\"descriptor_id\":\"managed-authz-policy-set\",\"descriptor_version\":1,\"evidence_digest\":\"df6da961581b149a28639add56e3b08401b3bed6afb07ad0c7b5ca3d51632be9\",\"expires_at\":\"2030-01-02T03:09:05+00:00\",\"issued_at\":\"2030-01-02T03:00:05+00:00\",\"nonce\":\"owner-control-b565a7b3115d408e250eeffe65af9513\",\"operation_id\":\"privileged-operation-1d762a6ac3895594ed85ba7aa9c39330\",\"owner_github_id\":494383370,\"plan_digest\":\"edf23f94b33d1188e34e143e7aff91075ec941053b3b95d367a45de67b1fe1d7\",\"policy_record_id\":\"owner-policy-1d762a6ac3895594ed85\",\"policy_revision\":1,\"policy_sha256\":\"b379db2fe113e77eef0b3bb05aec804189d9f0b359e67d941d837c7de59e6f8e\",\"pre_state_digest\":\"46df3876ade6b39b0edfbd3b8ea1a408173bbe5d8cc7154cea4d63e5d057239f\",\"request_digest\":\"e0e31f55312d2562bf610587d7a21b5badeed50224284b08d1662924379b4539\",\"schema_version\":1,\"server_review\":{\"items\":[{\"key\":\"descriptor\",\"label\":\"Operation class\",\"value\":\"managed-authz-policy-set\"},{\"key\":\"safety_class\",\"label\":\"Safety class\",\"value\":\"policy_admin\"}],\"review_id\":\"review-1d762a6ac3895594ed85ba7a\",\"schema_version\":1,\"summary\":\"Review this exact privileged operation before confirming.\",\"title\":\"Owner approval required\"}}",
+        "approval_request_sha256": "a60572025b121241d44c3f28ce22715841e348765dd50cfa514861e89334d9eb",
+        "attempt_count": 8,
+        "authority_state": "inert",
+        "binding_json": "{\"channel_session_id\":\"channel-session-c57b127e5947af58b1597cb51fa705f3\",\"owner_github_id\":494383370,\"owner_public_key\":\"A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg\",\"schema_version\":1,\"session_expires_at\":\"2030-01-02T03:20:05+00:00\",\"session_issued_at\":\"2030-01-02T03:00:00+00:00\",\"signature_algorithm\":\"ed25519\"}",
+        "binding_sha256": "278ee07f98754104407f5d42aadf5bd47090faaddc7db14c6a125b8d3bc56e1b",
+        "challenge_id": "owner-control-challenge-a60572025b121241d44c3f28ce227158",
+        "challenge_nonce": "owner-control-b565a7b3115d408e250eeffe65af9513",
+        "channel_session_id": "channel-session-c57b127e5947af58b1597cb51fa705f3",
+        "consumed_at": null,
+        "descriptor_id": "managed-authz-policy-set",
+        "expires_at": "2030-01-02T03:09:05+00:00",
+        "issued_at": "2030-01-02T03:00:05+00:00",
+        "operation_id": "privileged-operation-1d762a6ac3895594ed85ba7aa9c39330",
+        "owner_github_id": 494383370,
+        "schema_version": 1,
+        "state": "rejected",
+        "terminal_event_id": "owner-control-shadow-event-b3490a811f1a513800461fedb60053cf"
+      },
+      "name": "attempt-budget-exhausted",
+      "observed_at": "2030-01-02T03:05:05+00:00"
+    }
+  ]
 }

--- a/control_plane/owner_control_contract.py
+++ b/control_plane/owner_control_contract.py
@@ -277,7 +277,7 @@ def _signed_confirmation_envelope(
     *,
     binding: ChannelBindingRecord,
     request: ApprovalRequest,
-    private_key: Ed25519PrivateKey | None = None,
+    signer: Ed25519PrivateKey | None = None,
 ) -> OwnerControlConfirmationEnvelope:
     response = ChallengeResponse(
         approval_request=request,
@@ -286,12 +286,12 @@ def _signed_confirmation_envelope(
         channel_binding_sha256=owner_control_channel_binding_sha256(binding),
         confirmed_at="2030-01-02T03:04:05+00:00",
     )
-    signing_key = private_key or _artifact_synthetic_private_key()
+    resolved_signer = signer or _artifact_synthetic_private_key()
     return OwnerControlConfirmationEnvelope(
         channel_binding=binding,
         challenge_response=response,
         signature_algorithm="ed25519",
-        signature=_base64url(signing_key.sign(owner_control_signature_payload_bytes(response))),
+        signature=_base64url(resolved_signer.sign(owner_control_signature_payload_bytes(response))),
     )
 
 
@@ -524,7 +524,7 @@ def _verification_state_vectors() -> list[dict[str, Any]]:
             envelope=_signed_confirmation_envelope(
                 binding=binding,
                 request=request,
-                private_key=_artifact_synthetic_wrong_private_key(),
+                signer=_artifact_synthetic_wrong_private_key(),
             ),
             channel_session=session,
             issued_challenge=challenge,

--- a/control_plane/owner_control_contract.py
+++ b/control_plane/owner_control_contract.py
@@ -4,7 +4,7 @@ import base64
 import json
 from collections.abc import Mapping
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal, get_args
 
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
@@ -23,6 +23,23 @@ from control_plane.contracts.owner_control import (
     owner_control_signature_payload,
     owner_control_signature_payload_bytes,
 )
+from control_plane.contracts.owner_control_shadow_verifier import (
+    OWNER_CONTROL_SHADOW_AUTHORITY_STATE,
+    OWNER_CONTROL_SHADOW_MAX_ATTEMPTS,
+    OWNER_CONTROL_SHADOW_VERIFIER_MODE,
+    OWNER_CONTROL_SHADOW_VERIFIER_SCHEMA_VERSION,
+    OwnerControlChallengeIssueRequest,
+    OwnerControlChannelSessionRecord,
+    OwnerControlIssuedChallengeRecord,
+    OwnerControlShadowVerificationReason,
+    build_owner_control_channel_session_record,
+    evaluate_owner_control_shadow_verification,
+    issue_owner_control_challenge_record,
+    owner_control_confirmation_envelope_sha256,
+    owner_control_verification_event_id,
+    revoke_owner_control_channel_session_record,
+    terminalize_expired_owner_control_challenge_record,
+)
 from control_plane.contracts.privileged_operation import (
     PrivilegedOperationDescriptorId,
     PrivilegedOperationSafetyClass,
@@ -31,10 +48,21 @@ from control_plane.privileged_operation_registry import list_privileged_operatio
 from control_plane.privileged_operation_registry import read_privileged_operation_descriptor
 
 
-OWNER_CONTROL_CONTRACT_SCHEMA_VERSION = 2
+OWNER_CONTROL_CONTRACT_SCHEMA_VERSION = 3
+_OWNER_CONTROL_PREVIOUS_CONTRACT_SCHEMA_VERSION = 2
 _OWNER_CONTROL_VECTOR_SCHEMA_VERSION = 1
 _ARTIFACT_SYNTHETIC_PRIVATE_KEY_SEED = bytes(range(32))
 _ARTIFACT_SYNTHETIC_WRONG_PRIVATE_KEY_SEED = bytes(range(31, -1, -1))
+_PRESERVED_V2_SECTION_SHA256 = {
+    "canonical_json": "0c6b6454d737943d01d4621c217ff8412552a0bf0c69a0f50a761d38ac0e7d1f",
+    "canonicalization_vectors": "ca481ff769bba537310c8568b56850f5d12ebc0c90ace9ea2dc39ff714daa6a8",
+    "confirmation_golden_vectors": "58391f364a79ab321596d30200b87c9d29be366eaa1386a9ff4c242c8b38d50a",
+    "golden_vectors": "6955c5c8bb228c21bc6a68a4ddb7cf22456cd51615ffe6e421b0fa04f15d9584",
+    "negative_confirmation_vectors": "9d529ca0f5153c8c3eb3eb4862311efc6dc3c1dc7e5df55824ebde13194eb46d",
+    "negative_vectors": "232d29bc542df455c9f54a3196a2a4d41cb0912155f92d060c850df99c835b29",
+    "schemas": "00a8524a65afd637c8cfc88ef44e780154addc759b813a831f3ddf2ce1490bd0",
+    "signature_declaration": "7d9c62d55792931383d4a02ed99d31e21c67b5ce714c01d9144dc2a3bed34f72",
+}
 
 
 class OwnerControlContractError(ValueError):
@@ -243,6 +271,305 @@ def _confirmation_models_for_descriptor(
         ),
     )
     return binding, response, envelope
+
+
+def _signed_confirmation_envelope(
+    *,
+    binding: ChannelBindingRecord,
+    request: ApprovalRequest,
+    private_key: Ed25519PrivateKey | None = None,
+) -> OwnerControlConfirmationEnvelope:
+    response = ChallengeResponse(
+        approval_request=request,
+        approval_request_digest=owner_control_approval_request_digest(request),
+        decision="approved",
+        channel_binding_sha256=owner_control_channel_binding_sha256(binding),
+        confirmed_at="2030-01-02T03:04:05+00:00",
+    )
+    signing_key = private_key or _artifact_synthetic_private_key()
+    return OwnerControlConfirmationEnvelope(
+        channel_binding=binding,
+        challenge_response=response,
+        signature_algorithm="ed25519",
+        signature=_base64url(signing_key.sign(owner_control_signature_payload_bytes(response))),
+    )
+
+
+def _shadow_verifier_fixture_models() -> tuple[
+    ApprovalRequest,
+    ChannelBindingRecord,
+    OwnerControlChannelSessionRecord,
+    OwnerControlIssuedChallengeRecord,
+    OwnerControlConfirmationEnvelope,
+]:
+    descriptor = read_privileged_operation_descriptor("managed-authz-policy-set").descriptor
+    request = _approval_request_for_descriptor(
+        descriptor_id=descriptor.descriptor_id,
+        safety_class=descriptor.safety_class,
+    )
+    binding = ChannelBindingRecord(
+        channel_session_id=f"channel-session-{_digest_for_vector(descriptor_id=descriptor.descriptor_id, label='verification-session')[:32]}",
+        owner_github_id=request.owner_github_id,
+        signature_algorithm="ed25519",
+        owner_public_key=_synthetic_owner_public_key(_artifact_synthetic_private_key()),
+        session_issued_at="2030-01-02T03:00:00+00:00",
+        session_expires_at="2030-01-02T03:20:05+00:00",
+    )
+    session = build_owner_control_channel_session_record(
+        binding=binding,
+        enrolled_at=request.issued_at,
+    )
+    challenge = issue_owner_control_challenge_record(
+        issue_request=OwnerControlChallengeIssueRequest(
+            channel_session_id=binding.channel_session_id,
+            operation_id=request.operation_id,
+            expires_in_seconds=540,
+        ),
+        session=session,
+        approval_request=request,
+    )
+    envelope = _signed_confirmation_envelope(binding=binding, request=request)
+    return request, binding, session, challenge, envelope
+
+
+def _verification_state_vector(
+    *,
+    name: str,
+    envelope: OwnerControlConfirmationEnvelope,
+    channel_session: OwnerControlChannelSessionRecord | None,
+    issued_challenge: OwnerControlIssuedChallengeRecord | None,
+    observed_at: str,
+) -> dict[str, Any]:
+    evaluation = evaluate_owner_control_shadow_verification(
+        envelope=envelope,
+        channel_session=channel_session,
+        issued_challenge=issued_challenge,
+        observed_at=observed_at,
+    )
+    return {
+        "name": name,
+        "observed_at": observed_at,
+        "channel_session": (
+            channel_session.model_dump(mode="json") if channel_session is not None else None
+        ),
+        "issued_challenge": (
+            issued_challenge.model_dump(mode="json") if issued_challenge is not None else None
+        ),
+        "confirmation_envelope": envelope.model_dump(mode="json"),
+        "expected": {
+            **evaluation.model_dump(mode="json"),
+            "verifier_mode": OWNER_CONTROL_SHADOW_VERIFIER_MODE,
+            "authorizes_execution": False,
+            "authority_state": OWNER_CONTROL_SHADOW_AUTHORITY_STATE,
+        },
+    }
+
+
+def _terminal_challenge(
+    challenge: OwnerControlIssuedChallengeRecord,
+    *,
+    envelope: OwnerControlConfirmationEnvelope,
+    state: Literal["consumed", "rejected"],
+) -> OwnerControlIssuedChallengeRecord:
+    verification_status: Literal["verified", "rejected"]
+    rejection_reason: OwnerControlShadowVerificationReason | None
+    if state == "consumed":
+        verification_status = "verified"
+        rejection_reason = None
+        sequence = 1
+        updates: dict[str, object] = {
+            "state": "consumed",
+            "attempt_count": sequence,
+            "consumed_at": "2030-01-02T03:04:05+00:00",
+        }
+    else:
+        verification_status = "rejected"
+        rejection_reason = "signature_invalid"
+        sequence = OWNER_CONTROL_SHADOW_MAX_ATTEMPTS
+        updates = {
+            "state": "rejected",
+            "attempt_count": sequence,
+        }
+    updates["terminal_event_id"] = owner_control_verification_event_id(
+        challenge_id=challenge.challenge_id,
+        sequence=sequence,
+        envelope_sha256=owner_control_confirmation_envelope_sha256(envelope),
+        verification_status=verification_status,
+        rejection_reason=rejection_reason,
+    )
+    return OwnerControlIssuedChallengeRecord.model_validate({**challenge.model_dump(), **updates})
+
+
+def _verification_state_vectors() -> list[dict[str, Any]]:
+    request, binding, session, challenge, envelope = _shadow_verifier_fixture_models()
+    revoked_session = revoke_owner_control_channel_session_record(
+        session,
+        revoked_at="2030-01-02T03:03:05+00:00",
+    )
+    mismatched_binding = ChannelBindingRecord(
+        channel_session_id=f"channel-session-{_digest_for_vector(descriptor_id=request.descriptor_id, label='mismatched-session')[:32]}",
+        owner_github_id=request.owner_github_id,
+        signature_algorithm="ed25519",
+        owner_public_key=binding.owner_public_key,
+        session_issued_at=binding.session_issued_at,
+        session_expires_at=binding.session_expires_at,
+    )
+    mismatched_session = build_owner_control_channel_session_record(
+        binding=mismatched_binding,
+        enrolled_at=request.issued_at,
+    )
+    alternate_binding = ChannelBindingRecord(
+        channel_session_id=binding.channel_session_id,
+        owner_github_id=binding.owner_github_id,
+        signature_algorithm="ed25519",
+        owner_public_key=binding.owner_public_key,
+        session_issued_at=binding.session_issued_at,
+        session_expires_at="2030-01-02T03:19:05+00:00",
+    )
+    alternate_request = ApprovalRequest.model_validate(
+        {
+            **request.model_dump(),
+            "policy_revision": request.policy_revision + 1,
+        }
+    )
+    consumed_challenge = _terminal_challenge(
+        challenge,
+        envelope=envelope,
+        state="consumed",
+    )
+    rejected_challenge = _terminal_challenge(
+        challenge,
+        envelope=envelope,
+        state="rejected",
+    )
+    vectors = [
+        _verification_state_vector(
+            name="verified",
+            envelope=envelope,
+            channel_session=session,
+            issued_challenge=challenge,
+            observed_at="2030-01-02T03:04:05+00:00",
+        ),
+        _verification_state_vector(
+            name="unknown-channel-session",
+            envelope=envelope,
+            channel_session=None,
+            issued_challenge=None,
+            observed_at="2030-01-02T03:04:05+00:00",
+        ),
+        _verification_state_vector(
+            name="unknown-challenge",
+            envelope=envelope,
+            channel_session=session,
+            issued_challenge=None,
+            observed_at="2030-01-02T03:04:05+00:00",
+        ),
+        _verification_state_vector(
+            name="channel-session-revoked",
+            envelope=envelope,
+            channel_session=revoked_session,
+            issued_challenge=challenge,
+            observed_at="2030-01-02T03:04:05+00:00",
+        ),
+        _verification_state_vector(
+            name="channel-session-expired",
+            envelope=envelope,
+            channel_session=session,
+            issued_challenge=challenge,
+            observed_at="2030-01-02T03:20:06+00:00",
+        ),
+        _verification_state_vector(
+            name="challenge-channel-session-mismatch",
+            envelope=envelope,
+            channel_session=mismatched_session,
+            issued_challenge=challenge,
+            observed_at="2030-01-02T03:04:05+00:00",
+        ),
+        _verification_state_vector(
+            name="challenge-expired",
+            envelope=envelope,
+            channel_session=session,
+            issued_challenge=challenge,
+            observed_at="2030-01-02T03:09:06+00:00",
+        ),
+        _verification_state_vector(
+            name="challenge-replayed",
+            envelope=envelope,
+            channel_session=session,
+            issued_challenge=consumed_challenge,
+            observed_at="2030-01-02T03:05:05+00:00",
+        ),
+        _verification_state_vector(
+            name="stored-binding-mismatch",
+            envelope=_signed_confirmation_envelope(
+                binding=alternate_binding,
+                request=request,
+            ),
+            channel_session=session,
+            issued_challenge=challenge,
+            observed_at="2030-01-02T03:04:05+00:00",
+        ),
+        _verification_state_vector(
+            name="stored-approval-request-mismatch",
+            envelope=_signed_confirmation_envelope(
+                binding=binding,
+                request=alternate_request,
+            ),
+            channel_session=session,
+            issued_challenge=challenge,
+            observed_at="2030-01-02T03:04:05+00:00",
+        ),
+        _verification_state_vector(
+            name="signature-invalid",
+            envelope=_signed_confirmation_envelope(
+                binding=binding,
+                request=request,
+                private_key=_artifact_synthetic_wrong_private_key(),
+            ),
+            channel_session=session,
+            issued_challenge=challenge,
+            observed_at="2030-01-02T03:04:05+00:00",
+        ),
+        _verification_state_vector(
+            name="attempt-budget-exhausted",
+            envelope=envelope,
+            channel_session=session,
+            issued_challenge=rejected_challenge,
+            observed_at="2030-01-02T03:05:05+00:00",
+        ),
+    ]
+    expected_reasons = set(get_args(OwnerControlShadowVerificationReason))
+    actual_reasons = {
+        vector["expected"]["rejection_reason"]
+        for vector in vectors
+        if vector["expected"]["rejection_reason"] is not None
+    }
+    if actual_reasons != expected_reasons:
+        raise OwnerControlContractError(
+            "Owner-control verification vectors must cover every rejection reason"
+        )
+    if not any(vector["expected"]["verification_status"] == "verified" for vector in vectors):
+        raise OwnerControlContractError(
+            "Owner-control verification vectors must include a verified outcome"
+        )
+    return vectors
+
+
+def _challenge_lifecycle_vectors() -> list[dict[str, Any]]:
+    _, _, _, challenge, _ = _shadow_verifier_fixture_models()
+    terminalized, event = terminalize_expired_owner_control_challenge_record(
+        challenge,
+        observed_at=challenge.expires_at,
+    )
+    return [
+        {
+            "name": "issued-to-expired-at-boundary",
+            "observed_at": challenge.expires_at,
+            "issued_challenge": challenge.model_dump(mode="json"),
+            "expected_terminalized_challenge": terminalized.model_dump(mode="json"),
+            "expected_lifecycle_event": event.model_dump(mode="json"),
+        }
+    ]
 
 
 def _canonicalization_vectors() -> list[dict[str, Any]]:
@@ -564,14 +891,35 @@ def _signature_declaration() -> dict[str, Any]:
         "signature_bytes": 64,
         "signature_encoding": "base64url-unpadded",
         "legacy_golden_channel_binding": "synthetic-placeholder-not-channel-binding-record",
-        "contract_schema_version": OWNER_CONTROL_CONTRACT_SCHEMA_VERSION,
+        "contract_schema_version": _OWNER_CONTROL_PREVIOUS_CONTRACT_SCHEMA_VERSION,
     }
+
+
+def _compatibility_declaration() -> dict[str, Any]:
+    return {
+        "container_schema_version": OWNER_CONTROL_CONTRACT_SCHEMA_VERSION,
+        "previous_container_schema_version": _OWNER_CONTROL_PREVIOUS_CONTRACT_SCHEMA_VERSION,
+        "change_kind": "additive-server-state-vectors",
+        "unknown_container_versions": "reject",
+        "wire_model_schema_versions": [1],
+        "shadow_verifier_schema_versions": [OWNER_CONTROL_SHADOW_VERIFIER_SCHEMA_VERSION],
+        "preserved_v2_section_sha256": dict(_PRESERVED_V2_SECTION_SHA256),
+    }
+
+
+def _validate_preserved_v2_sections(artifact: Mapping[str, Any]) -> None:
+    for section, expected_sha256 in _PRESERVED_V2_SECTION_SHA256.items():
+        if canonical_json_sha256(artifact[section]) != expected_sha256:
+            raise OwnerControlContractError(
+                f"Owner-control v2 section {section!r} changed without a compatibility break"
+            )
 
 
 def _build_owner_control_contract() -> dict[str, Any]:
     descriptors = list_privileged_operation_descriptors()
     return {
         "schema_version": OWNER_CONTROL_CONTRACT_SCHEMA_VERSION,
+        "compatibility": _compatibility_declaration(),
         "canonical_json": {
             "encoding": "utf-8",
             "ensure_ascii": True,
@@ -612,13 +960,17 @@ def _build_owner_control_contract() -> dict[str, Any]:
         ],
         "negative_vectors": _negative_vectors(),
         "negative_confirmation_vectors": _negative_confirmation_vectors(),
+        "verification_state_vectors": _verification_state_vectors(),
+        "challenge_lifecycle_vectors": _challenge_lifecycle_vectors(),
     }
 
 
 def build_owner_control_contract() -> dict[str, Any]:
     """Build the deterministic, public owner-control conformance artifact."""
 
-    return _build_owner_control_contract()
+    artifact = _build_owner_control_contract()
+    _validate_preserved_v2_sections(artifact)
+    return artifact
 
 
 def _require_exact_keys(value: Mapping[str, Any], expected: set[str], location: str) -> None:
@@ -636,6 +988,7 @@ def validate_owner_control_contract(artifact: Mapping[str, Any]) -> None:
         artifact,
         {
             "schema_version",
+            "compatibility",
             "canonical_json",
             "signature_declaration",
             "canonicalization_vectors",
@@ -644,12 +997,17 @@ def validate_owner_control_contract(artifact: Mapping[str, Any]) -> None:
             "confirmation_golden_vectors",
             "negative_vectors",
             "negative_confirmation_vectors",
+            "verification_state_vectors",
+            "challenge_lifecycle_vectors",
         },
         "root",
     )
     if artifact["schema_version"] != OWNER_CONTROL_CONTRACT_SCHEMA_VERSION:
         raise OwnerControlContractError("Unsupported owner-control contract schema version")
     expected = _build_owner_control_contract()
+    if artifact["compatibility"] != expected["compatibility"]:
+        raise OwnerControlContractError("Owner-control compatibility declaration drifted")
+    _validate_preserved_v2_sections(artifact)
     if artifact["canonical_json"] != expected["canonical_json"]:
         raise OwnerControlContractError("Owner-control canonical JSON declaration drifted")
     if artifact["signature_declaration"] != expected["signature_declaration"]:
@@ -669,6 +1027,10 @@ def validate_owner_control_contract(artifact: Mapping[str, Any]) -> None:
         raise OwnerControlContractError("Owner-control negative vectors drifted")
     if artifact["negative_confirmation_vectors"] != expected["negative_confirmation_vectors"]:
         raise OwnerControlContractError("Owner-control negative confirmation vectors drifted")
+    if artifact["verification_state_vectors"] != expected["verification_state_vectors"]:
+        raise OwnerControlContractError("Owner-control verification state vectors drifted")
+    if artifact["challenge_lifecycle_vectors"] != expected["challenge_lifecycle_vectors"]:
+        raise OwnerControlContractError("Owner-control challenge lifecycle vectors drifted")
 
 
 def write_owner_control_contract(output_path: Path) -> Path:

--- a/docs/owner-control-channel.md
+++ b/docs/owner-control-channel.md
@@ -121,11 +121,16 @@ contains the JSON schemas, canonicalization declaration, and byte/digest golden
 vectors for every descriptor currently registered in
 `control_plane.privileged_operation_registry`.
 
-The artifact container is schema version `2`; the embedded approval, response,
-binding, signature-payload, and envelope models remain schema version `1`.
-Version `2` adds the signed-channel declarations and vectors while preserving
-the legacy version-1 canonicalization, approval, response, and negative-vector
-bytes.
+The artifact container is schema version `3`; the embedded approval, response,
+binding, signature-payload, envelope, and shadow-verifier record models remain
+schema version `1`. Version `2` added the signed-channel declarations and
+vectors. Version `3` adds deterministic server-state verification and reactive
+challenge-lifecycle vectors while preserving every version-2 section at its
+pinned canonical SHA-256. The compatibility declaration names those preserved
+section digests and requires consumers to reject unknown container versions.
+The preserved `signature_declaration.contract_schema_version` remains `2`
+because it identifies the unchanged signed-channel declaration; the top-level
+schema and compatibility block are authoritative for the version-3 container.
 
 Descriptor vectors derive all synthetic identity values from the descriptor ID,
 so registering another descriptor does not churn existing vectors. Negative
@@ -134,6 +139,17 @@ and cover version, digest, timestamp, nonce, issuance/expiry ordering, exact
 request binding, confirmation-time rejection, review-key uniqueness, and review
 text normalization. Timestamp vectors cover both lexical UTC form and calendar
 validity.
+
+`verification_state_vectors` carry synthetic channel-session state, issued
+challenge state, one confirmation envelope, a whole-second observation time,
+and the exact inert shadow evaluation. Their rejection-reason set must equal
+the complete `OwnerControlShadowVerificationReason` literal, and at least one
+vector must verify successfully. `challenge_lifecycle_vectors` separately
+replay the exact-boundary `issued -> expired` transition, preserving attempt
+count and emitting no envelope digest or verification sequence. Tests rebuild
+the strict models from the JSON payloads and replay both sections through the
+real verifier and lifecycle functions, so adding or changing an outcome cannot
+silently leave the shared artifact behind.
 
 Regenerate and verify the checked artifact with:
 
@@ -164,13 +180,13 @@ challenge permits at most eight audited verification attempts; the eighth
 non-terminal rejection closes the challenge as rejected, and later attempts
 cannot append more events.
 
-Challenge issuance accepts an exact `ApprovalRequest` only through an unrouted
-service-internal storage API. This slice does not claim that arbitrary supplied
-request fields are trusted or derive a challenge from a live privileged
-operation; the database service replaces the nonce and timestamp bounds with a
-server-generated nonce and database-clock values. The remaining
-operation-binding and transport boundary requires a separate review before any
-route exists. Unknown challenge nonces create no durable state.
+Challenge issuance remains an unrouted service-internal storage API. It accepts
+only the enrolled channel-session ID, planned operation ID, and bounded TTL,
+then derives the complete `ApprovalRequest` from the locked operation, active
+policy, enrolled owner, server-generated nonce, and database-clock bounds. The
+remaining transport, enrollment-provenance, and trusted-host principal boundary
+requires separate review before any route exists. Unknown challenge nonces create no durable
+state.
 
 Every stored event and returned result has `verifier_mode: "shadow"` and
 `authorizes_execution: false`. The slice adds no HTTP route, authorization

--- a/docs/records.md
+++ b/docs/records.md
@@ -2664,9 +2664,12 @@ review plus bounded diff and CAS/read-back evidence. See
 `docs/privileged-operations.md` for the full evidence and authorization
 boundary.
 
-The checked `contracts/owner-control-contract.json` artifact is not a record or
-runtime authority. It supplies deterministic cross-host serialization and
-synthetic golden vectors only.
+The checked schema-version-3 `contracts/owner-control-contract.json` artifact is
+not a record or runtime authority. It supplies deterministic cross-host
+serialization, synthetic wire/signature vectors, complete shadow-verifier
+outcome vectors, and one reactive expiry-lifecycle vector only. Its
+compatibility declaration pins every version-2 section digest so the additive
+server-state evidence cannot rewrite the existing wire contract silently.
 
 Owner-control shadow-verifier state is persisted only in PostgreSQL through
 `PostgresRecordStore`: `launchplane_owner_control_channel_sessions` stores one

--- a/tests/test_owner_control_contract.py
+++ b/tests/test_owner_control_contract.py
@@ -4,6 +4,7 @@ import copy
 import json
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from typing import Any, get_args
 import unittest
 
 from pydantic import BaseModel, ValidationError
@@ -21,6 +22,14 @@ from control_plane.contracts.owner_control import (
     owner_control_challenge_response_digest,
     owner_control_signature_payload_bytes,
     verify_owner_control_confirmation_signature,
+)
+from control_plane.contracts.owner_control_shadow_verifier import (
+    OwnerControlChallengeLifecycleEventRecord,
+    OwnerControlChannelSessionRecord,
+    OwnerControlIssuedChallengeRecord,
+    OwnerControlShadowVerificationReason,
+    evaluate_owner_control_shadow_verification,
+    terminalize_expired_owner_control_challenge_record,
 )
 from control_plane.contracts.privileged_operation import (
     ManagedSecretReencryptionPlanInput,
@@ -236,6 +245,32 @@ class OwnerControlContractModelTests(unittest.TestCase):
 
 
 class OwnerControlArtifactTests(unittest.TestCase):
+    def _assert_named_validation_error(
+        self,
+        error: ValidationError,
+        vector: dict[str, Any],
+    ) -> None:
+        errors = error.errors()
+        self.assertEqual(len(errors), 1)
+        self.assertEqual(list(errors[0]["loc"]), vector["error_location"])
+        if expected_message := vector.get("error_message_contains"):
+            self.assertIn(expected_message, errors[0]["msg"])
+
+    def test_v3_contract_preserves_every_v2_section(self) -> None:
+        artifact = build_owner_control_contract()
+        compatibility = artifact["compatibility"]
+
+        self.assertEqual(artifact["schema_version"], 3)
+        self.assertEqual(compatibility["container_schema_version"], 3)
+        self.assertEqual(compatibility["previous_container_schema_version"], 2)
+        self.assertEqual(compatibility["unknown_container_versions"], "reject")
+        self.assertEqual(compatibility["wire_model_schema_versions"], [1])
+        self.assertEqual(compatibility["shadow_verifier_schema_versions"], [1])
+        self.assertEqual(artifact["signature_declaration"]["contract_schema_version"], 2)
+        for section, expected_sha256 in compatibility["preserved_v2_section_sha256"].items():
+            with self.subTest(section=section):
+                self.assertEqual(canonical_json_sha256(artifact[section]), expected_sha256)
+
     def test_existing_approval_and_challenge_vectors_remain_byte_compatible(self) -> None:
         vector = next(
             vector
@@ -329,10 +364,118 @@ class OwnerControlArtifactTests(unittest.TestCase):
                 )
                 self.assertTrue(verify_owner_control_confirmation_signature(envelope))
 
+    def test_verification_state_vectors_cover_and_replay_every_outcome(self) -> None:
+        vectors = build_owner_control_contract()["verification_state_vectors"]
+        expected_reasons = set(get_args(OwnerControlShadowVerificationReason))
+        actual_reasons = {
+            vector["expected"]["rejection_reason"]
+            for vector in vectors
+            if vector["expected"]["rejection_reason"] is not None
+        }
+
+        self.assertEqual(actual_reasons, expected_reasons)
+        self.assertTrue(
+            any(vector["expected"]["verification_status"] == "verified" for vector in vectors)
+        )
+        for vector in vectors:
+            with self.subTest(name=vector["name"]):
+                session_payload = vector["channel_session"]
+                challenge_payload = vector["issued_challenge"]
+                evaluation = evaluate_owner_control_shadow_verification(
+                    envelope=OwnerControlConfirmationEnvelope.model_validate_json(
+                        json.dumps(vector["confirmation_envelope"])
+                    ),
+                    channel_session=(
+                        OwnerControlChannelSessionRecord.model_validate_json(
+                            json.dumps(session_payload)
+                        )
+                        if session_payload is not None
+                        else None
+                    ),
+                    issued_challenge=(
+                        OwnerControlIssuedChallengeRecord.model_validate_json(
+                            json.dumps(challenge_payload)
+                        )
+                        if challenge_payload is not None
+                        else None
+                    ),
+                    observed_at=vector["observed_at"],
+                )
+                expected = vector["expected"]
+                self.assertEqual(
+                    evaluation.model_dump(mode="json"),
+                    {
+                        "verification_status": expected["verification_status"],
+                        "rejection_reason": expected["rejection_reason"],
+                        "consume_challenge": expected["consume_challenge"],
+                        "resulting_challenge_state": expected["resulting_challenge_state"],
+                    },
+                )
+                self.assertEqual(expected["verifier_mode"], "shadow")
+                self.assertFalse(expected["authorizes_execution"])
+                self.assertEqual(expected["authority_state"], "inert")
+
+    def test_lifecycle_vector_replays_exact_boundary_without_attempt_consumption(self) -> None:
+        vectors = build_owner_control_contract()["challenge_lifecycle_vectors"]
+
+        self.assertEqual(len(vectors), 1)
+        vector = vectors[0]
+        issued = OwnerControlIssuedChallengeRecord.model_validate_json(
+            json.dumps(vector["issued_challenge"])
+        )
+        terminalized, event = terminalize_expired_owner_control_challenge_record(
+            issued,
+            observed_at=vector["observed_at"],
+        )
+
+        self.assertEqual(
+            terminalized.model_dump(mode="json"),
+            vector["expected_terminalized_challenge"],
+        )
+        self.assertEqual(
+            event,
+            OwnerControlChallengeLifecycleEventRecord.model_validate_json(
+                json.dumps(vector["expected_lifecycle_event"])
+            ),
+        )
+        self.assertEqual(terminalized.attempt_count, issued.attempt_count)
+        self.assertEqual(event.occurred_at, issued.expires_at)
+        self.assertFalse(event.authorizes_execution)
+        self.assertNotIn("envelope_sha256", vector["expected_lifecycle_event"])
+        self.assertNotIn("sequence", vector["expected_lifecycle_event"])
+
+    def test_server_state_vectors_are_public_safe(self) -> None:
+        artifact = build_owner_control_contract()
+        serialized = json.dumps(
+            {
+                "verification_state_vectors": artifact["verification_state_vectors"],
+                "challenge_lifecycle_vectors": artifact["challenge_lifecycle_vectors"],
+            },
+            sort_keys=True,
+        ).lower()
+
+        for forbidden_value in (
+            *(scheme + "://" for scheme in ("http", "https")),
+            "private_key",
+            "access_token",
+            "credential",
+            "repository",
+            "tenant",
+            "endpoint",
+        ):
+            with self.subTest(forbidden_value=forbidden_value):
+                self.assertNotIn(forbidden_value, serialized)
+
     def test_validator_rejects_contract_drift(self) -> None:
         artifact = build_owner_control_contract()
         changed = copy.deepcopy(artifact)
         changed["golden_vectors"][0]["approval_request"]["sha256"] = "0" * 64
+
+        with self.assertRaises(OwnerControlContractError):
+            validate_owner_control_contract(changed)
+
+        changed = copy.deepcopy(artifact)
+        changed["verification_state_vectors"][0]["expected"]["authorizes_execution"] = True
 
         with self.assertRaises(OwnerControlContractError):
             validate_owner_control_contract(changed)
@@ -349,11 +492,7 @@ class OwnerControlArtifactTests(unittest.TestCase):
             with self.subTest(rule=vector["rule"]):
                 with self.assertRaises(ValidationError) as raised:
                     models[vector["model"]].model_validate_json(json.dumps(vector["payload"]))
-                errors = raised.exception.errors()
-                self.assertEqual(len(errors), 1)
-                self.assertEqual(list(errors[0]["loc"]), vector["error_location"])
-                if expected_message := vector.get("error_message_contains"):
-                    self.assertIn(expected_message, errors[0]["msg"])
+                self._assert_named_validation_error(raised.exception, vector)
 
     def test_negative_confirmation_vectors_fail_closed(self) -> None:
         artifact = build_owner_control_contract()
@@ -369,11 +508,7 @@ class OwnerControlArtifactTests(unittest.TestCase):
                     OwnerControlConfirmationEnvelope.model_validate_json(
                         json.dumps(vector["payload"])
                     )
-                errors = raised.exception.errors()
-                self.assertEqual(len(errors), 1)
-                self.assertEqual(list(errors[0]["loc"]), vector["error_location"])
-                if expected_message := vector.get("error_message_contains"):
-                    self.assertIn(expected_message, errors[0]["msg"])
+                self._assert_named_validation_error(raised.exception, vector)
 
     def test_checked_artifact_matches_generated_contract(self) -> None:
         checked = json.loads(

--- a/tests/test_owner_control_shadow_verifier.py
+++ b/tests/test_owner_control_shadow_verifier.py
@@ -944,11 +944,8 @@ class OwnerControlShadowVerifierStorageTests(unittest.TestCase):
 
 
 class OwnerControlShadowVerifierFreezeBoundaryTests(unittest.TestCase):
-    def test_published_wire_contract_remains_frozen(self) -> None:
-        frozen_paths = (
-            "contracts/owner-control-contract.json",
-            "control_plane/contracts/owner_control.py",
-        )
+    def test_published_wire_models_remain_frozen(self) -> None:
+        frozen_paths = ("control_plane/contracts/owner_control.py",)
 
         for path in frozen_paths:
             with self.subTest(path=path):

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -2717,8 +2717,10 @@ class LaunchplaneServiceTests(unittest.TestCase):
 
         self.assertEqual(result.exit_code, 0, msg=result.output)
         self.assertEqual(result.output.strip(), str(output_path))
-        self.assertEqual(payload["schema_version"], 2)
+        self.assertEqual(payload["schema_version"], 3)
         self.assertTrue(payload["golden_vectors"])
+        self.assertTrue(payload["verification_state_vectors"])
+        self.assertTrue(payload["challenge_lifecycle_vectors"])
 
     def test_product_onboarding_endpoint_writes_full_launchplane_owned_bundle(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary
- bump the public owner-control artifact container to schema version 3 while keeping wire and shadow-record models at version 1
- publish deterministic synthetic vectors for every shadow-verifier rejection reason, one verified outcome, and the exact-boundary `issued -> expired` lifecycle transition
- pin canonical SHA-256 values for every preserved v2 section and fail closed on unknown container versions or unrepresented rejection reasons
- replay the checked vectors through the real verifier/lifecycle functions and document the unchanged no-route/no-authority boundary

## Artifact
- SHA-256: `e3e40e511f3246380291edd7bf3872847039c49c94121885e12fa6116a0b1fae`
- existing v2 sections remain byte-compatible at their canonical section serialization boundary
- contains only deterministic synthetic identifiers, timestamps, public keys/signatures, and digests

## Validation
- 58 focused owner-control, verifier, docs, and exporter tests passed
- official local suite: 3,147 targets, 12/12 shards passed
- real PostgreSQL 16 integration gate: 96 passed
- whole-repo Ruff lint and mypy passed; changed-file format check passed
- config-authority audit: `status: ok`
- CI-equivalent Gitleaks scan: no leaks found
- focused security review: `NO FINDINGS`
- JetBrains: new generator and conformance test scopes green; remaining warnings are pre-existing in untouched regions of `tests/test_service.py`
- exact head `9068747f4bedf56ebea82e361f6993f565e2599f`: Opus `LOVE`, Gemini `LOVE`

## Non-Goals
- no HTTP route, principal, credential, grant, policy revision, workflow permission, DB migration, runtime record, approval-producing stub, or execution coupling

Refs #2272
Refs #2257