### PR TITLE
test: cover VeriReel recovery schedule orchestration

### DIFF
--- a/tests/test_verireel_billing_recovery_schedule.py
+++ b/tests/test_verireel_billing_recovery_schedule.py
@@ -59,40 +59,56 @@ class DokployApplicationScheduleTests(unittest.TestCase):
         self.assertEqual(request.call_args.kwargs["path"], "/api/schedule.create")
         self.assertEqual(request.call_args.kwargs["payload"], schedule_payload)
 
-    def test_upsert_updates_existing_application_schedule(self) -> None:
+    def test_upsert_repairs_stale_existing_schedule_and_reads_back_exact_state(self) -> None:
         payload = _application_schedule(enabled=False)
         schedule_payload: dokploy_api.JsonObject = {
             key: value for key, value in payload.items() if key != "scheduleId"
         }
+        stale_payload = _application_schedule(cron_expression="0 * * * *")
+        stale_payload["timezone"] = "Etc/UTC"
         with (
             patch(
                 "control_plane.dokploy.api.list_dokploy_schedules",
-                side_effect=[(payload,), (payload,)],
+                side_effect=[(stale_payload,), (payload,)],
             ),
             patch("control_plane.dokploy.api.dokploy_request") as request,
         ):
-            dokploy_api.upsert_dokploy_application_schedule(
+            result = dokploy_api.upsert_dokploy_application_schedule(
                 host="https://dokploy.example.com",
                 token="token-123",
                 application_id="application-123",
                 schedule_payload=schedule_payload,
             )
 
+        self.assertEqual(result, payload)
         self.assertEqual(request.call_args.kwargs["path"], "/api/schedule.update")
-        self.assertEqual(request.call_args.kwargs["payload"]["scheduleId"], "schedule-123")
+        self.assertEqual(
+            request.call_args.kwargs["payload"],
+            {"scheduleId": "schedule-123", **schedule_payload},
+        )
 
     def test_duplicate_managed_application_schedule_blocks_mutation(self) -> None:
-        with patch(
-            "control_plane.dokploy.api.list_dokploy_schedules",
-            return_value=(_application_schedule(), _application_schedule()),
+        duplicate = _application_schedule()
+        duplicate["scheduleId"] = "schedule-456"
+        schedule_payload: dokploy_api.JsonObject = {
+            key: value for key, value in _application_schedule().items() if key != "scheduleId"
+        }
+        with (
+            patch(
+                "control_plane.dokploy.api.list_dokploy_schedules",
+                return_value=(_application_schedule(), duplicate),
+            ),
+            patch("control_plane.dokploy.api.dokploy_request") as request,
         ):
             with self.assertRaisesRegex(click.ClickException, "duplicate detected"):
-                dokploy_api.read_dokploy_application_schedule(
+                dokploy_api.upsert_dokploy_application_schedule(
                     host="https://dokploy.example.com",
                     token="token-123",
                     application_id="application-123",
-                    schedule_name=VERIREEL_BILLING_RECOVERY_SCHEDULE_NAME,
+                    schedule_payload=schedule_payload,
                 )
+
+        request.assert_not_called()
 
     def test_exact_readback_mismatch_blocks_schedule_activation(self) -> None:
         payload = _application_schedule()
@@ -119,13 +135,27 @@ class DokployApplicationScheduleTests(unittest.TestCase):
 
 class VeriReelBillingRecoveryScheduleTests(unittest.TestCase):
     def test_stable_and_preview_crons_have_staggered_semantics(self) -> None:
-        self.assertTrue(cron_matches_utc(recovery_schedule_cron("testing"), datetime(2026, 1, 1, 0, 2)))
-        self.assertTrue(cron_matches_utc(recovery_schedule_cron("testing"), datetime(2026, 1, 1, 4, 17)))
-        self.assertFalse(cron_matches_utc(recovery_schedule_cron("testing"), datetime(2026, 1, 1, 2, 7)))
-        self.assertTrue(cron_matches_utc(recovery_schedule_cron("prod"), datetime(2026, 1, 1, 4, 22)))
-        self.assertFalse(cron_matches_utc(recovery_schedule_cron("prod"), datetime(2026, 1, 1, 4, 17)))
-        self.assertTrue(cron_matches_utc(recovery_schedule_cron("preview"), datetime(2026, 1, 1, 12, 42)))
-        self.assertFalse(cron_matches_utc(recovery_schedule_cron("preview"), datetime(2026, 1, 1, 4, 47)))
+        self.assertTrue(
+            cron_matches_utc(recovery_schedule_cron("testing"), datetime(2026, 1, 1, 0, 2))
+        )
+        self.assertTrue(
+            cron_matches_utc(recovery_schedule_cron("testing"), datetime(2026, 1, 1, 4, 17))
+        )
+        self.assertFalse(
+            cron_matches_utc(recovery_schedule_cron("testing"), datetime(2026, 1, 1, 2, 7))
+        )
+        self.assertTrue(
+            cron_matches_utc(recovery_schedule_cron("prod"), datetime(2026, 1, 1, 4, 22))
+        )
+        self.assertFalse(
+            cron_matches_utc(recovery_schedule_cron("prod"), datetime(2026, 1, 1, 4, 17))
+        )
+        self.assertTrue(
+            cron_matches_utc(recovery_schedule_cron("preview"), datetime(2026, 1, 1, 12, 42))
+        )
+        self.assertFalse(
+            cron_matches_utc(recovery_schedule_cron("preview"), datetime(2026, 1, 1, 4, 47))
+        )
 
     def test_preview_command_is_commission_only_and_has_no_secret(self) -> None:
         command = recovery_schedule_command("preview")
@@ -135,6 +165,37 @@ class VeriReelBillingRecoveryScheduleTests(unittest.TestCase):
         self.assertNotIn("authorize", command.lower())
         for forbidden_value in ("cron-secret", "token-123", "Bearer ", "API_KEY"):
             self.assertNotIn(forbidden_value, command)
+
+    def test_quiesce_and_restore_leave_absent_schedule_absent(self) -> None:
+        with (
+            patch(
+                "control_plane.workflows.verireel_billing_recovery_schedule.dokploy_api.read_dokploy_application_schedule",
+                return_value=None,
+            ),
+            patch(
+                "control_plane.workflows.verireel_billing_recovery_schedule.reconcile_verireel_billing_recovery_schedule"
+            ) as reconcile,
+            patch(
+                "control_plane.workflows.verireel_billing_recovery_schedule.dokploy_api.upsert_dokploy_application_schedule"
+            ) as upsert,
+        ):
+            snapshot = quiesce_verireel_billing_recovery_schedule(
+                host="https://dokploy.example.com",
+                token="token-123",
+                application_id="application-123",
+                instance="testing",
+            )
+            restore_verireel_billing_recovery_schedule(
+                host="https://dokploy.example.com",
+                token="token-123",
+                application_id="application-123",
+                instance="testing",
+                snapshot=snapshot,
+            )
+
+        self.assertEqual(snapshot, VeriReelRecoveryScheduleSnapshot(existed=False))
+        reconcile.assert_not_called()
+        upsert.assert_not_called()
 
     def test_quiesce_and_failure_restore_preserve_prior_enabled_state(self) -> None:
         schedule = _application_schedule(enabled=True)
@@ -151,7 +212,7 @@ class VeriReelBillingRecoveryScheduleTests(unittest.TestCase):
             ) as upsert,
             patch(
                 "control_plane.workflows.verireel_billing_recovery_schedule.dokploy_api.run_dokploy_schedule"
-            ),
+            ) as run_schedule,
         ):
             snapshot = quiesce_verireel_billing_recovery_schedule(
                 host="https://dokploy.example.com",
@@ -168,8 +229,44 @@ class VeriReelBillingRecoveryScheduleTests(unittest.TestCase):
             )
 
         self.assertEqual(snapshot, VeriReelRecoveryScheduleSnapshot(existed=True, enabled=True))
+        self.assertEqual(upsert.call_count, 2)
         self.assertFalse(upsert.call_args_list[0].kwargs["schedule_payload"]["enabled"])
         self.assertTrue(upsert.call_args_list[1].kwargs["schedule_payload"]["enabled"])
+        run_schedule.assert_not_called()
+
+    def test_quiesce_and_restore_preserve_prior_disabled_state(self) -> None:
+        schedule = _application_schedule(enabled=False)
+        with (
+            patch(
+                "control_plane.workflows.verireel_billing_recovery_schedule.dokploy_api.read_dokploy_application_schedule",
+                return_value=schedule,
+            ),
+            patch(
+                "control_plane.workflows.verireel_billing_recovery_schedule.dokploy_api.upsert_dokploy_application_schedule"
+            ) as upsert,
+            patch(
+                "control_plane.workflows.verireel_billing_recovery_schedule.dokploy_api.run_dokploy_schedule"
+            ) as run_schedule,
+        ):
+            snapshot = quiesce_verireel_billing_recovery_schedule(
+                host="https://dokploy.example.com",
+                token="token-123",
+                application_id="application-123",
+                instance="testing",
+            )
+            restore_verireel_billing_recovery_schedule(
+                host="https://dokploy.example.com",
+                token="token-123",
+                application_id="application-123",
+                instance="testing",
+                snapshot=snapshot,
+            )
+
+        self.assertEqual(snapshot, VeriReelRecoveryScheduleSnapshot(existed=True, enabled=False))
+        self.assertEqual(upsert.call_count, 2)
+        self.assertFalse(upsert.call_args_list[0].kwargs["schedule_payload"]["enabled"])
+        self.assertFalse(upsert.call_args_list[1].kwargs["schedule_payload"]["enabled"])
+        run_schedule.assert_not_called()
 
     def test_reconcile_enables_preview_schedule_after_canary(self) -> None:
         schedule = _application_schedule(cron_expression="12,27,42,57 * * * *", enabled=False)
@@ -229,9 +326,39 @@ class VeriReelBillingRecoveryScheduleTests(unittest.TestCase):
                     instance="testing",
                 )
 
-        self.assertFalse(
-            delete_schedule.call_args.kwargs["schedule_payload"]["enabled"]
-        )
+        self.assertFalse(delete_schedule.call_args.kwargs["schedule_payload"]["enabled"])
+
+    def test_failed_existing_schedule_canary_leaves_it_disabled_without_deleting(self) -> None:
+        existing_schedule = _application_schedule()
+        disabled_schedule = _application_schedule(enabled=False)
+        with (
+            patch(
+                "control_plane.workflows.verireel_billing_recovery_schedule.dokploy_api.read_dokploy_application_schedule",
+                return_value=existing_schedule,
+            ),
+            patch(
+                "control_plane.workflows.verireel_billing_recovery_schedule.dokploy_api.upsert_dokploy_application_schedule",
+                return_value=disabled_schedule,
+            ) as upsert,
+            patch(
+                "control_plane.workflows.verireel_billing_recovery_schedule.dokploy_api.run_dokploy_schedule",
+                side_effect=click.ClickException("canary failed"),
+            ),
+            patch(
+                "control_plane.workflows.verireel_billing_recovery_schedule.dokploy_api.delete_dokploy_application_schedule"
+            ) as delete_schedule,
+        ):
+            with self.assertRaisesRegex(click.ClickException, "canary failed"):
+                reconcile_verireel_billing_recovery_schedule(
+                    host="https://dokploy.example.com",
+                    token="token-123",
+                    application_id="application-123",
+                    instance="testing",
+                )
+
+        upsert.assert_called_once()
+        self.assertFalse(upsert.call_args.kwargs["schedule_payload"]["enabled"])
+        delete_schedule.assert_not_called()
 
     def test_finalize_preserves_an_existing_disabled_schedule(self) -> None:
         snapshot = VeriReelRecoveryScheduleSnapshot(existed=True, enabled=False)

--- a/tests/test_verireel_preview_driver.py
+++ b/tests/test_verireel_preview_driver.py
@@ -231,7 +231,9 @@ class VeriReelPreviewDriverTests(unittest.TestCase):
             "preview-verireel-testing-verireel-pr-71-generation-0003",
         )
 
-    def test_destroy_continues_when_recovery_schedule_cleanup_detects_drift(self) -> None:
+    def test_destroy_deletes_schedule_before_application_and_tolerates_schedule_drift(
+        self,
+    ) -> None:
         request = VeriReelPreviewDestroyRequest.model_validate(
             {
                 "anchor_pr_number": 71,
@@ -239,9 +241,17 @@ class VeriReelPreviewDriverTests(unittest.TestCase):
                 "preview_slug": "pr-71",
             }
         )
-        self.delete_recovery_schedule.side_effect = click.ClickException(
-            "schedule readback drifted"
-        )
+        cleanup_order: list[str] = []
+
+        def _delete_recovery_schedule(**kwargs: object) -> None:
+            cleanup_order.append("schedule")
+            raise click.ClickException("schedule readback drifted")
+
+        def _destroy_application(**kwargs: object) -> PreviewResourceDestroyResult:
+            cleanup_order.append("application")
+            return PreviewResourceDestroyResult(status="pass")
+
+        self.delete_recovery_schedule.side_effect = _delete_recovery_schedule
 
         with (
             TemporaryDirectory() as temporary_directory_name,
@@ -272,7 +282,7 @@ class VeriReelPreviewDriverTests(unittest.TestCase):
             ),
             patch(
                 "control_plane.workflows.verireel_preview_driver.destroy_dokploy_preview_resource",
-                return_value=PreviewResourceDestroyResult(status="pass"),
+                side_effect=_destroy_application,
             ) as destroy_resource,
             patch(
                 "control_plane.workflows.verireel_preview_driver._run_application_command_with_retries"
@@ -283,6 +293,12 @@ class VeriReelPreviewDriverTests(unittest.TestCase):
                 request=request,
             )
 
+        self.assertEqual(cleanup_order, ["schedule", "application"])
+        self.delete_recovery_schedule.assert_called_once_with(
+            host="https://dokploy.example.com",
+            token="token-123",
+            application_id="app-preview",
+        )
         destroy_resource.assert_called_once()
         self.assertEqual(result.destroy_status, "pass")
         self.assertEqual(result.error_message, "")


### PR DESCRIPTION
## Summary
- cover stale schedule repair with exact readback and duplicate fail-closed mutation prevention
- cover quiesce/restore behavior for absent, enabled, and already-disabled schedules
- cover existing-schedule canary failure without deletion or re-enablement
- verify preview cleanup attempts schedule deletion before application deletion and tolerates schedule drift

## Validation
- `uv run --extra dev python -m unittest tests.test_verireel_billing_recovery_schedule tests.test_verireel_testing_deploy tests.test_verireel_prod_promotion tests.test_verireel_preview_driver`
- `uv run --extra dev ruff check --diff tests/test_verireel_billing_recovery_schedule.py tests/test_verireel_preview_driver.py`
- `uv run --extra dev ruff check tests/test_verireel_billing_recovery_schedule.py tests/test_verireel_preview_driver.py`
- `uv run --extra dev ruff format --check tests/test_verireel_billing_recovery_schedule.py tests/test_verireel_preview_driver.py`

## Notes
- Offline tests only; no provider, infrastructure, or PostgreSQL integration calls.
- No production behavior changed and no production defect was exposed by the requested scenarios.
- Changed-file PyCharm inspection reports 37 pre-existing warnings across the two existing test modules; the two warnings introduced during this change were removed before the final run.
- Self-hosted checks may remain queued while CM infrastructure recovers.

Refs #2248