### PR TITLE
Fix engineering-only impact policy binding

### DIFF
--- a/control_plane/merge_admission_live.py
+++ b/control_plane/merge_admission_live.py
@@ -437,11 +437,17 @@ class LiveMergeAdmissionEvaluator:
         ).strip()
         if decision_impact_digest:
             expected_impact_digests.add(decision_impact_digest)
-        expected_impact = (
-            next(iter(expected_impact_digests))
-            if len(expected_impact_digests) == 1
-            else _MISSING_POLICY_SHA256
-        )
+        if len(expected_impact_digests) == 1:
+            expected_impact = next(iter(expected_impact_digests))
+        elif (
+            not expected_impact_digests
+            and owner_decision.status == "not_required"
+            and impact.status == "success"
+            and impact.policy_digest
+        ):
+            expected_impact = impact.policy_digest
+        else:
+            expected_impact = _MISSING_POLICY_SHA256
         expected_engineering = (
             str(getattr(engineering_decision, "authority_digest", "")).strip()
             or _MISSING_POLICY_SHA256

--- a/docs/merge-readiness.md
+++ b/docs/merge-readiness.md
@@ -118,6 +118,13 @@ affected-product subjects, the adapter emits one canonical
 impact evidence is unavailable before subjects can be resolved, that same
 unscoped facet is `unknown` and fails closed.
 
+For that successful `not_required` path, there is intentionally no historical
+Owner or engineering binding from which to recover an expected impact-policy
+digest. The live adapter therefore binds the expected impact fingerprint to the
+same current policy evaluation that proved the change has no affected-product
+subjects. Missing or non-successful impact evidence never receives this
+fallback and continues to fail closed.
+
 ## Advisory Checks
 
 The `launchplane/owner-acceptance`, `launchplane/engineering-review`, and legacy

--- a/tests/test_merge_admission_live.py
+++ b/tests/test_merge_admission_live.py
@@ -16,7 +16,10 @@ from control_plane.contracts.merge_train_structural_provenance import (
     MergeTrainStructuralEntryObservation,
 )
 from control_plane.contracts.merge_readiness import MergeReadinessOwnerFacet
-from control_plane.contracts.owner_acceptance import OwnerAcceptanceAction
+from control_plane.contracts.owner_acceptance import (
+    OwnerAcceptanceAction,
+    OwnerAcceptanceDecision,
+)
 from control_plane.contracts.product_owner import (
     ProductOwnerGrant,
     ProductOwnerIdentity,
@@ -63,6 +66,7 @@ from tests.test_owner_acceptance import (
 from tests.test_merge_readiness import (
     BASE_SHA,
     HEAD_SHA,
+    POLICY_SHA,
     REPOSITORY,
     TREE_SHA,
     _evaluate,
@@ -590,6 +594,93 @@ class LiveMergeAdmissionRealStoreTests(unittest.TestCase):
 
 
 class LiveMergeAdmissionEvaluatorTests(unittest.TestCase):
+    def test_engineering_only_change_binds_current_impact_policy(self) -> None:
+        target = ChangeImpactTarget(
+            repository_id="101",
+            repository_owner_id="202",
+            repository=REPOSITORY,
+            pull_request_number=2083,
+            head_sha=HEAD_SHA,
+            tree_sha=TREE_SHA,
+        )
+        impact = ChangeImpactEvaluation(
+            status="success",
+            reason_code="change_impact_classified",
+            target=target,
+            policy_digest=POLICY_SHA,
+        )
+        evaluator = LiveMergeAdmissionEvaluator(
+            store=object(),
+            repository_evidence_provider=_UnusedRepositoryEvidenceProvider(),
+            technical_check_client=_TechnicalCheckClient(),
+        )
+
+        fingerprints = evaluator._policy_fingerprints(
+            impact=impact,
+            owner_decision=OwnerAcceptanceDecision(
+                status="not_required",
+                reason_code="engineering_only",
+                evaluated_at="2026-08-11T03:01:00Z",
+            ),
+            engineering_decision=None,
+            engineering_authority_digest=None,
+            technical_checks=_PassingTechnicalCheckClient().read_technical_checks(
+                repository=REPOSITORY,
+                base_branch="main",
+                base_sha=BASE_SHA,
+                head_sha=HEAD_SHA,
+                evaluated_at="2026-08-11T03:01:00Z",
+            ),
+            landing_policy_sha256=POLICY_SHA,
+            current_merge_train_policy_sha256=POLICY_SHA,
+        )
+
+        self.assertEqual(fingerprints.impact.expected_sha256, POLICY_SHA)
+        self.assertEqual(fingerprints.impact.current_sha256, POLICY_SHA)
+
+    def test_missing_owner_evidence_does_not_adopt_current_impact_policy(self) -> None:
+        target = ChangeImpactTarget(
+            repository_id="101",
+            repository_owner_id="202",
+            repository=REPOSITORY,
+            pull_request_number=2083,
+            head_sha=HEAD_SHA,
+            tree_sha=TREE_SHA,
+        )
+        evaluator = LiveMergeAdmissionEvaluator(
+            store=object(),
+            repository_evidence_provider=_UnusedRepositoryEvidenceProvider(),
+            technical_check_client=_TechnicalCheckClient(),
+        )
+
+        fingerprints = evaluator._policy_fingerprints(
+            impact=ChangeImpactEvaluation(
+                status="success",
+                reason_code="change_impact_classified",
+                target=target,
+                policy_digest=POLICY_SHA,
+            ),
+            owner_decision=OwnerAcceptanceDecision(
+                status="pending",
+                reason_code="acceptance_missing",
+                evaluated_at="2026-08-11T03:01:00Z",
+            ),
+            engineering_decision=None,
+            engineering_authority_digest=None,
+            technical_checks=_PassingTechnicalCheckClient().read_technical_checks(
+                repository=REPOSITORY,
+                base_branch="main",
+                base_sha=BASE_SHA,
+                head_sha=HEAD_SHA,
+                evaluated_at="2026-08-11T03:01:00Z",
+            ),
+            landing_policy_sha256=POLICY_SHA,
+            current_merge_train_policy_sha256=POLICY_SHA,
+        )
+
+        self.assertNotEqual(fingerprints.impact.expected_sha256, POLICY_SHA)
+        self.assertEqual(fingerprints.impact.current_sha256, POLICY_SHA)
+
     def test_repository_policy_controls_engineering_review_authority(self) -> None:
         candidate_record, landing_record, controller_state, structural_result = _guard_records()
         snapshot_reader = _StaticSnapshotReader(


### PR DESCRIPTION
## Summary
- bind the expected impact-policy fingerprint to the successful current evaluation when Owner review is explicitly not required
- preserve the missing-policy sentinel for pending, unavailable, or otherwise unbound Owner evidence
- document the engineering-only policy boundary and add positive/fail-closed regressions

## Validation
- `uv run --extra dev python -m unittest tests.test_merge_admission_live tests.test_merge_readiness tests.test_merge_admission_records`
- `uv run --extra dev ruff check control_plane/merge_admission_live.py tests/test_merge_admission_live.py`
- `uv run --extra dev ruff format --check control_plane/merge_admission_live.py tests/test_merge_admission_live.py`
- `uv run --extra dev mypy control_plane tests`
- `uv run --extra dev launchplane ci unittest-shard local --jobs 2` (3,181 targets / 12 shards; one unrelated ASGI startup timeout passed on isolated retry and the full rerun passed)
- JetBrains changed-files inspection: only existing findings in the touched files

Refs #2277