### PR TITLE
fix: allow lockfile-scoped dependency gate inputs

### DIFF
--- a/control_plane/config_authority_audit.py
+++ b/control_plane/config_authority_audit.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 import hashlib
 import json
 import os
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 import re
 import subprocess
 import tomllib
@@ -2631,6 +2631,11 @@ def _candidate_is_interesting(*, path: str, key: str, value: object) -> bool:
         return False
     if normalized.startswith(".github/workflows/") and _dependency_health_action_input_name(key):
         return True
+    if normalized.startswith(".github/workflows/") and key in {
+        "BASELINE_LOCKFILE",
+        "CANDIDATE_LOCKFILE",
+    }:
+        return True
     if normalized.startswith(".github/workflows/") and key == "TRIVY_IMAGE":
         return True
     if normalized == LAUNCHPLANE_CONFIG_AUTHORITY_WORKFLOW_PATH and (
@@ -3280,6 +3285,8 @@ def _is_dependency_health_workflow_mechanic(
     value: object,
 ) -> bool:
     value_text = _string_value(value).strip()
+    if key in {"BASELINE_LOCKFILE", "CANDIDATE_LOCKFILE"}:
+        return _is_repository_relative_package_lock_path(value_text)
     if key == "uses":
         return _is_immutable_launchplane_dependency_health_action_reference(value_text)
     if key == "TRIVY_IMAGE":
@@ -3309,6 +3316,7 @@ def _is_dependency_health_workflow_mechanic(
         return (
             _is_github_same_job_step_output_reference(value_text)
             or value_text == _dependabot_target_advisory_text_expression()
+            or _is_dependabot_production_scope_target_advisory_text_expression(value_text)
         )
     if input_name == "output-directory":
         return _is_step_output_path(value_text, suffix="/evaluation")
@@ -3329,6 +3337,32 @@ def _dependabot_target_advisory_text_expression() -> str:
         "github.event.pull_request.user.login == 'dependabot[bot]' && "
         "steps.dependabot.outputs.dependency-type != 'direct:development' && "
         "github.event.pull_request.body || '' }}"
+    )
+
+
+def _is_dependabot_production_scope_target_advisory_text_expression(
+    value: str,
+) -> bool:
+    return (
+        re.fullmatch(
+            r"\$\{\{ github\.event_name == 'pull_request' && "
+            r"github\.event\.pull_request\.user\.login == 'dependabot\[bot\]' && "
+            r"steps\.[A-Za-z_][A-Za-z0-9_-]*\.outputs\.production-scope == 'true' && "
+            r"github\.event\.pull_request\.body \|\| '' \}\}",
+            value,
+        )
+        is not None
+    )
+
+
+def _is_repository_relative_package_lock_path(value: str) -> bool:
+    path = PurePosixPath(value)
+    return bool(
+        value
+        and not path.is_absolute()
+        and ".." not in path.parts
+        and len(path.parts) > 1
+        and path.name == "package-lock.json"
     )
 
 

--- a/docs/dependency-health-contract.md
+++ b/docs/dependency-health-contract.md
@@ -183,6 +183,11 @@ artifact retention and fails the job when the comparison policy fails.
 
 Dependabot remains the update and advisory signal. This contract intentionally
 does not merge, close, replace, or manually modify Dependabot pull requests.
+Product workflows may omit advisory targeting for an npm update only when both
+the trusted baseline and candidate lockfiles mark every updated package as
+strictly development-only. Mixed, missing, malformed, or non-npm metadata must
+remain production-scoped and fail closed when a security update has no target
+advisory evidence.
 After downstream adoption, an ordinary Dependabot refresh should make a
 non-regressing update green automatically. A genuinely introduced or worsened
 high/critical finding remains red until the bot offers a safe update.

--- a/tests/test_config_authority_audit.py
+++ b/tests/test_config_authority_audit.py
@@ -631,6 +631,8 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
             "    runs-on: ubuntu-latest\n"
             "    env:\n"
             "      TRIVY_IMAGE: ghcr.io/aquasecurity/trivy:0.70.0@sha256:" + "b" * 64 + "\n"
+            "      BASELINE_LOCKFILE: dependency-health-baseline/package-lock.json\n"
+            "      CANDIDATE_LOCKFILE: dependency-health-candidate/package-lock.json\n"
             "    steps:\n"
             "      - id: compare\n"
             "        uses: >-\n"
@@ -815,6 +817,12 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
             "steps.dependabot.outputs.dependency-type != 'direct:development' && "
             "github.event.pull_request.body || '' }}"
         )
+        production_scope_expression = (
+            "${{ github.event_name == 'pull_request' && "
+            "github.event.pull_request.user.login == 'dependabot[bot]' && "
+            "steps.dependency_targets.outputs.production-scope == 'true' && "
+            "github.event.pull_request.body || '' }}"
+        )
         unsafe_expression = (
             "${{ github.event.pull_request.user.login != 'dependabot[bot]' && "
             "github.event.pull_request.body || 'dependabot' }}"
@@ -823,6 +831,7 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
 
         for expression, expected_status in (
             (safe_expression, "pass"),
+            (production_scope_expression, "pass"),
             (unsafe_expression, "fail"),
             (job_output_expression, "fail"),
         ):
@@ -850,6 +859,40 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
 
                     payload = build_config_authority_audit(control_plane_root=root)
                     gate = evaluate_config_authority_gate(payload, profile="product-repo")
+
+                self.assertEqual(gate["status"], expected_status)
+
+    def test_dependency_health_lockfile_paths_must_be_repository_relative(self) -> None:
+        for lockfile_path, expected_status in (
+            ("dependency-health-baseline/package-lock.json", "pass"),
+            ("dependency-health-image-candidate/package-lock.json", "pass"),
+            ("../package-lock.json", "fail"),
+            ("/tmp/package-lock.json", "fail"),
+            ("dependency-health-baseline/other-lock.json", "fail"),
+        ):
+            with self.subTest(lockfile_path=lockfile_path):
+                with TemporaryDirectory() as temp_dir:
+                    root = Path(temp_dir)
+                    _init_repo(root)
+                    workflow = root / ".github" / "workflows" / "ci.yml"
+                    workflow.parent.mkdir(parents=True)
+                    workflow.write_text(
+                        "name: Dependency health\n"
+                        '"on": pull_request\n'
+                        "jobs:\n"
+                        "  compare:\n"
+                        "    runs-on: ubuntu-latest\n"
+                        "    env:\n"
+                        f"      BASELINE_LOCKFILE: {lockfile_path}\n",
+                        encoding="utf-8",
+                    )
+                    _commit_all(root)
+
+                    payload = build_config_authority_audit(control_plane_root=root)
+                    gate = evaluate_config_authority_gate(
+                        payload,
+                        profile="product-repo",
+                    )
 
                 self.assertEqual(gate["status"], expected_status)
 


### PR DESCRIPTION
## Summary
- classify repository-relative baseline and candidate `package-lock.json` paths as dependency-health workflow mechanics
- allow advisory text guarded by a same-job `production-scope` output while preserving the exact Dependabot PR/body boundary
- keep absolute, traversal, malformed, and job-output authority inputs fail-closed
- document the lockfile-derived dev-only exemption contract

## Verification
- `tests.test_config_authority_audit` — 109 tests passed
- official local unittest gate — 3,224 targets passed across 12 shards
- targeted `ruff check` and `ruff format --check`
- targeted `mypy`
- audited VeriReel PR #359 with this change: lockfile-path findings clear; the remaining expression findings require the companion VeriReel event guard/pin update

## Inspection
- PyCharm inspection completed but reported existing warnings across the changed audit module; no reported finding pointed to the newly added dependency-health logic.

Companion: cbusillo/verireel#359
