### PR TITLE
fix: preserve historical privileged operation digests

### DIFF
--- a/control_plane/contracts/privileged_operation.py
+++ b/control_plane/contracts/privileged_operation.py
@@ -711,8 +711,9 @@ class PrivilegedOperationRecord(BaseModel):
         )
         if self.request_digest not in privileged_operation_request_digest_candidates(self.request):
             raise ValueError("Privileged-operation request_digest does not match request")
-        expected_evidence_digest = privileged_operation_evidence_digest(self.evidence)
-        if self.evidence_digest != expected_evidence_digest:
+        if self.evidence_digest not in privileged_operation_evidence_digest_candidates(
+            self.evidence
+        ):
             raise ValueError("Privileged-operation evidence_digest does not match evidence")
         object.__setattr__(self, "created_at", _timestamp(self.created_at, "created_at"))
         object.__setattr__(self, "updated_at", _timestamp(self.updated_at, "updated_at"))
@@ -964,6 +965,32 @@ def privileged_operation_evidence_digest(
     evidence: PrivilegedOperationHumanEvidence,
 ) -> str:
     return _digest_payload(evidence.model_dump(mode="json"))
+
+
+def privileged_operation_evidence_digest_candidates(
+    evidence: PrivilegedOperationHumanEvidence,
+) -> frozenset[str]:
+    payload = evidence.model_dump(mode="json")
+    candidates = {_digest_payload(payload)}
+    if isinstance(evidence, ManagedAuthzPolicySetHumanEvidence):
+        diff = payload["diff"]
+        assert isinstance(diff, dict)
+        legacy_defaults = {
+            "previous_administrator_quorum": 2,
+            "administrator_quorum": 2,
+            "administrator_quorum_changed": False,
+            "strict_human_administrator_count": 0,
+            "quorum_satisfied": False,
+            "solo_administration_active": False,
+        }
+        if all(diff.get(field_name) == value for field_name, value in legacy_defaults.items()):
+            legacy_payload = dict(payload)
+            legacy_diff = dict(diff)
+            for field_name in legacy_defaults:
+                legacy_diff.pop(field_name, None)
+            legacy_payload["diff"] = legacy_diff
+            candidates.add(_digest_payload(legacy_payload))
+    return frozenset(candidates)
 
 
 def privileged_operation_pre_state_digest(

--- a/control_plane/contracts/privileged_operation.py
+++ b/control_plane/contracts/privileged_operation.py
@@ -709,8 +709,7 @@ class PrivilegedOperationRecord(BaseModel):
             "evidence_digest",
             _sha256(self.evidence_digest, "evidence_digest"),
         )
-        expected_request_digest = privileged_operation_request_digest(self.request)
-        if self.request_digest != expected_request_digest:
+        if self.request_digest not in privileged_operation_request_digest_candidates(self.request):
             raise ValueError("Privileged-operation request_digest does not match request")
         expected_evidence_digest = privileged_operation_evidence_digest(self.evidence)
         if self.evidence_digest != expected_evidence_digest:
@@ -944,6 +943,21 @@ PrivilegedOperationSummary: TypeAlias = (
 
 def privileged_operation_request_digest(request: PrivilegedOperationRequest) -> str:
     return _digest_payload(request.model_dump(mode="json"))
+
+
+def privileged_operation_request_digest_candidates(
+    request: PrivilegedOperationRequest,
+) -> frozenset[str]:
+    payload = request.model_dump(mode="json")
+    candidates = {_digest_payload(payload)}
+    if (
+        isinstance(request, ManagedAuthzPolicySetProposalInput)
+        and request.administrator_quorum_change is None
+    ):
+        legacy_payload = dict(payload)
+        legacy_payload.pop("administrator_quorum_change", None)
+        candidates.add(_digest_payload(legacy_payload))
+    return frozenset(candidates)
 
 
 def privileged_operation_evidence_digest(

--- a/control_plane/privileged_operation_service.py
+++ b/control_plane/privileged_operation_service.py
@@ -24,6 +24,7 @@ from control_plane.contracts.privileged_operation import (
     privileged_operation_evidence_digest,
     privileged_operation_record_digest,
     privileged_operation_request_digest,
+    privileged_operation_request_digest_candidates,
 )
 from control_plane.privileged_operation_registry import (
     read_privileged_operation_descriptor,
@@ -161,7 +162,7 @@ def _replay_existing_plan(
         or record.safety_class != registration.descriptor.safety_class
         or record.source_event_id != source_event_id
         or record.requested_by != actor
-        or record.request_digest != privileged_operation_request_digest(request)
+        or record.request_digest not in privileged_operation_request_digest_candidates(request)
         or datetime.fromisoformat(record.expires_at) != expected_expiry
     ):
         raise PrivilegedOperationConflictError(

--- a/docs/privileged-operations.md
+++ b/docs/privileged-operations.md
@@ -25,6 +25,11 @@ route, execute action, static execution credential, or agent execution path.
   reconciliation planner with `mode="dry_run"` only. Its request contains one
   managed set, the exact desired schema-v2 policy fragment, reason, and optional
   related issue. Planning never writes the active authorization policy.
+  Historical requests created before the optional
+  `administrator_quorum_change` field remain readable when that value is absent
+  or `null`: validation accepts only the two exact canonical digest projections
+  for those equivalent shapes. New records continue to write the current digest,
+  and every other request-digest mismatch fails closed.
 - `managed-merge-train-policy-import` version 1 accepts one complete schema-
   valid candidate merge-train policy record, a reason, and optional related
   issue. Its planner reads exactly one active merge-train policy record and

--- a/docs/privileged-operations.md
+++ b/docs/privileged-operations.md
@@ -27,9 +27,11 @@ route, execute action, static execution credential, or agent execution path.
   related issue. Planning never writes the active authorization policy.
   Historical requests created before the optional
   `administrator_quorum_change` field remain readable when that value is absent
-  or `null`: validation accepts only the two exact canonical digest projections
-  for those equivalent shapes. New records continue to write the current digest,
-  and every other request-digest mismatch fails closed.
+  or `null`. Historical evidence created before the administrator-quorum summary
+  fields remains readable only when all six fields normalize to their original
+  defaults. Validation accepts only those exact canonical digest projections.
+  New records continue to write the current request and evidence digests, and
+  every other mismatch fails closed.
 - `managed-merge-train-policy-import` version 1 accepts one complete schema-
   valid candidate merge-train policy record, a reason, and optional related
   issue. Its planner reads exactly one active merge-train policy record and

--- a/tests/test_privileged_operation.py
+++ b/tests/test_privileged_operation.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import base64
 from datetime import datetime, timedelta, timezone
+import json
 from pathlib import Path
 from tempfile import TemporaryDirectory
 import unittest
@@ -12,6 +13,9 @@ from control_plane.contracts.privileged_operation import (
     AUTHZ_POLICY_OPERATION_PROPOSE_ACTION,
     MERGE_TRAIN_POLICY_OPERATION_APPROVE_ACTION,
     MERGE_TRAIN_POLICY_OPERATION_PROPOSE_ACTION,
+    ManagedAuthzPolicySetExecutionEvidence,
+    ManagedAuthzPolicySetHumanEvidence,
+    ManagedAuthzPolicySetProposalInput,
     ManagedMergeTrainPolicyImportAgentSummary,
     ManagedMergeTrainPolicyImportHumanEvidence,
     ManagedMergeTrainPolicyImportProposalInput,
@@ -22,6 +26,7 @@ from control_plane.contracts.privileged_operation import (
     PRIVILEGED_SECRET_OPERATION_PLAN_ACTION,
     PRIVILEGED_SECRET_OPERATION_READ_ACTION,
     PrivilegedOperationActor,
+    PrivilegedOperationApproval,
     PrivilegedOperationAgentActor,
     PrivilegedOperationConflictError,
     PrivilegedOperationEventRecord,
@@ -30,9 +35,13 @@ from control_plane.contracts.privileged_operation import (
     build_privileged_operation_id_for_actor,
     privileged_operation_agent_summary,
     privileged_operation_evidence_digest,
+    privileged_operation_pre_state_digest,
     privileged_operation_record_digest,
     privileged_operation_request_digest,
+    privileged_operation_request_digest_candidates,
 )
+from control_plane.authz_grant_service import AuthzManagedPolicyDiff
+from control_plane.contracts.canonical_json import canonical_json_sha256
 from control_plane.privileged_operation_registry import (
     MANAGED_MERGE_TRAIN_POLICY_IMPORT_DESCRIPTOR,
     MANAGED_SECRET_REENCRYPTION_DESCRIPTOR,
@@ -47,9 +56,12 @@ from control_plane.privileged_operation_service import (
     expire_privileged_operation_if_due,
     list_privileged_operations,
 )
-from control_plane.service_auth import action_safety
+from control_plane.service_auth import LaunchplaneAuthzPolicy, action_safety
 from control_plane.storage.filesystem import FilesystemRecordStore
-from control_plane.storage.postgres import PostgresRecordStore
+from control_plane.storage.postgres import (
+    LaunchplanePrivilegedOperationRow,
+    PostgresRecordStore,
+)
 from tests.merge_train_policy_fixtures import build_test_merge_train_policy_record
 
 
@@ -113,7 +125,132 @@ def _planned_event(record: PrivilegedOperationRecord) -> PrivilegedOperationEven
     )
 
 
+def _failed_authz_policy_record() -> PrivilegedOperationRecord:
+    request = ManagedAuthzPolicySetProposalInput(
+        managed_set_id="test.policy-operation",
+        desired_policy=LaunchplaneAuthzPolicy.model_validate(
+            {
+                "schema_version": 2,
+                "github_humans": [
+                    {
+                        "managed_set_id": "test.policy-operation",
+                        "managed_rule_id": "policy-operation-reader",
+                        "github_ids": [123],
+                        "roles": ["admin"],
+                        "products": ["launchplane"],
+                        "contexts": ["launchplane"],
+                        "actions": ["authz_policy_operation.read"],
+                    }
+                ],
+            }
+        ),
+        reason="Review the exact managed policy plan.",
+    )
+    evidence = ManagedAuthzPolicySetHumanEvidence(
+        result_status="ok",
+        plan_digest="d" * 64,
+        diff=AuthzManagedPolicyDiff(
+            managed_set_id="test.policy-operation",
+            previous_record_id="authz-policy-previous",
+            previous_revision=1,
+            candidate_revision=2,
+            previous_policy_sha256="a" * 64,
+            desired_policy_sha256="b" * 64,
+            desired_set_sha256="c" * 64,
+            plan_sha256="d" * 64,
+            strict_human_administrator_count=2,
+            quorum_satisfied=True,
+        ),
+    )
+    actor = PrivilegedOperationActor(
+        identity_type="github_human",
+        github_id=123,
+        login="operator",
+    )
+    request_digest = privileged_operation_request_digest(request)
+    evidence_digest = privileged_operation_evidence_digest(evidence)
+    approval = PrivilegedOperationApproval(
+        approver=actor,
+        descriptor_id="managed-authz-policy-set",
+        descriptor_version=1,
+        request_digest=request_digest,
+        evidence_digest=evidence_digest,
+        plan_digest=evidence.plan_digest,
+        pre_state_digest=privileged_operation_pre_state_digest(evidence),
+        policy_record_id="authz-policy-approval",
+        policy_revision=1,
+        policy_sha256="e" * 64,
+        policy_source="test-policy",
+        managed_set_id="privileged-operations.policy-planning",
+        managed_rule_id="human-policy-planner",
+        expires_at="2026-08-22T20:30:00+00:00",
+        reason="Reviewed the exact policy plan.",
+        rollback_class="policy_cas",
+    )
+    return PrivilegedOperationRecord(
+        operation_id=build_privileged_operation_id_for_actor(
+            descriptor_id="managed-authz-policy-set",
+            actor=actor,
+            source_event_id="historical-policy-failure",
+        ),
+        descriptor_id="managed-authz-policy-set",
+        descriptor_version=1,
+        safety_class="policy_admin",
+        status="execution_failed",
+        source_event_id="historical-policy-failure",
+        requested_by=actor,
+        request=request,
+        request_digest=request_digest,
+        evidence=evidence,
+        evidence_digest=evidence_digest,
+        created_at="2026-08-22T20:00:00+00:00",
+        updated_at="2026-08-22T20:10:00+00:00",
+        expires_at="2026-08-22T20:30:00+00:00",
+        approval=approval,
+        execution=ManagedAuthzPolicySetExecutionEvidence(
+            result_status="error",
+            result_digest="f" * 64,
+            changed=False,
+            reconciliation_required=True,
+            failure_code="policy_cas_conflict",
+        ),
+        terminal_at="2026-08-22T20:10:00+00:00",
+        terminal_reason="Policy execution failed closed.",
+    )
+
+
+def _legacy_authz_policy_payload() -> dict[str, object]:
+    payload = _failed_authz_policy_record().model_dump(mode="json", exclude_none=True)
+    request = payload["request"]
+    assert isinstance(request, dict)
+    legacy_digest = canonical_json_sha256(request)
+    payload["request_digest"] = legacy_digest
+    approval = payload["approval"]
+    assert isinstance(approval, dict)
+    approval["request_digest"] = legacy_digest
+    return payload
+
+
 class PrivilegedOperationContractTests(unittest.TestCase):
+    def test_historical_authz_request_digest_without_quorum_field_remains_valid(self) -> None:
+        current_record = _failed_authz_policy_record()
+        current_payload = current_record.model_dump(mode="json", exclude_none=True)
+        legacy_payload = _legacy_authz_policy_payload()
+
+        current_loaded = PrivilegedOperationRecord.model_validate(current_payload)
+        legacy_loaded = PrivilegedOperationRecord.model_validate(legacy_payload)
+
+        self.assertEqual(current_loaded.request_digest, current_record.request_digest)
+        self.assertNotEqual(legacy_loaded.request_digest, current_record.request_digest)
+        self.assertIn(
+            legacy_loaded.request_digest,
+            privileged_operation_request_digest_candidates(legacy_loaded.request),
+        )
+        tampered_payload = json.loads(json.dumps(legacy_payload))
+        tampered_payload["request_digest"] = "0" * 64
+        with self.assertRaisesRegex(ValueError, "request_digest does not match"):
+            PrivilegedOperationRecord.model_validate(tampered_payload)
+
     def test_action_safety_is_intentional(self) -> None:
         self.assertEqual(action_safety(PRIVILEGED_SECRET_OPERATION_PLAN_ACTION), "secret_backed")
         self.assertEqual(action_safety(PRIVILEGED_SECRET_OPERATION_READ_ACTION), "secret_backed")
@@ -411,6 +548,56 @@ class PrivilegedOperationStorageTests(unittest.TestCase):
                         now=lambda: datetime(2026, 8, 22, 20, 0, tzinfo=timezone.utc),
                     )
                     self.assertEqual(expired.status, "expired")
+            finally:
+                stores[1].close()
+
+    def test_historical_authz_failure_lists_across_stores(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            stores = self._stores(root)
+            payload = _legacy_authz_policy_payload()
+            operation_id = payload["operation_id"]
+            created_at = payload["created_at"]
+            updated_at = payload["updated_at"]
+            expires_at = payload["expires_at"]
+            assert isinstance(operation_id, str)
+            assert isinstance(created_at, str)
+            assert isinstance(updated_at, str)
+            assert isinstance(expires_at, str)
+            try:
+                filesystem_path = (
+                    root / "state" / "launchplane_privileged_operations" / f"{operation_id}.json"
+                )
+                filesystem_path.parent.mkdir(parents=True, exist_ok=True)
+                filesystem_path.write_text(
+                    json.dumps(payload, indent=2, sort_keys=True),
+                    encoding="utf-8",
+                )
+                postgres = stores[1]
+                with postgres._session_factory() as session:  # noqa: SLF001
+                    session.add(
+                        LaunchplanePrivilegedOperationRow(
+                            operation_id=operation_id,
+                            descriptor_id="managed-authz-policy-set",
+                            status="execution_failed",
+                            requester_github_id=123,
+                            created_at=created_at,
+                            updated_at=updated_at,
+                            expires_at=expires_at,
+                            payload=payload,
+                        )
+                    )
+                    session.commit()
+
+                for store in stores:
+                    records = store.list_privileged_operation_records(
+                        status="execution_failed",
+                        descriptor_id="managed-authz-policy-set",
+                        limit=50,
+                    )
+                    self.assertEqual(
+                        tuple(record.operation_id for record in records), (operation_id,)
+                    )
             finally:
                 stores[1].close()
 

--- a/tests/test_privileged_operation.py
+++ b/tests/test_privileged_operation.py
@@ -34,6 +34,7 @@ from control_plane.contracts.privileged_operation import (
     build_privileged_operation_id,
     build_privileged_operation_id_for_actor,
     privileged_operation_agent_summary,
+    privileged_operation_evidence_digest_candidates,
     privileged_operation_evidence_digest,
     privileged_operation_pre_state_digest,
     privileged_operation_record_digest,
@@ -53,6 +54,7 @@ from control_plane.privileged_operation_registry import (
 from control_plane.privileged_operation_service import (
     cancel_privileged_operation,
     create_privileged_operation_plan,
+    create_typed_privileged_operation_plan,
     expire_privileged_operation_if_due,
     list_privileged_operations,
 )
@@ -158,8 +160,6 @@ def _failed_authz_policy_record() -> PrivilegedOperationRecord:
             desired_policy_sha256="b" * 64,
             desired_set_sha256="c" * 64,
             plan_sha256="d" * 64,
-            strict_human_administrator_count=2,
-            quorum_satisfied=True,
         ),
     )
     actor = PrivilegedOperationActor(
@@ -220,14 +220,51 @@ def _failed_authz_policy_record() -> PrivilegedOperationRecord:
 
 
 def _legacy_authz_policy_payload() -> dict[str, object]:
-    payload = _failed_authz_policy_record().model_dump(mode="json", exclude_none=True)
+    record = _failed_authz_policy_record()
+    full_payload = record.model_dump(mode="json")
+    full_request = full_payload["request"]
+    full_evidence = full_payload["evidence"]
+    assert isinstance(full_request, dict)
+    assert isinstance(full_evidence, dict)
+    legacy_request = dict(full_request)
+    legacy_request.pop("administrator_quorum_change")
+    legacy_evidence = json.loads(json.dumps(full_evidence))
+    legacy_diff = legacy_evidence["diff"]
+    assert isinstance(legacy_diff, dict)
+    for field_name in (
+        "previous_administrator_quorum",
+        "administrator_quorum",
+        "administrator_quorum_changed",
+        "strict_human_administrator_count",
+        "quorum_satisfied",
+        "solo_administration_active",
+    ):
+        legacy_diff.pop(field_name)
+
+    payload = record.model_dump(mode="json", exclude_none=True)
     request = payload["request"]
+    evidence = payload["evidence"]
     assert isinstance(request, dict)
-    legacy_digest = canonical_json_sha256(request)
-    payload["request_digest"] = legacy_digest
+    assert isinstance(evidence, dict)
+    stored_diff = evidence["diff"]
+    assert isinstance(stored_diff, dict)
+    for field_name in (
+        "previous_administrator_quorum",
+        "administrator_quorum",
+        "administrator_quorum_changed",
+        "strict_human_administrator_count",
+        "quorum_satisfied",
+        "solo_administration_active",
+    ):
+        stored_diff.pop(field_name)
+    request_digest = canonical_json_sha256(legacy_request)
+    evidence_digest = canonical_json_sha256(legacy_evidence)
+    payload["request_digest"] = request_digest
+    payload["evidence_digest"] = evidence_digest
     approval = payload["approval"]
     assert isinstance(approval, dict)
-    approval["request_digest"] = legacy_digest
+    approval["request_digest"] = request_digest
+    approval["evidence_digest"] = evidence_digest
     return payload
 
 
@@ -246,10 +283,29 @@ class PrivilegedOperationContractTests(unittest.TestCase):
             legacy_loaded.request_digest,
             privileged_operation_request_digest_candidates(legacy_loaded.request),
         )
+        self.assertIn(
+            legacy_loaded.evidence_digest,
+            privileged_operation_evidence_digest_candidates(legacy_loaded.evidence),
+        )
         tampered_payload = json.loads(json.dumps(legacy_payload))
         tampered_payload["request_digest"] = "0" * 64
         with self.assertRaisesRegex(ValueError, "request_digest does not match"):
             PrivilegedOperationRecord.model_validate(tampered_payload)
+        tampered_payload = json.loads(json.dumps(legacy_payload))
+        tampered_payload["evidence_digest"] = "0" * 64
+        with self.assertRaisesRegex(ValueError, "evidence_digest does not match"):
+            PrivilegedOperationRecord.model_validate(tampered_payload)
+
+    def test_historical_digest_candidates_require_exact_optional_defaults(self) -> None:
+        record = _failed_authz_policy_record()
+        assert isinstance(record.evidence, ManagedAuthzPolicySetHumanEvidence)
+        quorum_request = record.request.model_copy(update={"administrator_quorum_change": 1})
+        quorum_evidence = record.evidence.model_copy(
+            update={"diff": record.evidence.diff.model_copy(update={"quorum_satisfied": True})}
+        )
+
+        self.assertEqual(len(privileged_operation_request_digest_candidates(quorum_request)), 1)
+        self.assertEqual(len(privileged_operation_evidence_digest_candidates(quorum_evidence)), 1)
 
     def test_action_safety_is_intentional(self) -> None:
         self.assertEqual(action_safety(PRIVILEGED_SECRET_OPERATION_PLAN_ACTION), "secret_backed")
@@ -600,6 +656,55 @@ class PrivilegedOperationStorageTests(unittest.TestCase):
                     )
             finally:
                 stores[1].close()
+
+    def test_service_replays_historical_authz_request_digest(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            state_dir = Path(temporary_directory)
+            store = FilesystemRecordStore(state_dir)
+            payload = _legacy_authz_policy_payload()
+            record = PrivilegedOperationRecord.model_validate(payload)
+            record_path = (
+                state_dir / "launchplane_privileged_operations" / f"{record.operation_id}.json"
+            )
+            record_path.parent.mkdir(parents=True, exist_ok=True)
+            record_path.write_text(
+                json.dumps(payload, indent=2, sort_keys=True),
+                encoding="utf-8",
+            )
+            planned_record = record.model_copy(
+                update={
+                    "status": "planned",
+                    "updated_at": record.created_at,
+                    "approval": None,
+                    "execution": None,
+                    "terminal_at": "",
+                    "terminal_reason": "",
+                }
+            )
+            event = _planned_event(planned_record)
+            event_path = (
+                state_dir / "launchplane_privileged_operation_events" / f"{event.event_id}.json"
+            )
+            event_path.parent.mkdir(parents=True, exist_ok=True)
+            event_path.write_text(
+                json.dumps(
+                    event.model_dump(mode="json", exclude_none=True), indent=2, sort_keys=True
+                ),
+                encoding="utf-8",
+            )
+
+            replay = create_typed_privileged_operation_plan(
+                record_store=store,
+                descriptor_id="managed-authz-policy-set",
+                actor=record.requested_by,
+                source_kind="browser_api",
+                source_event_id=record.source_event_id,
+                request=record.request,
+                expires_in_seconds=30 * 60,
+            )
+
+            self.assertEqual(replay.write_status, "replayed")
+            self.assertEqual(replay.record.request_digest, record.request_digest)
 
     def test_plan_replay_rejects_changed_payload(self) -> None:
         with TemporaryDirectory() as temporary_directory:

--- a/tests/test_privileged_operation_http.py
+++ b/tests/test_privileged_operation_http.py
@@ -26,6 +26,7 @@ from control_plane.contracts.privileged_operation import (
     MERGE_TRAIN_POLICY_OPERATION_READ_ACTION,
     MERGE_TRAIN_POLICY_OPERATION_REVOKE_ACTION,
     MERGE_TRAIN_POLICY_OPERATION_SUMMARY_READ_ACTION,
+    ManagedAuthzPolicySetHumanEvidence,
     PRIVILEGED_OPERATION_SUMMARY_READ_ACTION,
     PRIVILEGED_POLICY_OPERATION_SUMMARY_READ_ACTION,
     PRIVILEGED_SECRET_OPERATION_APPROVE_ACTION,
@@ -600,6 +601,34 @@ class PrivilegedOperationHttpTests(unittest.IsolatedAsyncioTestCase):
                         assert row is not None
                         payload = dict(row.payload)
                         payload["request_digest"] = canonical_json_sha256(payload["request"])
+                        evidence = ManagedAuthzPolicySetHumanEvidence.model_validate(
+                            payload["evidence"]
+                        ).model_dump(mode="json")
+                        evidence_diff = evidence["diff"]
+                        assert isinstance(evidence_diff, dict)
+                        for field_name in (
+                            "previous_administrator_quorum",
+                            "administrator_quorum",
+                            "administrator_quorum_changed",
+                            "strict_human_administrator_count",
+                            "quorum_satisfied",
+                            "solo_administration_active",
+                        ):
+                            evidence_diff.pop(field_name)
+                        payload["evidence_digest"] = canonical_json_sha256(evidence)
+                        stored_evidence = json.loads(json.dumps(payload["evidence"]))
+                        stored_diff = stored_evidence["diff"]
+                        assert isinstance(stored_diff, dict)
+                        for field_name in (
+                            "previous_administrator_quorum",
+                            "administrator_quorum",
+                            "administrator_quorum_changed",
+                            "strict_human_administrator_count",
+                            "quorum_satisfied",
+                            "solo_administration_active",
+                        ):
+                            stored_diff.pop(field_name)
+                        payload["evidence"] = stored_evidence
                         row.payload = payload
                         session.commit()
 

--- a/tests/test_privileged_operation_http.py
+++ b/tests/test_privileged_operation_http.py
@@ -13,6 +13,7 @@ from typing import cast
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel, ConfigDict
 
+from control_plane.contracts.canonical_json import canonical_json_sha256
 from control_plane.contracts.privileged_operation import (
     AUTHZ_POLICY_OPERATION_APPROVE_ACTION,
     AUTHZ_POLICY_OPERATION_CANCEL_ACTION,
@@ -50,7 +51,10 @@ from control_plane.service_auth import (
     TerminalAgentIdentity,
 )
 from control_plane.storage.filesystem import FilesystemRecordStore
-from control_plane.storage.postgres import PostgresRecordStore
+from control_plane.storage.postgres import (
+    LaunchplanePrivilegedOperationRow,
+    PostgresRecordStore,
+)
 from tests.support.http import lifespan_client
 from tests.support.stores import _sqlite_database_url
 
@@ -567,6 +571,50 @@ class PrivilegedOperationHttpTests(unittest.IsolatedAsyncioTestCase):
         self.assertNotIn("retirement_blocked_key_ids", summary_payload)
         self.assertNotIn("request", summary_payload)
         self.assertIn("configured_secret_count", summary_payload)
+
+    async def test_human_list_reads_historical_authz_request_digest(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(Path(temporary_directory) / "launchplane.sqlite3")
+            )
+            store.ensure_schema()
+            policy = _policy()
+            store.seed_authz_policy_if_absent(_policy_record(policy))
+            app = self._app(
+                store=store,
+                policy=policy,
+                policy_record_reader=lambda: store.list_authz_policy_records(
+                    status="active", limit=2
+                )[0],
+            )
+            try:
+                async with lifespan_client(app) as client:
+                    create_response = await client.post(
+                        "/v1/privileged-operations/plans",
+                        json=_managed_authz_plan_payload("historical-authz-plan"),
+                    )
+                    self.assertEqual(create_response.status_code, 200, create_response.text)
+                    operation_id = create_response.json()["record"]["operation_id"]
+                    with store._session_factory() as session:  # noqa: SLF001
+                        row = session.get(LaunchplanePrivilegedOperationRow, operation_id)
+                        assert row is not None
+                        payload = dict(row.payload)
+                        payload["request_digest"] = canonical_json_sha256(payload["request"])
+                        row.payload = payload
+                        session.commit()
+
+                    list_response = await client.get(
+                        "/v1/privileged-operations/plans",
+                        params={
+                            "descriptor_id": "managed-authz-policy-set",
+                            "limit": 50,
+                        },
+                    )
+            finally:
+                store.close()
+
+        self.assertEqual(list_response.status_code, 200, list_response.text)
+        self.assertEqual(list_response.json()["total"], 1)
 
     async def test_human_approval_and_revocation_are_replay_safe(self) -> None:
         with (


### PR DESCRIPTION
## Summary

- preserve historical managed-authz privileged-operation request digests created before `administrator_quorum_change` existed
- accept only the current exact digest and the exact legacy projection that omits that optional `None` field
- keep the current digest as the only digest generated for new records
- use the same compatibility set for idempotent plan replay checks
- document the persisted compatibility contract

## Production Evidence

A fresh signed-in owner request to the Access policy history returned HTTP 500. Bounded read-only probes isolated older managed-authz history, and redacted runtime logs identified `request_digest` validation. A production `SET TRANSACTION READ ONLY` comparison showed:

- historical stored digests match the request without `administrator_quorum_change`
- current normalization adds `administrator_quorum_change: null`
- storage omits `None`, so persisted field presence cannot distinguish the generation

No database write, provider mutation, policy mutation, row skipping, or broad validation exception was used.

## Validation

- focused privileged-operation contract/storage/HTTP modules: 33 tests passed
- exact regression cases: legacy/current/tampered contract, filesystem, SQLite/PostgreSQL mapping, authenticated HTTP list
- official local gate: 3,223 tests across 12 shards passed
- Ruff check and format check passed
- mypy passed across 798 source files
- JetBrains introduced-line findings were fixed; its remaining file-wide findings predate this diff

Refs #2303
