### PR TITLE
Fix merge admission lease authority binding

### DIFF
--- a/control_plane/governance_projection.py
+++ b/control_plane/governance_projection.py
@@ -159,6 +159,9 @@ class LiveGovernanceCurrentReadinessProvider:
             )
             if not controller_records:
                 return _unavailable_readiness()
+            controller_state = controller_records[0]
+            if controller_state.status != "running" or not controller_state.lease_owner:
+                return _unavailable_readiness()
             token = self.github_token(github_token_env_var).strip()
             if not token:
                 return _unavailable_readiness()
@@ -195,7 +198,8 @@ class LiveGovernanceCurrentReadinessProvider:
                 observed_base_tree_sha=observed_base_tree_sha,
                 observed_head_sha=repository_evidence.target.head_sha,
                 observed_head_tree_sha=repository_evidence.target.tree_sha,
-                controller_state=controller_records[0],
+                controller_state=controller_state,
+                expected_lease_owner=controller_state.lease_owner,
                 stack_collapse_record=stack_collapse_record,
                 evaluated_at=evaluated_at,
             )

--- a/control_plane/merge_admission.py
+++ b/control_plane/merge_admission.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import Protocol, cast
 
@@ -131,6 +131,7 @@ class MergeAdmissionEvaluator(Protocol):
         observed_head_sha: str,
         observed_head_tree_sha: str,
         controller_state: MergeTrainControllerStateRecord,
+        expected_lease_owner: str,
         stack_collapse_record: MergeTrainStackCollapsePlanRecord | None,
         evaluated_at: str,
     ) -> MergeAdmissionEvaluation: ...
@@ -148,6 +149,10 @@ class GuardedMergeAdmission:
     controller_state_provider: Callable[[], MergeTrainControllerStateRecord] | None = None
     admission_time_provider: Callable[[], str] = _utc_now_timestamp
     stack_collapse_record: MergeTrainStackCollapsePlanRecord | None = None
+    expected_lease_owner: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.expected_lease_owner = self.controller_state.lease_owner.strip()
 
     def update_landing_plan_record(
         self, landing_plan_record: MergeTrainBatchLandingPlanRecord
@@ -168,6 +173,11 @@ class GuardedMergeAdmission:
         observed_head_sha: str,
         observed_head_tree_sha: str,
     ) -> MergeAdmissionRecord:
+        if not self.expected_lease_owner:
+            raise MergeAdmissionDeniedError(
+                "Merge admission requires an acquired controller lease.",
+                reason_code="controller_fence_rejected",
+            )
         if self.controller_state_provider is not None:
             self.controller_state = self.controller_state_provider()
         evaluation_started_at = self.admission_time_provider()
@@ -196,6 +206,7 @@ class GuardedMergeAdmission:
             observed_head_sha=observed_head_sha,
             observed_head_tree_sha=observed_head_tree_sha,
             controller_state=self.controller_state,
+            expected_lease_owner=self.expected_lease_owner,
             stack_collapse_record=self.stack_collapse_record,
             evaluated_at=evaluation_started_at,
         )

--- a/control_plane/merge_admission_live.py
+++ b/control_plane/merge_admission_live.py
@@ -116,6 +116,7 @@ class LiveMergeAdmissionEvaluator:
         observed_head_sha: str,
         observed_head_tree_sha: str,
         controller_state: MergeTrainControllerStateRecord,
+        expected_lease_owner: str,
         stack_collapse_record: MergeTrainStackCollapsePlanRecord | None,
         evaluated_at: str,
     ) -> MergeAdmissionEvaluation:
@@ -262,7 +263,7 @@ class LiveMergeAdmissionEvaluator:
             candidate_record=candidate_record,
             structural_candidate_status=structural_result.status,
             controller_state=controller_state,
-            expected_lease_owner=controller_state.lease_owner,
+            expected_lease_owner=expected_lease_owner,
             observed_effect_sha=landing_plan.candidate_sha,
             evaluated_at=evaluated_at,
         )

--- a/docs/merge-admission.md
+++ b/docs/merge-admission.md
@@ -23,7 +23,10 @@ and GitHub queue for every entry rather than treating request-start policy or
 stored candidate order as live evidence.
 
 Only `ready` Level 2 evidence plus `exact` or `recorded_rolling` structural
-evidence may produce an admission. The admission binds the complete L2 and
+evidence may produce an admission. The guarded caller binds the expected lease
+owner from its acquired controller authority before each fresh controller-state
+observation, so a cleared or replaced lease becomes a normal fail-closed L2
+result rather than new authority. The admission binds the complete L2 and
 structural results, candidate and landing-plan digests, current lease identity,
 algorithm version, attempt sequence, and exact Git identities. Storage creation
 is insert-only. The storage transaction re-reads the persisted controller lease,

--- a/docs/merge-readiness.md
+++ b/docs/merge-readiness.md
@@ -141,17 +141,20 @@ ruleset drift enforcement remains owned by #2031 rather than this L2 contract.
 ## Revalidation
 
 Callers must recompute L2 under the current controller lease immediately before
-each later L3 attempt. A lost, missing, expired, or wrong-owner lease; controller
-scope mismatch; expected-SHA mismatch; current-head drift; queue movement;
-policy drift; or evidence loss produces a non-ready result. A previous L2 result
-is never reusable authority.
+each later L3 attempt. The guarded caller binds the expected lease owner from
+its acquired controller authority before current state is re-read; the fresh
+controller record remains observed evidence only. A lost, missing, expired, or
+wrong-owner lease; controller scope mismatch; expected-SHA mismatch;
+current-head drift; queue movement; policy drift; or evidence loss produces a
+non-ready result. A previous L2 result is never reusable authority.
 
 The production guarded landing adapter follows this rule for every constituent
 PR and persists the complete result only inside the subsequent immutable L3
 admission. See [merge-admission.md](merge-admission.md).
 
 The read-only governance projection uses the same live admission evaluator only
-when an active landing-plan lineage exists. It never persists the recomputed L2
-view and reports current evidence as unavailable rather than reusing a prior
-admission snapshot as current readiness. The immutable admission snapshot
-remains independently inspectable.
+when an active landing-plan lineage and running controller lease exist. It never
+persists the recomputed L2 view and reports current evidence as unavailable
+rather than deriving expected authority from an idle controller record or
+reusing a prior admission snapshot as current readiness. The immutable
+admission snapshot remains independently inspectable.

--- a/tests/support/merge_train.py
+++ b/tests/support/merge_train.py
@@ -34,7 +34,7 @@ from control_plane.merge_train import (
     discover_merge_train_stack,
 )
 from control_plane.merge_train_github import MergeTrainGitHubError, MergeTrainGitHubStaleHeadError
-from control_plane.merge_admission import MergeAdmissionDeniedError
+from control_plane.merge_admission import GuardedMergeAdmission, MergeAdmissionDeniedError
 from control_plane.service_auth import GitHubActionsIdentity, LaunchplaneAuthzPolicy
 from control_plane.storage.filesystem import FilesystemRecordStore
 from control_plane.workflows.merge_train_worker import (
@@ -112,16 +112,15 @@ class _FakeMergeTrainGitHubClient:
         landing_plan: MergeTrainBatchLandingPlan,
         admission_guard: _LandingPlanRecordUpdater,
         recorded_at: str,
-        provider_checkpoint: (
-            Callable[[MergeTrainBatchLandingPlan, MergeTrainBatchLandingEntry], None] | None
-        ) = None,
-        checkpoint: (
-            Callable[
-                [MergeTrainBatchLandingPlan, MergeTrainBatchLandingEntry, str],
-                MergeTrainBatchLandingPlanRecord | None,
-            ]
-            | None
-        ) = None,
+        provider_checkpoint: Callable[
+            [MergeTrainBatchLandingPlan, MergeTrainBatchLandingEntry], None
+        ]
+        | None = None,
+        checkpoint: Callable[
+            [MergeTrainBatchLandingPlan, MergeTrainBatchLandingEntry, str],
+            MergeTrainBatchLandingPlanRecord | None,
+        ]
+        | None = None,
     ) -> MergeTrainBatchLandingPlan:
         type(self).land_batch_candidate_calls += 1
         merged_entries: list[MergeTrainBatchLandingEntry] = []
@@ -385,6 +384,37 @@ class _CleanupAlreadyMissingMergeTrainGitHubClient(_FakeMergeTrainGitHubClient):
     def cleanup_batch_candidate_ref(self, *, landing_plan: MergeTrainBatchLandingPlan) -> bool:
         type(self).cleanup_batch_candidate_ref_calls += 1
         return False
+
+
+class _AdmissionInvokingMergeTrainGitHubClient(_FakeMergeTrainGitHubClient):
+    def land_batch_candidate(
+        self,
+        *,
+        landing_plan: MergeTrainBatchLandingPlan,
+        admission_guard: _LandingPlanRecordUpdater,
+        recorded_at: str,
+        provider_checkpoint: (
+            Callable[[MergeTrainBatchLandingPlan, MergeTrainBatchLandingEntry], None] | None
+        ) = None,
+        checkpoint: (
+            Callable[
+                [MergeTrainBatchLandingPlan, MergeTrainBatchLandingEntry, str],
+                MergeTrainBatchLandingPlanRecord | None,
+            ]
+            | None
+        ) = None,
+    ) -> MergeTrainBatchLandingPlan:
+        entry = landing_plan.entries[0]
+        if checkpoint is not None:
+            checkpoint(landing_plan, entry, "merge_entry")
+        cast(GuardedMergeAdmission, admission_guard).admit(
+            entry=entry,
+            observed_base_sha=entry.expected_base_sha,
+            observed_base_tree_sha=entry.recorded_candidate_parent_tree_sha,
+            observed_head_sha=entry.expected_head_sha,
+            observed_head_tree_sha=entry.expected_head_tree_sha,
+        )
+        raise AssertionError("admission evaluator should block the provider effect")
 
 
 class _CleanupFailingWithoutStatusMergeTrainGitHubClient(_FakeMergeTrainGitHubClient):

--- a/tests/test_governance_projection.py
+++ b/tests/test_governance_projection.py
@@ -100,6 +100,58 @@ class GovernanceProjectionTests(unittest.TestCase):
             evaluator.kwargs["landing_plan_record"],
             landing_record,
         )
+        self.assertEqual(
+            evaluator.kwargs["expected_lease_owner"],
+            controller_state.lease_owner,
+        )
+
+    def test_live_readiness_provider_requires_running_controller_lease(self) -> None:
+        candidate_record, landing_record, controller_state, _structural_result = _guard_records()
+        evidence = _repository_evidence(
+            head=candidate_record.candidate.entries[0].head_sha,
+            base_sha=candidate_record.candidate.base_sha,
+        ).model_copy(
+            update={
+                "target": _repository_evidence().target.model_copy(
+                    update={
+                        "repository": candidate_record.candidate.repository,
+                        "pull_request_number": candidate_record.candidate.entries[
+                            0
+                        ].pull_request_number,
+                        "head_sha": candidate_record.candidate.entries[0].head_sha,
+                        "tree_sha": candidate_record.candidate.entries[0].head_tree_sha,
+                    }
+                )
+            }
+        )
+        idle_controller_state = controller_state.model_copy(
+            update={
+                "status": "idle",
+                "lease_owner": "",
+                "lease_acquired_at": "",
+                "lease_expires_at": "",
+                "heartbeat_at": "",
+            }
+        )
+        with TemporaryDirectory() as directory:
+            store = _store(Path(directory))
+            store.write_merge_train_batch_candidate_record(candidate_record)
+            store.write_merge_train_batch_landing_plan_record(landing_record)
+            store.write_merge_train_controller_state_record(idle_controller_state)
+            provider = LiveGovernanceCurrentReadinessProvider(
+                github_token=lambda _env_var: self.fail("idle controller used a token")
+            )
+
+            result = provider(
+                store=store,
+                repository_evidence=evidence,
+                base_branch="main",
+                evaluated_at=NOW,
+                github_token_env_var="GH_TOKEN",
+            )
+
+        self.assertEqual(result.availability, "unavailable")
+        self.assertEqual(result.reason_code, "current_evidence_unavailable")
 
     def test_live_readiness_provider_treats_terminal_lineage_as_inactive(self) -> None:
         candidate_record, landing_record, controller_state, _structural_result = _guard_records()

--- a/tests/test_http_app_merge_train.py
+++ b/tests/test_http_app_merge_train.py
@@ -18,6 +18,7 @@ from control_plane.contracts.merge_train_stack_collapse import (
     execute_merge_train_stack_collapse_plan,
 )
 from control_plane.http_app import create_launchplane_fastapi_app
+from control_plane.merge_admission import MergeAdmissionDeniedError
 from control_plane.merge_train_controller_run_once import MERGE_TRAIN_CONTROLLER_ACTIVE_ACTION
 from control_plane.service_auth import (
     BearerIdentityConfig,
@@ -51,6 +52,7 @@ from tests.http_app_test_support import (
 from tests.merge_train_policy_fixtures import build_test_merge_train_policy_with_codex_skills
 from tests.support.auth import _identity, _local_operator_policy, _StubVerifier
 from tests.support.merge_train import (
+    _AdmissionInvokingMergeTrainGitHubClient,
     _BlockedAdmissionMergeTrainGitHubClient,
     _CleanupFailingMergeTrainGitHubClient,
     _FakeCollapsedRootStackedMergeTrainSnapshotReader,
@@ -76,6 +78,28 @@ from tests.support.merge_train import (
     _StaleCandidateMergeTrainGitHubClient,
     _StaleLandingMergeTrainGitHubClient,
 )
+
+
+class _FenceCapturingAdmissionEvaluator:
+    expected_lease_owner = ""
+    observed_lease_owner = ""
+
+    def __init__(self, **_: object) -> None:
+        type(self).expected_lease_owner = ""
+        type(self).observed_lease_owner = ""
+
+    def evaluate(self, **kwargs: object) -> object:
+        controller_state = kwargs["controller_state"]
+        expected_lease_owner = kwargs["expected_lease_owner"]
+        observed_lease_owner = getattr(controller_state, "lease_owner")
+        if not isinstance(expected_lease_owner, str) or not isinstance(observed_lease_owner, str):
+            raise AssertionError("controller lease owners must be strings")
+        type(self).expected_lease_owner = expected_lease_owner
+        type(self).observed_lease_owner = observed_lease_owner
+        raise MergeAdmissionDeniedError(
+            "test admission fence block",
+            reason_code="merge_readiness_not_ready",
+        )
 
 
 class FastApiMergeTrainReadTests(unittest.IsolatedAsyncioTestCase):
@@ -1698,6 +1722,66 @@ class FastApiMergeTrainRunOnceTests(unittest.IsolatedAsyncioTestCase):
 
 
 class FastApiMergeTrainControllerRunOnceTests(unittest.IsolatedAsyncioTestCase):
+    async def test_land_batch_binds_acquired_owner_before_live_observation(self) -> None:
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict("os.environ", {"GH_TOKEN": "token"}, clear=True),
+        ):
+            state_dir = Path(temporary_directory_name) / "state"
+            _seed_merge_train_policy(state_dir)
+            store = FilesystemRecordStore(state_dir=state_dir)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_merge_train_service_identity()),
+                authz_policy=_merge_train_service_policy(),
+                record_store_factory=lambda: store,
+            )
+            with (
+                patch(
+                    "control_plane.merge_train_controller_run_once.GitHubMergeTrainSnapshotReader",
+                    _FakeMergeTrainSnapshotReader,
+                ),
+                patch(
+                    "control_plane.merge_train_controller_run_once.GitHubMergeTrainClient",
+                    _AdmissionInvokingMergeTrainGitHubClient,
+                ),
+                patch(
+                    "control_plane.http_app.LiveMergeAdmissionEvaluator",
+                    _FenceCapturingAdmissionEvaluator,
+                ),
+            ):
+                responses = [
+                    await _post_merge_train_controller_run_once(
+                        app,
+                        {
+                            "schema_version": 1,
+                            "repository": "cbusillo/sellyouroutboard",
+                            "base_branch": "main",
+                            "mutate": True,
+                        },
+                    )
+                    for _ in range(5)
+                ]
+            controller_state = store.list_merge_train_controller_state_records(
+                repository="cbusillo/sellyouroutboard",
+                base_branch="main",
+                limit=1,
+            )[0]
+
+        self.assertTrue(all(response.status_code == 202 for response in responses))
+        self.assertEqual(responses[4].json()["result"]["controller_action"], "block")
+        self.assertTrue(
+            _FenceCapturingAdmissionEvaluator.expected_lease_owner.startswith(
+                "merge-train-controller:"
+            )
+        )
+        self.assertEqual(
+            _FenceCapturingAdmissionEvaluator.observed_lease_owner,
+            _FenceCapturingAdmissionEvaluator.expected_lease_owner,
+        )
+        self.assertEqual(controller_state.status, "idle")
+        self.assertEqual(controller_state.last_phase, "admit_pull_request")
+        self.assertEqual(store.list_merge_admission_records(), ())
+
     async def test_advances_unstacked_batch_flow(self) -> None:
         with (
             TemporaryDirectory() as temporary_directory_name,

--- a/tests/test_merge_admission_live.py
+++ b/tests/test_merge_admission_live.py
@@ -318,6 +318,7 @@ def _evaluate_owner_live(
             observed_head_sha=evidence.target.head_sha,
             observed_head_tree_sha=evidence.target.tree_sha,
             controller_state=controller_state,
+            expected_lease_owner=controller_state.lease_owner,
             stack_collapse_record=None,
             evaluated_at="2026-08-11T03:01:00Z",
         )
@@ -689,6 +690,7 @@ class LiveMergeAdmissionEvaluatorTests(unittest.TestCase):
                         observed_head_sha=HEAD_SHA,
                         observed_head_tree_sha=TREE_SHA,
                         controller_state=controller_state,
+                        expected_lease_owner=controller_state.lease_owner,
                         stack_collapse_record=None,
                         evaluated_at="2026-08-11T03:01:00Z",
                     )
@@ -745,6 +747,7 @@ class LiveMergeAdmissionEvaluatorTests(unittest.TestCase):
                     observed_head_sha=HEAD_SHA,
                     observed_head_tree_sha="2" * 40,
                     controller_state=controller_state,
+                    expected_lease_owner=controller_state.lease_owner,
                     stack_collapse_record=None,
                     evaluated_at="2026-08-11T03:01:00Z",
                 )
@@ -790,6 +793,7 @@ class LiveMergeAdmissionEvaluatorTests(unittest.TestCase):
                 observed_head_sha=HEAD_SHA,
                 observed_head_tree_sha="2" * 40,
                 controller_state=controller_state,
+                expected_lease_owner=controller_state.lease_owner,
                 stack_collapse_record=None,
                 evaluated_at="2026-08-11T03:01:00Z",
             )

--- a/tests/test_merge_admission_records.py
+++ b/tests/test_merge_admission_records.py
@@ -251,6 +251,16 @@ class _StaticEvaluator:
         return self.evaluation
 
 
+class _CapturingEvaluator(_StaticEvaluator):
+    def __init__(self, evaluation: MergeAdmissionEvaluation) -> None:
+        super().__init__(evaluation)
+        self.kwargs: dict[str, object] = {}
+
+    def evaluate(self, **kwargs: object) -> MergeAdmissionEvaluation:
+        self.kwargs = kwargs
+        return super().evaluate(**kwargs)
+
+
 class _ProviderError(RuntimeError):
     def __init__(self, status_code: int) -> None:
         super().__init__(f"provider rejected with {status_code}")
@@ -434,6 +444,7 @@ class GuardedMergeAdmissionScenarioTests(unittest.TestCase):
         *,
         evaluator: MergeAdmissionEvaluator | None = None,
         admission_time_provider: Callable[[], str] | None = None,
+        controller_state_provider: Callable[[], MergeTrainControllerStateRecord] | None = None,
     ) -> GuardedMergeAdmission:
         return GuardedMergeAdmission(
             record_store=self.store,
@@ -447,11 +458,14 @@ class GuardedMergeAdmissionScenarioTests(unittest.TestCase):
             candidate_record=self.candidate_record,
             landing_plan_record=self.landing_record,
             controller_state=self.controller_state,
-            controller_state_provider=lambda: self.store.list_merge_train_controller_state_records(
-                repository=REPOSITORY,
-                base_branch="main",
-                limit=1,
-            )[0],
+            controller_state_provider=controller_state_provider
+            or (
+                lambda: self.store.list_merge_train_controller_state_records(
+                    repository=REPOSITORY,
+                    base_branch="main",
+                    limit=1,
+                )[0]
+            ),
             admission_time_provider=admission_time_provider or (lambda: "2026-08-11T03:01:00Z"),
             trace_id="scenario-test",
         )
@@ -474,6 +488,43 @@ class GuardedMergeAdmissionScenarioTests(unittest.TestCase):
             admission,
         )
         self.assertEqual(admission.readiness.state, "ready")
+
+    def test_refresh_before_evaluation_preserves_acquired_lease_owner(self) -> None:
+        observed_controller_state = self.controller_state.model_copy(
+            update={
+                "status": "idle",
+                "lease_owner": "",
+                "lease_acquired_at": "",
+                "lease_expires_at": "",
+                "heartbeat_at": "",
+            }
+        )
+        evaluator = _CapturingEvaluator(
+            MergeAdmissionEvaluation(
+                readiness=self._readiness(
+                    fence_evidence=_fence(
+                        controller_status="idle",
+                        observed_lease_owner="",
+                        lease_expires_at="",
+                    )
+                ),
+                structural_result=self.structural_result,
+            )
+        )
+        guard = self._guard(
+            evaluator=evaluator,
+            controller_state_provider=lambda: observed_controller_state,
+        )
+
+        with self.assertRaisesRegex(
+            MergeAdmissionDeniedError,
+            "Fresh merge readiness evidence",
+        ):
+            self._admit(guard)
+
+        self.assertEqual(evaluator.kwargs["controller_state"], observed_controller_state)
+        self.assertEqual(evaluator.kwargs["expected_lease_owner"], "controller-run-1")
+        self.assertEqual(self.store.list_merge_admission_records(), ())
 
     def test_scenario_11_missing_outcome_blocks_provider_retry(self) -> None:
         guard = self._guard()

--- a/tests/test_merge_readiness.py
+++ b/tests/test_merge_readiness.py
@@ -837,6 +837,88 @@ class MergeReadinessDeterminismTests(unittest.TestCase):
 
 
 class MergeReadinessLiveAdapterTests(unittest.TestCase):
+    def test_cleared_observed_lease_uses_explicit_expected_owner(self) -> None:
+        controller_state = MergeTrainControllerStateRecord(
+            controller_key=build_merge_train_controller_key(
+                repository=REPOSITORY,
+                base_branch="main",
+            ),
+            repository=REPOSITORY,
+            base_branch="main",
+            policy_key="default",
+            policy_sha256=POLICY_SHA,
+            status="idle",
+            updated_at=EVALUATED_AT,
+        )
+
+        result = evaluate_merge_readiness_from_live_evidence(
+            target=_target(),
+            owner_decision=OwnerAcceptanceDecision(
+                status="not_required",
+                reason_code="engineering_only",
+                evaluated_at=EVALUATED_AT,
+            ),
+            engineering_decision=None,
+            engineering_runs=(),
+            technical_checks=None,
+            policy_fingerprints=_all_missing_policy_fingerprints(),
+            candidate_record=None,
+            structural_candidate_status="unknown",
+            controller_state=controller_state,
+            expected_lease_owner="controller-run-1",
+            observed_effect_sha=CANDIDATE_SHA,
+            evaluated_at=EVALUATED_AT,
+        )
+
+        self.assertEqual(result.fence.state, "blocked_candidate_identity")
+        self.assertEqual(
+            result.fence.evidence.expected_lease_owner,
+            "controller-run-1",
+        )
+        self.assertEqual(result.fence.evidence.observed_lease_owner, "")
+        self.assertIn("controller_lease_missing", result.fence.reason_codes)
+
+    def test_replaced_observed_lease_uses_explicit_expected_owner(self) -> None:
+        controller_state = MergeTrainControllerStateRecord(
+            controller_key=build_merge_train_controller_key(
+                repository=REPOSITORY,
+                base_branch="main",
+            ),
+            repository=REPOSITORY,
+            base_branch="main",
+            policy_key="default",
+            policy_sha256=POLICY_SHA,
+            status="running",
+            updated_at=EVALUATED_AT,
+            lease_owner="controller-run-2",
+            lease_acquired_at="2026-08-11T02:59:00Z",
+            lease_expires_at="2026-08-11T03:10:00Z",
+            heartbeat_at="2026-08-11T03:00:00Z",
+        )
+
+        result = evaluate_merge_readiness_from_live_evidence(
+            target=_target(),
+            owner_decision=OwnerAcceptanceDecision(
+                status="not_required",
+                reason_code="engineering_only",
+                evaluated_at=EVALUATED_AT,
+            ),
+            engineering_decision=None,
+            engineering_runs=(),
+            technical_checks=None,
+            policy_fingerprints=_all_missing_policy_fingerprints(),
+            candidate_record=None,
+            structural_candidate_status="unknown",
+            controller_state=controller_state,
+            expected_lease_owner="controller-run-1",
+            observed_effect_sha=CANDIDATE_SHA,
+            evaluated_at=EVALUATED_AT,
+        )
+
+        self.assertEqual(result.fence.state, "blocked_candidate_identity")
+        self.assertIn("controller_lease_lost", result.fence.reason_codes)
+        self.assertNotIn("controller_lease_held", result.fence.reason_codes)
+
     def test_adapter_consumes_existing_evidence_without_writes_or_advisory_authority(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary
- bind merge readiness to the controller lease owner acquired by the guarded caller
- treat refreshed controller state as observed evidence so cleared or replaced leases fail closed
- require a running lease for read-only governance readiness and document the authority boundary
- add live-adapter, guard, governance, and controller-managed landing regressions

## Validation
- `uv run --extra dev python -m unittest tests.test_merge_readiness tests.test_merge_admission_records tests.test_merge_admission_live tests.test_governance_projection tests.test_http_app_merge_train.FastApiMergeTrainControllerRunOnceTests.test_land_batch_binds_acquired_owner_before_live_observation`
- `uv run --extra dev python -m unittest tests.test_http_app_merge_train tests.test_merge_train_github`
- `uv run --extra dev ruff check <changed Python files>`
- `uv run --extra dev ruff format --check <changed Python files>`
- `uv run --extra dev mypy control_plane tests`
- `uv run --extra dev launchplane ci unittest-shard local --jobs 2` (3,181 targets / 12 shards)
- JetBrains changed-files inspection: no new type findings; remaining findings are existing weak `may be static` suggestions

Refs #2277