### PR TITLE
Reject parent traversal in runner lifecycle roots

### DIFF
--- a/control_plane/contracts/runner_lane_registration.py
+++ b/control_plane/contracts/runner_lane_registration.py
@@ -147,9 +147,11 @@ class RunnerLaneRegistrationPlan(BaseModel):
         self.lane_name = _required_text(
             self.lane_name, "runner lane registration plan requires lane_name"
         )
-        self.registration_root = _required_text(
-            self.registration_root,
-            "runner lane registration plan requires registration_root",
+        self.registration_root = _normalized_path(
+            _required_text(
+                self.registration_root,
+                "runner lane registration plan requires registration_root",
+            )
         )
         self.labels = _normalized_labels(self.labels)
         self.active_run_ids = tuple(sorted(set(self.active_run_ids)))
@@ -194,6 +196,10 @@ class RunnerLaneRegistrationAuditRecord(BaseModel):
             raise ValueError("runner lane registration audit request must match plan operation")
         if self.request.lane_name != self.plan.lane_name:
             raise ValueError("runner lane registration audit request must match plan lane")
+        if self.request.registration_root != self.plan.registration_root:
+            raise ValueError(
+                "runner lane registration audit request must match plan registration_root"
+            )
         if self.pre_inventory.repository != self.request.repository:
             raise ValueError("runner lane registration pre-inventory must match request repository")
         if (
@@ -527,9 +533,9 @@ def _normalized_path(value: str) -> str:
         raise ValueError(
             "runner lane registration paths must not contain parent-directory components"
         )
-    normalized = normalized.rstrip("/")
     if not normalized.startswith("/"):
         raise ValueError("runner lane registration paths must be absolute")
+    normalized = normalized.rstrip("/")
     segments: list[str] = []
     for segment in normalized.split("/"):
         if segment in {"", "."}:

--- a/control_plane/contracts/runner_lane_registration.py
+++ b/control_plane/contracts/runner_lane_registration.py
@@ -522,18 +522,21 @@ def _normalized_tokens(values: tuple[str, ...]) -> tuple[str, ...]:
 
 
 def _normalized_path(value: str) -> str:
-    normalized = value.strip().rstrip("/")
+    normalized = value.strip()
+    if ".." in normalized.split("/"):
+        raise ValueError(
+            "runner lane registration paths must not contain parent-directory components"
+        )
+    normalized = normalized.rstrip("/")
     if not normalized.startswith("/"):
         raise ValueError("runner lane registration paths must be absolute")
     segments: list[str] = []
     for segment in normalized.split("/"):
         if segment in {"", "."}:
             continue
-        if segment == "..":
-            if segments:
-                segments.pop()
-            continue
         segments.append(segment)
+    if not segments:
+        raise ValueError("runner lane registration paths must be scoped absolute paths")
     return "/" + "/".join(segments)
 
 

--- a/control_plane/workflows/runner_lane_registration_executor.py
+++ b/control_plane/workflows/runner_lane_registration_executor.py
@@ -451,18 +451,24 @@ def _redacted_command_output(value: str) -> str:
 
 
 def _normalized_path(value: str) -> str:
-    normalized = value.strip().rstrip("/")
+    normalized = value.strip()
+    if ".." in normalized.split("/"):
+        raise ValueError(
+            "runner lane registration executor registration_root must not contain "
+            "parent-directory components"
+        )
+    normalized = normalized.rstrip("/")
     if not normalized.startswith("/"):
         raise ValueError("runner lane registration executor requires absolute registration_root")
     segments: list[str] = []
     for segment in normalized.split("/"):
         if segment in {"", "."}:
             continue
-        if segment == "..":
-            if segments:
-                segments.pop()
-            continue
         segments.append(segment)
+    if not segments:
+        raise ValueError(
+            "runner lane registration executor requires scoped absolute registration_root"
+        )
     return "/" + "/".join(segments)
 
 

--- a/control_plane/workflows/runner_lane_registration_executor.py
+++ b/control_plane/workflows/runner_lane_registration_executor.py
@@ -457,9 +457,9 @@ def _normalized_path(value: str) -> str:
             "runner lane registration executor registration_root must not contain "
             "parent-directory components"
         )
-    normalized = normalized.rstrip("/")
     if not normalized.startswith("/"):
         raise ValueError("runner lane registration executor requires absolute registration_root")
+    normalized = normalized.rstrip("/")
     segments: list[str] = []
     for segment in normalized.split("/"):
         if segment in {"", "."}:

--- a/control_plane/workflows/runner_lane_retirement_executor.py
+++ b/control_plane/workflows/runner_lane_retirement_executor.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from collections.abc import Callable, Mapping, Sequence
 import os
-import posixpath
 import pwd
 import re
 from time import sleep
@@ -514,10 +513,19 @@ def _redacted_command_output(value: str) -> str:
 
 
 def _normalized_path(value: str) -> str:
-    normalized = posixpath.normpath(value.strip())
-    if not normalized.startswith("/") or normalized == "/":
+    normalized = value.strip()
+    if ".." in normalized.split("/"):
+        raise ValueError(
+            "runner lane retirement executor registration_root must not contain "
+            "parent-directory components"
+        )
+    normalized = normalized.rstrip("/")
+    if not normalized.startswith("/"):
         raise ValueError("runner lane retirement executor requires scoped absolute root")
-    return normalized
+    segments = [segment for segment in normalized.split("/") if segment not in {"", "."}]
+    if not segments:
+        raise ValueError("runner lane retirement executor requires scoped absolute root")
+    return "/" + "/".join(segments)
 
 
 def _required_text(value: str, message: str) -> str:

--- a/docs/runner-host-hygiene.md
+++ b/docs/runner-host-hygiene.md
@@ -529,9 +529,14 @@ the approved root and starts only the matching
 `launchplane-runner@<lane>.service`. Retirement requires an exact idle managed
 lane, stops and disables that exact root-authorized service, rechecks repository
 activity and GitHub identity, deletes only that runner registration, and removes
-the verified inactive directory. The shared lock prevents runner lifecycle and
-Docker hygiene mutations from interleaving. Existing-lane adoption,
-remove/recreate, generic restarts, and scaling remain outside this slice.
+the verified inactive directory. All lifecycle roots must be scoped absolute
+paths rather than bare `/` and reject explicit parent-directory (`..`)
+components. Benign `.` components, duplicate separators, and trailing separators
+remain supported when the normalized path stays scoped. Malformed roots fail
+model validation before a planned audit is written. The shared lock prevents
+runner lifecycle and Docker hygiene mutations from interleaving. Existing-lane
+adoption, remove/recreate, generic restarts, and scaling remain outside this
+slice.
 
 ## Host Replacement Runbook
 

--- a/tests/test_runner_lane_registration.py
+++ b/tests/test_runner_lane_registration.py
@@ -120,6 +120,37 @@ class RunnerLaneRegistrationPlanTests(unittest.TestCase):
                 audit_record_key="runner-lane-registration/2026-06-08/cm-website/test",
             )
 
+    def test_policy_rejects_parent_directory_components(self) -> None:
+        for root in ("/opt/actions-runners/..", "/opt/.."):
+            with self.subTest(root=root):
+                with self.assertRaisesRegex(ValueError, "parent-directory components"):
+                    RunnerLaneRegistrationPolicy(allowed_registration_roots=(root,))
+
+    def test_request_rejects_parent_directory_components(self) -> None:
+        with self.assertRaisesRegex(ValueError, "parent-directory components"):
+            _request(registration_root="/opt/actions-runners/../tmp", mutate=True)
+
+    def test_contract_roots_require_absolute_paths(self) -> None:
+        with self.assertRaisesRegex(ValueError, "paths must be absolute"):
+            RunnerLaneRegistrationPolicy(allowed_registration_roots=("opt/actions-runners",))
+        with self.assertRaisesRegex(ValueError, "paths must be absolute"):
+            _request(registration_root="opt/actions-runners", mutate=True)
+
+    def test_contract_roots_reject_root_equivalent_normalization(self) -> None:
+        with self.assertRaisesRegex(ValueError, "scoped absolute paths"):
+            RunnerLaneRegistrationPolicy(allowed_registration_roots=("/.",))
+        with self.assertRaisesRegex(ValueError, "scoped absolute paths"):
+            _request(registration_root="/.", mutate=True)
+
+    def test_contract_roots_preserve_benign_normalization(self) -> None:
+        policy = RunnerLaneRegistrationPolicy(
+            allowed_registration_roots=("/opt//actions-runners/./",)
+        )
+        request = _request(registration_root="/opt//actions-runners/./", mutate=True)
+
+        self.assertEqual(policy.allowed_registration_roots, ("/opt/actions-runners",))
+        self.assertEqual(request.registration_root, "/opt/actions-runners")
+
     def test_plan_blocks_without_mutate_and_without_allowed_repo(self) -> None:
         plan = plan_runner_lane_registration(
             policy=RunnerLaneRegistrationPolicy(
@@ -136,10 +167,10 @@ class RunnerLaneRegistrationPlanTests(unittest.TestCase):
             ["mutate_not_requested", "repository_not_allowed"],
         )
 
-    def test_plan_blocks_path_traversal_outside_allowed_root(self) -> None:
+    def test_plan_blocks_canonical_path_outside_allowed_root(self) -> None:
         plan = plan_runner_lane_registration(
             policy=_policy(),
-            request=_request(registration_root="/opt/actions-runners/../tmp", mutate=True),
+            request=_request(registration_root="/srv/actions-runners", mutate=True),
             inventory=_inventory(lanes=()),
         )
 
@@ -196,6 +227,32 @@ class RunnerLaneRegistrationExecutorTests(unittest.TestCase):
     def test_executor_request_rejects_unsafe_execution_lane(self) -> None:
         with self.assertRaisesRegex(ValueError, "execution_lane must use"):
             _executor_request(mutate=True, execution_lane="ops-gate;touch bad")
+
+    def test_executor_request_rejects_parent_directory_components(self) -> None:
+        with self.assertRaisesRegex(ValueError, "parent-directory components"):
+            _executor_request(
+                mutate=True,
+                registration_root="/home/launchplane-runner-hygiene/actions-runners/../tmp",
+            )
+
+    def test_executor_request_requires_absolute_registration_root(self) -> None:
+        with self.assertRaisesRegex(ValueError, "requires absolute registration_root"):
+            _executor_request(mutate=True, registration_root="opt/actions-runners")
+
+    def test_executor_request_rejects_root_equivalent_normalization(self) -> None:
+        with self.assertRaisesRegex(ValueError, "scoped absolute registration_root"):
+            _executor_request(mutate=True, registration_root="/.")
+
+    def test_executor_request_preserves_benign_root_normalization(self) -> None:
+        request = _executor_request(
+            mutate=True,
+            registration_root="/home//launchplane-runner-hygiene/./actions-runners/",
+        )
+
+        self.assertEqual(
+            request.registration_root,
+            "/home/launchplane-runner-hygiene/actions-runners",
+        )
 
     def test_blocked_plan_posts_planned_audit_without_token_or_command(self) -> None:
         token_fetcher = _TokenFetcher()
@@ -646,6 +703,7 @@ def _executor_request(
     *,
     mutate: bool,
     execution_lane: str = "chris-testing-ops-gate",
+    registration_root: str = "/home/launchplane-runner-hygiene/actions-runners",
     runner_package_url: str = (
         "https://github.com/actions/runner/releases/download/"
         "v2.327.1/actions-runner-linux-x64-2.327.1.tar.gz"
@@ -658,7 +716,7 @@ def _executor_request(
         execution_lane=execution_lane,
         service_user="launchplane-runner-hygiene",
         lane_name="cm-website-runner-1",
-        registration_root="/home/launchplane-runner-hygiene/actions-runners",
+        registration_root=registration_root,
         runner_package_url=runner_package_url,
         labels=("self-hosted", "launchplane", "launchplane-managed"),
         mutate=mutate,

--- a/tests/test_runner_lane_registration.py
+++ b/tests/test_runner_lane_registration.py
@@ -18,6 +18,8 @@ from control_plane.cli import main
 from control_plane.contracts.runner_lane_inventory import RunnerLaneInventory
 from control_plane.contracts.runner_lane_inventory import RunnerLaneRecord
 from control_plane.contracts.runner_lane_inventory import build_runner_lane_inventory
+from control_plane.contracts.runner_lane_registration import RunnerLaneRegistrationAuditRecord
+from control_plane.contracts.runner_lane_registration import RunnerLaneRegistrationPlan
 from control_plane.contracts.runner_lane_registration import RunnerLaneRegistrationPolicy
 from control_plane.contracts.runner_lane_registration import RunnerLaneRegistrationRequest
 from control_plane.contracts.runner_lane_registration import RunnerLaneRegistrationTokenRecord
@@ -137,10 +139,12 @@ class RunnerLaneRegistrationPlanTests(unittest.TestCase):
             _request(registration_root="opt/actions-runners", mutate=True)
 
     def test_contract_roots_reject_root_equivalent_normalization(self) -> None:
-        with self.assertRaisesRegex(ValueError, "scoped absolute paths"):
-            RunnerLaneRegistrationPolicy(allowed_registration_roots=("/.",))
-        with self.assertRaisesRegex(ValueError, "scoped absolute paths"):
-            _request(registration_root="/.", mutate=True)
+        for root in ("/.", "/"):
+            with self.subTest(root=root):
+                with self.assertRaisesRegex(ValueError, "scoped absolute paths"):
+                    RunnerLaneRegistrationPolicy(allowed_registration_roots=(root,))
+                with self.assertRaisesRegex(ValueError, "scoped absolute paths"):
+                    _request(registration_root=root, mutate=True)
 
     def test_contract_roots_preserve_benign_normalization(self) -> None:
         policy = RunnerLaneRegistrationPolicy(
@@ -179,6 +183,51 @@ class RunnerLaneRegistrationPlanTests(unittest.TestCase):
             [blocker.code for blocker in plan.blockers],
             ["registration_root_not_allowed"],
         )
+
+    def test_plan_blocks_sibling_prefix_outside_allowed_root(self) -> None:
+        plan = plan_runner_lane_registration(
+            policy=_policy(),
+            request=_request(registration_root="/opt/actions-runners-evil", mutate=True),
+            inventory=_inventory(lanes=()),
+        )
+
+        self.assertEqual(plan.status, "blocked")
+        self.assertEqual(
+            [blocker.code for blocker in plan.blockers],
+            ["registration_root_not_allowed"],
+        )
+
+    def test_plan_rejects_parent_directory_components(self) -> None:
+        plan = plan_runner_lane_registration(
+            policy=_policy(),
+            request=_request(mutate=True),
+            inventory=_inventory(lanes=()),
+        )
+        payload = plan.model_dump(mode="json")
+        payload["registration_root"] = "/opt/actions-runners/../../etc"
+
+        with self.assertRaisesRegex(ValueError, "parent-directory components"):
+            RunnerLaneRegistrationPlan.model_validate(payload)
+
+    def test_audit_rejects_plan_registration_root_mismatch(self) -> None:
+        request = _request(mutate=True)
+        plan = plan_runner_lane_registration(
+            policy=_policy(),
+            request=request,
+            inventory=_inventory(lanes=()),
+        )
+        plan_payload = plan.model_dump(mode="json")
+        plan_payload["registration_root"] = "/opt/other-actions-runners"
+
+        with self.assertRaisesRegex(ValueError, "must match plan registration_root"):
+            RunnerLaneRegistrationAuditRecord(
+                audit_record_key=request.audit_record_key,
+                status="planned",
+                request=request,
+                plan=RunnerLaneRegistrationPlan.model_validate(plan_payload),
+                pre_inventory=_inventory(lanes=()),
+                message="registration planned",
+            )
 
     def test_plan_is_ready_for_empty_inventory_and_required_labels(self) -> None:
         plan = plan_runner_lane_registration(
@@ -240,8 +289,10 @@ class RunnerLaneRegistrationExecutorTests(unittest.TestCase):
             _executor_request(mutate=True, registration_root="opt/actions-runners")
 
     def test_executor_request_rejects_root_equivalent_normalization(self) -> None:
-        with self.assertRaisesRegex(ValueError, "scoped absolute registration_root"):
-            _executor_request(mutate=True, registration_root="/.")
+        for root in ("/.", "/"):
+            with self.subTest(root=root):
+                with self.assertRaisesRegex(ValueError, "scoped absolute registration_root"):
+                    _executor_request(mutate=True, registration_root=root)
 
     def test_executor_request_preserves_benign_root_normalization(self) -> None:
         request = _executor_request(

--- a/tests/test_runner_lane_retirement.py
+++ b/tests/test_runner_lane_retirement.py
@@ -161,6 +161,22 @@ class RunnerLaneRetirementPlanTests(unittest.TestCase):
         self.assertEqual([blocker.code for blocker in missing.blockers], ["lane_missing"])
         self.assertEqual([blocker.code for blocker in ambiguous.blockers], ["lane_ambiguous"])
 
+    def test_plan_blocks_canonical_path_outside_allowed_root(self) -> None:
+        plan = plan_runner_lane_retirement(
+            policy=_policy(),
+            request=_retirement_request(
+                mutate=True,
+                registration_root="/srv/actions-runners",
+            ),
+            inventory=_inventory(lanes=(_lane(),)),
+        )
+
+        self.assertEqual(plan.status, "blocked")
+        self.assertEqual(
+            [blocker.code for blocker in plan.blockers],
+            ["registration_root_not_allowed"],
+        )
+
 
 class GitHubRunnerLaneRetirementTests(unittest.TestCase):
     def test_retirer_deletes_exact_runner_and_treats_not_found_as_complete(self) -> None:
@@ -195,6 +211,30 @@ class GitHubRunnerLaneRetirementTests(unittest.TestCase):
 
 
 class RunnerLaneRetirementExecutorTests(unittest.TestCase):
+    def test_executor_request_rejects_parent_directory_components(self) -> None:
+        with self.assertRaisesRegex(ValueError, "parent-directory components"):
+            _executor_request(
+                mutate=True,
+                registration_root="/home/launchplane-runner-hygiene/actions-runners/../tmp",
+            )
+
+    def test_executor_request_rejects_unscoped_roots(self) -> None:
+        for root in ("/", "/.", "home/launchplane-runner-hygiene/actions-runners"):
+            with self.subTest(root=root):
+                with self.assertRaisesRegex(ValueError, "requires scoped absolute root"):
+                    _executor_request(mutate=True, registration_root=root)
+
+    def test_executor_request_preserves_benign_root_normalization(self) -> None:
+        request = _executor_request(
+            mutate=True,
+            registration_root="//home//launchplane-runner-hygiene/./actions-runners/",
+        )
+
+        self.assertEqual(
+            request.registration_root,
+            "/home/launchplane-runner-hygiene/actions-runners",
+        )
+
     def test_executor_rechecks_live_state_before_delete_and_removes_root(self) -> None:
         events: list[str] = []
         command_runner = _CommandRunner(
@@ -464,13 +504,14 @@ def _retirement_request(
     mutate: bool,
     active_run_ids: tuple[int, ...] = (),
     target_worker_active: bool = False,
+    registration_root: str = "/home/launchplane-runner-hygiene/actions-runners",
 ) -> RunnerLaneRegistrationRequest:
     return RunnerLaneRegistrationRequest(
         operation="retire",
         repository="cbusillo/code",
         host_name="chris-testing",
         lane_name="code-ci-1",
-        registration_root="/home/launchplane-runner-hygiene/actions-runners",
+        registration_root=registration_root,
         labels=(),
         active_run_ids=active_run_ids,
         target_worker_active=target_worker_active,
@@ -479,14 +520,18 @@ def _retirement_request(
     )
 
 
-def _executor_request(*, mutate: bool) -> RunnerLaneRetirementExecutorRequest:
+def _executor_request(
+    *,
+    mutate: bool,
+    registration_root: str = "/home/launchplane-runner-hygiene/actions-runners",
+) -> RunnerLaneRetirementExecutorRequest:
     return RunnerLaneRetirementExecutorRequest(
         repository="cbusillo/code",
         host_name="chris-testing",
         execution_lane="chris-testing-ops-gate",
         service_user="launchplane-runner-hygiene",
         lane_name="code-ci-1",
-        registration_root="/home/launchplane-runner-hygiene/actions-runners",
+        registration_root=registration_root,
         mutate=mutate,
         audit_record_key="runner-lane-retirement/2026-07-26/code-ci-1",
     )


### PR DESCRIPTION
## Summary
- reject explicit parent-directory (`..`) components during policy, registration request, registration executor, and retirement executor model validation
- preserve scoped absolute-path validation plus benign `.`, duplicate-separator, and trailing-separator normalization
- retain separate canonical outside-root blocker coverage, document pre-audit rejection, and cover root-equivalent and retirement bare-`/` rejection

## Validation
- `uv run --extra dev python -m unittest tests.test_runner_lane_registration tests.test_runner_lane_retirement`
- `uv run --extra dev ruff check --diff control_plane/contracts/runner_lane_registration.py control_plane/workflows/runner_lane_registration_executor.py control_plane/workflows/runner_lane_retirement_executor.py tests/test_runner_lane_registration.py tests/test_runner_lane_retirement.py`
- `uv run --extra dev ruff check control_plane/contracts/runner_lane_registration.py control_plane/workflows/runner_lane_registration_executor.py control_plane/workflows/runner_lane_retirement_executor.py tests/test_runner_lane_registration.py tests/test_runner_lane_retirement.py`
- `uv run --extra dev ruff format --check control_plane/contracts/runner_lane_registration.py control_plane/workflows/runner_lane_registration_executor.py control_plane/workflows/runner_lane_retirement_executor.py tests/test_runner_lane_registration.py tests/test_runner_lane_retirement.py`
- `uv run --extra dev mypy control_plane tests`
- `uv run --extra dev launchplane ci unittest-shard local`
- `git diff --check`
- two independent exact-head reviews reported no actionable findings for `5898f87f`

## Inspection
- changed-file JetBrains inspection attempted through the configured helper; result was `UNKNOWN` because PyCharm timed out opening the exact isolated worktree (`project_open_blocked`), with no tracked-file mutation

Self-hosted checks may remain queued while the nine Launchplane runners are offline.

Refs #2281