### PR TITLE
fix: reflow stale merge-train candidates

### DIFF
--- a/control_plane/merge_train_controller_run_once.py
+++ b/control_plane/merge_train_controller_run_once.py
@@ -1283,6 +1283,7 @@ def _advance_active_candidate_record(
             "candidate": active_candidate_record.candidate.model_dump(mode="json"),
         }
 
+    candidate_build_error: MergeTrainGitHubStaleHeadError | None = None
     if active_candidate_record.candidate.status in {"planned", "building"}:
         controller_action = "build_candidate"
         if request.mutate:
@@ -1318,14 +1319,20 @@ def _advance_active_candidate_record(
                 },
             )
 
-        candidate = (
-            github_client.build_batch_candidate(
-                candidate=active_candidate_record.candidate,
-                checkpoint=checkpoint_candidate_progress,
-            )
-            if request.mutate
-            else active_candidate_record.candidate
-        )
+        if request.mutate:
+            try:
+                candidate = github_client.build_batch_candidate(
+                    candidate=active_candidate_record.candidate,
+                    checkpoint=checkpoint_candidate_progress,
+                )
+            except MergeTrainGitHubStaleHeadError as error:
+                controller_action = "candidate_failed"
+                candidate_build_error = error
+                candidate = active_candidate_record.candidate.model_copy(
+                    update={"status": "failed", "updated_at": recorded_at}
+                )
+        else:
+            candidate = active_candidate_record.candidate
     else:
         controller_action = "observe_candidate"
         if request.mutate:
@@ -1354,6 +1361,19 @@ def _advance_active_candidate_record(
         "controller_action": controller_action,
         "merge_train_batch_candidate_record_id": active_candidate_record.record_id,
     }
+    if candidate_build_error is not None:
+        message = (
+            str(candidate_build_error).strip()
+            or "Merge train candidate evidence no longer matches GitHub."
+        )
+        result["error"] = {
+            "code": "merge_train_github_stale_state",
+            "message": message,
+        }
+        result["details"] = {
+            "github_status_code": candidate_build_error.status_code,
+            "failed_pull_request_number": lease.record.active_pull_request_number,
+        }
     if request.mutate:
         updated_candidate_record = build_merge_train_batch_candidate_record(
             candidate=candidate,

--- a/docs/merge-train-policy.md
+++ b/docs/merge-train-policy.md
@@ -233,6 +233,13 @@ because a new queued PR repairs train validation, the controller may supersede
 the failed candidate batch lineage and plan a replacement candidate from the
 fresh snapshot.
 
+Candidate construction can fail before required checks run when GitHub rejects
+one rolling merge entry as stale or conflicting. The controller persists that
+candidate as `failed`, reports the exact pull request reached by the build, and
+releases the controller lease without replaying the rejected merge. The same
+queue-change rule then governs replacement planning; an unchanged queue remains
+stopped for operator attention.
+
 ## Example Policy Entries
 
 The example below is documentation/import material only. It is not packaged as a

--- a/tests/support/merge_train.py
+++ b/tests/support/merge_train.py
@@ -241,6 +241,24 @@ class _FakeFailingMergeTrainGitHubClient(_FakeMergeTrainGitHubClient):
         return candidate.model_copy(update={"required_checks_status": "fail", "status": "failed"})
 
 
+class _StaleCandidateMergeTrainGitHubClient(_FakeMergeTrainGitHubClient):
+    def build_batch_candidate(
+        self,
+        *,
+        candidate: MergeTrainBatchCandidate,
+        checkpoint: (
+            Callable[[MergeTrainBatchCandidate, MergeTrainBatchEntry | None, str], None] | None
+        ) = None,
+    ) -> MergeTrainBatchCandidate:
+        if checkpoint is not None:
+            checkpoint(candidate, None, "reset_candidate_ref")
+            checkpoint(candidate, None, "candidate_ref_ready")
+            checkpoint(candidate, candidate.entries[0], "merge_candidate_entry")
+        raise MergeTrainGitHubStaleHeadError(
+            "Candidate entry conflicts with the rolling merge base.", status_code=409
+        )
+
+
 class _StaleLandingMergeTrainGitHubClient(_FakeMergeTrainGitHubClient):
     def land_batch_candidate(
         self,

--- a/tests/test_http_app_merge_train.py
+++ b/tests/test_http_app_merge_train.py
@@ -73,6 +73,7 @@ from tests.support.merge_train import (
     _seed_merge_train_policy,
     _seed_merge_train_stack_collapse_plan_record,
     _StackCollapseWriteFailingFilesystemRecordStore,
+    _StaleCandidateMergeTrainGitHubClient,
     _StaleLandingMergeTrainGitHubClient,
 )
 
@@ -2047,6 +2048,76 @@ class FastApiMergeTrainControllerRunOnceTests(unittest.IsolatedAsyncioTestCase):
             [
                 entry["pull_request_number"]
                 for entry in build_payload["result"]["candidate"]["entries"]
+            ],
+            [1, 2],
+        )
+
+    async def test_reflows_candidate_after_build_stale_state(self) -> None:
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict("os.environ", {"GH_TOKEN": "token"}, clear=True),
+        ):
+            state_dir = Path(temporary_directory_name) / "state"
+            _seed_merge_train_policy(state_dir)
+            store = FilesystemRecordStore(state_dir=state_dir)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_merge_train_service_identity()),
+                authz_policy=_merge_train_service_policy(),
+                record_store_factory=lambda: store,
+            )
+            request_payload = {
+                "schema_version": 1,
+                "repository": "cbusillo/sellyouroutboard",
+                "base_branch": "main",
+                "mutate": True,
+            }
+            with (
+                patch(
+                    "control_plane.merge_train_controller_run_once.GitHubMergeTrainSnapshotReader",
+                    _FakeMergeTrainSnapshotReader,
+                ),
+                patch(
+                    "control_plane.merge_train_controller_run_once.GitHubMergeTrainClient",
+                    _FakeMergeTrainGitHubClient,
+                ),
+            ):
+                await _post_merge_train_controller_run_once(app, request_payload)
+            with patch(
+                "control_plane.merge_train_controller_run_once.GitHubMergeTrainClient",
+                _StaleCandidateMergeTrainGitHubClient,
+            ):
+                failed_response = await _post_merge_train_controller_run_once(app, request_payload)
+            with (
+                patch(
+                    "control_plane.merge_train_controller_run_once.GitHubMergeTrainSnapshotReader",
+                    _FakeExpandedMergeTrainSnapshotReader,
+                ),
+                patch(
+                    "control_plane.merge_train_controller_run_once.GitHubMergeTrainClient",
+                    _FakeMergeTrainGitHubClient,
+                ),
+            ):
+                reflow_response = await _post_merge_train_controller_run_once(app, request_payload)
+
+        failed_payload = failed_response.json()
+        reflow_payload = reflow_response.json()
+        self.assertEqual(failed_response.status_code, 202)
+        self.assertEqual(failed_payload["result"]["controller_action"], "candidate_failed")
+        self.assertEqual(failed_payload["result"]["candidate"]["status"], "failed")
+        self.assertEqual(
+            failed_payload["result"]["error"]["code"],
+            "merge_train_github_stale_state",
+        )
+        self.assertEqual(
+            failed_payload["result"]["details"],
+            {"failed_pull_request_number": 1, "github_status_code": 409},
+        )
+        self.assertEqual(reflow_response.status_code, 202)
+        self.assertEqual(reflow_payload["result"]["controller_action"], "plan_candidate")
+        self.assertEqual(
+            [
+                entry["pull_request_number"]
+                for entry in reflow_payload["result"]["candidate"]["entries"]
             ],
             [1, 2],
         )


### PR DESCRIPTION
## Summary
- persist build-time GitHub 409 candidate failures instead of leaving the controller in an unrecoverable reconciliation loop
- report the exact pull request reached by the rolling candidate build
- release the controller cleanly so a changed eligible queue can supersede the failed candidate
- document stale/conflicting candidate construction semantics

## Validation
- `uv run --extra dev python -m unittest tests.test_http_app_merge_train.FastApiMergeTrainControllerRunOnceTests tests.test_merge_train_controller`
- `uv run --extra dev ruff check control_plane/merge_train_controller_run_once.py tests/support/merge_train.py tests/test_http_app_merge_train.py`
- `uv run --extra dev ruff format --check control_plane/merge_train_controller_run_once.py tests/support/merge_train.py tests/test_http_app_merge_train.py`
- `uv run --extra dev mypy control_plane/merge_train_controller_run_once.py tests/support/merge_train.py tests/test_http_app_merge_train.py`
- `uv run --extra dev launchplane ci unittest-shard local --jobs 2` (3,181 targets; all 12 shards passed)

JetBrains inspection completed with warning-level existing findings across the large changed files; Ruff, mypy, focused tests, and the complete unittest gate are clean.

Refs #2277