### PR TITLE
fix: run VeriReel prod migrations without npx

### DIFF
--- a/control_plane/workflows/verireel_prod_promotion.py
+++ b/control_plane/workflows/verireel_prod_promotion.py
@@ -322,7 +322,7 @@ def _build_result(
 
 
 def _default_migration_command() -> str:
-    return "npx prisma migrate deploy --config prisma.config.ts"
+    return "./node_modules/.bin/prisma migrate deploy --config prisma.config.ts"
 
 
 def _default_migration_schedule_name() -> str:

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -2066,6 +2066,9 @@ return a typed blocked result rather than guessing a domain.
   artifacts.
 - TOML/env files are not runtime import surfaces; use DB-native
   runtime-environment records and managed secrets instead.
+- VeriReel production promotion runs Prisma migrations with the runtime image's
+  local `./node_modules/.bin/prisma` binary. The production image intentionally
+  omits global `npm` and `npx`, so promotion must not depend on either command.
 - Product repos and GitHub issues must not contain product secret values. Put
   the JSON bundle on an operator-controlled machine or inside the hosted
   Launchplane execution context, run `--dry-run` first, then run `--apply` only

--- a/tests/test_verireel_prod_promotion.py
+++ b/tests/test_verireel_prod_promotion.py
@@ -11,6 +11,7 @@ from control_plane.contracts.promotion_record import ArtifactIdentityReference, 
 from control_plane.storage.filesystem import FilesystemRecordStore
 from control_plane.workflows.verireel_prod_promotion import (
     VeriReelProdPromotionRequest,
+    _default_migration_command,
     execute_verireel_prod_promotion,
 )
 from control_plane.workflows.verireel_rollout import VeriReelRolloutVerificationResult
@@ -21,6 +22,12 @@ from control_plane.workflows.verireel_billing_recovery_schedule import (
 
 
 class VeriReelProdPromotionWorkflowTests(unittest.TestCase):
+    def test_default_migration_command_uses_runtime_prisma_binary(self) -> None:
+        self.assertEqual(
+            _default_migration_command(),
+            "./node_modules/.bin/prisma migrate deploy --config prisma.config.ts",
+        )
+
     def setUp(self) -> None:
         self.enterContext(
             patch(


### PR DESCRIPTION
## Summary

- run VeriReel production migrations with the Prisma binary bundled in the
  runtime image
- add a focused regression test for the production migration command
- document that the runtime image intentionally omits global `npm` and `npx`

## Incident

VeriReel promotion run `33584248501` deployed successfully but its migration
schedule failed because Launchplane invoked `npx prisma migrate deploy`. The
verified VeriReel runtime image intentionally removes global `npm` and `npx` and
already includes `./node_modules/.bin/prisma`, which the testing and preview
maintenance paths use successfully.

Production remained healthy on the previous image after the failed migration.

## Validation

- `uv run --extra dev python -m unittest tests.test_verireel_prod_promotion`
- `uv run --extra dev ruff check control_plane/workflows/verireel_prod_promotion.py tests/test_verireel_prod_promotion.py`
- `uv run --extra dev ruff format --check control_plane/workflows/verireel_prod_promotion.py tests/test_verireel_prod_promotion.py`
- `uv run --extra dev mypy control_plane/workflows/verireel_prod_promotion.py tests/test_verireel_prod_promotion.py`
- full local sharded suite attempted twice; unrelated ASGI tests timed out under
  local runner load while the focused module passed
- PyCharm inspection found no issue at the changed lines; its 21 warnings are
  pre-existing findings elsewhere in the touched production workflow file

Refs #2297
