### PR TITLE
fix: update GitHub CLI security dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,10 @@ RUN pnpm build
 
 FROM mirror.gcr.io/library/golang:1.26.6-bookworm AS github-cli-build
 
-ARG GITHUB_CLI_VERSION=v2.96.0
-ARG GITHUB_CLI_GRPC_VERSION=v1.82.1
-ARG GITHUB_CLI_X_TEXT_VERSION=v0.39.0
+ARG GITHUB_CLI_VERSION=v2.98.0
+ARG GITHUB_CLI_GRPC_VERSION=v1.83.0
+ARG GITHUB_CLI_X_CRYPTO_VERSION=v0.55.0
+ARG GITHUB_CLI_X_TEXT_VERSION=v0.41.0
 
 ENV CGO_ENABLED=0 \
     GOTOOLCHAIN=local
@@ -27,11 +28,13 @@ RUN github_cli_x_mod_version=v0.40.0 \
     && go mod init launchplane.local/github-cli-build \
     && go get "github.com/cli/cli/v2/cmd/gh@${GITHUB_CLI_VERSION}" \
     && go get "google.golang.org/grpc@${GITHUB_CLI_GRPC_VERSION}" \
+    && go get "golang.org/x/crypto@${GITHUB_CLI_X_CRYPTO_VERSION}" \
     && go get "golang.org/x/mod@${github_cli_x_mod_version}" \
     && go get "golang.org/x/text@${GITHUB_CLI_X_TEXT_VERSION}" \
     && go build -trimpath -o /go/bin/gh github.com/cli/cli/v2/cmd/gh \
     && go version -m /go/bin/gh | grep -F "github.com/cli/cli/v2" | grep -F "${GITHUB_CLI_VERSION}" \
     && go version -m /go/bin/gh | grep -F "google.golang.org/grpc" | grep -F "${GITHUB_CLI_GRPC_VERSION}" \
+    && go version -m /go/bin/gh | grep -F "golang.org/x/crypto" | grep -F "${GITHUB_CLI_X_CRYPTO_VERSION}" \
     && go version -m /go/bin/gh | grep -F "golang.org/x/mod" | grep -F "${github_cli_x_mod_version}" \
     && go version -m /go/bin/gh | grep -F "golang.org/x/text" | grep -F "${GITHUB_CLI_X_TEXT_VERSION}"
 

--- a/tests/test_service_image_contract.py
+++ b/tests/test_service_image_contract.py
@@ -14,6 +14,10 @@ GITHUB_CLI_MODULE_CONTRACTS = {
         "google.golang.org/grpc",
         "GITHUB_CLI_GRPC_VERSION",
     ),
+    "golang.org/x/crypto": (
+        "golang.org/x/crypto",
+        "GITHUB_CLI_X_CRYPTO_VERSION",
+    ),
     "golang.org/x/text": (
         "golang.org/x/text",
         "GITHUB_CLI_X_TEXT_VERSION",


### PR DESCRIPTION
## Summary
- update the runtime image to GitHub CLI `v2.98.0`
- pin `golang.org/x/crypto v0.55.0` to remediate `CVE-2026-56854`
- retain `golang.org/x/mod v0.40.0` to remediate `CVE-2026-56864` and `CVE-2026-56865`
- align the GitHub CLI gRPC and `x/text` dependencies with the release and verify module provenance

## Validation
- `uv run --extra dev python -m unittest tests.test_service_image_contract`
- `uv run --extra dev ruff check tests/test_service_image_contract.py`
- `uv run --extra dev ruff format --check tests/test_service_image_contract.py`
- `uv run --extra dev mypy tests/test_service_image_contract.py`
- `docker build -t launchplane-ci:cve-2026-56854-fix .`
- CI-equivalent Trivy `HIGH,CRITICAL` scan: zero findings

JetBrains inspection remained UNKNOWN because PyCharm could not open the isolated worktree; no IDE findings were produced.

Refs #2277