### PR TITLE
Add inert administrator enrollment records

### DIFF
--- a/control_plane/contracts/administrator_enrollment.py
+++ b/control_plane/contracts/administrator_enrollment.py
@@ -1,0 +1,417 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+import hashlib
+import hmac
+import re
+from typing import Final, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from control_plane.contracts.authz_policy_record import build_authz_policy_record_id
+
+
+ADMINISTRATOR_ENROLLMENT_SCHEMA_VERSION: Final[Literal[1]] = 1
+ADMINISTRATOR_ENROLLMENT_CHALLENGE_SECONDS: Final = 30 * 60
+ADMINISTRATOR_ENROLLMENT_AUTHORITY_STATE: Final[Literal["inert"]] = "inert"
+ADMINISTRATOR_ENROLLMENT_POLICY_BRIDGE_NOT_APPLIED: Final[Literal["not_applied"]] = "not_applied"
+ADMINISTRATOR_ENROLLMENT_POLICY_BRIDGE_APPLIED: Final[Literal["applied"]] = "applied"
+
+AdministratorEnrollmentState = Literal[
+    "issued",
+    "control_proven",
+    "withdrawn",
+    "expired",
+    "enrolled",
+]
+AdministratorEnrollmentPolicyBridgeState = Literal["not_applied", "applied"]
+_SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+_ENROLLMENT_ID_PATTERN = re.compile(r"^administrator-enrollment-[a-z0-9][a-z0-9_-]{7,127}$")
+
+
+class AdministratorEnrollmentConflictError(ValueError):
+    """Raised when an inert enrollment lifecycle transition is not allowed."""
+
+
+def _timestamp(value: str, field_name: str) -> datetime:
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError as error:
+        raise ValueError(f"{field_name} must be ISO-8601") from error
+    if parsed.tzinfo is None:
+        raise ValueError(f"{field_name} must include a timezone")
+    normalized = parsed.astimezone(UTC)
+    if normalized.microsecond:
+        raise ValueError(f"{field_name} must use whole-second precision")
+    return normalized
+
+
+def _sha256(value: str, field_name: str) -> str:
+    if _SHA256_PATTERN.fullmatch(value) is None:
+        raise ValueError(f"{field_name} must be a lowercase SHA-256 digest")
+    return value
+
+
+def administrator_enrollment_challenge_sha256(challenge: str) -> str:
+    """Digest a transient opaque challenge without retaining its plaintext."""
+
+    if not challenge:
+        raise ValueError("administrator enrollment challenge must not be empty")
+    return hashlib.sha256(challenge.encode("utf-8")).hexdigest()
+
+
+class AdministratorEnrollmentRecord(BaseModel):
+    """Inert evidence for a separately gated policy-administrator enrollment."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    schema_version: Literal[1] = ADMINISTRATOR_ENROLLMENT_SCHEMA_VERSION
+    enrollment_id: str
+    state: AdministratorEnrollmentState = "issued"
+    proposer_github_id: int = Field(gt=0)
+    candidate_github_id: int | None = Field(default=None, gt=0)
+    challenge_sha256: str
+    reason: str = Field(min_length=1, max_length=500)
+    provenance_sha256: str
+    created_at: str
+    expires_at: str
+    control_proven_at: str | None = None
+    withdrawn_at: str | None = None
+    expired_at: str | None = None
+    enrolled_at: str | None = None
+    enrolled_policy_record_id: str | None = Field(default=None, min_length=1, max_length=255)
+    enrolled_policy_revision: int | None = Field(default=None, gt=0)
+    enrolled_policy_sha256: str | None = None
+    reviewed_plan_sha256: str | None = None
+    bridge_idempotency_key_sha256: str | None = None
+    authority_state: Literal["inert"] = ADMINISTRATOR_ENROLLMENT_AUTHORITY_STATE
+    authorizes_policy: Literal[False] = False
+    policy_bridge_state: AdministratorEnrollmentPolicyBridgeState = (
+        ADMINISTRATOR_ENROLLMENT_POLICY_BRIDGE_NOT_APPLIED
+    )
+
+    @field_validator("reason")
+    @classmethod
+    def _normalize_reason(cls, value: str) -> str:
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("administrator enrollment reason must not be empty")
+        return normalized
+
+    @field_validator("enrolled_policy_record_id")
+    @classmethod
+    def _normalize_policy_record_id(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("enrolled_policy_record_id must not be empty")
+        return normalized
+
+    @field_validator(
+        "created_at",
+        "expires_at",
+        "control_proven_at",
+        "withdrawn_at",
+        "expired_at",
+        "enrolled_at",
+    )
+    @classmethod
+    def _normalize_timestamp(cls, value: str | None, info: object) -> str | None:
+        if value is None:
+            return None
+        field_name = str(getattr(info, "field_name", "timestamp"))
+        return _timestamp(value, field_name).isoformat()
+
+    @field_validator(
+        "challenge_sha256",
+        "provenance_sha256",
+        "enrolled_policy_sha256",
+        "reviewed_plan_sha256",
+        "bridge_idempotency_key_sha256",
+    )
+    @classmethod
+    def _validate_sha256(cls, value: str | None, info: object) -> str | None:
+        if value is None:
+            return None
+        field_name = getattr(info, "field_name", "sha256")
+        return _sha256(value, str(field_name))
+
+    @model_validator(mode="after")
+    def _validate_lifecycle(self) -> "AdministratorEnrollmentRecord":
+        if _ENROLLMENT_ID_PATTERN.fullmatch(self.enrollment_id) is None:
+            raise ValueError("enrollment_id must use the administrator-enrollment identifier form")
+        created_at = _timestamp(self.created_at, "created_at")
+        expires_at = _timestamp(self.expires_at, "expires_at")
+        if expires_at - created_at != timedelta(seconds=ADMINISTRATOR_ENROLLMENT_CHALLENGE_SECONDS):
+            raise ValueError(
+                "administrator enrollment challenge must expire exactly 30 minutes after creation"
+            )
+        control_proven_at = (
+            _timestamp(self.control_proven_at, "control_proven_at")
+            if self.control_proven_at is not None
+            else None
+        )
+        withdrawn_at = (
+            _timestamp(self.withdrawn_at, "withdrawn_at") if self.withdrawn_at is not None else None
+        )
+        expired_at = (
+            _timestamp(self.expired_at, "expired_at") if self.expired_at is not None else None
+        )
+        enrolled_at = (
+            _timestamp(self.enrolled_at, "enrolled_at") if self.enrolled_at is not None else None
+        )
+        if (self.candidate_github_id is None) != (control_proven_at is None):
+            raise ValueError(
+                "candidate_github_id and control_proven_at must be present or absent together"
+            )
+        if self.candidate_github_id == self.proposer_github_id:
+            raise ValueError("candidate_github_id must differ from proposer_github_id")
+        if control_proven_at is not None and not (created_at <= control_proven_at < expires_at):
+            raise ValueError("control_proven_at must be within the enrollment challenge window")
+        policy_evidence = (
+            self.enrolled_policy_record_id,
+            self.enrolled_policy_revision,
+            self.enrolled_policy_sha256,
+            self.reviewed_plan_sha256,
+            self.bridge_idempotency_key_sha256,
+        )
+        has_policy_evidence = all(value is not None for value in policy_evidence)
+        has_partial_policy_evidence = any(value is not None for value in policy_evidence)
+        if has_partial_policy_evidence and not has_policy_evidence:
+            raise ValueError("administrator enrollment policy evidence must be complete")
+        if has_policy_evidence:
+            assert self.enrolled_policy_revision is not None
+            assert self.enrolled_policy_sha256 is not None
+            if self.enrolled_policy_record_id != build_authz_policy_record_id(
+                revision=self.enrolled_policy_revision,
+                policy_sha256=self.enrolled_policy_sha256,
+            ):
+                raise ValueError(
+                    "enrolled policy record ID must match its revision and policy digest"
+                )
+        if self.state == "issued":
+            if any(
+                value is not None
+                for value in (
+                    self.candidate_github_id,
+                    self.control_proven_at,
+                    self.withdrawn_at,
+                    self.expired_at,
+                    self.enrolled_at,
+                    *policy_evidence,
+                )
+            ):
+                raise ValueError("issued enrollment must contain only issuance evidence")
+        elif self.state == "control_proven":
+            if control_proven_at is None or any(
+                value is not None
+                for value in (
+                    self.withdrawn_at,
+                    self.expired_at,
+                    self.enrolled_at,
+                    *policy_evidence,
+                )
+            ):
+                raise ValueError(
+                    "control-proven enrollment requires only candidate control evidence"
+                )
+        elif self.state == "withdrawn":
+            if withdrawn_at is None or any(
+                value is not None for value in (self.expired_at, self.enrolled_at, *policy_evidence)
+            ):
+                raise ValueError("withdrawn enrollment requires only withdrawal evidence")
+            minimum_withdrawal_time = control_proven_at or created_at
+            if not (minimum_withdrawal_time <= withdrawn_at < expires_at):
+                raise ValueError("withdrawn_at must be within the active enrollment window")
+        elif self.state == "expired":
+            if expired_at is None or any(
+                value is not None
+                for value in (self.withdrawn_at, self.enrolled_at, *policy_evidence)
+            ):
+                raise ValueError("expired enrollment requires only expiry evidence")
+            if expired_at < expires_at:
+                raise ValueError("expired_at must not precede expires_at")
+        else:
+            if control_proven_at is None or enrolled_at is None or not has_policy_evidence:
+                raise ValueError(
+                    "enrolled enrollment requires control proof and complete policy read-back evidence"
+                )
+            if self.withdrawn_at is not None or self.expired_at is not None:
+                raise ValueError(
+                    "enrolled enrollment must not contain withdrawal or expiry evidence"
+                )
+            if not (control_proven_at <= enrolled_at < expires_at):
+                raise ValueError("enrolled_at must be within the proven-control window")
+        expected_bridge_state = (
+            ADMINISTRATOR_ENROLLMENT_POLICY_BRIDGE_APPLIED
+            if self.state == "enrolled"
+            else ADMINISTRATOR_ENROLLMENT_POLICY_BRIDGE_NOT_APPLIED
+        )
+        if self.policy_bridge_state != expected_bridge_state:
+            raise ValueError("policy_bridge_state must match administrator enrollment lifecycle")
+        return self
+
+
+def _validated_update(
+    record: AdministratorEnrollmentRecord, **updates: object
+) -> AdministratorEnrollmentRecord:
+    return AdministratorEnrollmentRecord.model_validate(record.model_dump() | updates)
+
+
+def prove_administrator_enrollment_control(
+    record: AdministratorEnrollmentRecord,
+    *,
+    challenge: str,
+    server_derived_candidate_github_id: int,
+    control_proven_at: str,
+) -> AdministratorEnrollmentRecord:
+    challenge_matches = hmac.compare_digest(
+        record.challenge_sha256, administrator_enrollment_challenge_sha256(challenge)
+    )
+    if not challenge_matches:
+        raise AdministratorEnrollmentConflictError(
+            "administrator enrollment challenge does not match"
+        )
+    timestamp = _timestamp(control_proven_at, "control_proven_at")
+    created_at = _timestamp(record.created_at, "created_at")
+    expires_at = _timestamp(record.expires_at, "expires_at")
+    if not (created_at <= timestamp < expires_at):
+        raise AdministratorEnrollmentConflictError(
+            "administrator enrollment challenge is outside its active window"
+        )
+    if record.state == "control_proven":
+        if (
+            record.candidate_github_id == server_derived_candidate_github_id
+            and record.control_proven_at == timestamp.isoformat()
+        ):
+            return record
+        raise AdministratorEnrollmentConflictError(
+            "administrator enrollment control proof conflicts with persisted evidence"
+        )
+    if record.state != "issued":
+        raise AdministratorEnrollmentConflictError(
+            "administrator enrollment is no longer claimable"
+        )
+    if server_derived_candidate_github_id == record.proposer_github_id:
+        raise AdministratorEnrollmentConflictError(
+            "administrator enrollment candidate must differ from proposer"
+        )
+    return _validated_update(
+        record,
+        state="control_proven",
+        candidate_github_id=server_derived_candidate_github_id,
+        control_proven_at=timestamp.isoformat(),
+    )
+
+
+def expire_administrator_enrollment(
+    record: AdministratorEnrollmentRecord, *, expired_at: str
+) -> AdministratorEnrollmentRecord:
+    timestamp = _timestamp(expired_at, "expired_at")
+    if record.state == "expired":
+        if record.expired_at == timestamp.isoformat():
+            return record
+        raise AdministratorEnrollmentConflictError(
+            "administrator enrollment expiry conflicts with persisted evidence"
+        )
+    if record.state not in {"issued", "control_proven"} or timestamp < _timestamp(
+        record.expires_at, "expires_at"
+    ):
+        raise AdministratorEnrollmentConflictError(
+            "administrator enrollment is not eligible for expiry"
+        )
+    return _validated_update(record, state="expired", expired_at=timestamp.isoformat())
+
+
+def withdraw_administrator_enrollment(
+    record: AdministratorEnrollmentRecord, *, proposer_github_id: int, withdrawn_at: str
+) -> AdministratorEnrollmentRecord:
+    timestamp = _timestamp(withdrawn_at, "withdrawn_at")
+    if proposer_github_id != record.proposer_github_id:
+        raise AdministratorEnrollmentConflictError(
+            "only the immutable proposer may withdraw enrollment"
+        )
+    if record.state == "withdrawn":
+        if record.withdrawn_at == timestamp.isoformat():
+            return record
+        raise AdministratorEnrollmentConflictError(
+            "administrator enrollment withdrawal conflicts with persisted evidence"
+        )
+    if record.state not in {"issued", "control_proven"}:
+        raise AdministratorEnrollmentConflictError("administrator enrollment is terminal")
+    minimum_withdrawal_time = (
+        _timestamp(record.control_proven_at, "control_proven_at")
+        if record.control_proven_at is not None
+        else _timestamp(record.created_at, "created_at")
+    )
+    if not (minimum_withdrawal_time <= timestamp < _timestamp(record.expires_at, "expires_at")):
+        raise AdministratorEnrollmentConflictError(
+            "administrator enrollment withdrawal is outside its active window"
+        )
+    return _validated_update(record, state="withdrawn", withdrawn_at=timestamp.isoformat())
+
+
+def complete_administrator_enrollment(
+    record: AdministratorEnrollmentRecord,
+    *,
+    server_derived_candidate_github_id: int,
+    enrolled_at: str,
+    enrolled_policy_record_id: str,
+    enrolled_policy_revision: int,
+    enrolled_policy_sha256: str,
+    reviewed_plan_sha256: str,
+    bridge_idempotency_key_sha256: str,
+) -> AdministratorEnrollmentRecord:
+    timestamp = _timestamp(enrolled_at, "enrolled_at")
+    if record.state == "enrolled":
+        requested_evidence = (
+            server_derived_candidate_github_id,
+            timestamp.isoformat(),
+            enrolled_policy_record_id.strip(),
+            enrolled_policy_revision,
+            _sha256(enrolled_policy_sha256, "enrolled_policy_sha256"),
+            _sha256(reviewed_plan_sha256, "reviewed_plan_sha256"),
+            _sha256(bridge_idempotency_key_sha256, "bridge_idempotency_key_sha256"),
+        )
+        persisted_evidence = (
+            record.candidate_github_id,
+            record.enrolled_at,
+            record.enrolled_policy_record_id,
+            record.enrolled_policy_revision,
+            record.enrolled_policy_sha256,
+            record.reviewed_plan_sha256,
+            record.bridge_idempotency_key_sha256,
+        )
+        if requested_evidence == persisted_evidence:
+            return record
+        raise AdministratorEnrollmentConflictError(
+            "administrator enrollment completion conflicts with persisted evidence"
+        )
+    if (
+        record.state != "control_proven"
+        or record.candidate_github_id != server_derived_candidate_github_id
+        or record.control_proven_at is None
+    ):
+        raise AdministratorEnrollmentConflictError(
+            "administrator enrollment completion requires the control-proven candidate"
+        )
+    if not (
+        _timestamp(record.control_proven_at, "control_proven_at")
+        <= timestamp
+        < _timestamp(record.expires_at, "expires_at")
+    ):
+        raise AdministratorEnrollmentConflictError(
+            "administrator enrollment completion is outside its proven-control window"
+        )
+    return _validated_update(
+        record,
+        state="enrolled",
+        enrolled_at=timestamp.isoformat(),
+        enrolled_policy_record_id=enrolled_policy_record_id.strip(),
+        enrolled_policy_revision=enrolled_policy_revision,
+        enrolled_policy_sha256=enrolled_policy_sha256,
+        reviewed_plan_sha256=reviewed_plan_sha256,
+        bridge_idempotency_key_sha256=bridge_idempotency_key_sha256,
+        policy_bridge_state=ADMINISTRATOR_ENROLLMENT_POLICY_BRIDGE_APPLIED,
+    )

--- a/control_plane/storage/filesystem.py
+++ b/control_plane/storage/filesystem.py
@@ -16,6 +16,14 @@ from pydantic import BaseModel
 
 from control_plane.contracts.artifact_identity import ArtifactIdentityManifest
 from control_plane.contracts.agent_write_intent import AgentWriteIntentRecord
+from control_plane.contracts.administrator_enrollment import (
+    AdministratorEnrollmentConflictError,
+    AdministratorEnrollmentRecord,
+    complete_administrator_enrollment,
+    expire_administrator_enrollment,
+    prove_administrator_enrollment_control,
+    withdraw_administrator_enrollment,
+)
 from control_plane.contracts.authz_policy_record import LaunchplaneAuthzPolicyRecord
 from control_plane.contracts.backup_gate_record import BackupGateRecord
 from control_plane.contracts.change_impact import ChangeImpactPolicyRecord
@@ -6703,6 +6711,113 @@ class FilesystemRecordStore:
         if limit is not None:
             records = records[:limit]
         return tuple(records)
+
+    def create_administrator_enrollment_if_absent(
+        self, record: AdministratorEnrollmentRecord
+    ) -> tuple[AdministratorEnrollmentRecord, bool]:
+        record_type = "launchplane_administrator_enrollments"
+        with self._exclusive_record_lock(
+            "launchplane_administrator_enrollment_challenge_digests", "global"
+        ):
+            record_path = self._record_path(record_type, record.enrollment_id)
+            if record_path.exists():
+                existing = self._read_model_locked(
+                    AdministratorEnrollmentRecord, record_type, record.enrollment_id
+                )
+                if existing != record:
+                    raise AdministratorEnrollmentConflictError(
+                        "administrator enrollment creation conflicts with persisted record"
+                    )
+                return existing, False
+            for existing in self._list_models_locked(AdministratorEnrollmentRecord, record_type):
+                if existing.challenge_sha256 == record.challenge_sha256:
+                    raise AdministratorEnrollmentConflictError(
+                        "administrator enrollment challenge digest is already reserved"
+                    )
+            self._write_model_locked(record_type, record.enrollment_id, record)
+            return record, True
+
+    def read_administrator_enrollment(self, enrollment_id: str) -> AdministratorEnrollmentRecord:
+        return self._read_model(
+            AdministratorEnrollmentRecord, "launchplane_administrator_enrollments", enrollment_id
+        )
+
+    def _transition_administrator_enrollment(
+        self,
+        enrollment_id: str,
+        transition: Callable[[AdministratorEnrollmentRecord], AdministratorEnrollmentRecord],
+    ) -> AdministratorEnrollmentRecord:
+        record_type = "launchplane_administrator_enrollments"
+        with self._exclusive_record_lock(record_type, enrollment_id):
+            current = self._read_model_locked(
+                AdministratorEnrollmentRecord, record_type, enrollment_id
+            )
+            updated = transition(current)
+            if updated != current:
+                self._write_model_locked(record_type, enrollment_id, updated)
+            return updated
+
+    def prove_administrator_enrollment_control(
+        self,
+        *,
+        enrollment_id: str,
+        challenge: str,
+        server_derived_candidate_github_id: int,
+        control_proven_at: str,
+    ) -> AdministratorEnrollmentRecord:
+        return self._transition_administrator_enrollment(
+            enrollment_id,
+            lambda record: prove_administrator_enrollment_control(
+                record,
+                challenge=challenge,
+                server_derived_candidate_github_id=server_derived_candidate_github_id,
+                control_proven_at=control_proven_at,
+            ),
+        )
+
+    def expire_administrator_enrollment(
+        self, *, enrollment_id: str, expired_at: str
+    ) -> AdministratorEnrollmentRecord:
+        return self._transition_administrator_enrollment(
+            enrollment_id,
+            lambda record: expire_administrator_enrollment(record, expired_at=expired_at),
+        )
+
+    def withdraw_administrator_enrollment(
+        self, *, enrollment_id: str, proposer_github_id: int, withdrawn_at: str
+    ) -> AdministratorEnrollmentRecord:
+        return self._transition_administrator_enrollment(
+            enrollment_id,
+            lambda record: withdraw_administrator_enrollment(
+                record, proposer_github_id=proposer_github_id, withdrawn_at=withdrawn_at
+            ),
+        )
+
+    def complete_administrator_enrollment(
+        self,
+        *,
+        enrollment_id: str,
+        server_derived_candidate_github_id: int,
+        enrolled_at: str,
+        enrolled_policy_record_id: str,
+        enrolled_policy_revision: int,
+        enrolled_policy_sha256: str,
+        reviewed_plan_sha256: str,
+        bridge_idempotency_key_sha256: str,
+    ) -> AdministratorEnrollmentRecord:
+        return self._transition_administrator_enrollment(
+            enrollment_id,
+            lambda record: complete_administrator_enrollment(
+                record,
+                server_derived_candidate_github_id=server_derived_candidate_github_id,
+                enrolled_at=enrolled_at,
+                enrolled_policy_record_id=enrolled_policy_record_id,
+                enrolled_policy_revision=enrolled_policy_revision,
+                enrolled_policy_sha256=enrolled_policy_sha256,
+                reviewed_plan_sha256=reviewed_plan_sha256,
+                bridge_idempotency_key_sha256=bridge_idempotency_key_sha256,
+            ),
+        )
 
 
 def _odoo_target_replacement_lane_reservation_id(

--- a/control_plane/storage/migrations/versions/c4e6a8b0d2f5_add_administrator_enrollments.py
+++ b/control_plane/storage/migrations/versions/c4e6a8b0d2f5_add_administrator_enrollments.py
@@ -1,0 +1,208 @@
+"""Add inert administrator enrollment records.
+
+Revision ID: c4e6a8b0d2f5
+Revises: a7c9e1f3b5d7
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision: str = "c4e6a8b0d2f5"
+down_revision: str | None = "a7c9e1f3b5d7"
+branch_labels: tuple[str, ...] | None = None
+depends_on: tuple[str, ...] | None = None
+
+
+_TABLE = "launchplane_administrator_enrollments"
+_INDEX = "launchplane_administrator_enrollment_state_expiry_idx"
+
+
+def _table_exists() -> bool:
+    return _TABLE in set(sa.inspect(op.get_bind()).get_table_names())
+
+
+def _index_exists() -> bool:
+    return _table_exists() and _INDEX in {
+        str(name)
+        for index in sa.inspect(op.get_bind()).get_indexes(_TABLE)
+        if (name := index.get("name")) is not None
+    }
+
+
+def _payload_column() -> sa.Column[object]:
+    return sa.Column(
+        "payload",
+        sa.JSON().with_variant(postgresql.JSONB(astext_type=sa.Text()), "postgresql"),
+        nullable=False,
+    )
+
+
+def _table_has_rows() -> bool:
+    if not _table_exists():
+        return False
+    return bool(op.get_bind().scalar(sa.text(f"SELECT EXISTS (SELECT 1 FROM {_TABLE})")))
+
+
+def upgrade() -> None:
+    if not _table_exists():
+        op.create_table(
+            _TABLE,
+            sa.Column("enrollment_id", sa.String(), nullable=False),
+            sa.Column("state", sa.String(), nullable=False),
+            sa.Column("proposer_github_id", sa.BigInteger(), nullable=False),
+            sa.Column("candidate_github_id", sa.BigInteger(), nullable=True),
+            sa.Column("challenge_sha256", sa.String(), nullable=False),
+            sa.Column("reason", sa.String(), nullable=False),
+            sa.Column("provenance_sha256", sa.String(), nullable=False),
+            sa.Column("created_at", sa.String(), nullable=False),
+            sa.Column("expires_at", sa.String(), nullable=False),
+            sa.Column("control_proven_at", sa.String(), nullable=True),
+            sa.Column("withdrawn_at", sa.String(), nullable=True),
+            sa.Column("expired_at", sa.String(), nullable=True),
+            sa.Column("enrolled_at", sa.String(), nullable=True),
+            sa.Column("enrolled_policy_record_id", sa.String(), nullable=True),
+            sa.Column("enrolled_policy_revision", sa.BigInteger(), nullable=True),
+            sa.Column("enrolled_policy_sha256", sa.String(), nullable=True),
+            sa.Column("reviewed_plan_sha256", sa.String(), nullable=True),
+            sa.Column("bridge_idempotency_key_sha256", sa.String(), nullable=True),
+            sa.Column("authority_state", sa.String(), nullable=False, server_default="inert"),
+            sa.Column(
+                "authorizes_policy",
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.false(),
+            ),
+            sa.Column(
+                "policy_bridge_state",
+                sa.String(),
+                nullable=False,
+                server_default="not_applied",
+            ),
+            _payload_column(),
+            sa.CheckConstraint(
+                "state IN ('issued', 'control_proven', 'withdrawn', 'expired', 'enrolled')",
+                name="launchplane_administrator_enrollment_state_ck",
+            ),
+            sa.CheckConstraint(
+                "proposer_github_id > 0 AND "
+                "(candidate_github_id IS NULL OR candidate_github_id > 0)",
+                name="launchplane_administrator_enrollment_github_id_ck",
+            ),
+            sa.CheckConstraint(
+                "expires_at > created_at",
+                name="launchplane_administrator_enrollment_expiry_ck",
+            ),
+            sa.CheckConstraint(
+                "strftime('%s', created_at) IS NOT NULL "
+                "AND strftime('%s', expires_at) IS NOT NULL "
+                "AND CAST(strftime('%s', expires_at) AS INTEGER) "
+                "- CAST(strftime('%s', created_at) AS INTEGER) = 1800",
+                name="lp_admin_enrollment_ttl_sqlite_ck",
+            ).ddl_if(dialect="sqlite"),
+            sa.CheckConstraint(
+                "CAST(expires_at AS timestamptz) - CAST(created_at AS timestamptz) "
+                "= INTERVAL '30 minutes'",
+                name="lp_admin_enrollment_ttl_pg_ck",
+            ).ddl_if(dialect="postgresql"),
+            sa.CheckConstraint(
+                "candidate_github_id IS NULL OR candidate_github_id <> proposer_github_id",
+                name="launchplane_administrator_enrollment_distinct_human_ck",
+            ),
+            sa.CheckConstraint(
+                "authority_state = 'inert' AND authorizes_policy = false",
+                name="launchplane_administrator_enrollment_no_authority_ck",
+            ),
+            sa.CheckConstraint(
+                "policy_bridge_state IN ('not_applied', 'applied')",
+                name="launchplane_administrator_enrollment_bridge_state_ck",
+            ),
+            sa.CheckConstraint(
+                "(candidate_github_id IS NULL AND control_proven_at IS NULL) OR "
+                "(candidate_github_id IS NOT NULL AND control_proven_at IS NOT NULL)",
+                name="launchplane_administrator_enrollment_control_proof_ck",
+            ),
+            sa.CheckConstraint(
+                "control_proven_at IS NULL OR "
+                "(control_proven_at >= created_at AND control_proven_at < expires_at)",
+                name="launchplane_administrator_enrollment_control_time_ck",
+            ),
+            sa.CheckConstraint(
+                "withdrawn_at IS NULL OR "
+                "(withdrawn_at >= COALESCE(control_proven_at, created_at) "
+                "AND withdrawn_at < expires_at)",
+                name="launchplane_administrator_enrollment_withdrawal_time_ck",
+            ),
+            sa.CheckConstraint(
+                "expired_at IS NULL OR expired_at >= expires_at",
+                name="launchplane_administrator_enrollment_expired_time_ck",
+            ),
+            sa.CheckConstraint(
+                "enrolled_at IS NULL OR "
+                "(control_proven_at IS NOT NULL AND enrolled_at >= control_proven_at "
+                "AND enrolled_at < expires_at)",
+                name="launchplane_administrator_enrollment_enrolled_time_ck",
+            ),
+            sa.CheckConstraint(
+                "(enrolled_policy_record_id IS NULL AND enrolled_policy_revision IS NULL "
+                "AND enrolled_policy_sha256 IS NULL AND reviewed_plan_sha256 IS NULL "
+                "AND bridge_idempotency_key_sha256 IS NULL) OR "
+                "(enrolled_policy_record_id IS NOT NULL AND enrolled_policy_record_id <> '' "
+                "AND enrolled_policy_revision > 0 AND enrolled_policy_sha256 IS NOT NULL "
+                "AND reviewed_plan_sha256 IS NOT NULL "
+                "AND bridge_idempotency_key_sha256 IS NOT NULL)",
+                name="launchplane_administrator_enrollment_policy_evidence_ck",
+            ),
+            sa.CheckConstraint(
+                "state <> 'enrolled' OR enrolled_policy_record_id = "
+                "'launchplane-authz-policy-r' || printf('%020d', enrolled_policy_revision) "
+                "|| '-' || substr(enrolled_policy_sha256, 1, 12)",
+                name="lp_admin_enrollment_policy_record_sqlite_ck",
+            ).ddl_if(dialect="sqlite"),
+            sa.CheckConstraint(
+                "state <> 'enrolled' OR enrolled_policy_record_id = "
+                "'launchplane-authz-policy-r' "
+                "|| lpad(CAST(enrolled_policy_revision AS text), 20, '0') "
+                "|| '-' || substr(enrolled_policy_sha256, 1, 12)",
+                name="lp_admin_enrollment_policy_record_pg_ck",
+            ).ddl_if(dialect="postgresql"),
+            sa.CheckConstraint(
+                "(state = 'issued' AND candidate_github_id IS NULL AND control_proven_at IS NULL "
+                "AND withdrawn_at IS NULL AND expired_at IS NULL AND enrolled_at IS NULL "
+                "AND enrolled_policy_record_id IS NULL AND policy_bridge_state = 'not_applied') OR "
+                "(state = 'control_proven' AND candidate_github_id IS NOT NULL "
+                "AND control_proven_at IS NOT NULL AND withdrawn_at IS NULL "
+                "AND expired_at IS NULL AND enrolled_at IS NULL "
+                "AND enrolled_policy_record_id IS NULL AND policy_bridge_state = 'not_applied') OR "
+                "(state = 'withdrawn' AND withdrawn_at IS NOT NULL AND expired_at IS NULL "
+                "AND enrolled_at IS NULL AND enrolled_policy_record_id IS NULL "
+                "AND policy_bridge_state = 'not_applied') OR "
+                "(state = 'expired' AND expired_at IS NOT NULL AND withdrawn_at IS NULL "
+                "AND enrolled_at IS NULL AND enrolled_policy_record_id IS NULL "
+                "AND policy_bridge_state = 'not_applied') OR "
+                "(state = 'enrolled' AND candidate_github_id IS NOT NULL "
+                "AND control_proven_at IS NOT NULL AND enrolled_at IS NOT NULL "
+                "AND withdrawn_at IS NULL AND expired_at IS NULL "
+                "AND enrolled_policy_record_id IS NOT NULL AND policy_bridge_state = 'applied')",
+                name="launchplane_administrator_enrollment_terminal_ck",
+            ),
+            sa.PrimaryKeyConstraint("enrollment_id"),
+            sa.UniqueConstraint(
+                "challenge_sha256",
+                name="launchplane_administrator_enrollment_challenge_uq",
+            ),
+        )
+    if not _index_exists():
+        op.create_index(_INDEX, _TABLE, ["state", "expires_at"])
+
+
+def downgrade() -> None:
+    if _table_has_rows():
+        raise RuntimeError("Cannot downgrade administrator enrollment storage while records exist.")
+    if _index_exists():
+        op.drop_index(_INDEX, table_name=_TABLE)
+    if _table_exists():
+        op.drop_table(_TABLE)

--- a/control_plane/storage/postgres.py
+++ b/control_plane/storage/postgres.py
@@ -41,6 +41,14 @@ from sqlalchemy.pool import NullPool
 
 from control_plane.contracts.artifact_identity import ArtifactIdentityManifest
 from control_plane.contracts.agent_write_intent import AgentWriteIntentRecord
+from control_plane.contracts.administrator_enrollment import (
+    AdministratorEnrollmentConflictError,
+    AdministratorEnrollmentRecord,
+    complete_administrator_enrollment,
+    expire_administrator_enrollment,
+    prove_administrator_enrollment_control,
+    withdraw_administrator_enrollment,
+)
 from control_plane.contracts.authz_denial_record import AuthzDenialRecord
 from control_plane.contracts.authz_policy_record import (
     AuthzPolicyCompareWriteResult,
@@ -1096,6 +1104,146 @@ class LaunchplaneOwnerControlChannelSessionRow(Base):
         String,
         nullable=False,
         server_default="inert",
+    )
+    payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
+
+
+class LaunchplaneAdministratorEnrollmentRow(Base):
+    __tablename__ = "launchplane_administrator_enrollments"
+    __table_args__ = (
+        CheckConstraint(
+            "state IN ('issued', 'control_proven', 'withdrawn', 'expired', 'enrolled')",
+            name="launchplane_administrator_enrollment_state_ck",
+        ),
+        CheckConstraint(
+            "proposer_github_id > 0 AND (candidate_github_id IS NULL OR candidate_github_id > 0)",
+            name="launchplane_administrator_enrollment_github_id_ck",
+        ),
+        CheckConstraint(
+            "expires_at > created_at",
+            name="launchplane_administrator_enrollment_expiry_ck",
+        ),
+        CheckConstraint(
+            "strftime('%s', created_at) IS NOT NULL "
+            "AND strftime('%s', expires_at) IS NOT NULL "
+            "AND CAST(strftime('%s', expires_at) AS INTEGER) "
+            "- CAST(strftime('%s', created_at) AS INTEGER) = 1800",
+            name="lp_admin_enrollment_ttl_sqlite_ck",
+        ).ddl_if(dialect="sqlite"),
+        CheckConstraint(
+            "CAST(expires_at AS timestamptz) - CAST(created_at AS timestamptz) "
+            "= INTERVAL '30 minutes'",
+            name="lp_admin_enrollment_ttl_pg_ck",
+        ).ddl_if(dialect="postgresql"),
+        CheckConstraint(
+            "candidate_github_id IS NULL OR candidate_github_id <> proposer_github_id",
+            name="launchplane_administrator_enrollment_distinct_human_ck",
+        ),
+        CheckConstraint(
+            "authority_state = 'inert' AND authorizes_policy = false",
+            name="launchplane_administrator_enrollment_no_authority_ck",
+        ),
+        CheckConstraint(
+            "policy_bridge_state IN ('not_applied', 'applied')",
+            name="launchplane_administrator_enrollment_bridge_state_ck",
+        ),
+        CheckConstraint(
+            "(candidate_github_id IS NULL AND control_proven_at IS NULL) OR "
+            "(candidate_github_id IS NOT NULL AND control_proven_at IS NOT NULL)",
+            name="launchplane_administrator_enrollment_control_proof_ck",
+        ),
+        CheckConstraint(
+            "control_proven_at IS NULL OR "
+            "(control_proven_at >= created_at AND control_proven_at < expires_at)",
+            name="launchplane_administrator_enrollment_control_time_ck",
+        ),
+        CheckConstraint(
+            "withdrawn_at IS NULL OR "
+            "(withdrawn_at >= COALESCE(control_proven_at, created_at) "
+            "AND withdrawn_at < expires_at)",
+            name="launchplane_administrator_enrollment_withdrawal_time_ck",
+        ),
+        CheckConstraint(
+            "expired_at IS NULL OR expired_at >= expires_at",
+            name="launchplane_administrator_enrollment_expired_time_ck",
+        ),
+        CheckConstraint(
+            "enrolled_at IS NULL OR "
+            "(control_proven_at IS NOT NULL AND enrolled_at >= control_proven_at "
+            "AND enrolled_at < expires_at)",
+            name="launchplane_administrator_enrollment_enrolled_time_ck",
+        ),
+        CheckConstraint(
+            "(enrolled_policy_record_id IS NULL AND enrolled_policy_revision IS NULL "
+            "AND enrolled_policy_sha256 IS NULL AND reviewed_plan_sha256 IS NULL "
+            "AND bridge_idempotency_key_sha256 IS NULL) OR "
+            "(enrolled_policy_record_id IS NOT NULL AND enrolled_policy_record_id <> '' "
+            "AND enrolled_policy_revision > 0 AND enrolled_policy_sha256 IS NOT NULL "
+            "AND reviewed_plan_sha256 IS NOT NULL "
+            "AND bridge_idempotency_key_sha256 IS NOT NULL)",
+            name="launchplane_administrator_enrollment_policy_evidence_ck",
+        ),
+        CheckConstraint(
+            "state <> 'enrolled' OR enrolled_policy_record_id = "
+            "'launchplane-authz-policy-r' || printf('%020d', enrolled_policy_revision) "
+            "|| '-' || substr(enrolled_policy_sha256, 1, 12)",
+            name="lp_admin_enrollment_policy_record_sqlite_ck",
+        ).ddl_if(dialect="sqlite"),
+        CheckConstraint(
+            "state <> 'enrolled' OR enrolled_policy_record_id = "
+            "'launchplane-authz-policy-r' "
+            "|| lpad(CAST(enrolled_policy_revision AS text), 20, '0') "
+            "|| '-' || substr(enrolled_policy_sha256, 1, 12)",
+            name="lp_admin_enrollment_policy_record_pg_ck",
+        ).ddl_if(dialect="postgresql"),
+        CheckConstraint(
+            "(state = 'issued' AND candidate_github_id IS NULL AND control_proven_at IS NULL "
+            "AND withdrawn_at IS NULL AND expired_at IS NULL AND enrolled_at IS NULL "
+            "AND enrolled_policy_record_id IS NULL AND policy_bridge_state = 'not_applied') OR "
+            "(state = 'control_proven' AND candidate_github_id IS NOT NULL "
+            "AND control_proven_at IS NOT NULL AND withdrawn_at IS NULL "
+            "AND expired_at IS NULL AND enrolled_at IS NULL "
+            "AND enrolled_policy_record_id IS NULL AND policy_bridge_state = 'not_applied') OR "
+            "(state = 'withdrawn' AND withdrawn_at IS NOT NULL AND expired_at IS NULL "
+            "AND enrolled_at IS NULL AND enrolled_policy_record_id IS NULL "
+            "AND policy_bridge_state = 'not_applied') OR "
+            "(state = 'expired' AND expired_at IS NOT NULL AND withdrawn_at IS NULL "
+            "AND enrolled_at IS NULL AND enrolled_policy_record_id IS NULL "
+            "AND policy_bridge_state = 'not_applied') OR "
+            "(state = 'enrolled' AND candidate_github_id IS NOT NULL "
+            "AND control_proven_at IS NOT NULL AND enrolled_at IS NOT NULL "
+            "AND withdrawn_at IS NULL AND expired_at IS NULL "
+            "AND enrolled_policy_record_id IS NOT NULL AND policy_bridge_state = 'applied')",
+            name="launchplane_administrator_enrollment_terminal_ck",
+        ),
+        UniqueConstraint(
+            "challenge_sha256", name="launchplane_administrator_enrollment_challenge_uq"
+        ),
+        Index("launchplane_administrator_enrollment_state_expiry_idx", "state", "expires_at"),
+    )
+
+    enrollment_id: Mapped[str] = mapped_column(String, primary_key=True)
+    state: Mapped[str] = mapped_column(String, nullable=False)
+    proposer_github_id: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    candidate_github_id: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    challenge_sha256: Mapped[str] = mapped_column(String, nullable=False)
+    reason: Mapped[str] = mapped_column(String, nullable=False)
+    provenance_sha256: Mapped[str] = mapped_column(String, nullable=False)
+    created_at: Mapped[str] = mapped_column(String, nullable=False)
+    expires_at: Mapped[str] = mapped_column(String, nullable=False)
+    control_proven_at: Mapped[str | None] = mapped_column(String, nullable=True)
+    withdrawn_at: Mapped[str | None] = mapped_column(String, nullable=True)
+    expired_at: Mapped[str | None] = mapped_column(String, nullable=True)
+    enrolled_at: Mapped[str | None] = mapped_column(String, nullable=True)
+    enrolled_policy_record_id: Mapped[str | None] = mapped_column(String, nullable=True)
+    enrolled_policy_revision: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    enrolled_policy_sha256: Mapped[str | None] = mapped_column(String, nullable=True)
+    reviewed_plan_sha256: Mapped[str | None] = mapped_column(String, nullable=True)
+    bridge_idempotency_key_sha256: Mapped[str | None] = mapped_column(String, nullable=True)
+    authority_state: Mapped[str] = mapped_column(String, nullable=False, server_default="inert")
+    authorizes_policy: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=false())
+    policy_bridge_state: Mapped[str] = mapped_column(
+        String, nullable=False, server_default="not_applied"
     )
     payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
 
@@ -9753,6 +9901,170 @@ class PostgresRecordStore(HumanSessionStore):
             model_type=OwnerControlIssuedChallengeRecord,
             orm_model=LaunchplaneOwnerControlIssuedChallengeRow,
             filters=(LaunchplaneOwnerControlIssuedChallengeRow.challenge_nonce == challenge_nonce,),
+        )
+
+    @staticmethod
+    def _administrator_enrollment_row(
+        record: AdministratorEnrollmentRecord,
+    ) -> LaunchplaneAdministratorEnrollmentRow:
+        return LaunchplaneAdministratorEnrollmentRow(
+            enrollment_id=record.enrollment_id,
+            state=record.state,
+            proposer_github_id=record.proposer_github_id,
+            candidate_github_id=record.candidate_github_id,
+            challenge_sha256=record.challenge_sha256,
+            reason=record.reason,
+            provenance_sha256=record.provenance_sha256,
+            created_at=record.created_at,
+            expires_at=record.expires_at,
+            control_proven_at=record.control_proven_at,
+            withdrawn_at=record.withdrawn_at,
+            expired_at=record.expired_at,
+            enrolled_at=record.enrolled_at,
+            enrolled_policy_record_id=record.enrolled_policy_record_id,
+            enrolled_policy_revision=record.enrolled_policy_revision,
+            enrolled_policy_sha256=record.enrolled_policy_sha256,
+            reviewed_plan_sha256=record.reviewed_plan_sha256,
+            bridge_idempotency_key_sha256=record.bridge_idempotency_key_sha256,
+            authority_state=record.authority_state,
+            authorizes_policy=record.authorizes_policy,
+            policy_bridge_state=record.policy_bridge_state,
+            payload=PostgresRecordStore._payload_dict(record),
+        )
+
+    @staticmethod
+    def _sync_administrator_enrollment_row(
+        row: LaunchplaneAdministratorEnrollmentRow, record: AdministratorEnrollmentRecord
+    ) -> None:
+        row.state = record.state
+        row.candidate_github_id = record.candidate_github_id
+        row.control_proven_at = record.control_proven_at
+        row.withdrawn_at = record.withdrawn_at
+        row.expired_at = record.expired_at
+        row.enrolled_at = record.enrolled_at
+        row.enrolled_policy_record_id = record.enrolled_policy_record_id
+        row.enrolled_policy_revision = record.enrolled_policy_revision
+        row.enrolled_policy_sha256 = record.enrolled_policy_sha256
+        row.reviewed_plan_sha256 = record.reviewed_plan_sha256
+        row.bridge_idempotency_key_sha256 = record.bridge_idempotency_key_sha256
+        row.policy_bridge_state = record.policy_bridge_state
+        row.payload = PostgresRecordStore._payload_dict(record)
+
+    def create_administrator_enrollment_if_absent(
+        self, record: AdministratorEnrollmentRecord
+    ) -> tuple[AdministratorEnrollmentRecord, bool]:
+        with self._session_factory() as session:
+            session.add(self._administrator_enrollment_row(record))
+            try:
+                session.commit()
+                return record, True
+            except IntegrityError as error:
+                session.rollback()
+                existing_row = session.get(
+                    LaunchplaneAdministratorEnrollmentRow, record.enrollment_id
+                )
+                if existing_row is None:
+                    raise AdministratorEnrollmentConflictError(
+                        "administrator enrollment challenge digest is already reserved"
+                    ) from error
+                existing = AdministratorEnrollmentRecord.model_validate(existing_row.payload)
+                if existing != record:
+                    raise AdministratorEnrollmentConflictError(
+                        "administrator enrollment creation conflicts with persisted record"
+                    ) from error
+                return existing, False
+
+    def read_administrator_enrollment(self, enrollment_id: str) -> AdministratorEnrollmentRecord:
+        return self._read_model(
+            model_type=AdministratorEnrollmentRecord,
+            orm_model=LaunchplaneAdministratorEnrollmentRow,
+            filters=(LaunchplaneAdministratorEnrollmentRow.enrollment_id == enrollment_id,),
+        )
+
+    def _transition_administrator_enrollment(
+        self,
+        enrollment_id: str,
+        transition: Callable[[AdministratorEnrollmentRecord], AdministratorEnrollmentRecord],
+    ) -> AdministratorEnrollmentRecord:
+        with self._session_factory() as session:
+            self._begin_serialized_write(session)
+            statement = (
+                select(LaunchplaneAdministratorEnrollmentRow)
+                .where(LaunchplaneAdministratorEnrollmentRow.enrollment_id == enrollment_id)
+                .limit(1)
+            )
+            if not self.database_url.startswith("sqlite"):
+                statement = statement.with_for_update()
+            row = session.scalar(statement)
+            if row is None:
+                raise FileNotFoundError(enrollment_id)
+            current = AdministratorEnrollmentRecord.model_validate(row.payload)
+            updated = transition(current)
+            if updated != current:
+                self._sync_administrator_enrollment_row(row, updated)
+                session.commit()
+            return updated
+
+    def prove_administrator_enrollment_control(
+        self,
+        *,
+        enrollment_id: str,
+        challenge: str,
+        server_derived_candidate_github_id: int,
+        control_proven_at: str,
+    ) -> AdministratorEnrollmentRecord:
+        return self._transition_administrator_enrollment(
+            enrollment_id,
+            lambda record: prove_administrator_enrollment_control(
+                record,
+                challenge=challenge,
+                server_derived_candidate_github_id=server_derived_candidate_github_id,
+                control_proven_at=control_proven_at,
+            ),
+        )
+
+    def expire_administrator_enrollment(
+        self, *, enrollment_id: str, expired_at: str
+    ) -> AdministratorEnrollmentRecord:
+        return self._transition_administrator_enrollment(
+            enrollment_id,
+            lambda record: expire_administrator_enrollment(record, expired_at=expired_at),
+        )
+
+    def withdraw_administrator_enrollment(
+        self, *, enrollment_id: str, proposer_github_id: int, withdrawn_at: str
+    ) -> AdministratorEnrollmentRecord:
+        return self._transition_administrator_enrollment(
+            enrollment_id,
+            lambda record: withdraw_administrator_enrollment(
+                record, proposer_github_id=proposer_github_id, withdrawn_at=withdrawn_at
+            ),
+        )
+
+    def complete_administrator_enrollment(
+        self,
+        *,
+        enrollment_id: str,
+        server_derived_candidate_github_id: int,
+        enrolled_at: str,
+        enrolled_policy_record_id: str,
+        enrolled_policy_revision: int,
+        enrolled_policy_sha256: str,
+        reviewed_plan_sha256: str,
+        bridge_idempotency_key_sha256: str,
+    ) -> AdministratorEnrollmentRecord:
+        return self._transition_administrator_enrollment(
+            enrollment_id,
+            lambda record: complete_administrator_enrollment(
+                record,
+                server_derived_candidate_github_id=server_derived_candidate_github_id,
+                enrolled_at=enrolled_at,
+                enrolled_policy_record_id=enrolled_policy_record_id,
+                enrolled_policy_revision=enrolled_policy_revision,
+                enrolled_policy_sha256=enrolled_policy_sha256,
+                reviewed_plan_sha256=reviewed_plan_sha256,
+                bridge_idempotency_key_sha256=bridge_idempotency_key_sha256,
+            ),
         )
 
     def list_owner_control_challenge_lifecycle_events(

--- a/control_plane/storage/schema_invariants.py
+++ b/control_plane/storage/schema_invariants.py
@@ -10,7 +10,7 @@ from sqlalchemy.engine import Engine
 from sqlalchemy.exc import SQLAlchemyError
 
 AUTHZ_COMPATIBILITY_FLOOR_REVISION = "f3b5d7e9a1c2"
-EXPECTED_ALEMBIC_HEAD_REVISION = "a7c9e1f3b5d7"
+EXPECTED_ALEMBIC_HEAD_REVISION = "c4e6a8b0d2f5"
 RUNTIME_COMPATIBLE_ALEMBIC_REVISIONS = (EXPECTED_ALEMBIC_HEAD_REVISION,)
 _AUTHZ_POLICY_TABLE = "launchplane_authz_policies"
 _AUTHZ_POLICY_WRITE_FENCE_TRIGGER = "launchplane_authz_policy_write_fence"
@@ -466,6 +466,31 @@ CRITICAL_POSTGRES_COLUMN_TYPES: tuple[CriticalColumnType, ...] = (
         "payload",
         ("jsonb",),
     ),
+    CriticalColumnType(
+        "launchplane_administrator_enrollments",
+        "payload",
+        ("jsonb",),
+    ),
+    CriticalColumnType(
+        "launchplane_administrator_enrollments",
+        "proposer_github_id",
+        ("bigint", "int8"),
+    ),
+    CriticalColumnType(
+        "launchplane_administrator_enrollments",
+        "candidate_github_id",
+        ("bigint", "int8"),
+    ),
+    CriticalColumnType(
+        "launchplane_administrator_enrollments",
+        "enrolled_policy_revision",
+        ("bigint", "int8"),
+    ),
+    CriticalColumnType(
+        "launchplane_administrator_enrollments",
+        "authorizes_policy",
+        ("boolean", "bool"),
+    ),
 )
 
 _ACTIVE_OPERATION_PREDICATE_TOKENS = ("status", "pending", "running")
@@ -477,6 +502,17 @@ _ODOO_STABLE_ACTIVE_OPERATION_PREDICATE_TOKENS = (
 )
 
 CRITICAL_SCHEMA_INDEXES: tuple[CriticalIndex, ...] = (
+    CriticalIndex(
+        "launchplane_administrator_enrollments",
+        "launchplane_administrator_enrollment_challenge_uq",
+        ("challenge_sha256",),
+        unique=True,
+    ),
+    CriticalIndex(
+        "launchplane_administrator_enrollments",
+        "launchplane_administrator_enrollment_state_expiry_idx",
+        ("state", "expires_at"),
+    ),
     CriticalIndex(
         "launchplane_merge_admissions",
         "launchplane_merge_admissions_attempt_uidx",
@@ -1126,6 +1162,10 @@ CRITICAL_PRIMARY_KEYS: tuple[CriticalPrimaryKey, ...] = (
     CriticalPrimaryKey(
         "launchplane_owner_control_challenge_lifecycle_events",
         ("event_id",),
+    ),
+    CriticalPrimaryKey(
+        "launchplane_administrator_enrollments",
+        ("enrollment_id",),
     ),
 )
 

--- a/docs/authorization-authority.md
+++ b/docs/authorization-authority.md
@@ -44,6 +44,16 @@ or authorize approval or execution; rules that also depend on mutable login,
 organization, team, or role selectors are intentionally insufficient without a
 live authenticated human identity.
 
+Administrator-enrollment records are likewise inert evidence only. They may
+record an owner-created, 30-minute opaque challenge and a later server-derived
+candidate GitHub identity that proved control, but they do not create a policy
+administrator, grant a policy action, change a managed set, or make any route
+or workflow available. Every record is fixed to no authority. A future bridge
+may compile a final enrolled record into an owner-gated DB-native policy change
+only after separate design, review, apply, and read-back work under the active
+authorization-administration boundary. Landing enrollment storage does not
+approve or implement that bridge and does not relax `#2058`.
+
 Repository inventory follows the same authority boundary. Its
 `repository_inventory.read` and `repository_inventory.write` actions use the
 Launchplane service scope (`product=launchplane`, `context=launchplane`), but

--- a/docs/records.md
+++ b/docs/records.md
@@ -2701,5 +2701,25 @@ came from the lifecycle ledger or the envelope-bound shadow-verification ledger.
 Issuance never updates the privileged operation current projection or its
 append-only event ledger.
 
+`AdministratorEnrollmentRecord` is a separate, versioned, inert preparation
+record for a future second control-proven GitHub-human policy administrator.
+PostgreSQL stores it in `launchplane_administrator_enrollments`; filesystem
+storage mirrors it only for local/test/rehearsal parity. It retains an immutable
+proposer GitHub ID, a server-derived candidate GitHub ID only after a successful
+control proof, reason/provenance SHA-256 digests, lifecycle timestamps, and only an
+opaque single-use challenge SHA-256 digest—never the plaintext challenge.
+Challenges last exactly 30 minutes. The typed lifecycle is
+`issued -> control_proven -> enrolled`, with proposer-only withdrawal before
+enrollment and expiry from either nonterminal state. Exact terminal replay is
+idempotent, while conflicting replay fails closed. Final enrollment requires the
+exact active policy record ID, revision, policy digest, reviewed-plan digest,
+and bridge idempotency-key digest produced by the separately reviewed policy
+apply and read-back flow.
+The record is constrained to `authority_state = 'inert'`,
+`authorizes_policy = false`, and a lifecycle-bound bridge state that is
+`not_applied` until exact enrollment evidence is recorded and `applied`
+afterward. It has no rule, action, selector, grant, managed set, or repository
+field and cannot itself be evaluated as authorization.
+
 **Preserved history:** references to Phase 1 planning records describe the
 pre-worker lifecycle and do not constrain the current Phase 2 statuses.

--- a/tests/test_administrator_enrollment.py
+++ b/tests/test_administrator_enrollment.py
@@ -1,0 +1,380 @@
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Any, cast
+import threading
+import unittest
+
+from control_plane.contracts.administrator_enrollment import (
+    ADMINISTRATOR_ENROLLMENT_AUTHORITY_STATE,
+    AdministratorEnrollmentConflictError,
+    AdministratorEnrollmentRecord,
+    administrator_enrollment_challenge_sha256,
+)
+from control_plane.storage.filesystem import FilesystemRecordStore
+from control_plane.storage.postgres import PostgresRecordStore
+
+
+_POLICY_SHA256 = "b" * 64
+_POLICY_RECORD_ID = "launchplane-authz-policy-r00000000000000000368-bbbbbbbbbbbb"
+_PLAN_SHA256 = "c" * 64
+_IDEMPOTENCY_SHA256 = "d" * 64
+
+
+def _record(
+    *,
+    enrollment_id: str = "administrator-enrollment-test0001",
+    challenge: str = "opaque-challenge",
+    reason: str = "Second human control proof.",
+) -> AdministratorEnrollmentRecord:
+    return AdministratorEnrollmentRecord(
+        enrollment_id=enrollment_id,
+        proposer_github_id=101,
+        challenge_sha256=administrator_enrollment_challenge_sha256(challenge),
+        reason=reason,
+        provenance_sha256="a" * 64,
+        created_at="2026-08-31T12:00:00+00:00",
+        expires_at="2026-08-31T12:30:00+00:00",
+    )
+
+
+def _complete(store: Any, enrollment_id: str) -> AdministratorEnrollmentRecord:
+    return cast(
+        AdministratorEnrollmentRecord,
+        store.complete_administrator_enrollment(
+            enrollment_id=enrollment_id,
+            server_derived_candidate_github_id=202,
+            enrolled_at="2026-08-31T12:06:00+00:00",
+            enrolled_policy_record_id=_POLICY_RECORD_ID,
+            enrolled_policy_revision=368,
+            enrolled_policy_sha256=_POLICY_SHA256,
+            reviewed_plan_sha256=_PLAN_SHA256,
+            bridge_idempotency_key_sha256=_IDEMPOTENCY_SHA256,
+        ),
+    )
+
+
+class AdministratorEnrollmentContractTests(unittest.TestCase):
+    def test_lifecycle_is_inert_and_validates_terminal_states(self) -> None:
+        record = _record()
+        self.assertEqual(record.authority_state, ADMINISTRATOR_ENROLLMENT_AUTHORITY_STATE)
+        self.assertFalse(record.authorizes_policy)
+        self.assertEqual(record.policy_bridge_state, "not_applied")
+        with self.assertRaises(ValueError):
+            AdministratorEnrollmentRecord.model_validate(
+                record.model_dump() | {"authorizes_policy": True}
+            )
+        with self.assertRaises(ValueError):
+            AdministratorEnrollmentRecord.model_validate(
+                record.model_dump()
+                | {
+                    "candidate_github_id": record.proposer_github_id,
+                    "control_proven_at": "2026-08-31T12:05:00+00:00",
+                    "state": "control_proven",
+                }
+            )
+        with self.assertRaises(ValueError):
+            AdministratorEnrollmentRecord.model_validate(
+                record.model_dump()
+                | {
+                    "candidate_github_id": 202,
+                    "control_proven_at": "2026-08-31T12:31:00+00:00",
+                    "state": "control_proven",
+                }
+            )
+
+    def test_enrolled_state_requires_exact_complete_policy_evidence(self) -> None:
+        record = _record()
+        base = record.model_dump() | {
+            "state": "enrolled",
+            "candidate_github_id": 202,
+            "control_proven_at": "2026-08-31T12:05:00+00:00",
+            "enrolled_at": "2026-08-31T12:06:00+00:00",
+            "enrolled_policy_record_id": _POLICY_RECORD_ID,
+            "enrolled_policy_revision": 368,
+            "enrolled_policy_sha256": _POLICY_SHA256,
+            "reviewed_plan_sha256": _PLAN_SHA256,
+            "bridge_idempotency_key_sha256": _IDEMPOTENCY_SHA256,
+            "policy_bridge_state": "applied",
+        }
+        enrolled = AdministratorEnrollmentRecord.model_validate(base)
+        self.assertEqual(enrolled.state, "enrolled")
+        with self.assertRaises(ValueError):
+            AdministratorEnrollmentRecord.model_validate(base | {"reviewed_plan_sha256": None})
+        with self.assertRaises(ValueError):
+            AdministratorEnrollmentRecord.model_validate(
+                base | {"policy_bridge_state": "not_applied"}
+            )
+        with self.assertRaises(ValueError):
+            AdministratorEnrollmentRecord.model_validate(
+                base
+                | {
+                    "enrolled_policy_record_id": (
+                        "launchplane-authz-policy-r00000000000000000368-aaaaaaaaaaaa"
+                    )
+                }
+            )
+
+    def test_timestamps_are_normalized_to_utc_whole_seconds(self) -> None:
+        record = AdministratorEnrollmentRecord(
+            enrollment_id="administrator-enrollment-test0002",
+            proposer_github_id=101,
+            challenge_sha256="a" * 64,
+            reason="Normalize timestamps.",
+            provenance_sha256="b" * 64,
+            created_at="2026-08-31T08:00:00-04:00",
+            expires_at="2026-08-31T08:30:00-04:00",
+        )
+        self.assertEqual(record.created_at, "2026-08-31T12:00:00+00:00")
+        self.assertEqual(record.expires_at, "2026-08-31T12:30:00+00:00")
+        with self.assertRaises(ValueError):
+            AdministratorEnrollmentRecord.model_validate(
+                _record().model_dump() | {"created_at": "2026-08-31T12:00:00.1+00:00"}
+            )
+
+
+class AdministratorEnrollmentStorageTests(unittest.TestCase):
+    def _exercise_store(self, store: Any) -> None:
+        record, created = store.create_administrator_enrollment_if_absent(_record())
+        self.assertTrue(created)
+        replay, created = store.create_administrator_enrollment_if_absent(record)
+        self.assertFalse(created)
+        self.assertEqual(replay, record)
+
+        proven = store.prove_administrator_enrollment_control(
+            enrollment_id=record.enrollment_id,
+            challenge="opaque-challenge",
+            server_derived_candidate_github_id=202,
+            control_proven_at="2026-08-31T12:05:00+00:00",
+        )
+        self.assertEqual(proven.state, "control_proven")
+        self.assertEqual(proven.candidate_github_id, 202)
+        self.assertEqual(
+            store.prove_administrator_enrollment_control(
+                enrollment_id=record.enrollment_id,
+                challenge="opaque-challenge",
+                server_derived_candidate_github_id=202,
+                control_proven_at="2026-08-31T12:05:00+00:00",
+            ),
+            proven,
+        )
+        with self.assertRaises(AdministratorEnrollmentConflictError):
+            store.prove_administrator_enrollment_control(
+                enrollment_id=record.enrollment_id,
+                challenge="opaque-challenge",
+                server_derived_candidate_github_id=202,
+                control_proven_at="2026-08-31T12:06:00+00:00",
+            )
+
+        enrolled = _complete(store, record.enrollment_id)
+        self.assertEqual(enrolled.state, "enrolled")
+        self.assertEqual(enrolled.policy_bridge_state, "applied")
+        self.assertEqual(store.read_administrator_enrollment(record.enrollment_id), enrolled)
+        self.assertEqual(_complete(store, record.enrollment_id), enrolled)
+        with self.assertRaises(AdministratorEnrollmentConflictError):
+            store.complete_administrator_enrollment(
+                enrollment_id=record.enrollment_id,
+                server_derived_candidate_github_id=202,
+                enrolled_at="2026-08-31T12:06:00+00:00",
+                enrolled_policy_record_id=_POLICY_RECORD_ID,
+                enrolled_policy_revision=368,
+                enrolled_policy_sha256=_POLICY_SHA256,
+                reviewed_plan_sha256="e" * 64,
+                bridge_idempotency_key_sha256=_IDEMPOTENCY_SHA256,
+            )
+
+    def _exercise_duplicate_challenge(self, store: Any) -> None:
+        store.create_administrator_enrollment_if_absent(_record())
+        with self.assertRaises(AdministratorEnrollmentConflictError):
+            store.create_administrator_enrollment_if_absent(
+                _record(enrollment_id="administrator-enrollment-test0003")
+            )
+
+    def test_filesystem_round_trip_and_lifecycle(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            store = FilesystemRecordStore(Path(temporary_directory))
+            self._exercise_store(store)
+            record_path = (
+                Path(temporary_directory)
+                / "launchplane_administrator_enrollments"
+                / "administrator-enrollment-test0001.json"
+            )
+            self.assertNotIn("opaque-challenge", record_path.read_text(encoding="utf-8"))
+
+    def test_sqlite_postgres_store_round_trip_and_lifecycle(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            store = PostgresRecordStore(
+                database_url=f"sqlite+pysqlite:///{Path(temporary_directory) / 'records.sqlite3'}"
+            )
+            try:
+                store.ensure_schema()
+                self._exercise_store(store)
+            finally:
+                store.close()
+
+    def test_challenge_digest_is_globally_unique_in_both_backends(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            self._exercise_duplicate_challenge(
+                FilesystemRecordStore(Path(temporary_directory) / "filesystem")
+            )
+            store = PostgresRecordStore(
+                database_url=(f"sqlite+pysqlite:///{Path(temporary_directory) / 'records.sqlite3'}")
+            )
+            try:
+                store.ensure_schema()
+                self._exercise_duplicate_challenge(store)
+            finally:
+                store.close()
+
+    def test_filesystem_challenge_digest_reservation_is_atomic(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            state_dir = Path(temporary_directory)
+            barrier = threading.Barrier(2)
+
+            def create(enrollment_id: str) -> AdministratorEnrollmentRecord | BaseException:
+                store = FilesystemRecordStore(state_dir)
+                try:
+                    barrier.wait(timeout=5)
+                    record, _created = store.create_administrator_enrollment_if_absent(
+                        _record(enrollment_id=enrollment_id)
+                    )
+                    return record
+                except BaseException as error:  # noqa: BLE001
+                    return error
+
+            with ThreadPoolExecutor(max_workers=2) as executor:
+                results = tuple(
+                    executor.map(
+                        create,
+                        (
+                            "administrator-enrollment-test0004",
+                            "administrator-enrollment-test0005",
+                        ),
+                    )
+                )
+
+        self.assertEqual(
+            sum(isinstance(result, AdministratorEnrollmentRecord) for result in results),
+            1,
+        )
+        self.assertEqual(
+            sum(isinstance(result, AdministratorEnrollmentConflictError) for result in results),
+            1,
+        )
+
+    def test_sqlite_terminal_transition_is_atomic_across_store_instances(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            database_url = f"sqlite+pysqlite:///{Path(temporary_directory) / 'records.sqlite3'}"
+            setup_store = PostgresRecordStore(database_url=database_url)
+            try:
+                setup_store.ensure_schema()
+                record, _ = setup_store.create_administrator_enrollment_if_absent(_record())
+            finally:
+                setup_store.close()
+            barrier = threading.Barrier(2)
+
+            def transition(kind: str) -> AdministratorEnrollmentRecord | BaseException:
+                store = PostgresRecordStore(database_url=database_url)
+                try:
+                    barrier.wait(timeout=5)
+                    if kind == "withdraw":
+                        return store.withdraw_administrator_enrollment(
+                            enrollment_id=record.enrollment_id,
+                            proposer_github_id=101,
+                            withdrawn_at="2026-08-31T12:05:00+00:00",
+                        )
+                    return store.expire_administrator_enrollment(
+                        enrollment_id=record.enrollment_id,
+                        expired_at="2026-08-31T12:30:00+00:00",
+                    )
+                except BaseException as error:  # noqa: BLE001
+                    return error
+                finally:
+                    store.close()
+
+            with ThreadPoolExecutor(max_workers=2) as executor:
+                results = tuple(executor.map(transition, ("withdraw", "expire")))
+
+        self.assertEqual(
+            sum(isinstance(result, AdministratorEnrollmentRecord) for result in results),
+            1,
+        )
+        self.assertEqual(
+            sum(isinstance(result, AdministratorEnrollmentConflictError) for result in results),
+            1,
+        )
+
+    def test_expiry_precedes_replay_and_preserves_control_proof(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            store = FilesystemRecordStore(Path(temporary_directory))
+            record, _ = store.create_administrator_enrollment_if_absent(_record())
+            with self.assertRaises(AdministratorEnrollmentConflictError):
+                store.prove_administrator_enrollment_control(
+                    enrollment_id=record.enrollment_id,
+                    challenge="opaque-challenge",
+                    server_derived_candidate_github_id=202,
+                    control_proven_at="2026-08-31T12:30:00+00:00",
+                )
+            proven = store.prove_administrator_enrollment_control(
+                enrollment_id=record.enrollment_id,
+                challenge="opaque-challenge",
+                server_derived_candidate_github_id=202,
+                control_proven_at="2026-08-31T12:05:00+00:00",
+            )
+            expired = store.expire_administrator_enrollment(
+                enrollment_id=record.enrollment_id,
+                expired_at="2026-08-31T12:30:00+00:00",
+            )
+            self.assertEqual(expired.state, "expired")
+            self.assertEqual(expired.candidate_github_id, proven.candidate_github_id)
+            self.assertEqual(
+                store.expire_administrator_enrollment(
+                    enrollment_id=record.enrollment_id,
+                    expired_at="2026-08-31T12:30:00+00:00",
+                ),
+                expired,
+            )
+            with self.assertRaises(AdministratorEnrollmentConflictError):
+                store.expire_administrator_enrollment(
+                    enrollment_id=record.enrollment_id,
+                    expired_at="2026-08-31T12:31:00+00:00",
+                )
+            with self.assertRaises(AdministratorEnrollmentConflictError):
+                _complete(store, record.enrollment_id)
+
+    def test_withdrawal_is_proposer_only_and_exactly_idempotent(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            store = FilesystemRecordStore(Path(temporary_directory))
+            record, _ = store.create_administrator_enrollment_if_absent(_record())
+            with self.assertRaises(AdministratorEnrollmentConflictError):
+                store.withdraw_administrator_enrollment(
+                    enrollment_id=record.enrollment_id,
+                    proposer_github_id=999,
+                    withdrawn_at="2026-08-31T12:05:00+00:00",
+                )
+            withdrawn = store.withdraw_administrator_enrollment(
+                enrollment_id=record.enrollment_id,
+                proposer_github_id=101,
+                withdrawn_at="2026-08-31T12:05:00+00:00",
+            )
+            self.assertEqual(withdrawn.state, "withdrawn")
+            self.assertEqual(
+                store.withdraw_administrator_enrollment(
+                    enrollment_id=record.enrollment_id,
+                    proposer_github_id=101,
+                    withdrawn_at="2026-08-31T12:05:00+00:00",
+                ),
+                withdrawn,
+            )
+            with self.assertRaises(AdministratorEnrollmentConflictError):
+                store.withdraw_administrator_enrollment(
+                    enrollment_id=record.enrollment_id,
+                    proposer_github_id=101,
+                    withdrawn_at="2026-08-31T12:06:00+00:00",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_schema_migration.py
+++ b/tests/test_schema_migration.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, patch
 
 from alembic import command
 from sqlalchemy import create_engine, inspect, text
+from sqlalchemy.exc import IntegrityError
 
 from control_plane.contracts.authz_policy_record import LaunchplaneAuthzPolicyRecord
 from control_plane.contracts.product_owner import (
@@ -1505,7 +1506,7 @@ class SchemaMigrationTests(unittest.TestCase):
             for primary_key in CRITICAL_PRIMARY_KEYS
         }
 
-        self.assertEqual(EXPECTED_ALEMBIC_HEAD_REVISION, "a7c9e1f3b5d7")
+        self.assertEqual(EXPECTED_ALEMBIC_HEAD_REVISION, "c4e6a8b0d2f5")
         self.assertNotIn(
             ("launchplane_human_sessions", "launchplane_human_sessions_github_id_idx"),
             indexes,
@@ -1824,6 +1825,22 @@ class SchemaMigrationTests(unittest.TestCase):
                         "launchplane_owner_control_challenge_lifecycle_events"
                     )
                 }
+                enrollment_columns = {
+                    str(column["name"])
+                    for column in inspector.get_columns("launchplane_administrator_enrollments")
+                }
+                enrollment_indexes = {
+                    str(name): index
+                    for index in inspector.get_indexes("launchplane_administrator_enrollments")
+                    if (name := index.get("name")) is not None
+                }
+                enrollment_unique_constraints = {
+                    str(name): constraint
+                    for constraint in inspector.get_unique_constraints(
+                        "launchplane_administrator_enrollments"
+                    )
+                    if (name := constraint.get("name")) is not None
+                }
             finally:
                 engine.dispose()
             command.downgrade(config, "f2241a0b1c2d")
@@ -1883,6 +1900,35 @@ class SchemaMigrationTests(unittest.TestCase):
             "launchplane_owner_control_lifecycle_event_challenge_idx",
             lifecycle_event_indexes,
         )
+        self.assertTrue(
+            {
+                "enrollment_id",
+                "state",
+                "proposer_github_id",
+                "candidate_github_id",
+                "challenge_sha256",
+                "reason",
+                "provenance_sha256",
+                "control_proven_at",
+                "enrolled_at",
+                "enrolled_policy_record_id",
+                "enrolled_policy_revision",
+                "enrolled_policy_sha256",
+                "reviewed_plan_sha256",
+                "bridge_idempotency_key_sha256",
+                "authority_state",
+                "authorizes_policy",
+                "policy_bridge_state",
+                "payload",
+            }.issubset(enrollment_columns)
+        )
+        self.assertIn("launchplane_administrator_enrollment_state_expiry_idx", enrollment_indexes)
+        self.assertEqual(
+            enrollment_unique_constraints["launchplane_administrator_enrollment_challenge_uq"][
+                "column_names"
+            ],
+            ["challenge_sha256"],
+        )
         active_operation_index = challenge_indexes[
             "launchplane_owner_control_challenge_active_operation_uidx"
         ]
@@ -1895,6 +1941,7 @@ class SchemaMigrationTests(unittest.TestCase):
             "launchplane_owner_control_challenge_lifecycle_events",
             downgraded_tables,
         )
+        self.assertNotIn("launchplane_administrator_enrollments", downgraded_tables)
 
     def test_owner_control_lifecycle_migration_refuses_nonempty_downgrade(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
@@ -1935,6 +1982,105 @@ class SchemaMigrationTests(unittest.TestCase):
 
             with self.assertRaisesRegex(RuntimeError, "audit events exist"):
                 command.downgrade(config, "f6a1c3e5b7d9")
+
+    def test_administrator_enrollment_migration_refuses_nonempty_downgrade(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            database_url = (
+                f"sqlite+pysqlite:///{Path(temporary_directory_name) / 'records.sqlite3'}"
+            )
+            config = alembic_config(database_url)
+            command.upgrade(config, EXPECTED_ALEMBIC_HEAD_REVISION)
+            engine = create_engine(database_url)
+            try:
+                with engine.begin() as connection:
+                    connection.execute(
+                        text(
+                            "insert into launchplane_administrator_enrollments "
+                            "(enrollment_id, state, proposer_github_id, challenge_sha256, reason, "
+                            "provenance_sha256, created_at, expires_at, payload) values "
+                            "(:enrollment_id, 'issued', :proposer_github_id, :challenge_sha256, "
+                            ":reason, :provenance_sha256, :created_at, :expires_at, '{}')"
+                        ),
+                        {
+                            "enrollment_id": "administrator-enrollment-migration-test",
+                            "proposer_github_id": 101,
+                            "challenge_sha256": "a" * 64,
+                            "reason": "Downgrade refusal test.",
+                            "provenance_sha256": "b" * 64,
+                            "created_at": "2026-08-31T12:00:00+00:00",
+                            "expires_at": "2026-08-31T12:30:00+00:00",
+                        },
+                    )
+            finally:
+                engine.dispose()
+
+            with self.assertRaisesRegex(RuntimeError, "records exist"):
+                command.downgrade(config, "a7c9e1f3b5d7")
+
+    def test_administrator_enrollment_migration_enforces_ttl_and_policy_binding(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            database_url = (
+                f"sqlite+pysqlite:///{Path(temporary_directory_name) / 'records.sqlite3'}"
+            )
+            config = alembic_config(database_url)
+            command.upgrade(config, EXPECTED_ALEMBIC_HEAD_REVISION)
+            engine = create_engine(database_url)
+            try:
+                with self.assertRaises(IntegrityError):
+                    with engine.begin() as connection:
+                        connection.execute(
+                            text(
+                                "insert into launchplane_administrator_enrollments "
+                                "(enrollment_id, state, proposer_github_id, challenge_sha256, "
+                                "reason, provenance_sha256, created_at, expires_at, payload) values "
+                                "(:enrollment_id, 'issued', 101, :challenge_sha256, :reason, "
+                                ":provenance_sha256, :created_at, :expires_at, '{}')"
+                            ),
+                            {
+                                "enrollment_id": "administrator-enrollment-invalid-ttl",
+                                "challenge_sha256": "a" * 64,
+                                "reason": "Invalid TTL test.",
+                                "provenance_sha256": "b" * 64,
+                                "created_at": "2026-08-31T12:00:00+00:00",
+                                "expires_at": "2026-08-31T12:31:00+00:00",
+                            },
+                        )
+                with self.assertRaises(IntegrityError):
+                    with engine.begin() as connection:
+                        connection.execute(
+                            text(
+                                "insert into launchplane_administrator_enrollments "
+                                "(enrollment_id, state, proposer_github_id, candidate_github_id, "
+                                "challenge_sha256, reason, provenance_sha256, created_at, "
+                                "expires_at, control_proven_at, enrolled_at, "
+                                "enrolled_policy_record_id, enrolled_policy_revision, "
+                                "enrolled_policy_sha256, reviewed_plan_sha256, "
+                                "bridge_idempotency_key_sha256, policy_bridge_state, payload) "
+                                "values (:enrollment_id, 'enrolled', 101, 202, :challenge_sha256, "
+                                ":reason, :provenance_sha256, :created_at, :expires_at, "
+                                ":control_proven_at, :enrolled_at, :enrolled_policy_record_id, 368, "
+                                ":enrolled_policy_sha256, :reviewed_plan_sha256, "
+                                ":bridge_idempotency_key_sha256, 'applied', '{}')"
+                            ),
+                            {
+                                "enrollment_id": "administrator-enrollment-invalid-policy",
+                                "challenge_sha256": "c" * 64,
+                                "reason": "Invalid policy binding test.",
+                                "provenance_sha256": "d" * 64,
+                                "created_at": "2026-08-31T12:00:00+00:00",
+                                "expires_at": "2026-08-31T12:30:00+00:00",
+                                "control_proven_at": "2026-08-31T12:05:00+00:00",
+                                "enrolled_at": "2026-08-31T12:06:00+00:00",
+                                "enrolled_policy_record_id": (
+                                    "launchplane-authz-policy-r00000000000000000368-aaaaaaaaaaaa"
+                                ),
+                                "enrolled_policy_sha256": "b" * 64,
+                                "reviewed_plan_sha256": "e" * 64,
+                                "bridge_idempotency_key_sha256": "f" * 64,
+                            },
+                        )
+            finally:
+                engine.dispose()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add the inert `AdministratorEnrollmentRecord` lifecycle for a second control-proven GitHub human
- persist exact challenge, control-proof, terminal, and policy read-back evidence in filesystem and PostgreSQL stores
- add a unique Alembic migration with fail-closed constraints, exact 30-minute TTL, exact policy-record binding, and nonempty downgrade refusal
- document that the record grants no authority and exposes no route or policy mutation

## Validation
- `uv run --extra dev python -m unittest tests.test_administrator_enrollment tests.test_schema_migration`
- `uv run --extra dev launchplane ci unittest-shard local --jobs 6` (3,173 targets)
- `uv run --extra dev ruff check <changed Python files>`
- `uv run --extra dev ruff format --check <changed Python files>`
- `uv run --extra dev mypy control_plane tests`
- PostgreSQL and SQLite ORM DDL compilation for dialect-specific constraints
- `git diff --check`

## Boundaries
- no HTTP route
- no policy apply or authorization grant
- no plaintext challenge persistence
- no real operator or candidate identity in code/config

Refs #2284