### PR TITLE
Activate DB-native privileged policy operations

### DIFF
--- a/control_plane/authz_grant_service.py
+++ b/control_plane/authz_grant_service.py
@@ -1649,7 +1649,7 @@ def _is_strict_immutable_github_human_administrator_rule(
     )
 
 
-def _authz_policy_allows_immutable_github_id_administration(
+def authz_policy_allows_immutable_github_id_administration(
     *,
     policy: LaunchplaneAuthzPolicy,
     github_id: int,
@@ -1660,7 +1660,7 @@ def _authz_policy_allows_immutable_github_id_administration(
     )
 
 
-def _authz_policy_retains_independent_github_id_administration(
+def authz_policy_retains_independent_github_id_administration(
     *,
     policy: LaunchplaneAuthzPolicy,
     applying_github_id: int,
@@ -2074,10 +2074,11 @@ def authz_managed_policy_reconcile_audit_payload(
     diff: AuthzManagedPolicyDiff,
     trace_id: str,
     now_timestamp: TimestampProvider,
+    source: str = _MANAGED_AUTHZ_RECONCILE_SOURCE,
 ) -> dict[str, object]:
     return {
         "operation": "managed_rule_set_reconcile",
-        "source": _MANAGED_AUTHZ_RECONCILE_SOURCE,
+        "source": source,
         "mode": request.mode,
         "reason": request.reason,
         "related_issue": request.related_issue,
@@ -2113,6 +2114,7 @@ def execute_managed_authz_policy_reconcile(
     now_timestamp: TimestampProvider,
     authorized_policy_sha256: str = "",
     immutable_applying_github_id: int = 0,
+    source: str = _MANAGED_AUTHZ_RECONCILE_SOURCE,
 ) -> AuthzManagedPolicyRouteResult:
     active_records = record_store.list_authz_policy_records(status="active", limit=1)
     if not active_records:
@@ -2133,7 +2135,7 @@ def execute_managed_authz_policy_reconcile(
     )
     policy_safety_blockers = list(managed_diff.policy_safety_blockers)
     applying_admin_retained = (
-        _authz_policy_allows_immutable_github_id_administration(
+        authz_policy_allows_immutable_github_id_administration(
             policy=updated_policy,
             github_id=immutable_applying_github_id,
         )
@@ -2149,7 +2151,7 @@ def execute_managed_authz_policy_reconcile(
         policy_safety_blockers.append(
             _managed_policy_safety_blocker("authz_policy_applying_admin_removed")
         )
-    independent_admin_retained = _authz_policy_retains_independent_github_id_administration(
+    independent_admin_retained = authz_policy_retains_independent_github_id_administration(
         policy=updated_policy,
         applying_github_id=immutable_applying_github_id,
     )
@@ -2209,6 +2211,7 @@ def execute_managed_authz_policy_reconcile(
         diff=managed_diff,
         trace_id=trace_id,
         now_timestamp=now_timestamp,
+        source=source,
     )
     authz_policy_record = _dry_run_authz_policy_record(
         current_record=current_record,
@@ -2224,7 +2227,7 @@ def execute_managed_authz_policy_reconcile(
             ),
             revision=managed_diff.candidate_revision,
             status="active",
-            source=_MANAGED_AUTHZ_RECONCILE_SOURCE,
+            source=source,
             updated_at=updated_at,
             policy_sha256=managed_diff.desired_policy_sha256,
             policy=updated_policy,
@@ -2238,6 +2241,7 @@ def execute_managed_authz_policy_reconcile(
             diff=managed_diff,
             trace_id=trace_id,
             now_timestamp=now_timestamp,
+            source=source,
         )
         authz_policy_record.audit = audit
     result, driver_result = build_authz_managed_policy_reconcile_service_result(

--- a/control_plane/authz_policy_activation.py
+++ b/control_plane/authz_policy_activation.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from control_plane.authz_grant_service import (
+    AuthzManagedPolicyDiff,
+    AuthzManagedPolicyReconcileEnvelope,
+    authz_policy_allows_immutable_github_id_administration,
+    authz_policy_retains_independent_github_id_administration,
+)
+from control_plane.contracts.authz_policy_record import LaunchplaneAuthzPolicyRecord
+from control_plane.contracts.privileged_operation import (
+    AUTHZ_POLICY_OPERATION_APPROVE_ACTION,
+    AUTHZ_POLICY_OPERATION_CANCEL_ACTION,
+    AUTHZ_POLICY_OPERATION_PROPOSE_ACTION,
+    AUTHZ_POLICY_OPERATION_READ_ACTION,
+    AUTHZ_POLICY_OPERATION_REVOKE_ACTION,
+)
+from control_plane.service_auth import GitHubHumanPolicyRule, LaunchplaneAuthzPolicy
+
+
+AUTHZ_POLICY_OPERATION_ACTIVATION_MANAGED_SET_ID = "operator.privileged-policy-operation"
+AUTHZ_POLICY_OPERATION_ACTIVATION_MANAGED_RULE_ID = "github-human-policy-operator"
+AUTHZ_POLICY_OPERATION_ACTIVATION_SOURCE = "service:authz-policy-operation-activation"
+AUTHZ_POLICY_OPERATION_ACTIVATION_ACTIONS = (
+    AUTHZ_POLICY_OPERATION_APPROVE_ACTION,
+    AUTHZ_POLICY_OPERATION_CANCEL_ACTION,
+    AUTHZ_POLICY_OPERATION_PROPOSE_ACTION,
+    AUTHZ_POLICY_OPERATION_READ_ACTION,
+    AUTHZ_POLICY_OPERATION_REVOKE_ACTION,
+)
+AuthzPolicyOperationActivationState = Literal["available", "active", "conflict"]
+
+
+class AuthzPolicyOperationActivationDryRunRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    reason: str = Field(min_length=1, max_length=1000)
+
+    @field_validator("reason")
+    @classmethod
+    def _normalize_reason(cls, value: str) -> str:
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("Activation dry-run requires reason.")
+        return normalized
+
+
+class AuthzPolicyOperationActivationApplyRequest(AuthzPolicyOperationActivationDryRunRequest):
+    reviewed_plan_sha256: str = Field(min_length=64, max_length=64)
+
+    @field_validator("reviewed_plan_sha256")
+    @classmethod
+    def _normalize_reviewed_plan_sha256(cls, value: str) -> str:
+        normalized = value.strip().lower()
+        if re.fullmatch(r"[0-9a-f]{64}", normalized) is None:
+            raise ValueError("Activation apply requires a reviewed dry-run digest.")
+        return normalized
+
+
+def build_authz_policy_operation_activation_reconcile_request(
+    *,
+    github_id: int,
+    mode: Literal["dry_run", "apply"],
+    reason: str,
+    reviewed_plan_sha256: str = "",
+) -> AuthzManagedPolicyReconcileEnvelope:
+    if github_id < 1:
+        raise ValueError("Activation requires an immutable GitHub ID.")
+    desired_policy = LaunchplaneAuthzPolicy(
+        schema_version=2,
+        github_humans=(
+            GitHubHumanPolicyRule(
+                managed_set_id=AUTHZ_POLICY_OPERATION_ACTIVATION_MANAGED_SET_ID,
+                managed_rule_id=AUTHZ_POLICY_OPERATION_ACTIVATION_MANAGED_RULE_ID,
+                github_ids=(github_id,),
+                roles=("admin",),
+                products=("launchplane",),
+                contexts=("launchplane",),
+                actions=AUTHZ_POLICY_OPERATION_ACTIVATION_ACTIONS,
+            ),
+        ),
+    )
+    return AuthzManagedPolicyReconcileEnvelope(
+        product="launchplane",
+        mode=mode,
+        managed_set_id=AUTHZ_POLICY_OPERATION_ACTIVATION_MANAGED_SET_ID,
+        reason=reason,
+        related_issue="#2277",
+        reviewed_plan_sha256=reviewed_plan_sha256,
+        desired_policy=desired_policy,
+    )
+
+
+def authz_policy_operation_activation_state(
+    policy: LaunchplaneAuthzPolicy,
+) -> AuthzPolicyOperationActivationState:
+    matching_rules = tuple(
+        (principal_type, rule)
+        for principal_type, rules in (
+            ("github_actions", policy.github_actions),
+            ("github_humans", policy.github_humans),
+            ("terminal_agents", policy.terminal_agents),
+            ("local_operators", policy.local_operators),
+            ("local_admins", policy.local_admins),
+        )
+        for rule in rules
+        if rule.managed_set_id == AUTHZ_POLICY_OPERATION_ACTIVATION_MANAGED_SET_ID
+    )
+    if not matching_rules:
+        return "available"
+    if len(matching_rules) != 1:
+        return "conflict"
+    principal_type, rule = matching_rules[0]
+    if (
+        principal_type != "github_humans"
+        or not isinstance(rule, GitHubHumanPolicyRule)
+        or rule.managed_rule_id != AUTHZ_POLICY_OPERATION_ACTIVATION_MANAGED_RULE_ID
+        or len(rule.github_ids) != 1
+        or rule.roles != ("admin",)
+        or rule.products != ("launchplane",)
+        or rule.contexts != ("launchplane",)
+        or rule.actions != AUTHZ_POLICY_OPERATION_ACTIVATION_ACTIONS
+        or rule.logins
+        or rule.organizations
+        or rule.teams
+        or rule.instances
+    ):
+        return "conflict"
+    return "active"
+
+
+def authz_policy_operation_activation_github_id(
+    policy: LaunchplaneAuthzPolicy,
+) -> int:
+    if authz_policy_operation_activation_state(policy) != "active":
+        return 0
+    rule = next(
+        rule
+        for rule in policy.github_humans
+        if rule.managed_set_id == AUTHZ_POLICY_OPERATION_ACTIVATION_MANAGED_SET_ID
+    )
+    return rule.github_ids[0]
+
+
+def authz_policy_operation_activation_idempotency_scope(github_id: int) -> str:
+    if github_id < 1:
+        raise ValueError("Activation idempotency requires an immutable GitHub ID.")
+    return f"github-human-id|{github_id}"
+
+
+def authz_policy_operation_activation_evidence(
+    *,
+    mode: Literal["dry_run", "apply"],
+    applying_github_id: int,
+    previous_record: LaunchplaneAuthzPolicyRecord,
+    resulting_record: LaunchplaneAuthzPolicyRecord,
+    candidate_policy: LaunchplaneAuthzPolicy,
+    diff: AuthzManagedPolicyDiff,
+    changed: bool,
+) -> dict[str, object]:
+    return {
+        "mode": mode,
+        "bridge_state": "retired" if mode == "apply" else "available",
+        "managed_set_id": AUTHZ_POLICY_OPERATION_ACTIVATION_MANAGED_SET_ID,
+        "managed_rule_id": AUTHZ_POLICY_OPERATION_ACTIVATION_MANAGED_RULE_ID,
+        "principal_type": "github_human",
+        "applying_github_id_sha256": hashlib.sha256(
+            json.dumps(applying_github_id).encode()
+        ).hexdigest(),
+        "actions": list(AUTHZ_POLICY_OPERATION_ACTIVATION_ACTIONS),
+        "product": "launchplane",
+        "context": "launchplane",
+        "changed": changed,
+        "observed_record_id": previous_record.record_id,
+        "observed_revision": previous_record.revision,
+        "observed_policy_sha256": previous_record.policy_sha256,
+        "candidate_revision": diff.candidate_revision,
+        "candidate_policy_sha256": diff.desired_policy_sha256,
+        "desired_set_sha256": diff.desired_set_sha256,
+        "review_digest": diff.plan_sha256,
+        "applying_admin_retained": authz_policy_allows_immutable_github_id_administration(
+            policy=candidate_policy,
+            github_id=applying_github_id,
+        ),
+        "independent_admin_reachable": (
+            authz_policy_retains_independent_github_id_administration(
+                policy=candidate_policy,
+                applying_github_id=applying_github_id,
+            )
+        ),
+        "policy_safety_blockers": [
+            blocker.model_dump(mode="json") for blocker in diff.policy_safety_blockers
+        ],
+        "read_back": {
+            "record_id": resulting_record.record_id,
+            "revision": resulting_record.revision,
+            "policy_sha256": resulting_record.policy_sha256,
+            "activation_state": authz_policy_operation_activation_state(resulting_record.policy),
+        },
+    }

--- a/control_plane/authz_policy_activation.py
+++ b/control_plane/authz_policy_activation.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import hashlib
-import json
 import re
 from typing import Literal
 
@@ -170,9 +168,6 @@ def authz_policy_operation_activation_evidence(
         "managed_set_id": AUTHZ_POLICY_OPERATION_ACTIVATION_MANAGED_SET_ID,
         "managed_rule_id": AUTHZ_POLICY_OPERATION_ACTIVATION_MANAGED_RULE_ID,
         "principal_type": "github_human",
-        "applying_github_id_sha256": hashlib.sha256(
-            json.dumps(applying_github_id).encode()
-        ).hexdigest(),
         "actions": list(AUTHZ_POLICY_OPERATION_ACTIVATION_ACTIONS),
         "product": "launchplane",
         "context": "launchplane",
@@ -197,7 +192,7 @@ def authz_policy_operation_activation_evidence(
         "policy_safety_blockers": [
             blocker.model_dump(mode="json") for blocker in diff.policy_safety_blockers
         ],
-        "read_back": {
+        "resulting_policy": {
             "record_id": resulting_record.record_id,
             "revision": resulting_record.revision,
             "policy_sha256": resulting_record.policy_sha256,

--- a/control_plane/authz_policy_activation.py
+++ b/control_plane/authz_policy_activation.py
@@ -157,14 +157,16 @@ def authz_policy_operation_activation_evidence(
     mode: Literal["dry_run", "apply"],
     applying_github_id: int,
     previous_record: LaunchplaneAuthzPolicyRecord,
-    resulting_record: LaunchplaneAuthzPolicyRecord,
     candidate_policy: LaunchplaneAuthzPolicy,
     diff: AuthzManagedPolicyDiff,
     changed: bool,
 ) -> dict[str, object]:
     return {
         "mode": mode,
-        "bridge_state": "retired" if mode == "apply" else "available",
+        "activation_state": {
+            "observed": authz_policy_operation_activation_state(previous_record.policy),
+            "candidate": authz_policy_operation_activation_state(candidate_policy),
+        },
         "managed_set_id": AUTHZ_POLICY_OPERATION_ACTIVATION_MANAGED_SET_ID,
         "managed_rule_id": AUTHZ_POLICY_OPERATION_ACTIVATION_MANAGED_RULE_ID,
         "principal_type": "github_human",
@@ -192,10 +194,4 @@ def authz_policy_operation_activation_evidence(
         "policy_safety_blockers": [
             blocker.model_dump(mode="json") for blocker in diff.policy_safety_blockers
         ],
-        "resulting_policy": {
-            "record_id": resulting_record.record_id,
-            "revision": resulting_record.revision,
-            "policy_sha256": resulting_record.policy_sha256,
-            "activation_state": authz_policy_operation_activation_state(resulting_record.policy),
-        },
     }

--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -14584,25 +14584,6 @@ def create_launchplane_fastapi_app(
         identity: GitHubHumanIdentity,
         trace_id: str,
     ) -> None:
-        activation_state = (
-            control_plane_authz_policy_activation.authz_policy_operation_activation_state(
-                active_record.policy
-            )
-        )
-        if activation_state == "active":
-            raise _launchplane_http_error(
-                status_code=410,
-                trace_id=trace_id,
-                code="authz_policy_operation_activation_retired",
-                message="The privileged-policy operation activation bridge is retired.",
-            )
-        if activation_state == "conflict":
-            raise _launchplane_http_error(
-                status_code=409,
-                trace_id=trace_id,
-                code="authz_policy_operation_activation_conflict",
-                message="The activation managed set conflicts with the compiled bridge contract.",
-            )
         if not control_plane_authz_grant_service.authz_policy_allows_immutable_github_id_administration(
             policy=active_record.policy,
             github_id=identity.github_id,
@@ -14626,6 +14607,25 @@ def create_launchplane_fastapi_app(
                 ),
                 authz_policy_provenance=AuthzPolicyProvenance.from_record(active_record),
             )
+        activation_state = (
+            control_plane_authz_policy_activation.authz_policy_operation_activation_state(
+                active_record.policy
+            )
+        )
+        if activation_state == "active":
+            raise _launchplane_http_error(
+                status_code=410,
+                trace_id=trace_id,
+                code="authz_policy_operation_activation_retired",
+                message="The privileged-policy operation activation bridge is retired.",
+            )
+        if activation_state == "conflict":
+            raise _launchplane_http_error(
+                status_code=409,
+                trace_id=trace_id,
+                code="authz_policy_operation_activation_conflict",
+                message="The activation managed set conflicts with the compiled bridge contract.",
+            )
 
     def build_authz_policy_operation_activation_response(
         *,
@@ -14647,7 +14647,6 @@ def create_launchplane_fastapi_app(
             mode=mode,
             applying_github_id=identity.github_id,
             previous_record=route_result.previous_authz_policy_record,
-            resulting_record=resulting_record,
             candidate_policy=route_result.updated_policy,
             diff=diff,
             changed=route_result.changed,

--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -29,6 +29,7 @@ from requests.exceptions import RequestException
 from sqlalchemy.exc import SQLAlchemyError
 from control_plane import authz_grant_service as control_plane_authz_grant_service
 from control_plane import authz_activation_preflight as control_plane_authz_activation_preflight
+from control_plane import authz_policy_activation as control_plane_authz_policy_activation
 from control_plane import authz_diagnostics as control_plane_authz_diagnostics
 from control_plane import authz_repository_scope as control_plane_authz_repository_scope
 from control_plane import ingress_route_scope as control_plane_ingress_route_scope
@@ -877,6 +878,13 @@ _OWNER_ACCEPTANCE_MAX_BODY_BYTES = 16 * 1024
 _CHANGE_IMPACT_EVALUATION_MAX_BODY_BYTES = 16 * 1024
 _CHANGE_IMPACT_POLICY_MAX_BODY_BYTES = 64 * 1024
 _PRIVILEGED_OPERATION_MAX_BODY_BYTES = 256 * 1024
+_AUTHZ_POLICY_OPERATION_ACTIVATION_MAX_BODY_BYTES = 16 * 1024
+_AUTHZ_POLICY_OPERATION_ACTIVATION_DRY_RUN_ROUTE = (
+    "/v1/authz-policies/privileged-policy-operations/activation/dry-run"
+)
+_AUTHZ_POLICY_OPERATION_ACTIVATION_APPLY_ROUTE = (
+    "/v1/authz-policies/privileged-policy-operations/activation/apply"
+)
 _PRODUCT_HEALTH_MONITORING_APPLY_ROUTE = "/v1/product-profiles/health-monitoring/apply"
 _PRODUCT_PRELAUNCH_REBUILD_POLICY_APPLY_ROUTE = "/v1/product-profiles/prelaunch-rebuild/apply"
 _PRODUCT_STABLE_LANE_REPAIR_APPLY_ROUTE = "/v1/product-profiles/stable-lane-repair/apply"
@@ -942,6 +950,18 @@ _BOUNDED_REQUEST_BODY_CONTRACTS: dict[str, tuple[str, int, bool, bool]] = {
     PRIVILEGED_OPERATION_AGENT_PLANS_ROUTE: (
         "Agent privileged-operation proposal",
         _PRIVILEGED_OPERATION_MAX_BODY_BYTES,
+        True,
+        True,
+    ),
+    _AUTHZ_POLICY_OPERATION_ACTIVATION_DRY_RUN_ROUTE: (
+        "Privileged-policy operation activation dry-run",
+        _AUTHZ_POLICY_OPERATION_ACTIVATION_MAX_BODY_BYTES,
+        True,
+        True,
+    ),
+    _AUTHZ_POLICY_OPERATION_ACTIVATION_APPLY_ROUTE: (
+        "Privileged-policy operation activation apply",
+        _AUTHZ_POLICY_OPERATION_ACTIVATION_MAX_BODY_BYTES,
         True,
         True,
     ),
@@ -1071,8 +1091,10 @@ _AUTHZ_POLICY_CANDIDATE_PREVIEW_ROUTE = "/v1/authz-diagnostics/candidate-policy/
 _AUTHZ_REPOSITORY_SCOPE_READ_ROUTE = "/v1/authz-diagnostics/repository-scope/read"
 _AUTHZ_DENIAL_EXPLANATION_ROUTE = "/v1/authz-diagnostics/denials/{trace_id}"
 _AUTHZ_POLICY_MANAGED_RECONCILE_ROUTE = "/v1/authz-policies/managed-rule-sets/reconcile"
-_AUTHZ_NONPERSISTING_SENSITIVE_READ_ROUTES = frozenset(
+_AUTHZ_NONPERSISTING_SENSITIVE_ROUTES = frozenset(
     {
+        _AUTHZ_POLICY_OPERATION_ACTIVATION_DRY_RUN_ROUTE,
+        _AUTHZ_POLICY_OPERATION_ACTIVATION_APPLY_ROUTE,
         _AUTHZ_POLICY_ADMINISTRATION_ROUTE,
         _AUTHZ_POLICY_REVISION_HISTORY_ROUTE,
     }
@@ -4017,7 +4039,7 @@ def create_launchplane_fastapi_app(
         try:
             response = cast(Response, await call_next(request))
             if request.url.path == _AUTHZ_ACTIVATION_PREFLIGHT_ROUTE or (
-                request.url.path in _AUTHZ_NONPERSISTING_SENSITIVE_READ_ROUTES
+                request.url.path in _AUTHZ_NONPERSISTING_SENSITIVE_ROUTES
             ):
                 response.headers["Cache-Control"] = "no-store"
             return response
@@ -14551,6 +14573,396 @@ def create_launchplane_fastapi_app(
         )
         return response
 
+    def require_authz_policy_operation_activation_available(
+        *,
+        active_record: LaunchplaneAuthzPolicyRecord,
+        identity: GitHubHumanIdentity,
+        trace_id: str,
+    ) -> None:
+        activation_state = (
+            control_plane_authz_policy_activation.authz_policy_operation_activation_state(
+                active_record.policy
+            )
+        )
+        if activation_state == "active":
+            raise _launchplane_http_error(
+                status_code=410,
+                trace_id=trace_id,
+                code="authz_policy_operation_activation_retired",
+                message="The privileged-policy operation activation bridge is retired.",
+            )
+        if activation_state == "conflict":
+            raise _launchplane_http_error(
+                status_code=409,
+                trace_id=trace_id,
+                code="authz_policy_operation_activation_conflict",
+                message="The activation managed set conflicts with the compiled bridge contract.",
+            )
+        if not control_plane_authz_grant_service.authz_policy_allows_immutable_github_id_administration(
+            policy=active_record.policy,
+            github_id=identity.github_id,
+        ):
+            raise _launchplane_http_error(
+                status_code=403,
+                trace_id=trace_id,
+                code="authorization_denied",
+                message=(
+                    "Activation requires existing immutable-ID DB policy administration authority."
+                ),
+            )
+
+    def build_authz_policy_operation_activation_response(
+        *,
+        mode: Literal["dry_run", "apply"],
+        identity: GitHubHumanIdentity,
+        route_result: control_plane_authz_grant_service.AuthzManagedPolicyRouteResult,
+        trace_id: str,
+    ) -> AcceptedEvidenceResponse:
+        diff_payload = route_result.driver_result.get("diff")
+        if not isinstance(diff_payload, dict):
+            raise RuntimeError("Activation reconciliation requires typed diff evidence.")
+        diff = control_plane_authz_grant_service.AuthzManagedPolicyDiff.model_validate(diff_payload)
+        resulting_record = (
+            route_result.authz_policy_record
+            if mode == "apply"
+            else route_result.previous_authz_policy_record
+        )
+        evidence = control_plane_authz_policy_activation.authz_policy_operation_activation_evidence(
+            mode=mode,
+            applying_github_id=identity.github_id,
+            previous_record=route_result.previous_authz_policy_record,
+            resulting_record=resulting_record,
+            candidate_policy=route_result.updated_policy,
+            diff=diff,
+            changed=route_result.changed,
+        )
+        return accepted_evidence_response(
+            trace_id=trace_id,
+            records={
+                "authz_policy_record_id": resulting_record.record_id,
+                "managed_set_id": (
+                    control_plane_authz_policy_activation.AUTHZ_POLICY_OPERATION_ACTIVATION_MANAGED_SET_ID
+                ),
+            },
+            result={
+                "activation": evidence,
+                "reconcile": route_result.driver_result,
+            },
+        )
+
+    def execute_authz_policy_operation_activation(
+        *,
+        mode: Literal["dry_run", "apply"],
+        reason: str,
+        reviewed_plan_sha256: str,
+        identity: GitHubHumanIdentity,
+        database_store: PostgresRecordStore,
+        trace_id: str,
+    ) -> control_plane_authz_grant_service.AuthzManagedPolicyRouteResult:
+        active_record = read_single_active_authz_policy_record(
+            database_store=database_store,
+            trace_id=trace_id,
+        )
+        require_authz_policy_operation_activation_available(
+            active_record=active_record,
+            identity=identity,
+            trace_id=trace_id,
+        )
+        activation_request = control_plane_authz_policy_activation.build_authz_policy_operation_activation_reconcile_request(
+            github_id=identity.github_id,
+            mode=mode,
+            reason=reason,
+            reviewed_plan_sha256=reviewed_plan_sha256,
+        )
+        try:
+            route_result = control_plane_authz_grant_service.execute_managed_authz_policy_reconcile(
+                record_store=database_store,
+                request=activation_request,
+                identity=identity,
+                trace_id=trace_id,
+                now_timestamp=authz_policy_record_timestamp,
+                authorized_policy_sha256=resolved_authz_policy_runtime.policy_sha256,
+                immutable_applying_github_id=identity.github_id,
+                source=(
+                    control_plane_authz_policy_activation.AUTHZ_POLICY_OPERATION_ACTIVATION_SOURCE
+                ),
+            )
+        except control_plane_authz_grant_service.AuthzPolicyRequestError as error:
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_request",
+                message=str(error),
+            ) from error
+        except control_plane_authz_grant_service.AuthzPolicySafetyError as error:
+            raise _launchplane_http_error(
+                status_code=409,
+                trace_id=trace_id,
+                code=error.code,
+                message=str(error),
+            ) from error
+        except control_plane_authz_grant_service.AuthzPolicyConflictError as error:
+            raise _launchplane_http_error(
+                status_code=409,
+                trace_id=trace_id,
+                code="authz_policy_conflict",
+                message=str(error),
+            ) from error
+        except ValueError as error:
+            raise _launchplane_http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="authz_policy_unavailable",
+                message="Launchplane active authz policy is unavailable.",
+            ) from error
+        if (
+            not route_result.changed
+            or control_plane_authz_policy_activation.authz_policy_operation_activation_state(
+                route_result.updated_policy
+            )
+            != "active"
+            or control_plane_authz_policy_activation.authz_policy_operation_activation_github_id(
+                route_result.updated_policy
+            )
+            != identity.github_id
+        ):
+            raise _launchplane_http_error(
+                status_code=409,
+                trace_id=trace_id,
+                code="authz_policy_operation_activation_conflict",
+                message="The compiled activation candidate did not produce the exact managed set.",
+            )
+        return route_result
+
+    def dry_run_authz_policy_operation_activation(
+        envelope: control_plane_authz_policy_activation.AuthzPolicyOperationActivationDryRunRequest,
+        response: Response,
+        identity: Annotated[
+            GitHubHumanIdentity,
+            Depends(read_github_human_browser_mutation_identity),
+        ],
+        record_store: Annotated[object, Depends(get_record_store)],
+    ) -> AcceptedEvidenceResponse:
+        trace_id = next_trace_id()
+        response.headers["Cache-Control"] = "no-store"
+        database_store = require_authz_policy_database_store(
+            record_store=record_store,
+            trace_id=trace_id,
+            message="Activation dry-run requires Launchplane database storage.",
+        )
+        route_result = execute_authz_policy_operation_activation(
+            mode="dry_run",
+            reason=envelope.reason,
+            reviewed_plan_sha256="",
+            identity=identity,
+            database_store=database_store,
+            trace_id=trace_id,
+        )
+        return build_authz_policy_operation_activation_response(
+            mode="dry_run",
+            identity=identity,
+            route_result=route_result,
+            trace_id=trace_id,
+        )
+
+    async def apply_authz_policy_operation_activation(
+        envelope: control_plane_authz_policy_activation.AuthzPolicyOperationActivationApplyRequest,
+        response: Response,
+        request: Request,
+        identity: Annotated[
+            GitHubHumanIdentity,
+            Depends(read_github_human_browser_mutation_identity),
+        ],
+        record_store: Annotated[object, Depends(get_record_store)],
+        idempotency_key: Annotated[str, Header(alias="Idempotency-Key")] = "",
+    ) -> AcceptedEvidenceResponse:
+        trace_id = next_trace_id()
+        response.headers["Cache-Control"] = "no-store"
+        database_store = require_authz_policy_database_store(
+            record_store=record_store,
+            trace_id=trace_id,
+            message="Activation apply requires Launchplane database storage.",
+        )
+        normalized_idempotency_key = idempotency_key.strip()
+        if not normalized_idempotency_key:
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="idempotency_key_required",
+                message="Activation apply requires an Idempotency-Key.",
+            )
+        activation_scope = control_plane_authz_policy_activation.authz_policy_operation_activation_idempotency_scope(
+            identity.github_id
+        )
+        (
+            normalized_idempotency_key,
+            payload_fingerprint,
+            replay_response,
+        ) = await replay_apply_idempotency(
+            request=request,
+            record_store=database_store,
+            identity=identity,
+            route_path=_AUTHZ_POLICY_OPERATION_ACTIVATION_APPLY_ROUTE,
+            idempotency_key=normalized_idempotency_key,
+            trace_id=trace_id,
+            check_replay=True,
+            request_payload=envelope.model_dump(mode="json"),
+            idempotency_scope_override=activation_scope,
+        )
+        if replay_response is not None:
+            return replay_response
+        route_result = execute_authz_policy_operation_activation(
+            mode="apply",
+            reason=envelope.reason,
+            reviewed_plan_sha256=envelope.reviewed_plan_sha256,
+            identity=identity,
+            database_store=database_store,
+            trace_id=trace_id,
+        )
+        mutation_digest = hashlib.sha256(
+            "\x1f".join(
+                (
+                    activation_scope,
+                    _AUTHZ_POLICY_OPERATION_ACTIVATION_APPLY_ROUTE,
+                    normalized_idempotency_key,
+                )
+            ).encode()
+        ).hexdigest()
+        audit_context: dict[str, object] = {
+            "request_fingerprint": payload_fingerprint,
+            "idempotency_scope_sha256": hashlib.sha256(activation_scope.encode()).hexdigest(),
+            "idempotency_record_id": f"mutation-reservation-{mutation_digest}",
+            "idempotency_key_sha256": hashlib.sha256(
+                normalized_idempotency_key.encode()
+            ).hexdigest(),
+        }
+        route_result.authz_policy_record.audit.update(audit_context)
+        response_audit = route_result.driver_result.get("audit")
+        if isinstance(response_audit, dict):
+            response_audit.update(audit_context)
+        accepted_response = build_authz_policy_operation_activation_response(
+            mode="apply",
+            identity=identity,
+            route_result=route_result,
+            trace_id=trace_id,
+        )
+        write_result = database_store.compare_and_write_authz_policy_record(
+            expected_record=route_result.previous_authz_policy_record,
+            replacement_record=route_result.authz_policy_record,
+            mutation=DbOnlyMutationRequest(
+                scope=activation_scope,
+                route_path=_AUTHZ_POLICY_OPERATION_ACTIVATION_APPLY_ROUTE,
+                idempotency_key=normalized_idempotency_key,
+                request_fingerprint=payload_fingerprint,
+                lease_owner=trace_id,
+                response_status_code=202,
+                response_trace_id=trace_id,
+                response_payload=accepted_response.model_dump(mode="json", exclude_none=True),
+                lease_seconds=int(_DB_ONLY_MUTATION_LEASE.total_seconds()),
+            ),
+        )
+        if write_result.status == "replayed":
+            if write_result.idempotency_record is None:
+                raise RuntimeError("Replayed activation write requires evidence.")
+            return replay_idempotent_response(
+                trace_id=trace_id,
+                stored_record=write_result.idempotency_record,
+                route_path=_AUTHZ_POLICY_OPERATION_ACTIVATION_APPLY_ROUTE,
+            )
+        if write_result.status == "idempotency_conflict":
+            raise _launchplane_http_error(
+                status_code=409,
+                trace_id=trace_id,
+                code="idempotency_key_reused",
+                message="Idempotency-Key was already used for a different activation request.",
+            )
+        if write_result.status == "reservation_in_progress":
+            raise _launchplane_http_error(
+                status_code=409,
+                trace_id=trace_id,
+                code="mutation_in_progress",
+                message="A matching activation mutation is already running.",
+            )
+        if write_result.status == "reconciliation_required":
+            raise _launchplane_http_error(
+                status_code=409,
+                trace_id=trace_id,
+                code="mutation_reconciliation_required",
+                message="The activation mutation requires reconciliation before retry.",
+            )
+        if write_result.status == "stale":
+            raise _launchplane_http_error(
+                status_code=409,
+                trace_id=trace_id,
+                code="authz_policy_plan_stale",
+                message="The reviewed activation plan is stale.",
+            )
+        if write_result.status == "ambiguous_active":
+            raise _launchplane_http_error(
+                status_code=409,
+                trace_id=trace_id,
+                code="active_authz_policy_ambiguous",
+                message="Multiple active Launchplane authz policy records were found.",
+            )
+        if write_result.status == "missing":
+            raise _launchplane_http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="authz_policy_unavailable",
+                message="Launchplane active authz policy is unavailable.",
+            )
+        if write_result.status != "written":
+            raise _launchplane_http_error(
+                status_code=409,
+                trace_id=trace_id,
+                code="authz_policy_operation_activation_conflict",
+                message="Activation did not produce a new active authorization policy.",
+            )
+        resulting_record = write_result.current_record
+        if resulting_record is None:
+            active_records = database_store.list_authz_policy_records(status="active", limit=2)
+            if len(active_records) != 1:
+                raise _launchplane_http_error(
+                    status_code=503,
+                    trace_id=trace_id,
+                    code="authz_policy_operation_activation_readback_failed",
+                    message="Activation policy read-back failed.",
+                )
+            resulting_record = active_records[0]
+        expected_record = route_result.authz_policy_record
+        if (
+            resulting_record.record_id != expected_record.record_id
+            or resulting_record.revision != expected_record.revision
+            or resulting_record.policy_sha256 != expected_record.policy_sha256
+            or resulting_record.policy != route_result.updated_policy
+            or control_plane_authz_policy_activation.authz_policy_operation_activation_state(
+                resulting_record.policy
+            )
+            != "active"
+            or control_plane_authz_policy_activation.authz_policy_operation_activation_github_id(
+                resulting_record.policy
+            )
+            != identity.github_id
+        ):
+            raise _launchplane_http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="authz_policy_operation_activation_readback_failed",
+                message="Activation policy read-back failed.",
+            )
+        resolved_authz_policy_runtime.update(
+            resulting_record.policy,
+            policy_sha256=resulting_record.policy_sha256,
+            source="db",
+            record_id=resulting_record.record_id,
+            revision=resulting_record.revision,
+        )
+        reconcile_all_manager_preview_approvals_best_effort(
+            record_store=database_store,
+            control_plane_root=resolved_control_plane_root,
+        )
+        return accepted_response
+
     async def read_active_authz_policy(
         identity: Annotated[LaunchplaneIdentity, Depends(read_browser_mutation_identity)],
         record_store: Annotated[object, Depends(get_record_store)],
@@ -23002,6 +23414,42 @@ def create_launchplane_fastapi_app(
     )
 
     app.add_api_route(
+        _AUTHZ_POLICY_OPERATION_ACTIVATION_DRY_RUN_ROUTE,
+        dry_run_authz_policy_operation_activation,
+        methods=["POST"],
+        status_code=202,
+        response_model=AcceptedEvidenceResponse,
+        response_model_exclude_none=True,
+        include_in_schema=False,
+        responses={
+            400: {"model": LaunchplaneErrorResponse},
+            401: {"model": LaunchplaneErrorResponse},
+            403: {"model": LaunchplaneErrorResponse},
+            409: {"model": LaunchplaneErrorResponse},
+            410: {"model": LaunchplaneErrorResponse},
+            503: {"model": LaunchplaneErrorResponse},
+        },
+    )
+
+    app.add_api_route(
+        _AUTHZ_POLICY_OPERATION_ACTIVATION_APPLY_ROUTE,
+        apply_authz_policy_operation_activation,
+        methods=["POST"],
+        status_code=202,
+        response_model=AcceptedEvidenceResponse,
+        response_model_exclude_none=True,
+        include_in_schema=False,
+        responses={
+            400: {"model": LaunchplaneErrorResponse},
+            401: {"model": LaunchplaneErrorResponse},
+            403: {"model": LaunchplaneErrorResponse},
+            409: {"model": LaunchplaneErrorResponse},
+            410: {"model": LaunchplaneErrorResponse},
+            503: {"model": LaunchplaneErrorResponse},
+        },
+    )
+
+    app.add_api_route(
         _AUTHZ_POLICY_MANAGED_RECONCILE_ROUTE,
         reconcile_managed_authz_policy,
         methods=["POST"],
@@ -23297,7 +23745,7 @@ def create_launchplane_fastapi_app(
         if (
             http_error.status_code == 403
             and code == "authorization_denied"
-            and request.url.path not in _AUTHZ_NONPERSISTING_SENSITIVE_READ_ROUTES
+            and request.url.path not in _AUTHZ_NONPERSISTING_SENSITIVE_ROUTES
         ):
             if authz_policy_provenance is None:
                 request_provenance = getattr(
@@ -23327,7 +23775,7 @@ def create_launchplane_fastapi_app(
                 **(
                     {"Cache-Control": "no-store"}
                     if request.url.path == _AUTHZ_ACTIVATION_PREFLIGHT_ROUTE
-                    or request.url.path in _AUTHZ_NONPERSISTING_SENSITIVE_READ_ROUTES
+                    or request.url.path in _AUTHZ_NONPERSISTING_SENSITIVE_ROUTES
                     else {}
                 ),
             },
@@ -23370,7 +23818,7 @@ def create_launchplane_fastapi_app(
                 **(
                     {"Cache-Control": "no-store"}
                     if request.url.path == _AUTHZ_ACTIVATION_PREFLIGHT_ROUTE
-                    or request.url.path in _AUTHZ_NONPERSISTING_SENSITIVE_READ_ROUTES
+                    or request.url.path in _AUTHZ_NONPERSISTING_SENSITIVE_ROUTES
                     else {}
                 ),
             },
@@ -23399,7 +23847,7 @@ def create_launchplane_fastapi_app(
                 in {
                     _AUTHZ_REPOSITORY_SCOPE_READ_ROUTE,
                     _AUTHZ_ACTIVATION_PREFLIGHT_ROUTE,
-                    *_AUTHZ_NONPERSISTING_SENSITIVE_READ_ROUTES,
+                    *_AUTHZ_NONPERSISTING_SENSITIVE_ROUTES,
                 }
                 else None
             ),

--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -1091,12 +1091,17 @@ _AUTHZ_POLICY_CANDIDATE_PREVIEW_ROUTE = "/v1/authz-diagnostics/candidate-policy/
 _AUTHZ_REPOSITORY_SCOPE_READ_ROUTE = "/v1/authz-diagnostics/repository-scope/read"
 _AUTHZ_DENIAL_EXPLANATION_ROUTE = "/v1/authz-diagnostics/denials/{trace_id}"
 _AUTHZ_POLICY_MANAGED_RECONCILE_ROUTE = "/v1/authz-policies/managed-rule-sets/reconcile"
-_AUTHZ_NONPERSISTING_SENSITIVE_ROUTES = frozenset(
+_AUTHZ_NONPERSISTING_SENSITIVE_READ_ROUTES = frozenset(
+    {
+        _AUTHZ_POLICY_ADMINISTRATION_ROUTE,
+        _AUTHZ_POLICY_REVISION_HISTORY_ROUTE,
+    }
+)
+_AUTHZ_NO_STORE_ROUTES = frozenset(
     {
         _AUTHZ_POLICY_OPERATION_ACTIVATION_DRY_RUN_ROUTE,
         _AUTHZ_POLICY_OPERATION_ACTIVATION_APPLY_ROUTE,
-        _AUTHZ_POLICY_ADMINISTRATION_ROUTE,
-        _AUTHZ_POLICY_REVISION_HISTORY_ROUTE,
+        *_AUTHZ_NONPERSISTING_SENSITIVE_READ_ROUTES,
     }
 )
 _GENERIC_WEB_PREVIEW_AUTHZ_PLAN_ROUTE = (
@@ -4039,7 +4044,7 @@ def create_launchplane_fastapi_app(
         try:
             response = cast(Response, await call_next(request))
             if request.url.path == _AUTHZ_ACTIVATION_PREFLIGHT_ROUTE or (
-                request.url.path in _AUTHZ_NONPERSISTING_SENSITIVE_ROUTES
+                request.url.path in _AUTHZ_NO_STORE_ROUTES
             ):
                 response.headers["Cache-Control"] = "no-store"
             return response
@@ -14609,6 +14614,17 @@ def create_launchplane_fastapi_app(
                 message=(
                     "Activation requires existing immutable-ID DB policy administration authority."
                 ),
+                authz_evaluation=AuthzEvaluation(
+                    decision="denied",
+                    reason_code="no_matching_grant",
+                    principal_type="github_human",
+                    action="authz_policy_grant.write",
+                    product="launchplane",
+                    context="launchplane",
+                    target_scope="global",
+                    instance_specified=False,
+                ),
+                authz_policy_provenance=AuthzPolicyProvenance.from_record(active_record),
             )
 
     def build_authz_policy_operation_activation_response(
@@ -14681,7 +14697,7 @@ def create_launchplane_fastapi_app(
                 identity=identity,
                 trace_id=trace_id,
                 now_timestamp=authz_policy_record_timestamp,
-                authorized_policy_sha256=resolved_authz_policy_runtime.policy_sha256,
+                authorized_policy_sha256=active_record.policy_sha256,
                 immutable_applying_github_id=identity.github_id,
                 source=(
                     control_plane_authz_policy_activation.AUTHZ_POLICY_OPERATION_ACTIVATION_SOURCE
@@ -14819,19 +14835,14 @@ def create_launchplane_fastapi_app(
             database_store=database_store,
             trace_id=trace_id,
         )
-        mutation_digest = hashlib.sha256(
-            "\x1f".join(
-                (
-                    activation_scope,
-                    _AUTHZ_POLICY_OPERATION_ACTIVATION_APPLY_ROUTE,
-                    normalized_idempotency_key,
-                )
-            ).encode()
-        ).hexdigest()
         audit_context: dict[str, object] = {
             "request_fingerprint": payload_fingerprint,
             "idempotency_scope_sha256": hashlib.sha256(activation_scope.encode()).hexdigest(),
-            "idempotency_record_id": f"mutation-reservation-{mutation_digest}",
+            "idempotency_record_id": build_launchplane_mutation_reservation_id(
+                scope=activation_scope,
+                route_path=_AUTHZ_POLICY_OPERATION_ACTIVATION_APPLY_ROUTE,
+                idempotency_key=normalized_idempotency_key,
+            ),
             "idempotency_key_sha256": hashlib.sha256(
                 normalized_idempotency_key.encode()
             ).hexdigest(),
@@ -23745,7 +23756,7 @@ def create_launchplane_fastapi_app(
         if (
             http_error.status_code == 403
             and code == "authorization_denied"
-            and request.url.path not in _AUTHZ_NONPERSISTING_SENSITIVE_ROUTES
+            and request.url.path not in _AUTHZ_NONPERSISTING_SENSITIVE_READ_ROUTES
         ):
             if authz_policy_provenance is None:
                 request_provenance = getattr(
@@ -23775,7 +23786,7 @@ def create_launchplane_fastapi_app(
                 **(
                     {"Cache-Control": "no-store"}
                     if request.url.path == _AUTHZ_ACTIVATION_PREFLIGHT_ROUTE
-                    or request.url.path in _AUTHZ_NONPERSISTING_SENSITIVE_ROUTES
+                    or request.url.path in _AUTHZ_NO_STORE_ROUTES
                     else {}
                 ),
             },
@@ -23818,7 +23829,7 @@ def create_launchplane_fastapi_app(
                 **(
                     {"Cache-Control": "no-store"}
                     if request.url.path == _AUTHZ_ACTIVATION_PREFLIGHT_ROUTE
-                    or request.url.path in _AUTHZ_NONPERSISTING_SENSITIVE_ROUTES
+                    or request.url.path in _AUTHZ_NO_STORE_ROUTES
                     else {}
                 ),
             },
@@ -23847,7 +23858,7 @@ def create_launchplane_fastapi_app(
                 in {
                     _AUTHZ_REPOSITORY_SCOPE_READ_ROUTE,
                     _AUTHZ_ACTIVATION_PREFLIGHT_ROUTE,
-                    *_AUTHZ_NONPERSISTING_SENSITIVE_ROUTES,
+                    *_AUTHZ_NO_STORE_ROUTES,
                 }
                 else None
             ),
@@ -23909,22 +23920,23 @@ def _launchplane_http_error(
     code: str,
     message: str,
     authz: dict[str, object] | None = None,
+    authz_evaluation: AuthzEvaluation | None = None,
     authz_policy_provenance: AuthzPolicyProvenance | None = None,
     headers: dict[str, str] | None = None,
 ) -> LaunchplaneHTTPException:
     detail: dict[str, object] = {"trace_id": trace_id, "code": code, "message": message}
     if authz is not None:
         detail["authz"] = authz
-    authz_evaluation = None
-    if code == "authorization_denied":
+    resolved_authz_evaluation = authz_evaluation
+    if code == "authorization_denied" and resolved_authz_evaluation is None:
         evaluation = current_authz_evaluation()
         if evaluation is not None and evaluation.decision == "denied":
-            authz_evaluation = evaluation
+            resolved_authz_evaluation = evaluation
     return LaunchplaneHTTPException(
         status_code=status_code,
         detail=detail,
         headers=headers,
-        authz_evaluation=authz_evaluation,
+        authz_evaluation=resolved_authz_evaluation,
         authz_policy_provenance=authz_policy_provenance,
     )
 

--- a/docs/authorization-authority.md
+++ b/docs/authorization-authority.md
@@ -185,6 +185,40 @@ or action inventory. The route and all of its errors are
 denial, audit, idempotency, outbox, policy, operation, provider, runtime, or
 secret write. No additional diagnostic grant or credential is required.
 
+Issue `#2277` adds one narrow browser-human activation bridge for the compiled
+privileged-policy operation managed set. The bridge has separate dry-run and
+apply POST routes, accepts only a bounded reason, the reviewed dry-run digest on
+apply, and an `Idempotency-Key`, and derives the immutable GitHub ID exclusively
+from the authenticated Launchplane session. Both routes require strict
+same-origin fetch metadata and a single-use CSRF token. Bearer, workflow,
+terminal-agent, local-operator, and local-admin identities fail before policy
+evaluation.
+
+The bridge does not trust the session role or mutable login, organization, or
+team selectors. It reloads the single active DB policy and requires an exact
+immutable-ID human administrator rule with explicit `admin` role, literal
+`authz_policy_grant.write`, and exact `launchplane` product/context scope. Its
+code-compiled managed set contains one GitHub-human rule for that same immutable
+ID and exactly `authz_policy_operation.propose`,
+`authz_policy_operation.read`, `authz_policy_operation.approve`,
+`authz_policy_operation.revoke`, and `authz_policy_operation.cancel`. It cannot
+create workflow, terminal-agent, local-operator, local-admin, wildcard,
+provider, deployment, or unrelated authority.
+
+Dry-run binds the observed active record ID, revision, policy digest, candidate
+revision and digest, desired-set digest, exact action set, applying-admin
+continuity, and distinct reachable-administrator evidence. Apply repeats that
+compiled request with the reviewed digest, non-empty reason, immutable-ID-scoped
+idempotency, active-policy compare-and-swap, and exact record/revision/digest and
+policy read-back. The written record uses the distinct
+`service:authz-policy-operation-activation` source. Once the exact managed set
+is active, both activation routes return the terminal
+`authz_policy_operation_activation_retired` result; an occupied but non-exact
+set fails as a conflict. This state-derived retirement is not total-lockout
+recovery, a recurring break-glass path, or operator-configured authority. The
+routes remain hidden from the general OpenAPI surface so the bridge can be
+deleted after production activation evidence is preserved.
+
 The next read-only administration slice adds
 `authz_policy_candidate_preview.read` for an authenticated GitHub administrator
 or local administrator. It accepts one complete schema-v2 candidate policy and

--- a/docs/authorization-authority.md
+++ b/docs/authorization-authority.md
@@ -205,6 +205,12 @@ ID and exactly `authz_policy_operation.propose`,
 create workflow, terminal-agent, local-operator, local-admin, wildcard,
 provider, deployment, or unrelated authority.
 
+An immutable-ID administration denial remains ordinary redacted authorization
+evidence: the service records its trace, fixed action and scope, reason category,
+and active-policy provenance. The route response and every error remain
+`Cache-Control: no-store`; no principal selector or raw policy is persisted in
+the denial record.
+
 Dry-run binds the observed active record ID, revision, policy digest, candidate
 revision and digest, desired-set digest, exact action set, applying-admin
 continuity, and distinct reachable-administrator evidence. Apply repeats that

--- a/docs/privileged-operations.md
+++ b/docs/privileged-operations.md
@@ -64,20 +64,20 @@ The human routes use a named GitHub-human browser dependency that:
 
 The planning and approval actions are:
 
-| Action | Safety | Surface |
-| --- | --- | --- |
-| `privileged_secret_operation.plan` | `secret_backed` | GitHub-human plan creation |
-| `privileged_secret_operation.read` | `secret_backed` | GitHub-human plan reads |
-| `privileged_secret_operation.cancel` | `secret_backed` | GitHub-human cancellation |
-| `privileged_secret_operation.approve` | `secret_backed` | GitHub-human browser approval |
-| `privileged_secret_operation.revoke` | `secret_backed` | GitHub-human browser revocation |
-| `privileged_operation_summary.read` | `read` | Counts-only agent projection |
-| `authz_policy_operation.propose` | `policy_admin` | Inert GitHub-human or terminal-agent proposal |
-| `authz_policy_operation.read` | `policy_admin` | GitHub-human policy-plan reads |
-| `authz_policy_operation.cancel` | `policy_admin` | GitHub-human policy-plan cancellation |
-| `authz_policy_operation.approve` | `policy_admin` | GitHub-human browser approval |
-| `authz_policy_operation.revoke` | `policy_admin` | GitHub-human browser revocation |
-| `privileged_policy_operation_summary.read` | `read` | Proposal-owner agent projection |
+| Action                                     | Safety          | Surface                                         |
+| ------------------------------------------ | --------------- | ----------------------------------------------- |
+| `privileged_secret_operation.plan`         | `secret_backed` | GitHub-human plan creation                      |
+| `privileged_secret_operation.read`         | `secret_backed` | GitHub-human plan reads                         |
+| `privileged_secret_operation.cancel`       | `secret_backed` | GitHub-human cancellation                       |
+| `privileged_secret_operation.approve`      | `secret_backed` | GitHub-human browser approval                   |
+| `privileged_secret_operation.revoke`       | `secret_backed` | GitHub-human browser revocation                 |
+| `privileged_operation_summary.read`        | `read`          | Counts-only agent projection                    |
+| `authz_policy_operation.propose`           | `policy_admin`  | Inert GitHub-human or terminal-agent proposal   |
+| `authz_policy_operation.read`              | `policy_admin`  | GitHub-human policy-plan reads                  |
+| `authz_policy_operation.cancel`            | `policy_admin`  | GitHub-human policy-plan cancellation           |
+| `authz_policy_operation.approve`           | `policy_admin`  | GitHub-human browser approval                   |
+| `authz_policy_operation.revoke`            | `policy_admin`  | GitHub-human browser revocation                 |
+| `privileged_policy_operation_summary.read` | `read`          | Proposal-owner agent projection                 |
 
 Approval requires exactly one managed GitHub-human rule that is pinned to
 non-empty immutable `github_ids`. Login, organization, team, or role selectors
@@ -95,6 +95,24 @@ administrator authority again, then requires the candidate policy to retain the
 applying administrator and at least one distinct reachable policy
 administrator. An approval-only rule cannot bootstrap its holder into policy
 administration.
+
+The one-time issue `#2277` activation bridge exists only to make this ordinary
+policy-operation lifecycle reachable for an already-authorized immutable-ID
+GitHub-human policy administrator. Its compiled managed set grants that one
+human ID exactly the five `authz_policy_operation.*` propose, read, approve,
+revoke, and cancel actions. It grants no agent summary, workflow, terminal,
+operator, local-admin, provider, deployment, wildcard, or policy-write action.
+The caller supplies no rule, selector, principal, action, policy body, or
+managed ID.
+
+The bridge dry-run exposes bounded active-policy, candidate, exact-action, and
+continuity evidence. Apply requires the reviewed digest, reason,
+immutable-ID-scoped idempotency, policy CAS, and exact read-back. If the active
+policy already contains the exact compiled set, the bridge is permanently
+retired by DB state and rejects new dry-runs or applies; a same-key replay can
+still return the original completed response. A conflicting use of the managed
+set fails closed. This is a temporary transport for existing DB authority, not
+an alternate policy editor, total-lockout recovery, or break-glass credential.
 
 The dry-run planner does not know which human will approve, so its evidence
 cannot include the identity-dependent applying-administrator and independent-

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -783,6 +783,11 @@ active DB policy, and requires that ID to have an exact immutable-ID
 `authz_policy_grant.write` administrator rule. It does not rely on the session
 role or mutable login, organization, or team membership.
 
+An immutable-ID authorization failure writes the ordinary redacted denial
+record for its trace and fixed `authz_policy_grant.write` scope while keeping
+the HTTP response `Cache-Control: no-store`. No raw policy, selector, session,
+or principal detail is added to that record.
+
 The dry-run request contains only `reason`. The apply request contains only
 `reason` and `reviewed_plan_sha256`, with the stable `Idempotency-Key` in the
 header. Both bodies are exact-length JSON capped at 16 KiB. The server compiles

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -651,6 +651,8 @@ The cookie-capable mutation inventory is intentionally limited to:
 - `POST /v1/product-config/apply`
 - `POST /v1/merge-train/policies/import`
 - `POST /v1/authz-policies/managed-rule-sets/reconcile`
+- `POST /v1/authz-policies/privileged-policy-operations/activation/dry-run`
+- `POST /v1/authz-policies/privileged-policy-operations/activation/apply`
 - `POST /v1/tenant-admission/technical-human-waivers/apply`
 - `POST /v1/tenant-admission/trusted-maintenance-policies/apply`
 
@@ -770,6 +772,35 @@ limited to allowed/denied, an hour-bounded evaluation time, an opaque keyed poli
 generation, and a trace ID. The route and all errors are
 `Cache-Control: no-store`; the path performs no durable write and requires no
 separate diagnostic authorization grant.
+
+`POST /v1/authz-policies/privileged-policy-operations/activation/dry-run` and
+`POST /v1/authz-policies/privileged-policy-operations/activation/apply` are the
+temporary issue `#2277` browser-human activation bridge. Both routes require an
+authenticated GitHub-human session, strict same-origin/fetch-metadata headers,
+and single-use CSRF proof; every bearer and non-human identity is rejected. The
+service derives the immutable GitHub ID from the session, reloads the singleton
+active DB policy, and requires that ID to have an exact immutable-ID
+`authz_policy_grant.write` administrator rule. It does not rely on the session
+role or mutable login, organization, or team membership.
+
+The dry-run request contains only `reason`. The apply request contains only
+`reason` and `reviewed_plan_sha256`, with the stable `Idempotency-Key` in the
+header. Both bodies are exact-length JSON capped at 16 KiB. The server compiles
+one fixed GitHub-human managed rule for the authenticated ID with only the five
+`authz_policy_operation` propose/read/approve/revoke/cancel actions. Dry-run
+returns bounded observed-policy, candidate, exact-action, and continuity
+evidence. Apply uses the existing DB-only mutation reservation and active-policy
+CAS, requires the applying administrator plus a distinct reachable immutable-ID
+administrator, and verifies the exact resulting record ID, revision, digest,
+policy, managed set, and bound GitHub ID before updating in-process policy.
+
+The apply idempotency scope is the immutable GitHub ID, not the mutable login or
+browser session. A completed same-key replay remains available after activation.
+Otherwise, once the exact managed set is active, both routes return `410` with
+`authz_policy_operation_activation_retired`; an occupied but non-exact set
+returns `409`. The routes are omitted from general OpenAPI generation and are
+not an operator-configured feature, total-lockout recovery path, recurring
+break-glass mechanism, or general policy editor.
 
 `POST /v1/authz-diagnostics/candidate-policy/preview` is a separate
 administrator-read contract protected by `authz_policy_candidate_preview.read`.
@@ -2149,8 +2180,11 @@ active DB-backed policy, retains unrelated managed rules, and returns a complete
 dry-run reconcile envelope. It never writes policy. The existing
 `POST /v1/authz-policies/managed-rule-sets/reconcile` route remains the sole
 transitional workflow writer, accepts only GitHub Actions OIDC workload
-transport, and requires `authz_policy_grant.write` for apply. Browser-human,
-terminal-agent, and local bearer identities fail closed. Signed-in humans use
+transport, and requires `authz_policy_grant.write` for apply. The separate,
+self-retiring issue `#2277` browser-human activation bridge can install only the
+compiled privileged-policy operation set and cannot accept a general managed
+policy payload. All other browser-human, terminal-agent, and local bearer
+identities fail closed on the workflow route. Signed-in humans use
 the separate `managed-authz-policy-set` privileged-operation lifecycle for
 proposal review and approval; only the service-internal worker executes that
 approved path. The advanced

--- a/tests/test_authz_grant_service.py
+++ b/tests/test_authz_grant_service.py
@@ -234,26 +234,26 @@ class AuthzManagedPolicyServiceTests(unittest.TestCase):
         )
 
         self.assertTrue(
-            control_plane_authz_grant_service._authz_policy_allows_immutable_github_id_administration(
+            control_plane_authz_grant_service.authz_policy_allows_immutable_github_id_administration(
                 policy=policy,
                 github_id=101,
             )
         )
         for github_id in (103, 104, 105, 106, 107, 108, 109, 110):
             self.assertFalse(
-                control_plane_authz_grant_service._authz_policy_allows_immutable_github_id_administration(
+                control_plane_authz_grant_service.authz_policy_allows_immutable_github_id_administration(
                     policy=policy,
                     github_id=github_id,
                 )
             )
         self.assertTrue(
-            control_plane_authz_grant_service._authz_policy_retains_independent_github_id_administration(
+            control_plane_authz_grant_service.authz_policy_retains_independent_github_id_administration(
                 policy=policy,
                 applying_github_id=101,
             )
         )
         self.assertFalse(
-            control_plane_authz_grant_service._authz_policy_retains_independent_github_id_administration(
+            control_plane_authz_grant_service.authz_policy_retains_independent_github_id_administration(
                 policy=policy.model_copy(
                     update={
                         "github_humans": (strict_admin.model_copy(update={"github_ids": (101,)}),)

--- a/tests/test_authz_policy_activation.py
+++ b/tests/test_authz_policy_activation.py
@@ -212,7 +212,9 @@ class AuthzPolicyOperationActivationHttpTests(unittest.IsolatedAsyncioTestCase):
                     self.assertTrue(activation["changed"])
                     self.assertTrue(activation["applying_admin_retained"])
                     self.assertTrue(activation["independent_admin_reachable"])
-                    self.assertEqual(activation["read_back"]["activation_state"], "available")
+                    self.assertEqual(
+                        activation["resulting_policy"]["activation_state"], "available"
+                    )
                     review_digest = activation["review_digest"]
                     apply_payload = {
                         "reason": "Activate the reviewed privileged-policy lifecycle.",
@@ -250,7 +252,9 @@ class AuthzPolicyOperationActivationHttpTests(unittest.IsolatedAsyncioTestCase):
                         applied_payload["result"]["activation"]["bridge_state"], "retired"
                     )
                     self.assertEqual(
-                        applied_payload["result"]["activation"]["read_back"]["activation_state"],
+                        applied_payload["result"]["activation"]["resulting_policy"][
+                            "activation_state"
+                        ],
                         "active",
                     )
                     replayed = await client.post(
@@ -489,11 +493,20 @@ class AuthzPolicyOperationActivationHttpTests(unittest.IsolatedAsyncioTestCase):
                         },
                         content=json.dumps({"reason": "forbidden"}),
                     )
+                denial_record = store.read_authz_denial_record(
+                    trace_id=response.json()["trace_id"],
+                    observed_at="2026-08-30T00:00:00Z",
+                )
             finally:
                 store.close()
 
         self.assertEqual(response.status_code, 403, response.text)
         self.assertEqual(response.json()["error"]["code"], "authorization_denied")
+        self.assertIsNotNone(denial_record)
+        assert denial_record is not None
+        self.assertEqual(denial_record.route_path, _DRY_RUN_ROUTE)
+        self.assertEqual(denial_record.action, "authz_policy_grant.write")
+        self.assertEqual(denial_record.principal_type, "github_human")
 
     async def test_apply_requires_distinct_reachable_policy_administrator(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:

--- a/tests/test_authz_policy_activation.py
+++ b/tests/test_authz_policy_activation.py
@@ -43,6 +43,18 @@ def _human_identity(*, github_id: int = 123) -> GitHubHumanIdentity:
     )
 
 
+def _reader_identity() -> GitHubHumanIdentity:
+    return GitHubHumanIdentity(
+        login="example-reader",
+        github_id=789,
+        name="Example Reader",
+        email="reader@example.test",
+        organizations=frozenset(),
+        teams=frozenset(),
+        role="read_only",
+    )
+
+
 def _admin_rule(*, github_id: int, managed_rule_id: str) -> dict[str, object]:
     return {
         "managed_set_id": "test.policy-administrators",
@@ -59,6 +71,17 @@ def _policy(*, independent_admin: bool = True) -> LaunchplaneAuthzPolicy:
     rules = [_admin_rule(github_id=123, managed_rule_id="applying-admin")]
     if independent_admin:
         rules.append(_admin_rule(github_id=456, managed_rule_id="independent-admin"))
+    rules.append(
+        {
+            "managed_set_id": "test.activation-reader",
+            "managed_rule_id": "non-admin-reader",
+            "github_ids": [789],
+            "roles": ["read_only"],
+            "products": ["launchplane"],
+            "contexts": ["launchplane"],
+            "actions": ["authz_policy_health.read"],
+        }
+    )
     return LaunchplaneAuthzPolicy.model_validate(
         {
             "schema_version": 2,
@@ -212,9 +235,8 @@ class AuthzPolicyOperationActivationHttpTests(unittest.IsolatedAsyncioTestCase):
                     self.assertTrue(activation["changed"])
                     self.assertTrue(activation["applying_admin_retained"])
                     self.assertTrue(activation["independent_admin_reachable"])
-                    self.assertEqual(
-                        activation["resulting_policy"]["activation_state"], "available"
-                    )
+                    self.assertEqual(activation["activation_state"]["observed"], "available")
+                    self.assertEqual(activation["activation_state"]["candidate"], "active")
                     review_digest = activation["review_digest"]
                     apply_payload = {
                         "reason": "Activate the reviewed privileged-policy lifecycle.",
@@ -249,12 +271,11 @@ class AuthzPolicyOperationActivationHttpTests(unittest.IsolatedAsyncioTestCase):
                     self.assertEqual(applied.status_code, 202, applied.text)
                     applied_payload = applied.json()
                     self.assertEqual(
-                        applied_payload["result"]["activation"]["bridge_state"], "retired"
+                        applied_payload["result"]["activation"]["activation_state"]["observed"],
+                        "available",
                     )
                     self.assertEqual(
-                        applied_payload["result"]["activation"]["resulting_policy"][
-                            "activation_state"
-                        ],
+                        applied_payload["result"]["activation"]["activation_state"]["candidate"],
                         "active",
                     )
                     replayed = await client.post(
@@ -290,6 +311,24 @@ class AuthzPolicyOperationActivationHttpTests(unittest.IsolatedAsyncioTestCase):
                     self.assertEqual(
                         conflicting_replay.json()["error"]["code"],
                         "idempotency_key_reused",
+                    )
+                    reader_session = session_manager.issue(_reader_identity())
+                    concealed_retirement = await client.post(
+                        _DRY_RUN_ROUTE,
+                        headers={
+                            **_browser_mutation_headers(session_manager, reader_session),
+                            "Content-Type": "application/json",
+                        },
+                        content=json.dumps({"reason": "Inspect activation state."}),
+                    )
+                    self.assertEqual(
+                        concealed_retirement.status_code,
+                        403,
+                        concealed_retirement.text,
+                    )
+                    self.assertEqual(
+                        concealed_retirement.json()["error"]["code"],
+                        "authorization_denied",
                     )
                     retired_apply = await client.post(
                         _APPLY_ROUTE,
@@ -337,7 +376,7 @@ class AuthzPolicyOperationActivationHttpTests(unittest.IsolatedAsyncioTestCase):
             ),
             123,
         )
-        self.assertEqual(len(active_record.policy.github_humans), 3)
+        self.assertEqual(len(active_record.policy.github_humans), 4)
         self.assertEqual(
             {
                 rule.managed_rule_id

--- a/tests/test_authz_policy_activation.py
+++ b/tests/test_authz_policy_activation.py
@@ -1,0 +1,562 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from tempfile import TemporaryDirectory
+import unittest
+
+from pydantic import ValidationError
+
+from control_plane import authz_policy_activation
+from control_plane.contracts.authz_policy_record import (
+    LaunchplaneAuthzPolicyRecord,
+    authz_policy_sha256,
+    build_authz_policy_record_id,
+)
+from control_plane.http_app import create_launchplane_fastapi_app
+from control_plane.service_auth import GitHubHumanIdentity, LaunchplaneAuthzPolicy
+from control_plane.service_human_auth import HumanSessionManager, InMemoryHumanSessionStore
+from control_plane.storage.postgres import PostgresRecordStore
+from tests.http_app_test_support import (
+    _RejectingVerifier,
+    _browser_mutation_headers,
+    _github_oauth_config,
+)
+from tests.support.auth import _identity, _StubVerifier
+from tests.support.http import lifespan_client
+from tests.support.stores import _sqlite_database_url
+
+
+_DRY_RUN_ROUTE = "/v1/authz-policies/privileged-policy-operations/activation/dry-run"
+_APPLY_ROUTE = "/v1/authz-policies/privileged-policy-operations/activation/apply"
+
+
+def _human_identity(*, github_id: int = 123) -> GitHubHumanIdentity:
+    return GitHubHumanIdentity(
+        login="example-owner",
+        github_id=github_id,
+        name="Example Owner",
+        email="owner@example.test",
+        organizations=frozenset({"example-org"}),
+        teams=frozenset({"example-org/owners"}),
+        role="admin",
+    )
+
+
+def _admin_rule(*, github_id: int, managed_rule_id: str) -> dict[str, object]:
+    return {
+        "managed_set_id": "test.policy-administrators",
+        "managed_rule_id": managed_rule_id,
+        "github_ids": [github_id],
+        "roles": ["admin"],
+        "products": ["launchplane"],
+        "contexts": ["launchplane"],
+        "actions": ["authz_policy_grant.write"],
+    }
+
+
+def _policy(*, independent_admin: bool = True) -> LaunchplaneAuthzPolicy:
+    rules = [_admin_rule(github_id=123, managed_rule_id="applying-admin")]
+    if independent_admin:
+        rules.append(_admin_rule(github_id=456, managed_rule_id="independent-admin"))
+    return LaunchplaneAuthzPolicy.model_validate(
+        {
+            "schema_version": 2,
+            "github_humans": rules,
+        }
+    )
+
+
+def _mutable_only_policy() -> LaunchplaneAuthzPolicy:
+    return LaunchplaneAuthzPolicy.model_validate(
+        {
+            "schema_version": 2,
+            "github_humans": [
+                {
+                    "managed_set_id": "test.policy-administrators",
+                    "managed_rule_id": "mutable-admin",
+                    "logins": ["example-owner"],
+                    "roles": ["admin"],
+                    "products": ["launchplane"],
+                    "contexts": ["launchplane"],
+                    "actions": ["authz_policy_grant.write"],
+                }
+            ],
+        }
+    )
+
+
+def _record(policy: LaunchplaneAuthzPolicy) -> LaunchplaneAuthzPolicyRecord:
+    digest = authz_policy_sha256(policy)
+    return LaunchplaneAuthzPolicyRecord(
+        record_id=build_authz_policy_record_id(revision=1, policy_sha256=digest),
+        revision=1,
+        source="test:authz-policy-activation",
+        updated_at="2026-08-30T00:00:00Z",
+        policy_sha256=digest,
+        policy=policy,
+    )
+
+
+class AuthzPolicyOperationActivationDomainTests(unittest.TestCase):
+    def test_compiled_set_is_exactly_one_immutable_human_rule(self) -> None:
+        request = authz_policy_activation.build_authz_policy_operation_activation_reconcile_request(
+            github_id=123,
+            mode="dry_run",
+            reason="Activate the reviewed privileged-policy lifecycle.",
+        )
+
+        self.assertEqual(
+            request.managed_set_id,
+            authz_policy_activation.AUTHZ_POLICY_OPERATION_ACTIVATION_MANAGED_SET_ID,
+        )
+        self.assertEqual(request.desired_policy.github_actions, ())
+        self.assertEqual(request.desired_policy.terminal_agents, ())
+        self.assertEqual(request.desired_policy.local_operators, ())
+        self.assertEqual(request.desired_policy.local_admins, ())
+        self.assertEqual(len(request.desired_policy.github_humans), 1)
+        rule = request.desired_policy.github_humans[0]
+        self.assertEqual(rule.github_ids, (123,))
+        self.assertEqual(rule.logins, ())
+        self.assertEqual(rule.organizations, ())
+        self.assertEqual(rule.teams, ())
+        self.assertEqual(rule.roles, ("admin",))
+        self.assertEqual(rule.products, ("launchplane",))
+        self.assertEqual(rule.contexts, ("launchplane",))
+        self.assertEqual(
+            rule.actions,
+            authz_policy_activation.AUTHZ_POLICY_OPERATION_ACTIVATION_ACTIONS,
+        )
+
+    def test_activation_state_rejects_noncompiled_managed_set(self) -> None:
+        conflicting_policy = LaunchplaneAuthzPolicy.model_validate(
+            {
+                "schema_version": 2,
+                "github_humans": [
+                    {
+                        "managed_set_id": (
+                            authz_policy_activation.AUTHZ_POLICY_OPERATION_ACTIVATION_MANAGED_SET_ID
+                        ),
+                        "managed_rule_id": "wrong-rule",
+                        "github_ids": [123],
+                        "roles": ["admin"],
+                        "products": ["launchplane"],
+                        "contexts": ["launchplane"],
+                        "actions": ["authz_policy_operation.read"],
+                    }
+                ],
+            }
+        )
+
+        self.assertEqual(
+            authz_policy_activation.authz_policy_operation_activation_state(conflicting_policy),
+            "conflict",
+        )
+
+    def test_request_contract_rejects_caller_supplied_identity_and_policy(self) -> None:
+        for field_name, value in (
+            ("github_id", 999),
+            ("login", "alternate-user"),
+            ("managed_set_id", "alternate-set"),
+            ("desired_policy", {}),
+        ):
+            with self.subTest(field_name=field_name), self.assertRaises(ValidationError):
+                authz_policy_activation.AuthzPolicyOperationActivationDryRunRequest.model_validate(
+                    {
+                        "reason": "Activate the reviewed privileged-policy lifecycle.",
+                        field_name: value,
+                    }
+                )
+
+
+class AuthzPolicyOperationActivationHttpTests(unittest.IsolatedAsyncioTestCase):
+    async def test_dry_run_apply_readback_replay_and_self_retirement(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(root / "launchplane.sqlite3")
+            )
+            store.ensure_schema()
+            policy = _policy()
+            store.seed_authz_policy_if_absent(_record(policy))
+            session_manager = HumanSessionManager(
+                config=_github_oauth_config(),
+                session_store=InMemoryHumanSessionStore(),
+            )
+            session = session_manager.issue(_human_identity())
+            app = create_launchplane_fastapi_app(
+                verifier=_RejectingVerifier(),
+                authz_policy=policy,
+                record_store_factory=lambda: store,
+                human_session_manager=session_manager,
+                control_plane_root_path=root,
+                state_dir=root / "state",
+            )
+            self.assertNotIn(_DRY_RUN_ROUTE, app.openapi()["paths"])
+            self.assertNotIn(_APPLY_ROUTE, app.openapi()["paths"])
+            try:
+                async with lifespan_client(app) as client:
+                    dry_run = await client.post(
+                        _DRY_RUN_ROUTE,
+                        headers={
+                            **_browser_mutation_headers(session_manager, session),
+                            "Content-Type": "application/json",
+                        },
+                        content=json.dumps(
+                            {"reason": "Activate the reviewed privileged-policy lifecycle."}
+                        ),
+                    )
+                    self.assertEqual(dry_run.status_code, 202, dry_run.text)
+                    dry_run_payload = dry_run.json()
+                    activation = dry_run_payload["result"]["activation"]
+                    self.assertTrue(activation["changed"])
+                    self.assertTrue(activation["applying_admin_retained"])
+                    self.assertTrue(activation["independent_admin_reachable"])
+                    self.assertEqual(activation["read_back"]["activation_state"], "available")
+                    review_digest = activation["review_digest"]
+                    apply_payload = {
+                        "reason": "Activate the reviewed privileged-policy lifecycle.",
+                        "reviewed_plan_sha256": review_digest,
+                    }
+                    stale_review = await client.post(
+                        _APPLY_ROUTE,
+                        headers={
+                            **_browser_mutation_headers(session_manager, session),
+                            "Content-Type": "application/json",
+                            "Idempotency-Key": "issue-2277-stale-review",
+                        },
+                        content=json.dumps(
+                            {
+                                **apply_payload,
+                                "reviewed_plan_sha256": "0" * 64,
+                            }
+                        ),
+                    )
+                    self.assertEqual(stale_review.status_code, 409, stale_review.text)
+                    self.assertEqual(stale_review.json()["error"]["code"], "authz_policy_conflict")
+                    apply_headers = {
+                        **_browser_mutation_headers(session_manager, session),
+                        "Content-Type": "application/json",
+                        "Idempotency-Key": "issue-2277-activation",
+                    }
+                    applied = await client.post(
+                        _APPLY_ROUTE,
+                        headers=apply_headers,
+                        content=json.dumps(apply_payload),
+                    )
+                    self.assertEqual(applied.status_code, 202, applied.text)
+                    applied_payload = applied.json()
+                    self.assertEqual(
+                        applied_payload["result"]["activation"]["bridge_state"], "retired"
+                    )
+                    self.assertEqual(
+                        applied_payload["result"]["activation"]["read_back"]["activation_state"],
+                        "active",
+                    )
+                    replayed = await client.post(
+                        _APPLY_ROUTE,
+                        headers={
+                            **_browser_mutation_headers(session_manager, session),
+                            "Content-Type": "application/json",
+                            "Idempotency-Key": "issue-2277-activation",
+                        },
+                        content=json.dumps(apply_payload),
+                    )
+                    self.assertEqual(replayed.status_code, 202, replayed.text)
+                    self.assertTrue(replayed.json()["replayed"])
+                    conflicting_replay = await client.post(
+                        _APPLY_ROUTE,
+                        headers={
+                            **_browser_mutation_headers(session_manager, session),
+                            "Content-Type": "application/json",
+                            "Idempotency-Key": "issue-2277-activation",
+                        },
+                        content=json.dumps(
+                            {
+                                **apply_payload,
+                                "reason": "A different activation request.",
+                            }
+                        ),
+                    )
+                    self.assertEqual(
+                        conflicting_replay.status_code,
+                        409,
+                        conflicting_replay.text,
+                    )
+                    self.assertEqual(
+                        conflicting_replay.json()["error"]["code"],
+                        "idempotency_key_reused",
+                    )
+                    retired_apply = await client.post(
+                        _APPLY_ROUTE,
+                        headers={
+                            **_browser_mutation_headers(session_manager, session),
+                            "Content-Type": "application/json",
+                            "Idempotency-Key": "issue-2277-second-activation",
+                        },
+                        content=json.dumps(apply_payload),
+                    )
+                    self.assertEqual(retired_apply.status_code, 410, retired_apply.text)
+                    self.assertEqual(
+                        retired_apply.json()["error"]["code"],
+                        "authz_policy_operation_activation_retired",
+                    )
+                    retired = await client.post(
+                        _DRY_RUN_ROUTE,
+                        headers={
+                            **_browser_mutation_headers(session_manager, session),
+                            "Content-Type": "application/json",
+                        },
+                        content=json.dumps({"reason": "Attempt a second activation dry-run."}),
+                    )
+                active_records = store.list_authz_policy_records(status="active", limit=2)
+            finally:
+                store.close()
+
+        self.assertEqual(retired.status_code, 410, retired.text)
+        self.assertEqual(
+            retired.json()["error"]["code"], "authz_policy_operation_activation_retired"
+        )
+        self.assertEqual(len(active_records), 1)
+        active_record = active_records[0]
+        self.assertEqual(
+            active_record.source,
+            authz_policy_activation.AUTHZ_POLICY_OPERATION_ACTIVATION_SOURCE,
+        )
+        self.assertEqual(
+            authz_policy_activation.authz_policy_operation_activation_state(active_record.policy),
+            "active",
+        )
+        self.assertEqual(
+            authz_policy_activation.authz_policy_operation_activation_github_id(
+                active_record.policy
+            ),
+            123,
+        )
+        self.assertEqual(len(active_record.policy.github_humans), 3)
+        self.assertEqual(
+            {
+                rule.managed_rule_id
+                for rule in active_record.policy.github_humans
+                if rule.managed_set_id == "test.policy-administrators"
+            },
+            {"applying-admin", "independent-admin"},
+        )
+
+    async def test_browser_mutation_requires_and_consumes_single_use_csrf(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(root / "launchplane.sqlite3")
+            )
+            store.ensure_schema()
+            policy = _policy()
+            store.seed_authz_policy_if_absent(_record(policy))
+            session_manager = HumanSessionManager(
+                config=_github_oauth_config(),
+                session_store=InMemoryHumanSessionStore(),
+            )
+            session = session_manager.issue(_human_identity())
+            app = create_launchplane_fastapi_app(
+                verifier=_RejectingVerifier(),
+                authz_policy=policy,
+                record_store_factory=lambda: store,
+                human_session_manager=session_manager,
+                control_plane_root_path=root,
+                state_dir=root / "state",
+            )
+            try:
+                cookie_header = session_manager.session_cookie_header(session)
+                mutation_headers = {
+                    **_browser_mutation_headers(session_manager, session),
+                    "Content-Type": "application/json",
+                }
+                async with lifespan_client(app) as client:
+                    missing_proof = await client.post(
+                        _DRY_RUN_ROUTE,
+                        headers={
+                            "Cookie": cookie_header,
+                            "Content-Type": "application/json",
+                        },
+                        content=json.dumps({"reason": "Missing browser proof."}),
+                    )
+                    accepted = await client.post(
+                        _DRY_RUN_ROUTE,
+                        headers=mutation_headers,
+                        content=json.dumps({"reason": "Consume browser proof."}),
+                    )
+                    replayed_csrf = await client.post(
+                        _DRY_RUN_ROUTE,
+                        headers=mutation_headers,
+                        content=json.dumps({"reason": "Replay browser proof."}),
+                    )
+            finally:
+                store.close()
+
+        self.assertEqual(missing_proof.status_code, 403, missing_proof.text)
+        self.assertEqual(missing_proof.json()["error"]["code"], "browser_mutation_denied")
+        self.assertEqual(missing_proof.headers["cache-control"], "no-store")
+        self.assertEqual(accepted.status_code, 202, accepted.text)
+        self.assertEqual(accepted.headers["cache-control"], "no-store")
+        self.assertEqual(replayed_csrf.status_code, 403, replayed_csrf.text)
+        self.assertEqual(replayed_csrf.json()["error"]["code"], "browser_mutation_denied")
+        self.assertEqual(replayed_csrf.headers["cache-control"], "no-store")
+
+    async def test_route_rejects_nonhuman_transport_and_caller_supplied_identity(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(root / "launchplane.sqlite3")
+            )
+            store.ensure_schema()
+            policy = _policy()
+            store.seed_authz_policy_if_absent(_record(policy))
+            session_manager = HumanSessionManager(
+                config=_github_oauth_config(),
+                session_store=InMemoryHumanSessionStore(),
+            )
+            session = session_manager.issue(_human_identity())
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                record_store_factory=lambda: store,
+                human_session_manager=session_manager,
+                control_plane_root_path=root,
+                state_dir=root / "state",
+            )
+            try:
+                async with lifespan_client(app) as client:
+                    bearer_response = await client.post(
+                        _DRY_RUN_ROUTE,
+                        headers={
+                            "Authorization": "Bearer valid-token",
+                            "Content-Type": "application/json",
+                        },
+                        content=json.dumps({"reason": "forbidden"}),
+                    )
+                    identity_response = await client.post(
+                        _DRY_RUN_ROUTE,
+                        headers={
+                            **_browser_mutation_headers(session_manager, session),
+                            "Content-Type": "application/json",
+                        },
+                        content=json.dumps(
+                            {
+                                "reason": "forbidden",
+                                "github_id": 999,
+                            }
+                        ),
+                    )
+            finally:
+                store.close()
+
+        self.assertEqual(bearer_response.status_code, 403, bearer_response.text)
+        self.assertEqual(bearer_response.json()["error"]["code"], "authorization_denied")
+        self.assertEqual(bearer_response.headers["cache-control"], "no-store")
+        self.assertEqual(identity_response.status_code, 400, identity_response.text)
+        self.assertEqual(identity_response.json()["error"]["code"], "invalid_request")
+        self.assertEqual(identity_response.headers["cache-control"], "no-store")
+
+    async def test_route_rejects_mutable_only_policy_administrator(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(root / "launchplane.sqlite3")
+            )
+            store.ensure_schema()
+            policy = _mutable_only_policy()
+            store.seed_authz_policy_if_absent(_record(policy))
+            session_manager = HumanSessionManager(
+                config=_github_oauth_config(),
+                session_store=InMemoryHumanSessionStore(),
+            )
+            session = session_manager.issue(_human_identity())
+            app = create_launchplane_fastapi_app(
+                verifier=_RejectingVerifier(),
+                authz_policy=policy,
+                record_store_factory=lambda: store,
+                human_session_manager=session_manager,
+                control_plane_root_path=root,
+                state_dir=root / "state",
+            )
+            try:
+                async with lifespan_client(app) as client:
+                    response = await client.post(
+                        _DRY_RUN_ROUTE,
+                        headers={
+                            **_browser_mutation_headers(session_manager, session),
+                            "Content-Type": "application/json",
+                        },
+                        content=json.dumps({"reason": "forbidden"}),
+                    )
+            finally:
+                store.close()
+
+        self.assertEqual(response.status_code, 403, response.text)
+        self.assertEqual(response.json()["error"]["code"], "authorization_denied")
+
+    async def test_apply_requires_distinct_reachable_policy_administrator(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(root / "launchplane.sqlite3")
+            )
+            store.ensure_schema()
+            policy = _policy(independent_admin=False)
+            store.seed_authz_policy_if_absent(_record(policy))
+            session_manager = HumanSessionManager(
+                config=_github_oauth_config(),
+                session_store=InMemoryHumanSessionStore(),
+            )
+            session = session_manager.issue(_human_identity())
+            app = create_launchplane_fastapi_app(
+                verifier=_RejectingVerifier(),
+                authz_policy=policy,
+                record_store_factory=lambda: store,
+                human_session_manager=session_manager,
+                control_plane_root_path=root,
+                state_dir=root / "state",
+            )
+            try:
+                async with lifespan_client(app) as client:
+                    dry_run = await client.post(
+                        _DRY_RUN_ROUTE,
+                        headers={
+                            **_browser_mutation_headers(session_manager, session),
+                            "Content-Type": "application/json",
+                        },
+                        content=json.dumps({"reason": "Review continuity."}),
+                    )
+                    self.assertEqual(dry_run.status_code, 202, dry_run.text)
+                    activation = dry_run.json()["result"]["activation"]
+                    self.assertFalse(activation["independent_admin_reachable"])
+                    apply_response = await client.post(
+                        _APPLY_ROUTE,
+                        headers={
+                            **_browser_mutation_headers(session_manager, session),
+                            "Content-Type": "application/json",
+                            "Idempotency-Key": "missing-independent-admin",
+                        },
+                        content=json.dumps(
+                            {
+                                "reason": "Review continuity.",
+                                "reviewed_plan_sha256": activation["review_digest"],
+                            }
+                        ),
+                    )
+                active_records = store.list_authz_policy_records(status="active", limit=2)
+            finally:
+                store.close()
+
+        self.assertEqual(apply_response.status_code, 409, apply_response.text)
+        self.assertEqual(
+            apply_response.json()["error"]["code"],
+            "authz_policy_independent_admin_unreachable",
+        )
+        self.assertEqual(len(active_records), 1)
+        self.assertEqual(
+            authz_policy_activation.authz_policy_operation_activation_state(
+                active_records[0].policy
+            ),
+            "available",
+        )

--- a/tests/test_docs_contracts.py
+++ b/tests/test_docs_contracts.py
@@ -19,6 +19,29 @@ def _assert_no_workflow_violations(
 
 
 class DocsContractsTests(TestCase):
+    def test_privileged_policy_operation_activation_bridge_is_documented(self) -> None:
+        authorization = Path("docs/authorization-authority.md").read_text(encoding="utf-8")
+        privileged_operations = Path("docs/privileged-operations.md").read_text(encoding="utf-8")
+        service_boundary = Path("docs/service-boundary.md").read_text(encoding="utf-8")
+
+        for required_text in (
+            "authz_policy_operation_activation_retired",
+            "service:authz-policy-operation-activation",
+            "not total-lockout",
+        ):
+            self.assertIn(required_text, authorization)
+        self.assertIn("same-key replay", privileged_operations)
+        self.assertIn("caller supplies no rule", privileged_operations)
+        self.assertIn(
+            "/v1/authz-policies/privileged-policy-operations/activation/dry-run",
+            service_boundary,
+        )
+        self.assertIn(
+            "/v1/authz-policies/privileged-policy-operations/activation/apply",
+            service_boundary,
+        )
+        self.assertIn("exact-length JSON capped at 16 KiB", service_boundary)
+
     def test_generic_web_preview_retirement_authority_is_documented(self) -> None:
         operations = Path("docs/operations.md").read_text(encoding="utf-8")
         service_boundary = Path("docs/service-boundary.md").read_text(encoding="utf-8")

--- a/tests/test_http_app_browser_mutation.py
+++ b/tests/test_http_app_browser_mutation.py
@@ -35,6 +35,8 @@ class FastApiBrowserMutationBoundaryTests(unittest.IsolatedAsyncioTestCase):
             "/auth/logout",
             "/v1/agent/write-intents/evaluate",
             "/v1/authz-diagnostics/effective-access/evaluate",
+            "/v1/authz-policies/privileged-policy-operations/activation/apply",
+            "/v1/authz-policies/privileged-policy-operations/activation/dry-run",
             "/v1/drivers/generic-web/prod-promotion",
             "/v1/drivers/generic-web/prod-promotion-workflow",
             "/v1/merge-train/policies/import",

--- a/tests/test_postgres_integration.py
+++ b/tests/test_postgres_integration.py
@@ -4,6 +4,7 @@ import base64
 from collections.abc import Iterator
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
+from dataclasses import replace
 from datetime import datetime, timedelta, timezone
 import json
 import os
@@ -22,6 +23,7 @@ from sqlalchemy.engine import Engine
 from sqlalchemy.engine import make_url
 from sqlalchemy.exc import IntegrityError, OperationalError
 
+from control_plane import authz_grant_service, authz_policy_activation
 from control_plane.contracts.idempotency_record import (
     LaunchplaneIdempotencyRecord,
     build_launchplane_idempotency_record_id,
@@ -1584,6 +1586,130 @@ class RealPostgresSchemaIntegrationTests(unittest.TestCase):
         self.assertEqual(sorted(results), [False, True])
         self.assertEqual(len(active_records), 1)
         self.assertIn(active_records[0].record_id, {record.record_id for record in replacements})
+
+    def test_privileged_policy_activation_uses_atomic_cas_and_idempotency(self) -> None:
+        with _isolated_postgres_database() as database_url:
+            migrate_schema(database_url=database_url)
+            applying_identity = GitHubHumanIdentity(
+                login="postgres-owner",
+                github_id=123,
+                name="Postgres Owner",
+                email="postgres-owner@example.test",
+                organizations=frozenset(),
+                teams=frozenset(),
+                role="admin",
+            )
+            admin_rules = tuple(
+                GitHubHumanPolicyRule(
+                    managed_set_id="test.activation-admins",
+                    managed_rule_id=managed_rule_id,
+                    github_ids=(github_id,),
+                    roles=("admin",),
+                    products=("launchplane",),
+                    contexts=("launchplane",),
+                    actions=("authz_policy_grant.write",),
+                )
+                for managed_rule_id, github_id in (
+                    ("applying-admin", 123),
+                    ("independent-admin", 456),
+                )
+            )
+            policy = LaunchplaneAuthzPolicy(schema_version=2, github_humans=admin_rules)
+            policy_digest = authz_policy_sha256(policy)
+            seed_record = LaunchplaneAuthzPolicyRecord(
+                record_id=build_authz_policy_record_id(
+                    revision=1,
+                    policy_sha256=policy_digest,
+                ),
+                revision=1,
+                source="test:activation-postgres",
+                updated_at="2026-08-30T00:00:00Z",
+                policy_sha256=policy_digest,
+                policy=policy,
+            )
+            store = PostgresRecordStore(database_url=database_url)
+            try:
+                seed_record = store.seed_authz_policy_if_absent(seed_record)
+                dry_run_request = authz_policy_activation.build_authz_policy_operation_activation_reconcile_request(
+                    github_id=applying_identity.github_id,
+                    mode="dry_run",
+                    reason="Review the privileged-policy activation.",
+                )
+                dry_run_result = authz_grant_service.execute_managed_authz_policy_reconcile(
+                    record_store=store,
+                    request=dry_run_request,
+                    identity=applying_identity,
+                    trace_id="postgres-activation-dry-run",
+                    now_timestamp=lambda: "2026-08-30T00:01:00Z",
+                    authorized_policy_sha256=seed_record.policy_sha256,
+                    immutable_applying_github_id=applying_identity.github_id,
+                    source=authz_policy_activation.AUTHZ_POLICY_OPERATION_ACTIVATION_SOURCE,
+                )
+                dry_run_diff = authz_grant_service.AuthzManagedPolicyDiff.model_validate(
+                    dry_run_result.driver_result["diff"]
+                )
+                apply_request = authz_policy_activation.build_authz_policy_operation_activation_reconcile_request(
+                    github_id=applying_identity.github_id,
+                    mode="apply",
+                    reason="Review the privileged-policy activation.",
+                    reviewed_plan_sha256=dry_run_diff.plan_sha256,
+                )
+                apply_result = authz_grant_service.execute_managed_authz_policy_reconcile(
+                    record_store=store,
+                    request=apply_request,
+                    identity=applying_identity,
+                    trace_id="postgres-activation-apply",
+                    now_timestamp=lambda: "2026-08-30T00:02:00Z",
+                    authorized_policy_sha256=seed_record.policy_sha256,
+                    immutable_applying_github_id=applying_identity.github_id,
+                    source=authz_policy_activation.AUTHZ_POLICY_OPERATION_ACTIVATION_SOURCE,
+                )
+                mutation = DbOnlyMutationRequest(
+                    scope=authz_policy_activation.authz_policy_operation_activation_idempotency_scope(
+                        applying_identity.github_id
+                    ),
+                    route_path="/v1/authz-policies/privileged-policy-operations/activation/apply",
+                    idempotency_key="postgres-activation",
+                    request_fingerprint="a" * 64,
+                    lease_owner="postgres-activation-apply",
+                    response_status_code=202,
+                    response_trace_id="postgres-activation-apply",
+                    response_payload={"status": "accepted"},
+                    lease_seconds=300,
+                )
+                written = store.compare_and_write_authz_policy_record(
+                    expected_record=apply_result.previous_authz_policy_record,
+                    replacement_record=apply_result.authz_policy_record,
+                    mutation=mutation,
+                )
+                replayed = store.compare_and_write_authz_policy_record(
+                    expected_record=apply_result.previous_authz_policy_record,
+                    replacement_record=apply_result.authz_policy_record,
+                    mutation=mutation,
+                )
+                conflicting = store.compare_and_write_authz_policy_record(
+                    expected_record=apply_result.previous_authz_policy_record,
+                    replacement_record=apply_result.authz_policy_record,
+                    mutation=replace(mutation, request_fingerprint="b" * 64),
+                )
+                active_records = store.list_authz_policy_records(status="active", limit=2)
+            finally:
+                store.close()
+
+        self.assertEqual(written.status, "written")
+        self.assertEqual(replayed.status, "replayed")
+        self.assertEqual(conflicting.status, "idempotency_conflict")
+        self.assertEqual(len(active_records), 1)
+        self.assertEqual(
+            active_records[0].source,
+            authz_policy_activation.AUTHZ_POLICY_OPERATION_ACTIVATION_SOURCE,
+        )
+        self.assertEqual(
+            authz_policy_activation.authz_policy_operation_activation_state(
+                active_records[0].policy
+            ),
+            "active",
+        )
 
     def test_schema_migration_serializes_concurrent_startups(self) -> None:
         with _isolated_postgres_database() as database_url:


### PR DESCRIPTION
## Summary

- add a one-time browser-GitHub-human activation bridge for the compiled `authz_policy_operation.*` managed set
- derive the immutable GitHub ID from the signed session and require its existing strict DB-backed `authz_policy_grant.write` authority
- bind dry-run/apply to the exact active policy, reviewed digest, immutable-ID idempotency scope, CAS, continuity checks, and exact read-back
- retire the bridge from DB state after activation and preserve redacted denial/audit evidence
- keep the routes hidden from general OpenAPI and grant no workflow, terminal, operator, local-admin, wildcard, provider, deployment, or unrelated authority

## Security Boundary

This is a narrow transport for authority already present in the active DB policy. It is not a break-glass credential, total-lockout recovery, a general policy editor, GitHub workflow authority, or a caller-supplied policy path.

## Validation

- `uv run --extra dev launchplane ci unittest-shard local --jobs 4` — 3,149 targets passed
- focused real-PostgreSQL activation CAS/idempotency test — passed
- `uv run --extra dev ruff check .` — passed
- changed-file `ruff format --check` — passed
- `uv run --extra dev mypy control_plane tests` — 784 source files passed
- `pnpm --dir frontend validate` — 65 tests, OpenAPI drift, typecheck, and production build passed
- focused security review — no findings
- exact-head Opus review at `ad4fe2e9` — `LOVE`
- exact-head Gemini review at `ad4fe2e9` — `LOVE`
- JetBrains changed-file inspection — no findings in branch-added lines; 23 inherited warnings remain elsewhere in the existing PostgreSQL integration module

## Landing Boundary

This PR intentionally does not add or use GitHub secrets, workflow-managed authorization, direct database writes, alternate credentials, or a raw GitHub merge. If the existing merge controller still denies this repository, landing remains blocked on the same DB-native authority gap this change closes.

Refs #2277
