### PR TITLE
Retry failed unbuilt merge candidates

### DIFF
--- a/control_plane/merge_train_controller_run_once.py
+++ b/control_plane/merge_train_controller_run_once.py
@@ -2007,11 +2007,12 @@ def try_reflow_failed_merge_train_candidate(
     dry_run_result = build_merge_train_dry_run_result(policy=policy, snapshot=snapshot)
     if dry_run_result.intended_next_action != "merge":
         return None
-    if _merge_train_candidate_matches_dry_run_queue(
+    queue_unchanged = _merge_train_candidate_matches_dry_run_queue(
         candidate=active_candidate_record.candidate,
         dry_run_result=dry_run_result,
         base_sha=snapshot.base_sha,
-    ):
+    )
+    if queue_unchanged and active_candidate_record.candidate.candidate_sha:
         return None
     candidate = build_merge_train_batch_candidate(
         dry_run_result=dry_run_result,

--- a/docs/merge-train-policy.md
+++ b/docs/merge-train-policy.md
@@ -574,7 +574,11 @@ Controller actions have these retry/stop semantics:
 - `candidate_failed`: Candidate checks failed and still matches the current
   eligible queue. Stop and surface the candidate record id and failed check
   evidence. If the eligible queue/base changes, the next controller action may
-  become `plan_candidate` for a superseding candidate.
+  become `plan_candidate` for a superseding candidate. A failed candidate with
+  no recorded candidate SHA never reached checks, so the controller may also
+  supersede and replan it against the unchanged queue after a transient build
+  failure is repaired. Failed candidates with a recorded candidate SHA remain
+  terminal until the queue or base changes.
 - `plan_landing`: A passed candidate is ready for PR-native landing-plan
   creation. Mutate once, then call again.
 - `land_batch`: A landing plan with planned or in-progress merge entries is

--- a/tests/test_http_app_merge_train.py
+++ b/tests/test_http_app_merge_train.py
@@ -2206,6 +2206,111 @@ class FastApiMergeTrainControllerRunOnceTests(unittest.IsolatedAsyncioTestCase):
             [1, 2],
         )
 
+    async def test_reflows_unbuilt_failed_candidate_with_unchanged_queue(self) -> None:
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict("os.environ", {"GH_TOKEN": "token"}, clear=True),
+        ):
+            state_dir = Path(temporary_directory_name) / "state"
+            _seed_merge_train_policy(state_dir)
+            store = FilesystemRecordStore(state_dir=state_dir)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_merge_train_service_identity()),
+                authz_policy=_merge_train_service_policy(),
+                record_store_factory=lambda: store,
+            )
+            request_payload = {
+                "schema_version": 1,
+                "repository": "cbusillo/sellyouroutboard",
+                "base_branch": "main",
+                "mutate": True,
+            }
+            with (
+                patch(
+                    "control_plane.merge_train_controller_run_once.GitHubMergeTrainSnapshotReader",
+                    _FakeMergeTrainSnapshotReader,
+                ),
+                patch(
+                    "control_plane.merge_train_controller_run_once.GitHubMergeTrainClient",
+                    _FakeMergeTrainGitHubClient,
+                ),
+            ):
+                await _post_merge_train_controller_run_once(app, request_payload)
+            with patch(
+                "control_plane.merge_train_controller_run_once.GitHubMergeTrainClient",
+                _StaleCandidateMergeTrainGitHubClient,
+            ):
+                failed_response = await _post_merge_train_controller_run_once(app, request_payload)
+            with patch(
+                "control_plane.merge_train_controller_run_once.GitHubMergeTrainSnapshotReader",
+                _FakeMergeTrainSnapshotReader,
+            ):
+                reflow_response = await _post_merge_train_controller_run_once(app, request_payload)
+
+        failed_payload = failed_response.json()
+        reflow_payload = reflow_response.json()
+        self.assertEqual(failed_payload["result"]["candidate"]["candidate_sha"], "")
+        self.assertEqual(reflow_response.status_code, 202)
+        self.assertEqual(reflow_payload["result"]["controller_action"], "plan_candidate")
+        self.assertEqual(
+            reflow_payload["result"]["superseded_merge_train_batch_candidate_record_id"],
+            failed_payload["records"]["merge_train_batch_candidate_record_id"],
+        )
+
+    async def test_keeps_checked_failed_candidate_terminal_with_unchanged_queue(self) -> None:
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict("os.environ", {"GH_TOKEN": "token"}, clear=True),
+        ):
+            state_dir = Path(temporary_directory_name) / "state"
+            _seed_merge_train_policy(state_dir)
+            store = FilesystemRecordStore(state_dir=state_dir)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_merge_train_service_identity()),
+                authz_policy=_merge_train_service_policy(),
+                record_store_factory=lambda: store,
+            )
+            request_payload = {
+                "schema_version": 1,
+                "repository": "cbusillo/sellyouroutboard",
+                "base_branch": "main",
+                "mutate": True,
+            }
+            with (
+                patch(
+                    "control_plane.merge_train_controller_run_once.GitHubMergeTrainSnapshotReader",
+                    _FakeMergeTrainSnapshotReader,
+                ),
+                patch(
+                    "control_plane.merge_train_controller_run_once.GitHubMergeTrainClient",
+                    _FakeMergeTrainGitHubClient,
+                ),
+            ):
+                await _post_merge_train_controller_run_once(app, request_payload)
+                await _post_merge_train_controller_run_once(app, request_payload)
+            with patch(
+                "control_plane.merge_train_controller_run_once.GitHubMergeTrainClient",
+                _FakeFailingMergeTrainGitHubClient,
+            ):
+                failed_response = await _post_merge_train_controller_run_once(app, request_payload)
+            with patch(
+                "control_plane.merge_train_controller_run_once.GitHubMergeTrainSnapshotReader",
+                _FakeMergeTrainSnapshotReader,
+            ):
+                terminal_response = await _post_merge_train_controller_run_once(
+                    app, request_payload
+                )
+
+        failed_payload = failed_response.json()
+        terminal_payload = terminal_response.json()
+        self.assertTrue(failed_payload["result"]["candidate"]["candidate_sha"])
+        self.assertEqual(terminal_response.status_code, 202)
+        self.assertEqual(terminal_payload["result"]["controller_action"], "candidate_failed")
+        self.assertEqual(
+            terminal_payload["records"]["merge_train_batch_candidate_record_id"],
+            failed_payload["records"]["merge_train_batch_candidate_record_id"],
+        )
+
     async def test_advances_stacked_batch_flow(self) -> None:
         with (
             TemporaryDirectory() as temporary_directory_name,


### PR DESCRIPTION
## Summary

- allow the controller to supersede and replan a failed candidate against an unchanged queue only when no candidate SHA was ever recorded
- keep candidates that reached the check phase terminal until the queue or base changes
- document the recovery boundary and add unchanged-queue recovery plus checked-failure regression tests

## Recovery Context

The codex-skills train candidate created during trace `launchplane_req_406ecfafe994438184bd39e834ea9979` failed before its candidate SHA was persisted. PR #2294 prevents the original GitHub ref-read race; this change provides the bounded controller-owned path to supersede that durable unbuilt failure without deleting refs or fabricating queue drift.

## Validation

- focused unchanged-queue recovery and terminal checked-failure tests passed
- changed-file Ruff, format, and mypy passed
- full local suite: first run had one unrelated ASGI lifespan timeout; the exact test passed immediately; full rerun passed all 3,185 targets across 12 shards
- PyCharm inspection completed with inherited findings outside both changed hunks; no new controller or test hunk had a finding

Refs #2276
Refs #2277
Refs #2294