### PR TITLE
Handle GitHub candidate ref read lag

### DIFF
--- a/control_plane/merge_train_github.py
+++ b/control_plane/merge_train_github.py
@@ -1,4 +1,5 @@
 import json
+from time import sleep
 from typing import Callable, Protocol, TypeVar
 from urllib.error import HTTPError, URLError
 from urllib.parse import quote, urlencode
@@ -37,10 +38,11 @@ class MergeTrainGitHubError(RuntimeError):
 
 
 class MergeTrainGitHubStaleHeadError(MergeTrainGitHubError):
-    """Raised when GitHub refuses a guarded merge because the head SHA changed."""
+    """Raised when GitHub state no longer matches guarded merge evidence."""
 
 
 ModelT = TypeVar("ModelT", bound=BaseModel)
+MERGE_REF_READ_DELAYS_SECONDS = (0.25, 0.5, 1.0, 2.0, 4.0)
 
 
 class MergeTrainGitHubTransport(Protocol):
@@ -200,10 +202,12 @@ class GitHubMergeTrainClient(MergeTrainStackCollapseBranchClient):
             if not isinstance(payload, dict):
                 raise MergeTrainGitHubError("GitHub merge response must be a JSON object.")
             response_sha = _required_text(payload.get("sha"), "GitHub merge response requires sha.")
-            observed_candidate_sha = _base_branch_sha(
+            observed_candidate_sha = _wait_for_branch_sha(
                 transport=self.transport,
                 repository_path=repository_path,
                 base_branch=candidate_branch,
+                expected_sha=response_sha,
+                previous_sha=parent_sha,
             )
             if observed_candidate_sha != response_sha:
                 raise MergeTrainGitHubStaleHeadError(
@@ -1695,6 +1699,31 @@ def _base_branch_sha(
     )
     commit = _json_object(branch.get("commit"), "GitHub branch commit")
     return _required_text(commit.get("sha"), "GitHub branch commit requires sha.")
+
+
+def _wait_for_branch_sha(
+    *,
+    transport: MergeTrainGitHubTransport,
+    repository_path: str,
+    base_branch: str,
+    expected_sha: str,
+    previous_sha: str,
+) -> str:
+    observed_sha = _base_branch_sha(
+        transport=transport,
+        repository_path=repository_path,
+        base_branch=base_branch,
+    )
+    for delay_seconds in MERGE_REF_READ_DELAYS_SECONDS:
+        if observed_sha != previous_sha or observed_sha == expected_sha:
+            return observed_sha
+        sleep(delay_seconds)
+        observed_sha = _base_branch_sha(
+            transport=transport,
+            repository_path=repository_path,
+            base_branch=base_branch,
+        )
+    return observed_sha
 
 
 def _base_branch_identity(

--- a/docs/merge-train-policy.md
+++ b/docs/merge-train-policy.md
@@ -163,6 +163,11 @@ temporary candidate ref or branch so GitHub Actions can run checks against a
 real commit SHA. The exact ref naming and cleanup policy are part of the batch
 train implementation, not the repository policy TOML.
 
+After GitHub creates a candidate merge commit, Launchplane performs a bounded
+read-after-write convergence check before declaring the candidate ref stale.
+This tolerates transient GitHub ref-read lag without weakening the exact
+expected-commit comparison; exhaustion still fails closed as stale state.
+
 ### Candidate Validation
 
 Required checks must pass on the candidate commit that includes the queued PRs

--- a/tests/test_merge_train_github.py
+++ b/tests/test_merge_train_github.py
@@ -653,6 +653,138 @@ class GitHubMergeTrainClientTests(unittest.TestCase):
                 )
                 self.assertEqual(transport.requests[1].body, {"sha": "base-main", "force": True})
 
+    def test_build_batch_candidate_retries_eventually_consistent_ref_read(self) -> None:
+        candidate = _batch_candidate()
+        transport = RecordingMergeTrainGitHubTransport(
+            responses=(
+                {"ref": candidate.candidate_ref, "object": {"sha": "base-main"}},
+                _git_commit("base-main", "tree-base"),
+                _git_commit("head-1", "tree-head-1"),
+                _git_commit("head-2", "tree-head-2"),
+                _merge_commit("candidate-after-1", "tree-candidate-1"),
+                _github_branch(sha="base-main", tree_sha="tree-base"),
+                _github_branch(sha="candidate-after-1", tree_sha="tree-candidate-1"),
+                _git_commit(
+                    "candidate-after-1", "tree-candidate-1", parents=("base-main", "head-1")
+                ),
+                _merge_commit("candidate-after-2", "tree-candidate-2"),
+                _github_branch(sha="candidate-after-2", tree_sha="tree-candidate-2"),
+                _git_commit(
+                    "candidate-after-2",
+                    "tree-candidate-2",
+                    parents=("candidate-after-1", "head-2"),
+                ),
+            )
+        )
+
+        with patch("control_plane.merge_train_github.sleep") as sleep_mock:
+            built_candidate = GitHubMergeTrainClient(transport=transport).build_batch_candidate(
+                candidate=candidate
+            )
+
+        self.assertEqual(built_candidate.status, "ready_for_checks")
+        self.assertEqual(built_candidate.candidate_sha, "candidate-after-2")
+        sleep_mock.assert_called_once_with(0.25)
+        self.assertEqual(
+            [request.method for request in transport.requests].count("POST"),
+            3,
+        )
+
+    def test_build_batch_candidate_accepts_expected_sha_on_final_ref_read(self) -> None:
+        candidate = _batch_candidate()
+        stale_branch = _github_branch(sha="base-main", tree_sha="tree-base")
+        transport = RecordingMergeTrainGitHubTransport(
+            responses=(
+                {"ref": candidate.candidate_ref, "object": {"sha": "base-main"}},
+                _git_commit("base-main", "tree-base"),
+                _git_commit("head-1", "tree-head-1"),
+                _git_commit("head-2", "tree-head-2"),
+                _merge_commit("candidate-after-1", "tree-candidate-1"),
+                stale_branch,
+                stale_branch,
+                stale_branch,
+                stale_branch,
+                stale_branch,
+                _github_branch(sha="candidate-after-1", tree_sha="tree-candidate-1"),
+                _git_commit(
+                    "candidate-after-1", "tree-candidate-1", parents=("base-main", "head-1")
+                ),
+                _merge_commit("candidate-after-2", "tree-candidate-2"),
+                _github_branch(sha="candidate-after-2", tree_sha="tree-candidate-2"),
+                _git_commit(
+                    "candidate-after-2",
+                    "tree-candidate-2",
+                    parents=("candidate-after-1", "head-2"),
+                ),
+            )
+        )
+
+        with patch("control_plane.merge_train_github.sleep") as sleep_mock:
+            built_candidate = GitHubMergeTrainClient(transport=transport).build_batch_candidate(
+                candidate=candidate
+            )
+
+        self.assertEqual(built_candidate.status, "ready_for_checks")
+        self.assertEqual(
+            [call.args[0] for call in sleep_mock.call_args_list],
+            [0.25, 0.5, 1.0, 2.0, 4.0],
+        )
+
+    def test_build_batch_candidate_fails_closed_after_ref_read_exhaustion(self) -> None:
+        candidate = _batch_candidate()
+        stale_branch = _github_branch(sha="base-main", tree_sha="tree-base")
+        transport = RecordingMergeTrainGitHubTransport(
+            responses=(
+                {"ref": candidate.candidate_ref, "object": {"sha": "base-main"}},
+                _git_commit("base-main", "tree-base"),
+                _git_commit("head-1", "tree-head-1"),
+                _git_commit("head-2", "tree-head-2"),
+                _merge_commit("candidate-after-1", "tree-candidate-1"),
+                stale_branch,
+                stale_branch,
+                stale_branch,
+                stale_branch,
+                stale_branch,
+                stale_branch,
+            )
+        )
+
+        with patch("control_plane.merge_train_github.sleep") as sleep_mock:
+            with self.assertRaisesRegex(
+                MergeTrainGitHubStaleHeadError,
+                "candidate ref did not resolve",
+            ):
+                GitHubMergeTrainClient(transport=transport).build_batch_candidate(
+                    candidate=candidate
+                )
+
+        self.assertEqual(sleep_mock.call_count, 5)
+        self.assertEqual(
+            [request.method for request in transport.requests].count("POST"),
+            2,
+        )
+
+    def test_build_batch_candidate_does_not_wait_on_unrelated_ref_sha(self) -> None:
+        candidate = _batch_candidate()
+        transport = RecordingMergeTrainGitHubTransport(
+            responses=(
+                {"ref": candidate.candidate_ref, "object": {"sha": "base-main"}},
+                _git_commit("base-main", "tree-base"),
+                _git_commit("head-1", "tree-head-1"),
+                _git_commit("head-2", "tree-head-2"),
+                _merge_commit("candidate-after-1", "tree-candidate-1"),
+                _github_branch(sha="unexpected-sha", tree_sha="unexpected-tree"),
+            )
+        )
+
+        with patch("control_plane.merge_train_github.sleep") as sleep_mock:
+            with self.assertRaises(MergeTrainGitHubStaleHeadError):
+                GitHubMergeTrainClient(transport=transport).build_batch_candidate(
+                    candidate=candidate
+                )
+
+        sleep_mock.assert_not_called()
+
     def test_build_batch_candidate_reports_conflict_without_landing_prs(self) -> None:
         candidate = _batch_candidate()
         transport = RecordingMergeTrainGitHubTransport(


### PR DESCRIPTION
## Summary

- add bounded read-after-write convergence after GitHub returns a merge-train candidate commit
- retry only while the candidate ref still shows the known predecessor SHA
- fail closed immediately on unrelated ref movement and after the bounded delay schedule is exhausted
- document the convergence boundary and add success, final-attempt, exhaustion, and unrelated-drift tests

## Incident Evidence

Launchplane controller trace `launchplane_req_406ecfafe994438184bd39e834ea9979` persisted `candidate_failed` because an immediate branch read did not yet resolve to GitHub's reported merge commit. Read-back later proved the candidate ref pointed to that exact commit with the expected base and PR-head parents. No landing attempt occurred.

## Validation

- `uv run --extra dev python -m unittest tests.test_merge_train_github tests.test_merge_train_controller` — 84 passed
- `uv run --extra dev launchplane ci unittest-shard local --jobs 2` — all 3,185 targets passed across 12 shards
- changed-file Ruff and format checks passed
- changed-file mypy passed
- PyCharm inspection found no findings in the new helper or new tests; the module-wide result remains red from inherited findings outside all changed hunks

Refs #2276
Refs #2277