### PR TITLE
Fix runner maintainer planner gates

### DIFF
--- a/control_plane/cli_runner_lanes.py
+++ b/control_plane/cli_runner_lanes.py
@@ -584,7 +584,7 @@ def runner_control_plan(
     "--require-baseline-readiness/--allow-missing-baseline-readiness",
     default=True,
     show_default=True,
-    help="Whether baseline readiness must pass before maintainer planning is ready.",
+    help="Whether an existing online lane must pass baseline readiness before adoption is recommended.",
 )
 @click.option(
     "--inventory-file",

--- a/control_plane/cli_runner_lanes.py
+++ b/control_plane/cli_runner_lanes.py
@@ -584,7 +584,10 @@ def runner_control_plan(
     "--require-baseline-readiness/--allow-missing-baseline-readiness",
     default=True,
     show_default=True,
-    help="Whether an existing online lane must pass baseline readiness before adoption is recommended.",
+    help=(
+        "Whether an existing lane requires aggregate baseline readiness before adoption or "
+        "remove/recreate is recommended. Absent-lane create recommendations are not baseline-gated."
+    ),
 )
 @click.option(
     "--inventory-file",

--- a/control_plane/cli_runner_lanes.py
+++ b/control_plane/cli_runner_lanes.py
@@ -585,8 +585,9 @@ def runner_control_plan(
     default=True,
     show_default=True,
     help=(
-        "Whether an existing lane requires aggregate baseline readiness before adoption or "
-        "remove/recreate is recommended. Absent-lane create recommendations are not baseline-gated."
+        "Whether non-ready aggregate baseline evidence blocks planning. Existing lanes and "
+        "absent lanes with observed failures are blocked; only an absent lane with a "
+        "zero-observation packet is exempt."
     ),
 )
 @click.option(

--- a/control_plane/contracts/runner_lane_maintainer.py
+++ b/control_plane/contracts/runner_lane_maintainer.py
@@ -218,14 +218,6 @@ def plan_runner_lane_maintainer(
                     f"runner desired state is missing required label: {label}",
                 )
             )
-    if policy.require_baseline_readiness and not baseline_readiness.ready:
-        blockers.append(
-            _blocker(
-                "baseline_not_ready",
-                f"runner lane baseline is not ready: {baseline_readiness.summary}",
-            )
-        )
-
     matching_lanes = tuple(
         lane for lane in inventory.lanes if lane.name.strip().lower() == desired_state.lane_name
     )
@@ -245,6 +237,17 @@ def plan_runner_lane_maintainer(
                     "existing_lane_not_managed",
                     "existing runner lane is not marked as Launchplane-managed: "
                     f"{desired_state.lane_name}",
+                )
+            )
+        if (
+            lane.status == "online"
+            and policy.require_baseline_readiness
+            and not baseline_readiness.ready
+        ):
+            blockers.append(
+                _blocker(
+                    "baseline_not_ready",
+                    f"runner lane baseline is not ready: {baseline_readiness.summary}",
                 )
             )
 
@@ -391,9 +394,7 @@ def _normalized_path(value: str) -> str:
         if segment in {"", "."}:
             continue
         if segment == "..":
-            if segments:
-                segments.pop()
-            continue
+            raise ValueError("runner lane maintainer paths must not contain '..' components")
         segments.append(segment)
     return "/" + "/".join(segments)
 

--- a/control_plane/contracts/runner_lane_maintainer.py
+++ b/control_plane/contracts/runner_lane_maintainer.py
@@ -231,7 +231,7 @@ def plan_runner_lane_maintainer(
         )
     if len(matching_lanes) == 1:
         lane = matching_lanes[0]
-        lane_labels = set(_normalized_identifiers(lane.labels, "label"))
+        lane_labels = set(_normalized_observed_labels(lane.labels))
         if policy.required_managed_label not in lane_labels:
             blockers.append(
                 _blocker(
@@ -247,13 +247,22 @@ def plan_runner_lane_maintainer(
                     f"existing runner lane has an unsupported status: {lane.status}",
                 )
             )
-        if policy.require_baseline_readiness and not baseline_readiness.ready:
-            blockers.append(
-                _blocker(
-                    "baseline_not_ready",
-                    f"runner lane baseline is not ready: {baseline_readiness.summary}",
-                )
+    baseline_unavailable = (
+        baseline_readiness.observed_lanes == 0
+        and baseline_readiness.compliant_lanes == 0
+        and not baseline_readiness.violations
+    )
+    if (
+        policy.require_baseline_readiness
+        and not baseline_readiness.ready
+        and (matching_lanes or not baseline_unavailable)
+    ):
+        blockers.append(
+            _blocker(
+                "baseline_not_ready",
+                f"runner lane baseline is not ready: {baseline_readiness.summary}",
             )
+        )
 
     decision = _decision(blockers=tuple(blockers), matching_lanes=matching_lanes)
     if decision != "blocked":
@@ -369,6 +378,10 @@ def _normalized_identifiers(values: tuple[str, ...], label: str) -> tuple[str, .
     return tuple(
         sorted({_normalized_identifier(value, label) for value in values if value.strip()})
     )
+
+
+def _normalized_observed_labels(values: tuple[str, ...]) -> tuple[str, ...]:
+    return tuple(sorted({value.strip().lower() for value in values if value.strip()}))
 
 
 def _normalized_identifier(value: str, label: str) -> str:

--- a/control_plane/contracts/runner_lane_maintainer.py
+++ b/control_plane/contracts/runner_lane_maintainer.py
@@ -26,6 +26,7 @@ RunnerLaneMaintainerBlockerCode = Literal[
     "host_not_allowed",
     "inventory_repository_mismatch",
     "lane_name_ambiguous",
+    "lane_status_unknown",
     "repository_not_allowed",
     "runner_directory_not_allowed",
     "service_user_not_allowed",
@@ -239,11 +240,14 @@ def plan_runner_lane_maintainer(
                     f"{desired_state.lane_name}",
                 )
             )
-        if (
-            lane.status == "online"
-            and policy.require_baseline_readiness
-            and not baseline_readiness.ready
-        ):
+        if lane.status not in {"online", "offline"}:
+            blockers.append(
+                _blocker(
+                    "lane_status_unknown",
+                    f"existing runner lane has an unsupported status: {lane.status}",
+                )
+            )
+        if policy.require_baseline_readiness and not baseline_readiness.ready:
             blockers.append(
                 _blocker(
                     "baseline_not_ready",

--- a/docs/runner-lane-baseline.md
+++ b/docs/runner-lane-baseline.md
@@ -213,23 +213,29 @@ otherwise-valid create, adoption-verification, and remove/recreate plans remain
 
 Baseline readiness has different timing for absent-lane planning and existing
 lane remediation. An absent lane may be policy-ready for `recommend_create`
-when no baseline observation can exist yet. Any matching existing lane must
-have a ready aggregate baseline packet before the planner can recommend
-adoption verification or remove/recreate; otherwise it returns
-`decision: blocked` with `baseline_not_ready`. The current readiness packet is
-fleet-aggregate evidence and does not prove that the desired lane itself was
-observed. A future supervised executor must bind post-action baseline evidence
-to the exact lane before it can claim completion or product-job admission; this
-read-only planner does not implement that completion gate.
+only when the supplied readiness packet has zero observed lanes, zero compliant
+lanes, and no violations. A non-ready packet with existing fleet observations
+or violations blocks even an absent-lane recommendation. By default, any
+matching existing lane must have a ready aggregate baseline packet before the
+planner can recommend adoption verification or remove/recreate; otherwise it
+returns `decision: blocked` with `baseline_not_ready`. The operator may
+explicitly disable this coarse pre-action gate with
+`--allow-missing-baseline-readiness`, but the recommendation remains blocked by
+`supervised_maintainer_required` and does not become completion evidence. The
+current readiness packet is fleet-aggregate evidence and does not prove that
+the desired lane itself was observed. A future supervised executor must bind
+post-action baseline evidence to the exact lane before it can claim completion
+or product-job admission; this read-only planner does not implement that
+completion gate.
 
 Other policy blockers such as an unapproved host, unsafe runner directory,
-missing managed label, duplicate lane name, or repository mismatch also produce
-`decision: blocked` with `policy_ready: false` and must be resolved before any
-host mutation can be considered. The maintainer planner's desired runner
-directories and allowed registration roots reject explicit `..` path
-components rather than resolving them into a different path. Registration and
-retirement remain separate lifecycle contracts and are not covered by this
-planner validation.
+missing managed label, unsupported observed lane status, duplicate lane name,
+or repository mismatch also produce `decision: blocked` with
+`policy_ready: false` and must be resolved before any host mutation can be
+considered. The maintainer planner's desired runner directories and allowed
+registration roots reject explicit `..` path components rather than resolving
+them into a different path. Registration and retirement remain separate
+lifecycle contracts and are not covered by this planner validation.
 
 ## Lifecycle Executors
 

--- a/docs/runner-lane-baseline.md
+++ b/docs/runner-lane-baseline.md
@@ -209,11 +209,24 @@ perform that action. Until the supervised host maintainer exists,
 otherwise-valid create, adoption-verification, and remove/recreate plans remain
 `status: blocked` with the typed capability blocker
 `supervised_maintainer_required`. These packets set `policy_ready: true` and
-`capability_ready: false`. Policy blockers such as an unapproved host, unsafe
-runner directory, missing managed label, duplicate lane name, repository
-mismatch, or failed baseline readiness produce `decision: blocked` with
-`policy_ready: false` and must be resolved before any host mutation can be
-considered.
+`capability_ready: false` and expose no mutation capability.
+
+Baseline readiness has different timing for pre-action planning and completed
+lane evidence. An absent lane may be policy-ready for `recommend_create`, and an
+offline managed lane may be policy-ready for `recommend_remove_recreate`, when
+baseline observations are unavailable because the future supervised action must
+create or recreate the running service first. Baseline readiness is then a
+required post-action completion check before the lane can be admitted for
+product jobs. An existing online lane must already pass baseline readiness for
+the planner to recommend adoption verification; otherwise it returns
+`decision: blocked` with `baseline_not_ready`.
+
+Other policy blockers such as an unapproved host, unsafe runner directory,
+missing managed label, duplicate lane name, or repository mismatch also produce
+`decision: blocked` with `policy_ready: false` and must be resolved before any
+host mutation can be considered. Desired runner directories and allowed
+registration roots reject explicit `..` path components rather than resolving
+them into a different path.
 
 ## Lifecycle Executors
 

--- a/docs/runner-lane-baseline.md
+++ b/docs/runner-lane-baseline.md
@@ -211,22 +211,25 @@ otherwise-valid create, adoption-verification, and remove/recreate plans remain
 `supervised_maintainer_required`. These packets set `policy_ready: true` and
 `capability_ready: false` and expose no mutation capability.
 
-Baseline readiness has different timing for pre-action planning and completed
-lane evidence. An absent lane may be policy-ready for `recommend_create`, and an
-offline managed lane may be policy-ready for `recommend_remove_recreate`, when
-baseline observations are unavailable because the future supervised action must
-create or recreate the running service first. Baseline readiness is then a
-required post-action completion check before the lane can be admitted for
-product jobs. An existing online lane must already pass baseline readiness for
-the planner to recommend adoption verification; otherwise it returns
-`decision: blocked` with `baseline_not_ready`.
+Baseline readiness has different timing for absent-lane planning and existing
+lane remediation. An absent lane may be policy-ready for `recommend_create`
+when no baseline observation can exist yet. Any matching existing lane must
+have a ready aggregate baseline packet before the planner can recommend
+adoption verification or remove/recreate; otherwise it returns
+`decision: blocked` with `baseline_not_ready`. The current readiness packet is
+fleet-aggregate evidence and does not prove that the desired lane itself was
+observed. A future supervised executor must bind post-action baseline evidence
+to the exact lane before it can claim completion or product-job admission; this
+read-only planner does not implement that completion gate.
 
 Other policy blockers such as an unapproved host, unsafe runner directory,
 missing managed label, duplicate lane name, or repository mismatch also produce
 `decision: blocked` with `policy_ready: false` and must be resolved before any
-host mutation can be considered. Desired runner directories and allowed
-registration roots reject explicit `..` path components rather than resolving
-them into a different path.
+host mutation can be considered. The maintainer planner's desired runner
+directories and allowed registration roots reject explicit `..` path
+components rather than resolving them into a different path. Registration and
+retirement remain separate lifecycle contracts and are not covered by this
+planner validation.
 
 ## Lifecycle Executors
 

--- a/docs/runner-lane-baseline.md
+++ b/docs/runner-lane-baseline.md
@@ -212,14 +212,15 @@ otherwise-valid create, adoption-verification, and remove/recreate plans remain
 `capability_ready: false` and expose no mutation capability.
 
 Baseline readiness has different timing for absent-lane planning and existing
-lane remediation. An absent lane may be policy-ready for `recommend_create`
-only when the supplied readiness packet has zero observed lanes, zero compliant
-lanes, and no violations. A non-ready packet with existing fleet observations
-or violations blocks even an absent-lane recommendation. By default, any
-matching existing lane must have a ready aggregate baseline packet before the
-planner can recommend adoption verification or remove/recreate; otherwise it
-returns `decision: blocked` with `baseline_not_ready`. The operator may
-explicitly disable this coarse pre-action gate with
+lane remediation. An absent lane may remain policy-ready for
+`recommend_create` despite a non-ready packet only when that packet has zero
+observed lanes, zero compliant lanes, and no violations. A non-ready packet
+with existing fleet observations or violations blocks even an absent-lane
+recommendation. By default, any matching existing lane must have a ready
+aggregate baseline packet before the planner can recommend adoption
+verification or remove/recreate; otherwise it returns `decision: blocked` with
+`baseline_not_ready`. The operator may explicitly disable this coarse
+pre-action gate with
 `--allow-missing-baseline-readiness`, but the recommendation remains blocked by
 `supervised_maintainer_required` and does not become completion evidence. The
 current readiness packet is fleet-aggregate evidence and does not prove that

--- a/tests/test_runner_lane_maintainer.py
+++ b/tests/test_runner_lane_maintainer.py
@@ -12,6 +12,7 @@ from click.testing import Result
 
 from control_plane.cli import main
 from control_plane.contracts.runner_lane_baseline import RunnerLaneBaselineReadiness
+from control_plane.contracts.runner_lane_baseline import RunnerLaneBaselineViolation
 from control_plane.contracts.runner_lane_inventory import RunnerLaneInventory
 from control_plane.contracts.runner_lane_inventory import RunnerLaneRecord
 from control_plane.contracts.runner_lane_inventory import build_runner_lane_inventory
@@ -106,6 +107,20 @@ class RunnerLaneMaintainerPlanTests(unittest.TestCase):
             [blocker.code for blocker in plan.blockers], ["supervised_maintainer_required"]
         )
 
+    def test_plan_blocks_create_when_existing_baseline_evidence_is_not_ready(self) -> None:
+        plan = plan_runner_lane_maintainer(
+            policy=_policy(),
+            desired_state=_desired_state(),
+            inventory=_inventory(lanes=()),
+            baseline_readiness=_failing_baseline(),
+        )
+
+        self.assertEqual(plan.status, "blocked")
+        self.assertEqual(plan.decision, "blocked")
+        self.assertFalse(plan.policy_ready)
+        self.assertTrue(plan.capability_ready)
+        self.assertEqual([blocker.code for blocker in plan.blockers], ["baseline_not_ready"])
+
     def test_plan_blocks_offline_lane_without_baseline_readiness(self) -> None:
         plan = plan_runner_lane_maintainer(
             policy=_policy(),
@@ -148,6 +163,43 @@ class RunnerLaneMaintainerPlanTests(unittest.TestCase):
         self.assertTrue(plan.capability_ready)
         self.assertEqual([blocker.code for blocker in plan.blockers], ["lane_status_unknown"])
 
+    def test_plan_blocks_unknown_status_when_baseline_gate_is_disabled(self) -> None:
+        plan = plan_runner_lane_maintainer(
+            policy=_policy(require_baseline_readiness=False),
+            desired_state=_desired_state(),
+            inventory=_inventory(lanes=(_lane(status="unknown"),)),
+            baseline_readiness=_unavailable_baseline(),
+        )
+
+        self.assertEqual(plan.status, "blocked")
+        self.assertEqual(plan.decision, "blocked")
+        self.assertFalse(plan.policy_ready)
+        self.assertTrue(plan.capability_ready)
+        self.assertEqual([blocker.code for blocker in plan.blockers], ["lane_status_unknown"])
+
+    def test_plan_accepts_non_policy_observed_labels(self) -> None:
+        plan = plan_runner_lane_maintainer(
+            policy=_policy(),
+            desired_state=_desired_state(),
+            inventory=_inventory(
+                lanes=(
+                    _lane(
+                        status="online",
+                        labels=(
+                            "self-hosted",
+                            "launchplane",
+                            "launchplane-managed",
+                            "gpu:a100",
+                        ),
+                    ),
+                )
+            ),
+            baseline_readiness=_ready_baseline(),
+        )
+
+        self.assertEqual(plan.decision, "recommend_verify_adoption")
+        self.assertTrue(plan.policy_ready)
+
     def test_plan_can_disable_baseline_gate_for_online_lane(self) -> None:
         plan = plan_runner_lane_maintainer(
             policy=_policy(require_baseline_readiness=False),
@@ -158,6 +210,22 @@ class RunnerLaneMaintainerPlanTests(unittest.TestCase):
 
         self.assertEqual(plan.status, "blocked")
         self.assertEqual(plan.decision, "recommend_verify_adoption")
+        self.assertTrue(plan.policy_ready)
+        self.assertFalse(plan.capability_ready)
+        self.assertEqual(
+            [blocker.code for blocker in plan.blockers], ["supervised_maintainer_required"]
+        )
+
+    def test_plan_can_disable_baseline_gate_for_offline_lane(self) -> None:
+        plan = plan_runner_lane_maintainer(
+            policy=_policy(require_baseline_readiness=False),
+            desired_state=_desired_state(),
+            inventory=_inventory(lanes=(_lane(status="offline"),)),
+            baseline_readiness=_unavailable_baseline(),
+        )
+
+        self.assertEqual(plan.status, "blocked")
+        self.assertEqual(plan.decision, "recommend_remove_recreate")
         self.assertTrue(plan.policy_ready)
         self.assertFalse(plan.capability_ready)
         self.assertEqual(
@@ -261,7 +329,10 @@ class RunnerLaneMaintainerCliTests(unittest.TestCase):
         self.assertEqual(payload["plan"]["decision"], "recommend_create")
         self.assertTrue(payload["plan"]["policy_ready"])
         self.assertFalse(payload["plan"]["capability_ready"])
-        self.assertEqual(payload["plan"]["blockers"][0]["code"], "supervised_maintainer_required")
+        self.assertEqual(
+            [blocker["code"] for blocker in payload["plan"]["blockers"]],
+            ["supervised_maintainer_required"],
+        )
         self.assertEqual(payload["desired_state"]["systemd_unit_name"], _UNIT_NAME)
 
     def test_cli_emits_remove_recreate_decision_for_offline_lane(self) -> None:
@@ -288,7 +359,10 @@ class RunnerLaneMaintainerCliTests(unittest.TestCase):
         self.assertEqual(result.exit_code, 0, result.output)
         payload = json.loads(result.output)
         self.assertEqual(payload["plan"]["decision"], "blocked")
-        self.assertEqual(payload["plan"]["blockers"][0]["code"], "baseline_not_ready")
+        self.assertEqual(
+            [blocker["code"] for blocker in payload["plan"]["blockers"]],
+            ["baseline_not_ready"],
+        )
 
     def test_cli_can_disable_baseline_gate_for_existing_lane(self) -> None:
         result = _invoke_cli(
@@ -303,6 +377,35 @@ class RunnerLaneMaintainerCliTests(unittest.TestCase):
         self.assertEqual(
             [blocker["code"] for blocker in payload["plan"]["blockers"]],
             ["supervised_maintainer_required"],
+        )
+
+    def test_cli_can_disable_baseline_gate_for_offline_lane(self) -> None:
+        result = _invoke_cli(
+            lanes=(_lane(status="offline"),),
+            baseline_readiness=_unavailable_baseline(),
+            allow_missing_baseline=True,
+        )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        payload = json.loads(result.output)
+        self.assertEqual(payload["plan"]["decision"], "recommend_remove_recreate")
+        self.assertEqual(
+            [blocker["code"] for blocker in payload["plan"]["blockers"]],
+            ["supervised_maintainer_required"],
+        )
+
+    def test_cli_blocks_lane_with_unknown_status(self) -> None:
+        result = _invoke_cli(
+            lanes=(_lane(status="unknown"),),
+            allow_missing_baseline=True,
+        )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        payload = json.loads(result.output)
+        self.assertEqual(payload["plan"]["decision"], "blocked")
+        self.assertEqual(
+            [blocker["code"] for blocker in payload["plan"]["blockers"]],
+            ["lane_status_unknown"],
         )
 
 
@@ -362,6 +465,22 @@ def _unavailable_baseline() -> RunnerLaneBaselineReadiness:
         compliant_lanes=0,
         violations=(),
         summary="no runner lane baseline observations supplied",
+    )
+
+
+def _failing_baseline() -> RunnerLaneBaselineReadiness:
+    return RunnerLaneBaselineReadiness(
+        ready=False,
+        observed_lanes=1,
+        compliant_lanes=0,
+        violations=(
+            RunnerLaneBaselineViolation(
+                runner_name="another-lane",
+                code="required_label_missing",
+                message="runner lane is missing required labels: launchplane-managed",
+            ),
+        ),
+        summary="runner lane baseline violations found",
     )
 
 

--- a/tests/test_runner_lane_maintainer.py
+++ b/tests/test_runner_lane_maintainer.py
@@ -90,21 +90,48 @@ class RunnerLaneMaintainerPlanTests(unittest.TestCase):
         self.assertTrue(plan.capability_ready)
         self.assertEqual([blocker.code for blocker in plan.blockers], ["existing_lane_not_managed"])
 
-    def test_plan_blocks_without_baseline_readiness(self) -> None:
+    def test_plan_recommends_create_before_baseline_is_available(self) -> None:
         plan = plan_runner_lane_maintainer(
             policy=_policy(),
             desired_state=_desired_state(),
             inventory=_inventory(lanes=()),
-            baseline_readiness=RunnerLaneBaselineReadiness(
-                ready=False,
-                observed_lanes=0,
-                compliant_lanes=0,
-                violations=(),
-                summary="no runner lane baseline observations supplied",
-            ),
+            baseline_readiness=_unavailable_baseline(),
         )
 
         self.assertEqual(plan.status, "blocked")
+        self.assertEqual(plan.decision, "recommend_create")
+        self.assertTrue(plan.policy_ready)
+        self.assertFalse(plan.capability_ready)
+        self.assertEqual(
+            [blocker.code for blocker in plan.blockers], ["supervised_maintainer_required"]
+        )
+
+    def test_plan_recommends_remove_recreate_before_baseline_is_available(self) -> None:
+        plan = plan_runner_lane_maintainer(
+            policy=_policy(),
+            desired_state=_desired_state(),
+            inventory=_inventory(lanes=(_lane(status="offline", github_id=21),)),
+            baseline_readiness=_unavailable_baseline(),
+        )
+
+        self.assertEqual(plan.status, "blocked")
+        self.assertEqual(plan.decision, "recommend_remove_recreate")
+        self.assertTrue(plan.policy_ready)
+        self.assertFalse(plan.capability_ready)
+        self.assertEqual(
+            [blocker.code for blocker in plan.blockers], ["supervised_maintainer_required"]
+        )
+
+    def test_plan_blocks_online_lane_without_baseline_readiness(self) -> None:
+        plan = plan_runner_lane_maintainer(
+            policy=_policy(),
+            desired_state=_desired_state(),
+            inventory=_inventory(lanes=(_lane(status="online"),)),
+            baseline_readiness=_unavailable_baseline(),
+        )
+
+        self.assertEqual(plan.status, "blocked")
+        self.assertEqual(plan.decision, "blocked")
         self.assertFalse(plan.policy_ready)
         self.assertTrue(plan.capability_ready)
         self.assertEqual([blocker.code for blocker in plan.blockers], ["baseline_not_ready"])
@@ -171,6 +198,24 @@ class RunnerLaneMaintainerPlanTests(unittest.TestCase):
                 service_user="launchplane-runner-hygiene",
                 systemd_unit_name=_UNIT_NAME,
                 labels=("self-hosted", "launchplane", "launchplane-managed"),
+            )
+
+    def test_desired_state_rejects_parent_path_components(self) -> None:
+        with self.assertRaisesRegex(ValueError, "must not contain '\\.\\.' components"):
+            RunnerLaneDesiredState(
+                repository="cbusillo/odoo-tenant-cm-website",
+                host_name="chris-testing",
+                lane_name="cm-website-chris-testing",
+                runner_directory="/home/launchplane-runner-hygiene/actions-runners/../cm-website-chris-testing",
+                service_user="launchplane-runner-hygiene",
+                systemd_unit_name=_UNIT_NAME,
+                labels=("self-hosted", "launchplane", "launchplane-managed"),
+            )
+
+    def test_policy_rejects_parent_path_components_in_allowed_roots(self) -> None:
+        with self.assertRaisesRegex(ValueError, "must not contain '\\.\\.' components"):
+            RunnerLaneMaintainerPolicy(
+                allowed_registration_roots=("/home/launchplane-runner-hygiene/../actions-runners",),
             )
 
     def test_desired_state_requires_systemd_unit_for_lane(self) -> None:
@@ -248,6 +293,16 @@ def _ready_baseline() -> RunnerLaneBaselineReadiness:
         compliant_lanes=1,
         violations=(),
         summary="runner lane baseline satisfied",
+    )
+
+
+def _unavailable_baseline() -> RunnerLaneBaselineReadiness:
+    return RunnerLaneBaselineReadiness(
+        ready=False,
+        observed_lanes=0,
+        compliant_lanes=0,
+        violations=(),
+        summary="no runner lane baseline observations supplied",
     )
 
 

--- a/tests/test_runner_lane_maintainer.py
+++ b/tests/test_runner_lane_maintainer.py
@@ -106,7 +106,7 @@ class RunnerLaneMaintainerPlanTests(unittest.TestCase):
             [blocker.code for blocker in plan.blockers], ["supervised_maintainer_required"]
         )
 
-    def test_plan_recommends_remove_recreate_before_baseline_is_available(self) -> None:
+    def test_plan_blocks_offline_lane_without_baseline_readiness(self) -> None:
         plan = plan_runner_lane_maintainer(
             policy=_policy(),
             desired_state=_desired_state(),
@@ -115,12 +115,10 @@ class RunnerLaneMaintainerPlanTests(unittest.TestCase):
         )
 
         self.assertEqual(plan.status, "blocked")
-        self.assertEqual(plan.decision, "recommend_remove_recreate")
-        self.assertTrue(plan.policy_ready)
-        self.assertFalse(plan.capability_ready)
-        self.assertEqual(
-            [blocker.code for blocker in plan.blockers], ["supervised_maintainer_required"]
-        )
+        self.assertEqual(plan.decision, "blocked")
+        self.assertFalse(plan.policy_ready)
+        self.assertTrue(plan.capability_ready)
+        self.assertEqual([blocker.code for blocker in plan.blockers], ["baseline_not_ready"])
 
     def test_plan_blocks_online_lane_without_baseline_readiness(self) -> None:
         plan = plan_runner_lane_maintainer(
@@ -135,6 +133,36 @@ class RunnerLaneMaintainerPlanTests(unittest.TestCase):
         self.assertFalse(plan.policy_ready)
         self.assertTrue(plan.capability_ready)
         self.assertEqual([blocker.code for blocker in plan.blockers], ["baseline_not_ready"])
+
+    def test_plan_blocks_lane_with_unknown_status(self) -> None:
+        plan = plan_runner_lane_maintainer(
+            policy=_policy(),
+            desired_state=_desired_state(),
+            inventory=_inventory(lanes=(_lane(status="unknown"),)),
+            baseline_readiness=_ready_baseline(),
+        )
+
+        self.assertEqual(plan.status, "blocked")
+        self.assertEqual(plan.decision, "blocked")
+        self.assertFalse(plan.policy_ready)
+        self.assertTrue(plan.capability_ready)
+        self.assertEqual([blocker.code for blocker in plan.blockers], ["lane_status_unknown"])
+
+    def test_plan_can_disable_baseline_gate_for_online_lane(self) -> None:
+        plan = plan_runner_lane_maintainer(
+            policy=_policy(require_baseline_readiness=False),
+            desired_state=_desired_state(),
+            inventory=_inventory(lanes=(_lane(status="online"),)),
+            baseline_readiness=_unavailable_baseline(),
+        )
+
+        self.assertEqual(plan.status, "blocked")
+        self.assertEqual(plan.decision, "recommend_verify_adoption")
+        self.assertTrue(plan.policy_ready)
+        self.assertFalse(plan.capability_ready)
+        self.assertEqual(
+            [blocker.code for blocker in plan.blockers], ["supervised_maintainer_required"]
+        )
 
     def test_plan_blocks_unsafe_or_out_of_policy_state(self) -> None:
         plan = plan_runner_lane_maintainer(
@@ -251,16 +279,47 @@ class RunnerLaneMaintainerCliTests(unittest.TestCase):
         payload = json.loads(result.output)
         self.assertEqual(payload["plan"]["decision"], "recommend_create")
 
+    def test_cli_blocks_existing_lane_without_baseline_readiness(self) -> None:
+        result = _invoke_cli(
+            lanes=(_lane(status="online"),),
+            baseline_readiness=_unavailable_baseline(),
+        )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        payload = json.loads(result.output)
+        self.assertEqual(payload["plan"]["decision"], "blocked")
+        self.assertEqual(payload["plan"]["blockers"][0]["code"], "baseline_not_ready")
+
+    def test_cli_can_disable_baseline_gate_for_existing_lane(self) -> None:
+        result = _invoke_cli(
+            lanes=(_lane(status="online"),),
+            baseline_readiness=_unavailable_baseline(),
+            allow_missing_baseline=True,
+        )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        payload = json.loads(result.output)
+        self.assertEqual(payload["plan"]["decision"], "recommend_verify_adoption")
+        self.assertEqual(
+            [blocker["code"] for blocker in payload["plan"]["blockers"]],
+            ["supervised_maintainer_required"],
+        )
+
 
 _UNIT_NAME = "launchplane-runner@cm-website-chris-testing.service"
 
 
-def _policy(*, approved_hosts: tuple[str, ...] = ("chris-testing",)) -> RunnerLaneMaintainerPolicy:
+def _policy(
+    *,
+    approved_hosts: tuple[str, ...] = ("chris-testing",),
+    require_baseline_readiness: bool = True,
+) -> RunnerLaneMaintainerPolicy:
     return RunnerLaneMaintainerPolicy(
         allowed_repositories=("cbusillo/odoo-tenant-cm-website",),
         approved_hosts=approved_hosts,
         allowed_registration_roots=("/home/launchplane-runner-hygiene/actions-runners",),
         allowed_service_users=("launchplane-runner-hygiene",),
+        require_baseline_readiness=require_baseline_readiness,
     )
 
 
@@ -337,7 +396,13 @@ def _lane(
     )
 
 
-def _invoke_cli(*, lanes: tuple[RunnerLaneRecord, ...], nested_baseline: bool = False) -> Result:
+def _invoke_cli(
+    *,
+    lanes: tuple[RunnerLaneRecord, ...],
+    nested_baseline: bool = False,
+    baseline_readiness: RunnerLaneBaselineReadiness | None = None,
+    allow_missing_baseline: bool = False,
+) -> Result:
     with TemporaryDirectory() as temp_dir:
         temp_path = Path(temp_dir)
         inventory_file = temp_path / "inventory.json"
@@ -346,52 +411,54 @@ def _invoke_cli(*, lanes: tuple[RunnerLaneRecord, ...], nested_baseline: bool = 
             json.dumps(_inventory(lanes=lanes).model_dump(mode="json")),
             encoding="utf-8",
         )
-        baseline_payload: dict[str, object] = _ready_baseline().model_dump(mode="json")
+        baseline_payload: dict[str, object] = (baseline_readiness or _ready_baseline()).model_dump(
+            mode="json"
+        )
         if nested_baseline:
             baseline_payload = {"readiness": baseline_payload}
         baseline_file.write_text(json.dumps(baseline_payload), encoding="utf-8")
 
-        return CliRunner().invoke(
-            CLI_MAIN,
-            [
-                "work-graph",
-                "runner-maintainer-plan",
-                "--repository",
-                "cbusillo/odoo-tenant-cm-website",
-                "--host-name",
-                "chris-testing",
-                "--lane-name",
-                "cm-website-chris-testing",
-                "--runner-directory",
-                "/home/launchplane-runner-hygiene/actions-runners/cm-website-chris-testing",
-                "--service-user",
-                "launchplane-runner-hygiene",
-                "--systemd-unit-name",
-                _UNIT_NAME,
-                "--label",
-                "self-hosted",
-                "--label",
-                "launchplane",
-                "--label",
-                "launchplane-managed",
-                "--label",
-                "chris-testing",
-                "--label",
-                "cm-website",
-                "--allowed-repository",
-                "cbusillo/odoo-tenant-cm-website",
-                "--approved-host",
-                "chris-testing",
-                "--allowed-registration-root",
-                "/home/launchplane-runner-hygiene/actions-runners",
-                "--allowed-service-user",
-                "launchplane-runner-hygiene",
-                "--inventory-file",
-                str(inventory_file),
-                "--baseline-readiness-file",
-                str(baseline_file),
-            ],
-        )
+        arguments = [
+            "work-graph",
+            "runner-maintainer-plan",
+            "--repository",
+            "cbusillo/odoo-tenant-cm-website",
+            "--host-name",
+            "chris-testing",
+            "--lane-name",
+            "cm-website-chris-testing",
+            "--runner-directory",
+            "/home/launchplane-runner-hygiene/actions-runners/cm-website-chris-testing",
+            "--service-user",
+            "launchplane-runner-hygiene",
+            "--systemd-unit-name",
+            _UNIT_NAME,
+            "--label",
+            "self-hosted",
+            "--label",
+            "launchplane",
+            "--label",
+            "launchplane-managed",
+            "--label",
+            "chris-testing",
+            "--label",
+            "cm-website",
+            "--allowed-repository",
+            "cbusillo/odoo-tenant-cm-website",
+            "--approved-host",
+            "chris-testing",
+            "--allowed-registration-root",
+            "/home/launchplane-runner-hygiene/actions-runners",
+            "--allowed-service-user",
+            "launchplane-runner-hygiene",
+            "--inventory-file",
+            str(inventory_file),
+            "--baseline-readiness-file",
+            str(baseline_file),
+        ]
+        if allow_missing_baseline:
+            arguments.append("--allow-missing-baseline-readiness")
+        return CliRunner().invoke(CLI_MAIN, arguments)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- classify the matching runner lane before applying baseline readiness
- allow absent-lane create recommendations only when a non-ready baseline packet contains no observations, compliant lanes, or violations
- keep every matching existing lane baseline-gated by default and fail closed on unsupported statuses
- handle observed GitHub labels leniently while preserving the required managed-label check
- reject explicit `..` path components in maintainer desired paths and allowed roots
- document aggregate baseline evidence, the explicit opt-out, and the future lane-bound completion boundary without claiming an implemented executor

## Validation
- `uv run --extra dev python -m unittest tests.test_runner_lane_maintainer` — 28 tests passed
- `uv run --extra dev ruff check --diff control_plane/contracts/runner_lane_maintainer.py control_plane/cli_runner_lanes.py tests/test_runner_lane_maintainer.py`
- `uv run --extra dev ruff check control_plane/contracts/runner_lane_maintainer.py control_plane/cli_runner_lanes.py tests/test_runner_lane_maintainer.py`
- `uv run --extra dev ruff format --check control_plane/contracts/runner_lane_maintainer.py control_plane/cli_runner_lanes.py tests/test_runner_lane_maintainer.py`
- `uv run --extra dev mypy control_plane/contracts/runner_lane_maintainer.py control_plane/cli_runner_lanes.py tests/test_runner_lane_maintainer.py`
- `uv run --extra dev launchplane ci unittest-shard local` — all 12 shards and 3,168 targets passed
- `git diff --check`
- JetBrains changed-file inspection attempted twice; inconclusive because PyCharm timed out opening the exact worktree (`project_open_blocked`)

## Review
- Exact-head Claude Opus review at `8f5a32c6` returned `LOVE`
- Exact-head GPT review at `8f5a32c6` returned `LOVE`

## Notes
- No public executor, storage, HTTP, authorization, workflow, systemd, or live-infrastructure behavior changed.
- Registration and retirement path normalization remain separate pre-existing lifecycle boundaries and are not changed by this PR.
- All nine Launchplane self-hosted runners are currently offline, so required self-hosted checks are expected to remain queued.

Refs #1235
